### PR TITLE
chore(bigtable): Update minitest to 5.14

### DIFF
--- a/google-cloud-bigtable/.rubocop.yml
+++ b/google-cloud-bigtable/.rubocop.yml
@@ -1,10 +1,9 @@
-require: rubocop-minitest
-
 inherit_gem:
   google-style: google-style.yml
 
 AllCops:
   Exclude:
+    - "acceptance/**/*"
     - "conformance/**/*"
     - "lib/**/*_pb.rb"
     - "lib/google/cloud/bigtable/admin.rb"
@@ -13,6 +12,7 @@ AllCops:
     - "lib/google/cloud/bigtable/v2/**/*"
     - "samples/**/*"
     - "support/**/*"
+    - "test/**/*"
 
 Documentation:
   Exclude:

--- a/google-cloud-bigtable/.rubocop.yml
+++ b/google-cloud-bigtable/.rubocop.yml
@@ -1,9 +1,10 @@
+require: rubocop-minitest
+
 inherit_gem:
   google-style: google-style.yml
 
 AllCops:
   Exclude:
-    - "acceptance/**/*"
     - "conformance/**/*"
     - "lib/**/*_pb.rb"
     - "lib/google/cloud/bigtable/admin.rb"
@@ -12,7 +13,6 @@ AllCops:
     - "lib/google/cloud/bigtable/v2/**/*"
     - "samples/**/*"
     - "support/**/*"
-    - "test/**/*"
 
 Documentation:
   Exclude:

--- a/google-cloud-bigtable/Gemfile
+++ b/google-cloud-bigtable/Gemfile
@@ -8,7 +8,3 @@ gem "google-cloud-errors", path: "../google-cloud-errors"
 
 gem "minitest-reporters", "~> 1.3.5", require: false
 gem "rake"
-
-# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
-# See https://github.com/googleapis/google-cloud-ruby/issues/4110
-gem "minitest", "~> 5.11.3"

--- a/google-cloud-bigtable/Gemfile
+++ b/google-cloud-bigtable/Gemfile
@@ -8,5 +8,3 @@ gem "google-cloud-errors", path: "../google-cloud-errors"
 
 gem "minitest-reporters", "~> 1.3.5", require: false
 gem "rake"
-
-gem "rubocop-minitest"

--- a/google-cloud-bigtable/Gemfile
+++ b/google-cloud-bigtable/Gemfile
@@ -8,3 +8,5 @@ gem "google-cloud-errors", path: "../google-cloud-errors"
 
 gem "minitest-reporters", "~> 1.3.5", require: false
 gem "rake"
+
+gem "rubocop-minitest"

--- a/google-cloud-bigtable/acceptance/bigtable/app_profile_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/app_profile_test.rb
@@ -24,19 +24,19 @@ describe "Instance AppProfiles", :bigtable do
     app_profile_id = "default"
 
     app_profiles = instance.app_profiles.to_a
-    app_profiles.wont_be :empty?
+    _(app_profiles).wont_be :empty?
     app_profiles.each do |profile|
-      profile.must_be_kind_of Google::Cloud::Bigtable::AppProfile
+      _(profile).must_be_kind_of Google::Cloud::Bigtable::AppProfile
     end
 
     app_profile = instance.app_profile(app_profile_id)
-    app_profile.must_be_kind_of Google::Cloud::Bigtable::AppProfile
+    _(app_profile).must_be_kind_of Google::Cloud::Bigtable::AppProfile
   end
 
   it "create multi cluster routing app profile and delete" do
     app_profile_id = "multi-cluster-#{Time.now.to_i}"
     routing_policy = Google::Cloud::Bigtable::AppProfile.multi_cluster_routing
-    routing_policy.must_be_instance_of Google::Cloud::Bigtable::MultiClusterRoutingUseAny
+    _(routing_policy).must_be_instance_of Google::Cloud::Bigtable::MultiClusterRoutingUseAny
 
     app_profile = instance.create_app_profile(
       app_profile_id,
@@ -45,15 +45,15 @@ describe "Instance AppProfiles", :bigtable do
       ignore_warnings: true
     )
 
-    app_profile.must_be_kind_of Google::Cloud::Bigtable::AppProfile
-    app_profile.single_cluster_routing.must_be :nil?
-    app_profile.multi_cluster_routing.must_be_instance_of Google::Cloud::Bigtable::MultiClusterRoutingUseAny
+    _(app_profile).must_be_kind_of Google::Cloud::Bigtable::AppProfile
+    _(app_profile.single_cluster_routing).must_be :nil?
+    _(app_profile.multi_cluster_routing).must_be_instance_of Google::Cloud::Bigtable::MultiClusterRoutingUseAny
 
     app_profile = instance.app_profile(app_profile_id)
-    app_profile.must_be_kind_of Google::Cloud::Bigtable::AppProfile
+    _(app_profile).must_be_kind_of Google::Cloud::Bigtable::AppProfile
     app_profile.delete(ignore_warnings: true)
 
-    instance.app_profile(app_profile_id).must_be :nil?
+    _(instance.app_profile(app_profile_id)).must_be :nil?
   end
 
   it "create single cluster routing app profile and delete" do
@@ -62,9 +62,9 @@ describe "Instance AppProfiles", :bigtable do
       bigtable_cluster_id,
       allow_transactional_writes: true
     )
-    routing_policy.must_be_instance_of Google::Cloud::Bigtable::SingleClusterRouting
-    routing_policy.cluster_id.must_equal bigtable_cluster_id
-    routing_policy.allow_transactional_writes.must_equal true
+    _(routing_policy).must_be_instance_of Google::Cloud::Bigtable::SingleClusterRouting
+    _(routing_policy.cluster_id).must_equal bigtable_cluster_id
+    _(routing_policy.allow_transactional_writes).must_equal true
 
     app_profile = instance.create_app_profile(
       app_profile_id,
@@ -72,17 +72,17 @@ describe "Instance AppProfiles", :bigtable do
       description: "App profile test single cluster routing",
       ignore_warnings: true
     )
-    app_profile.must_be_kind_of Google::Cloud::Bigtable::AppProfile
-    app_profile.multi_cluster_routing.must_be :nil?
-    app_profile.single_cluster_routing.must_be_instance_of Google::Cloud::Bigtable::SingleClusterRouting
-    app_profile.single_cluster_routing.cluster_id.must_equal bigtable_cluster_id
-    app_profile.single_cluster_routing.allow_transactional_writes.must_equal true
+    _(app_profile).must_be_kind_of Google::Cloud::Bigtable::AppProfile
+    _(app_profile.multi_cluster_routing).must_be :nil?
+    _(app_profile.single_cluster_routing).must_be_instance_of Google::Cloud::Bigtable::SingleClusterRouting
+    _(app_profile.single_cluster_routing.cluster_id).must_equal bigtable_cluster_id
+    _(app_profile.single_cluster_routing.allow_transactional_writes).must_equal true
 
     app_profile = instance.app_profile(app_profile_id)
-    app_profile.must_be_kind_of Google::Cloud::Bigtable::AppProfile
+    _(app_profile).must_be_kind_of Google::Cloud::Bigtable::AppProfile
     app_profile.delete(ignore_warnings: true)
 
-    instance.app_profile(app_profile_id).must_be :nil?
+    _(instance.app_profile(app_profile_id)).must_be :nil?
   end
 
   it "update app profile routing policy" do
@@ -98,20 +98,20 @@ describe "Instance AppProfiles", :bigtable do
       description: "App profile test single cluster routing",
       ignore_warnings: true
     )
-    app_profile.must_be_kind_of Google::Cloud::Bigtable::AppProfile
-    app_profile.multi_cluster_routing.must_be :nil?
-    app_profile.single_cluster_routing.must_be_instance_of Google::Cloud::Bigtable::SingleClusterRouting
+    _(app_profile).must_be_kind_of Google::Cloud::Bigtable::AppProfile
+    _(app_profile.multi_cluster_routing).must_be :nil?
+    _(app_profile.single_cluster_routing).must_be_instance_of Google::Cloud::Bigtable::SingleClusterRouting
 
     app_profile.routing_policy = Google::Cloud::Bigtable::AppProfile.multi_cluster_routing
     job = app_profile.save(ignore_warnings: true)
     job.wait_until_done!
-    job.app_profile.must_be_kind_of Google::Cloud::Bigtable::AppProfile
+    _(job.app_profile).must_be_kind_of Google::Cloud::Bigtable::AppProfile
 
     app_profile.reload!
-    app_profile.single_cluster_routing.must_be :nil?
-    app_profile.multi_cluster_routing.must_be_instance_of Google::Cloud::Bigtable::MultiClusterRoutingUseAny
+    _(app_profile.single_cluster_routing).must_be :nil?
+    _(app_profile.multi_cluster_routing).must_be_instance_of Google::Cloud::Bigtable::MultiClusterRoutingUseAny
 
     app_profile.delete(ignore_warnings: true)
-    instance.app_profile(app_profile_id).must_be :nil?
+    _(instance.app_profile(app_profile_id)).must_be :nil?
   end
 end

--- a/google-cloud-bigtable/acceptance/bigtable/cluster_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/cluster_test.rb
@@ -22,14 +22,14 @@ describe "Instance Clusters", :bigtable do
 
   it "lists and get cluster" do
     clusters = instance.clusters.to_a
-    clusters.wont_be :empty?
+    _(clusters).wont_be :empty?
     clusters.each do |cluster|
-      cluster.must_be_kind_of Google::Cloud::Bigtable::Cluster
+      _(cluster).must_be_kind_of Google::Cloud::Bigtable::Cluster
     end
 
     cluster_id = clusters.first.cluster_id
     first_cluster = instance.cluster(cluster_id)
-    first_cluster.must_be_kind_of Google::Cloud::Bigtable::Cluster
+    _(first_cluster).must_be_kind_of Google::Cloud::Bigtable::Cluster
   end
 
   it "create cluster, update and delete" do
@@ -40,20 +40,20 @@ describe "Instance Clusters", :bigtable do
     job.wait_until_done!
 
     clusters = instance.clusters.to_a
-    clusters.length.must_equal 2
+    _(clusters.length).must_equal 2
 
     cluster = job.cluster
-    cluster.must_be_kind_of Google::Cloud::Bigtable::Cluster
-    instance.cluster(cluster_id).wont_be :nil?
+    _(cluster).must_be_kind_of Google::Cloud::Bigtable::Cluster
+    _(instance.cluster(cluster_id)).wont_be :nil?
 
     cluster.nodes = 5
     job = cluster.save
     job.wait_until_done!
 
     cluster = instance.cluster(cluster_id)
-    cluster.nodes.must_equal 5
+    _(cluster.nodes).must_equal 5
 
     cluster.delete
-    instance.cluster(cluster_id).must_be :nil?
+    _(instance.cluster(cluster_id)).must_be :nil?
   end if ENV["BIGTABLE_ALL_ACCEPTANCE_TESTS"]
 end

--- a/google-cloud-bigtable/acceptance/bigtable/column_family_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/column_family_test.rb
@@ -37,16 +37,16 @@ describe Google::Cloud::Bigtable::Table, :column_families, :bigtable do
     end
 
     cf = column_families["cfcreate"]
-    cf.must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
-    cf.name.must_equal "cfcreate"
-    cf.gc_rule.wont_be :nil?
-    cf.gc_rule.max_versions.must_equal 1
+    _(cf).must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
+    _(cf.name).must_equal "cfcreate"
+    _(cf.gc_rule).wont_be :nil?
+    _(cf.gc_rule.max_versions).must_equal 1
 
     cf = table.column_families["cfcreate"] # was updated by table.column_families
-    cf.must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
-    cf.name.must_equal "cfcreate"
-    cf.gc_rule.wont_be :nil?
-    cf.gc_rule.max_versions.must_equal 1
+    _(cf).must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
+    _(cf.name).must_equal "cfcreate"
+    _(cf.gc_rule).wont_be :nil?
+    _(cf.gc_rule.max_versions).must_equal 1
   end
 
   it "adds a column family" do
@@ -57,16 +57,16 @@ describe Google::Cloud::Bigtable::Table, :column_families, :bigtable do
     end
 
     cf = column_families["cfcreate"]
-    cf.must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
-    cf.name.must_equal "cfcreate"
-    cf.gc_rule.wont_be :nil?
-    cf.gc_rule.max_versions.must_equal 1
+    _(cf).must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
+    _(cf.name).must_equal "cfcreate"
+    _(cf.gc_rule).wont_be :nil?
+    _(cf.gc_rule.max_versions).must_equal 1
 
     cf = table.column_families["cfcreate"] # was updated by table.column_families
-    cf.must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
-    cf.name.must_equal "cfcreate"
-    cf.gc_rule.wont_be :nil?
-    cf.gc_rule.max_versions.must_equal 1
+    _(cf).must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
+    _(cf.name).must_equal "cfcreate"
+    _(cf.gc_rule).wont_be :nil?
+    _(cf.gc_rule.max_versions).must_equal 1
   end
 
   it "adds a column family without gc_rule" do
@@ -75,14 +75,14 @@ describe Google::Cloud::Bigtable::Table, :column_families, :bigtable do
     end
 
     cf = column_families["cfcreate"]
-    cf.must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
-    cf.name.must_equal "cfcreate"
-    cf.gc_rule.must_be :nil?
+    _(cf).must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
+    _(cf.name).must_equal "cfcreate"
+    _(cf.gc_rule).must_be :nil?
 
     cf = table.column_families["cfcreate"]
-    cf.must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
-    cf.name.must_equal "cfcreate"
-    cf.gc_rule.must_be :nil?
+    _(cf).must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
+    _(cf.name).must_equal "cfcreate"
+    _(cf.gc_rule).must_be :nil?
   end
 
   it "updates a column family" do
@@ -93,40 +93,40 @@ describe Google::Cloud::Bigtable::Table, :column_families, :bigtable do
     end
 
     cf = column_families["cf1"]
-    cf.must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
-    cf.gc_rule.max_age.must_equal 300
+    _(cf).must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
+    _(cf.gc_rule.max_age).must_equal 300
 
     cf = table.column_families["cf1"]
-    cf.must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
-    cf.gc_rule.max_age.must_equal 300
+    _(cf).must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
+    _(cf.gc_rule.max_age).must_equal 300
   end
 
   it "updates a column family without gc_rule" do
     cf = table.column_families["cf1"]
-    cf.gc_rule.wont_be :nil?
+    _(cf.gc_rule).wont_be :nil?
 
     column_families = table.column_families do |cfs|
       cfs.update "cf1"
     end
 
     cf = column_families["cf1"]
-    cf.must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
-    cf.gc_rule.must_be :nil?
+    _(cf).must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
+    _(cf.gc_rule).must_be :nil?
 
     cf = table.column_families["cf1"]
-    cf.must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
-    cf.gc_rule.must_be :nil?
+    _(cf).must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
+    _(cf.gc_rule).must_be :nil?
   end
 
   it "deletes a column family" do
-    table.column_families["cf2"].wont_be :nil?
+    _(table.column_families["cf2"]).wont_be :nil?
 
     column_families = table.column_families do |cfs|
       cfs.delete "cf2"
     end
 
-    column_families["cf2"].must_be :nil?
-    table.column_families["cf2"].must_be :nil?
+    _(column_families["cf2"]).must_be :nil?
+    _(table.column_families["cf2"]).must_be :nil?
   end
 
   it "adds a column family with union gc rules" do
@@ -139,20 +139,20 @@ describe Google::Cloud::Bigtable::Table, :column_families, :bigtable do
     end
 
     cf = column_families["cfunion"]
-    cf.must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
-    cf.name.must_equal "cfunion"
+    _(cf).must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
+    _(cf.name).must_equal "cfunion"
     rules = cf.gc_rule.union
-    rules.must_be_kind_of Array
-    rules.count.must_equal 2
-    rules[0].must_be_kind_of Google::Cloud::Bigtable::GcRule
-    rules[0].max_versions.must_equal 3
-    rules[1].must_be_kind_of Google::Cloud::Bigtable::GcRule
-    rules[1].max_age.must_equal 300
+    _(rules).must_be_kind_of Array
+    _(rules.count).must_equal 2
+    _(rules[0]).must_be_kind_of Google::Cloud::Bigtable::GcRule
+    _(rules[0].max_versions).must_equal 3
+    _(rules[1]).must_be_kind_of Google::Cloud::Bigtable::GcRule
+    _(rules[1].max_age).must_equal 300
 
     cf = table.column_families["cfunion"]
-    cf.must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
-    cf.name.must_equal "cfunion"
-    cf.gc_rule.union.count.must_equal 2
+    _(cf).must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
+    _(cf.name).must_equal "cfunion"
+    _(cf.gc_rule.union.count).must_equal 2
   end
 
   it "adds a column family with intersection gc rules" do
@@ -167,19 +167,19 @@ describe Google::Cloud::Bigtable::Table, :column_families, :bigtable do
     end
 
     cf = column_families["cfintersect"]
-    cf.must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
-    cf.name.must_equal "cfintersect"
+    _(cf).must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
+    _(cf.name).must_equal "cfintersect"
     rules = cf.gc_rule.intersection
-    rules.must_be_kind_of Array
-    rules.count.must_equal 2
-    rules[0].must_be_kind_of Google::Cloud::Bigtable::GcRule
-    rules[0].max_versions.must_equal 1
-    rules[1].must_be_kind_of Google::Cloud::Bigtable::GcRule
-    rules[1].max_age.must_equal 600
+    _(rules).must_be_kind_of Array
+    _(rules.count).must_equal 2
+    _(rules[0]).must_be_kind_of Google::Cloud::Bigtable::GcRule
+    _(rules[0].max_versions).must_equal 1
+    _(rules[1]).must_be_kind_of Google::Cloud::Bigtable::GcRule
+    _(rules[1].max_age).must_equal 600
 
     cf = table.column_families["cfintersect"]
-    cf.must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
-    cf.name.must_equal "cfintersect"
-    cf.gc_rule.intersection.count.must_equal 2
+    _(cf).must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
+    _(cf.name).must_equal "cfintersect"
+    _(cf.gc_rule.intersection.count).must_equal 2
   end
 end

--- a/google-cloud-bigtable/acceptance/bigtable/instance_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/instance_test.rb
@@ -20,15 +20,15 @@ require "bigtable_helper"
 describe "Instances", :bigtable do
   it "lists and get a instance" do
     instances = bigtable.instances.all.to_a
-    instances.wont_be :empty?
+    _(instances).wont_be :empty?
     instances.each do |instance|
-      instance.must_be_kind_of Google::Cloud::Bigtable::Instance
+      _(instance).must_be_kind_of Google::Cloud::Bigtable::Instance
     end
 
     instance_id = instances.first.instance_id
 
     first_instance = bigtable.instance(instance_id)
-    first_instance.must_be_kind_of Google::Cloud::Bigtable::Instance
+    _(first_instance).must_be_kind_of Google::Cloud::Bigtable::Instance
   end
 
   it "update instance labels and display name" do
@@ -43,8 +43,8 @@ describe "Instances", :bigtable do
     job.wait_until_done!
 
     instance.reload!
-    instance.display_name.must_equal display_name
-    instance.labels["updated-at"].must_equal time
+    _(instance.display_name).must_equal display_name
+    _(instance.labels["updated-at"]).must_equal time
   end
 
   describe "IAM policies and permissions" do
@@ -55,15 +55,15 @@ describe "Instances", :bigtable do
 
       roles = ["bigtable.instances.get", "bigtable.tables.get"]
       permissions = instance.test_iam_permissions(roles)
-      permissions.must_be_kind_of Array
-      permissions.must_equal roles
+      _(permissions).must_be_kind_of Array
+      _(permissions).must_equal roles
     end
 
     it "allows policy to be updated on an instance" do
       instance = bigtable_instance
-      instance.policy.must_be_kind_of Google::Cloud::Bigtable::Policy
+      _(instance.policy).must_be_kind_of Google::Cloud::Bigtable::Policy
 
-      service_account.wont_be :nil?
+      _(service_account).wont_be :nil?
 
       role = "roles/bigtable.user"
       member = "serviceAccount:#{service_account}"
@@ -72,10 +72,10 @@ describe "Instances", :bigtable do
       policy.add(role, member)
       updated_policy = instance.update_policy(policy)
 
-      updated_policy.role(role).wont_be :nil?
+      _(updated_policy.role(role)).wont_be :nil?
 
       role_member = instance.policy.role(role).select { |m| m == member }
-      role_member.size.must_equal 1
+      _(role_member.size).must_equal 1
     end
   end
 end

--- a/google-cloud-bigtable/acceptance/bigtable/project_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/project_test.rb
@@ -43,9 +43,9 @@ describe Google::Cloud::Bigtable::Project, :bigtable do
     raise GRPC::BadStatus.new(job.error.code, job.error.message) if job.error?
 
     instance = job.instance
-    instance.must_be_kind_of Google::Cloud::Bigtable::Instance
-    instance.development?.must_equal true
-    instance.clusters.count.must_equal 1
-    instance.clusters.first.nodes.must_equal 1
+    _(instance).must_be_kind_of Google::Cloud::Bigtable::Instance
+    _(instance.development?).must_equal true
+    _(instance.clusters.count).must_equal 1
+    _(instance.clusters.first.nodes).must_equal 1
   end
 end

--- a/google-cloud-bigtable/acceptance/bigtable/table/check_and_mutate_row_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/table/check_and_mutate_row_test.rb
@@ -44,7 +44,7 @@ describe "DataClient Check and Mutate Row", :bigtable do
       otherwise: otherwise_mutations
     )
 
-    response.must_equal true
+    _(response).must_equal true
   end
 
   it "raises Google::Cloud::InvalidArgumentError for invalid id for collection columnFamilies" do
@@ -56,8 +56,8 @@ describe "DataClient Check and Mutate Row", :bigtable do
     )
     otherwise_mutations = table.new_mutation_entry.delete_from_family(family)
 
-    proc {
+    _ { proc {
       table.check_and_mutate_row row_key, predicate_filter, on_match: matched_mutations, otherwise: otherwise_mutations
-    }.must_raise Google::Cloud::InvalidArgumentError
+    } }.must_raise Google::Cloud::InvalidArgumentError
   end
 end

--- a/google-cloud-bigtable/acceptance/bigtable/table/check_and_mutate_row_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/table/check_and_mutate_row_test.rb
@@ -56,8 +56,8 @@ describe "DataClient Check and Mutate Row", :bigtable do
     )
     otherwise_mutations = table.new_mutation_entry.delete_from_family(family)
 
-    _ { proc {
+    assert_raises Google::Cloud::InvalidArgumentError do
       table.check_and_mutate_row row_key, predicate_filter, on_match: matched_mutations, otherwise: otherwise_mutations
-    } }.must_raise Google::Cloud::InvalidArgumentError
+    end
   end
 end

--- a/google-cloud-bigtable/acceptance/bigtable/table/drop_rows_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/table/drop_rows_test.rb
@@ -21,18 +21,18 @@ describe "Table drop rows", :bigtable do
   it "delete all rows" do
     table_id = "test-table-#{random_str}"
     table = create_table(table_id, row_count: 2)
-    table.delete_all_rows(timeout: 300).must_equal true
+    _(table.delete_all_rows(timeout: 300)).must_equal true
 
     rows = table.read_rows.to_a
-    rows.must_be_empty
+    _(rows).must_be_empty
   end
 
   it "delete rows by prefix" do
     table_id = "test-table-#{random_str}"
     table = create_table(table_id, row_count: 2)
-    table.delete_rows_by_prefix("test-1", timeout: 300).must_equal true
+    _(table.delete_rows_by_prefix("test-1", timeout: 300)).must_equal true
 
     rows = table.read_rows.to_a
-    rows.length.must_equal 1
+    _(rows.length).must_equal 1
   end
 end

--- a/google-cloud-bigtable/acceptance/bigtable/table/mutate_row_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/table/mutate_row_test.rb
@@ -27,9 +27,9 @@ describe "DataClient Mutate Row", :bigtable do
     # Set cell
     entry = table.new_mutation_entry("setcell-#{postfix}")
     entry.set_cell(family + "&  *^(*&^%^%&^", "mutate-row-#{postfix}", "mutatetest value #{postfix}")
-    proc {
+    _ { proc {
       table.mutate_row(entry)
-    }.must_raise Google::Cloud::InvalidArgumentError
+    } }.must_raise Google::Cloud::InvalidArgumentError
   end
 
   it "set cell and delete cells" do
@@ -41,17 +41,17 @@ describe "DataClient Mutate Row", :bigtable do
     entry = table.new_mutation_entry(row_key)
     entry.set_cell(family, qualifier, "mutatetest value #{postfix}")
 
-    table.mutate_row(entry).must_equal true
+    _(table.mutate_row(entry)).must_equal true
     row = table.read_row(row_key)
     cell = row.cells[family].select{|v| v.qualifier == qualifier}.first
-    cell.must_be_kind_of Google::Cloud::Bigtable::Row::Cell
+    _(cell).must_be_kind_of Google::Cloud::Bigtable::Row::Cell
 
     # Delete cell
     entry = table.new_mutation_entry(row_key)
     entry.delete_cells(family, qualifier)
 
     table.mutate_row(entry)
-    table.read_row(row_key).must_be :nil?
+    _(table.read_row(row_key)).must_be :nil?
   end
 
   it "set cell with timestamp and delete cells with integer timestamp range" do
@@ -70,9 +70,9 @@ describe "DataClient Mutate Row", :bigtable do
       family, qualifier, "mutatetest value #{postfix}", timestamp: timestamp + 2000
     )
 
-    table.mutate_row(entry).must_equal true
+    _(table.mutate_row(entry)).must_equal true
     row = table.read_row(row_key)
-    row.cells[family].select{|v| v.qualifier == qualifier}.length.must_equal 3
+    _(row.cells[family].select{|v| v.qualifier == qualifier}.length).must_equal 3
 
     # Delete cell
     entry = table.new_mutation_entry(row_key)
@@ -82,7 +82,7 @@ describe "DataClient Mutate Row", :bigtable do
 
     table.mutate_row(entry)
     row = table.read_row(row_key)
-    row.cells[family].select{|v| v.qualifier == qualifier}.length.must_equal 1
+    _(row.cells[family].select{|v| v.qualifier == qualifier}.length).must_equal 1
   end
 
   it "raises when set_cell with incorrect Time timestamp" do
@@ -90,7 +90,7 @@ describe "DataClient Mutate Row", :bigtable do
     row_key = "setcell-#{postfix}"
     qualifier = "mutate-row-#{postfix}"
 
-    table.granularity.must_equal :MILLIS
+    _(table.granularity).must_equal :MILLIS
 
     # Set cell
     entry = table.new_mutation_entry(row_key)
@@ -99,7 +99,7 @@ describe "DataClient Mutate Row", :bigtable do
         family, qualifier, "mutatetest value #{postfix}", timestamp: Time.now
       )
     end.must_raise Google::Protobuf::TypeError
-    err.message.must_match "Expected number type for integral field 'timestamp_micros' (given Time)."
+    _(err.message).must_match "Expected number type for integral field 'timestamp_micros' (given Time)."
   end
 
   it "raises when set_cell with incorrect microsecond integer timestamp" do
@@ -109,7 +109,7 @@ describe "DataClient Mutate Row", :bigtable do
     timestamp_micros = (Time.now.to_f * 1000000).round
     timestamp_micros += 1 if (timestamp_micros % 10).zero?
 
-    table.granularity.must_equal :MILLIS
+    _(table.granularity).must_equal :MILLIS
 
     # Set cell
     entry = table.new_mutation_entry(row_key)
@@ -119,7 +119,7 @@ describe "DataClient Mutate Row", :bigtable do
     err = expect do
       table.mutate_row(entry)
     end.must_raise Google::Cloud::InvalidArgumentError
-    err.message.must_match /Timestamp granularity mismatch. Expected a multiple of 1000 \(millisecond granularity\), but got #{timestamp_micros}/
+    _(err.message).must_match /Timestamp granularity mismatch. Expected a multiple of 1000 \(millisecond granularity\), but got #{timestamp_micros}/
   end
 
   it "raises when set_cell with incorrect millisecond integer timestamp" do
@@ -129,7 +129,7 @@ describe "DataClient Mutate Row", :bigtable do
     timestamp_millis = (Time.now.to_f * 1000).to_i
     timestamp_millis += 1 if (timestamp_millis % 10).zero?
 
-    table.granularity.must_equal :MILLIS
+    _(table.granularity).must_equal :MILLIS
 
     # Set cell
     entry = table.new_mutation_entry(row_key)
@@ -139,7 +139,7 @@ describe "DataClient Mutate Row", :bigtable do
     err = expect do
       table.mutate_row(entry)
     end.must_raise Google::Cloud::InvalidArgumentError
-    err.message.must_match /Timestamp granularity mismatch. Expected a multiple of 1000 \(millisecond granularity\), but got #{timestamp_millis}/
+    _(err.message).must_match /Timestamp granularity mismatch. Expected a multiple of 1000 \(millisecond granularity\), but got #{timestamp_millis}/
   end
 
   it "set_cell with correct microseconds rounded to milliseconds integer timestamp" do
@@ -148,7 +148,7 @@ describe "DataClient Mutate Row", :bigtable do
     qualifier = "mutate-row-#{postfix}"
     timestamp_micros = (Time.now.to_f * 1000000).round(-3)
 
-    table.granularity.must_equal :MILLIS
+    _(table.granularity).must_equal :MILLIS
 
     # Set cell
     entry = table.new_mutation_entry(row_key)
@@ -156,11 +156,11 @@ describe "DataClient Mutate Row", :bigtable do
       family, qualifier, "mutatetest value #{postfix}", timestamp: timestamp_micros
     )
 
-    table.mutate_row(entry).must_equal true
+    _(table.mutate_row(entry)).must_equal true
     row = table.read_row(row_key)
     cells = row.cells[family].select{|v| v.qualifier == qualifier}
-    cells.length.must_equal 1
-    cells.first.timestamp.must_equal timestamp_micros
+    _(cells.length).must_equal 1
+    _(cells.first.timestamp).must_equal timestamp_micros
 
     # Delete cell
     entry = table.new_mutation_entry(row_key)
@@ -175,11 +175,11 @@ describe "DataClient Mutate Row", :bigtable do
 
     entry = table.new_mutation_entry(row_key)
     entry.set_cell(family, qualifier, "mutatetest value #{postfix}")
-    table.mutate_row(entry).must_equal true
+    _(table.mutate_row(entry)).must_equal true
 
     entry = table.new_mutation_entry(row_key).delete_from_family(family)
-    table.mutate_row(entry).must_equal true
-    table.read_row(row_key).must_be :nil?
+    _(table.mutate_row(entry)).must_equal true
+    _(table.read_row(row_key)).must_be :nil?
   end
 
   it "delete row" do
@@ -189,11 +189,11 @@ describe "DataClient Mutate Row", :bigtable do
 
     entry = table.new_mutation_entry(row_key)
     entry.set_cell(family, qualifier, "mutatetest value #{postfix}")
-    table.mutate_row(entry).must_equal true
+    _(table.mutate_row(entry)).must_equal true
 
     entry = table.new_mutation_entry(row_key).delete_from_row
-    table.mutate_row(entry).must_equal true
-    table.read_row(row_key).must_be :nil?
+    _(table.mutate_row(entry)).must_equal true
+    _(table.read_row(row_key)).must_be :nil?
   end
 
   it "set integer cell value" do
@@ -203,10 +203,10 @@ describe "DataClient Mutate Row", :bigtable do
 
     entry = table.new_mutation_entry(row_key)
     entry.set_cell(family, qualifier, 100)
-    table.mutate_row(entry).must_equal true
+    _(table.mutate_row(entry)).must_equal true
 
     row = table.read_row(row_key)
     cell = row.cells[family].select{|v| v.qualifier == qualifier}.first
-    cell.to_i.must_equal 100
+    _(cell.to_i).must_equal 100
   end
 end

--- a/google-cloud-bigtable/acceptance/bigtable/table/mutate_row_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/table/mutate_row_test.rb
@@ -27,9 +27,9 @@ describe "DataClient Mutate Row", :bigtable do
     # Set cell
     entry = table.new_mutation_entry("setcell-#{postfix}")
     entry.set_cell(family + "&  *^(*&^%^%&^", "mutate-row-#{postfix}", "mutatetest value #{postfix}")
-    _ { proc {
+    assert_raises Google::Cloud::InvalidArgumentError do
       table.mutate_row(entry)
-    } }.must_raise Google::Cloud::InvalidArgumentError
+    end
   end
 
   it "set cell and delete cells" do

--- a/google-cloud-bigtable/acceptance/bigtable/table/mutate_rows_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/table/mutate_rows_test.rb
@@ -33,12 +33,12 @@ describe "DataClient Mutate Rows", :bigtable do
     entry2.set_cell(family, qualifier, "mutatetest value #{postfix} 2")
 
     responses = table.mutate_rows([entry1, entry2])
-    responses.length.must_equal 2
+    _(responses.length).must_equal 2
 
     success_count = responses.count{ |r| r.status.code == 0 }
 
     keys = ["#{row_key}-1", "#{row_key}-2"]
     rows = table.read_rows(keys: keys).to_a
-    rows.length.must_equal success_count
+    _(rows.length).must_equal success_count
   end
 end

--- a/google-cloud-bigtable/acceptance/bigtable/table/read_modify_write_row_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/table/read_modify_write_row_test.rb
@@ -60,8 +60,8 @@ describe "DataClient Read Modify Write Row", :bigtable do
       family + "&  *^(*&^%^%&^", qualifier, 1
     )
 
-    _ { proc {
+    assert_raises Google::Cloud::InvalidArgumentError do
       table.read_modify_write_row(row_key, rule)
-    } }.must_raise Google::Cloud::InvalidArgumentError
+    end
   end
 end

--- a/google-cloud-bigtable/acceptance/bigtable/table/read_modify_write_row_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/table/read_modify_write_row_test.rb
@@ -34,7 +34,7 @@ describe "DataClient Read Modify Write Row", :bigtable do
     )
 
     row = table.read_modify_write_row(row_key, rule)
-    row.cells[family].first.value.must_equal "Value append-xyz"
+    _(row.cells[family].first.value).must_equal "Value append-xyz"
   end
 
   it "increment row cell value" do
@@ -50,7 +50,7 @@ describe "DataClient Read Modify Write Row", :bigtable do
     )
 
     row = table.read_modify_write_row(row_key, rule)
-    row.cells[family].first.to_i.must_equal 101
+    _(row.cells[family].first.to_i).must_equal 101
   end
 
   it "raises Google::Cloud::InvalidArgumentError for invalid id for collection columnFamilies" do
@@ -60,8 +60,8 @@ describe "DataClient Read Modify Write Row", :bigtable do
       family + "&  *^(*&^%^%&^", qualifier, 1
     )
 
-    proc {
+    _ { proc {
       table.read_modify_write_row(row_key, rule)
-    }.must_raise Google::Cloud::InvalidArgumentError
+    } }.must_raise Google::Cloud::InvalidArgumentError
   end
 end

--- a/google-cloud-bigtable/acceptance/bigtable/table/read_rows_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/table/read_rows_test.rb
@@ -23,75 +23,75 @@ describe "DataClient Read Rows", :bigtable do
 
   it "read single row" do
     row = table.read_row("test-1")
-    row.key.must_equal "test-1"
-    row.must_be_kind_of Google::Cloud::Bigtable::Row
+    _(row.key).must_equal "test-1"
+    _(row).must_be_kind_of Google::Cloud::Bigtable::Row
   end
 
   it "read single row with filter" do
     filter = table.filter.label("readtest")
     row = table.read_row("test-1", filter: filter)
-    row.must_be_kind_of Google::Cloud::Bigtable::Row
+    _(row).must_be_kind_of Google::Cloud::Bigtable::Row
 
     row.cells.each do |_, cells|
       cells.each do |cell|
-        cell.labels.must_equal ["readtest"]
+        _(cell.labels).must_equal ["readtest"]
       end
     end
   end
 
   it "read rows" do
     rows = table.read_rows.map do |row|
-      row.must_be_kind_of Google::Cloud::Bigtable::Row
+      _(row).must_be_kind_of Google::Cloud::Bigtable::Row
       row
     end
 
-    rows.wont_be :empty?
+    _(rows).wont_be :empty?
   end
 
   it "read rows with limit" do
     rows = table.read_rows(limit: 2).map do |row|
-      row.must_be_kind_of Google::Cloud::Bigtable::Row
+      _(row).must_be_kind_of Google::Cloud::Bigtable::Row
       row
     end
 
-    rows.length.must_equal 2
+    _(rows.length).must_equal 2
   end
 
   it "read rows using row keys" do
     keys = ["test-1", "test-3"]
     rows = table.read_rows(keys: keys).map do |row|
-      row.must_be_kind_of Google::Cloud::Bigtable::Row
+      _(row).must_be_kind_of Google::Cloud::Bigtable::Row
       row
     end
 
-    rows.length.must_equal 2
-    rows.map(&:key).must_equal keys
+    _(rows.length).must_equal 2
+    _(rows.map(&:key)).must_equal keys
   end
 
   it "read rows with filter" do
     filter = table.filter.key("test-.*")
 
     rows = table.read_rows(filter: filter).map do |row|
-      row.must_be_kind_of Google::Cloud::Bigtable::Row
+      _(row).must_be_kind_of Google::Cloud::Bigtable::Row
       row
     end
 
-    rows.wont_be :empty?
+    _(rows).wont_be :empty?
     rows.each do |row|
-      row.key.start_with?("test-").must_equal true
+      _(row.key.start_with?("test-")).must_equal true
     end
   end
 
   it "read rows with range" do
     range = table.new_row_range.from("test-5")
     rows = table.read_rows(ranges: range).map do |row|
-      row.must_be_kind_of Google::Cloud::Bigtable::Row
+      _(row).must_be_kind_of Google::Cloud::Bigtable::Row
       row
     end
 
-    rows.wont_be :empty?
+    _(rows).wont_be :empty?
     rows.each do |row|
-      (row.key >= "test-5").must_equal true
+      _((row.key >= "test-5")).must_equal true
     end
   end
 
@@ -101,19 +101,19 @@ describe "DataClient Read Rows", :bigtable do
     limit = 5
 
     rows = table.read_rows(ranges: range, filter: filter, limit: limit).map do |row|
-      row.must_be_kind_of Google::Cloud::Bigtable::Row
+      _(row).must_be_kind_of Google::Cloud::Bigtable::Row
       row
     end
 
-    rows.wont_be :empty?
-    rows.length.must_equal 5
+    _(rows).wont_be :empty?
+    _(rows.length).must_equal 5
     rows.each do |row|
-      (row.key >= "test-1").must_equal true
+      _((row.key >= "test-1")).must_equal true
     end
 
     rows.each do |row|
       row.cells[family].each do |cell|
-        cell.qualifier.start_with?("field").must_equal true
+        _(cell.qualifier.start_with?("field")).must_equal true
       end
     end
   end

--- a/google-cloud-bigtable/acceptance/bigtable/table/row_filter_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/table/row_filter_test.rb
@@ -25,34 +25,34 @@ describe "DataClient Read Rows Filters", :bigtable do
     filter = table.filter.strip_value
 
     rows = table.read_rows(filter: filter, limit: 1).to_a
-    rows.wont_be :empty?
+    _(rows).wont_be :empty?
     cell = rows.first.cells[family].first
-    cell.value.must_be :empty?
+    _(cell.value).must_be :empty?
   end
 
   it "key regex filter" do
     filter = table.filter.key("test-1.*")
     rows = table.read_rows(filter: filter).to_a
-    rows.wont_be :empty?
+    _(rows).wont_be :empty?
     rows.each do |r|
-      r.key.start_with?("test-1").must_equal true
+      _(r.key.start_with?("test-1")).must_equal true
     end
   end
 
   it "sample probability filter" do
     filter = table.filter.sample(0.5)
     rows = table.read_rows(filter: filter).to_a
-    rows.length.must_be :>=, 0
+    _(rows.length).must_be :>=, 0
   end
 
   it "family filter" do
     filter = table.filter.family("c.*")
     rows = table.read_rows(filter: filter, limit: 2).to_a
-    rows.wont_be :empty?
+    _(rows).wont_be :empty?
 
     rows.each do |row|
       row.cells.each do |family, _|
-        family.start_with?("c").must_equal true
+        _(family.start_with?("c")).must_equal true
       end
     end
   end
@@ -60,11 +60,11 @@ describe "DataClient Read Rows Filters", :bigtable do
   it "family filter" do
     filter = table.filter.qualifier("field.*")
     rows = table.read_rows(filter: filter, limit: 2).to_a
-    rows.wont_be :empty?
+    _(rows).wont_be :empty?
 
     rows.each do |row|
       row.cells[family].each do |cell|
-        cell.qualifier.start_with?("field").must_equal true
+        _(cell.qualifier.start_with?("field")).must_equal true
       end
     end
   end
@@ -72,11 +72,11 @@ describe "DataClient Read Rows Filters", :bigtable do
   it "value filter" do
     filter = table.filter.value("value.*")
     rows = table.read_rows(filter: filter, limit: 2).to_a
-    rows.wont_be :empty?
+    _(rows).wont_be :empty?
 
     rows.each do |row|
       row.cells[family].each do |cell|
-        cell.value.start_with?("value").must_equal true
+        _(cell.value.start_with?("value")).must_equal true
       end
     end
   end
@@ -84,30 +84,30 @@ describe "DataClient Read Rows Filters", :bigtable do
   it "cells per row offset filter" do
     filter = table.filter.cells_per_row_offset(1)
     rows = table.read_rows(filter: filter, limit: 2).to_a
-    rows.wont_be :empty?
+    _(rows).wont_be :empty?
 
     rows.each do |row|
-      row.cells[family].length.must_equal 1
+      _(row.cells[family].length).must_equal 1
     end
   end
 
   it "cells per row filter" do
     filter = table.filter.cells_per_row(1)
     rows = table.read_rows(filter: filter, limit: 2).to_a
-    rows.wont_be :empty?
+    _(rows).wont_be :empty?
 
     rows.each do |row|
-      row.cells[family].length.must_equal 1
+      _(row.cells[family].length).must_equal 1
     end
   end
 
   it "cells per column filter" do
     filter = table.filter.cells_per_column(1)
     rows = table.read_rows(keys: ["test-1"], filter: filter).to_a
-    rows.wont_be :empty?
+    _(rows).wont_be :empty?
 
     rows.each do |row|
-      row.cells[family].map(&:qualifier).length.must_equal 2
+      _(row.cells[family].map(&:qualifier).length).must_equal 2
     end
   end
 
@@ -119,11 +119,11 @@ describe "DataClient Read Rows Filters", :bigtable do
 
     filter = table.filter.timestamp_range(from: timestamp_micros)
     rows = table.read_rows(filter: filter, limit: 2).to_a
-    rows.wont_be :empty?
+    _(rows).wont_be :empty?
 
     rows.each do |row|
       row.cells[family].each do |cell|
-        cell.timestamp.must_be :>=, timestamp_micros
+        _(cell.timestamp).must_be :>=, timestamp_micros
       end
     end
   end
@@ -133,12 +133,12 @@ describe "DataClient Read Rows Filters", :bigtable do
 
     filter = table.filter.value_range(range)
     rows = table.read_rows(filter: filter).to_a
-    rows.wont_be :empty?
+    _(rows).wont_be :empty?
 
     rows.each do |row|
       row.cells[family].each do |cell|
-        cell.value.must_be :>=, "value-1"
-        cell.value.must_be :<=, "value-2"
+        _(cell.value).must_be :>=, "value-1"
+        _(cell.value).must_be :<=, "value-2"
       end
     end
   end
@@ -148,11 +148,11 @@ describe "DataClient Read Rows Filters", :bigtable do
 
     filter = table.filter.column_range(range)
     rows = table.read_rows(filter: filter, limit: 2).to_a
-    rows.wont_be :empty?
+    _(rows).wont_be :empty?
 
     rows.each do |row|
       row.cells[family].each do |cell|
-        cell.qualifier.must_be :>=, "field1"
+        _(cell.qualifier).must_be :>=, "field1"
       end
     end
   end
@@ -166,20 +166,20 @@ describe "DataClient Read Rows Filters", :bigtable do
     condition.on_match(label).otherwise(strip_value)
 
     rows = table.read_rows(filter: condition).to_a
-    rows.wont_be :empty?
+    _(rows).wont_be :empty?
   end
 
   it "chain filter" do
     filter = table.filter.chain.key("test-.*").strip_value.label("test")
 
     rows = table.read_rows(filter: filter).to_a
-    rows.wont_be :empty?
+    _(rows).wont_be :empty?
   end
 
   it "interleave filter" do
     filter = table.filter.interleave.key("test-.*").cells_per_row(1)
 
     rows = table.read_rows(filter: filter).to_a
-    rows.wont_be :empty?
+    _(rows).wont_be :empty?
   end
 end

--- a/google-cloud-bigtable/acceptance/bigtable/table/sample_row_keys_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/table/sample_row_keys_test.rb
@@ -20,6 +20,6 @@ require "bigtable_helper"
 describe "DataClient Sample Rows Keys", :bigtable do
   it "read sample rows keys" do
     sample_row_keys = bigtable_read_table.sample_row_keys.to_a
-    sample_row_keys.wont_be :empty?
+    _(sample_row_keys).wont_be :empty?
   end
 end

--- a/google-cloud-bigtable/acceptance/bigtable/table_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/table_test.rb
@@ -27,19 +27,19 @@ describe "Instance Tables", :bigtable do
       cfs.add("cf", gc_rule: Google::Cloud::Bigtable::GcRule.max_versions(3))
     end
 
-    table.must_be_kind_of Google::Cloud::Bigtable::Table
+    _(table).must_be_kind_of Google::Cloud::Bigtable::Table
 
     tables = bigtable.tables(instance_id).to_a
-    tables.wont_be :empty?
+    _(tables).wont_be :empty?
     tables.each do |t|
-      t.must_be_kind_of Google::Cloud::Bigtable::Table
+      _(t).must_be_kind_of Google::Cloud::Bigtable::Table
     end
 
     table = bigtable.table(instance_id, table_id, perform_lookup: true)
-    table.must_be_kind_of Google::Cloud::Bigtable::Table
+    _(table).must_be_kind_of Google::Cloud::Bigtable::Table
 
     table.delete
-    table.exists?.must_equal false
+    _(table.exists?).must_equal false
   end
 
   it "create table with initial splits and granularity" do
@@ -54,9 +54,9 @@ describe "Instance Tables", :bigtable do
       cfs.add("cf", gc_rule: Google::Cloud::Bigtable::GcRule.max_versions(1))
     end
 
-    table.must_be_kind_of Google::Cloud::Bigtable::Table
-    table.granularity_millis?.must_equal true
-    table.exists?.must_equal true
+    _(table).must_be_kind_of Google::Cloud::Bigtable::Table
+    _(table.granularity_millis?).must_equal true
+    _(table.exists?).must_equal true
 
     entries = 10.times.map do |i|
       key = "customer-#{"%03d" % (i+1).to_s}"
@@ -64,13 +64,13 @@ describe "Instance Tables", :bigtable do
     end
 
     responses = table.mutate_rows(entries)
-    responses.count.must_equal entries.count
-    responses.each { |r| r.status.code.must_equal 0 }
+    _(responses.count).must_equal entries.count
+    responses.each { |r| _(r.status.code).must_equal 0 }
 
     sample_keys = table.sample_row_keys.to_a.map(&:key)
 
     initial_splits.each do |key|
-      sample_keys.must_include(key)
+      _(sample_keys).must_include(key)
     end
 
     table.delete
@@ -86,21 +86,21 @@ describe "Instance Tables", :bigtable do
     end
 
     column_families = table.column_families
-    column_families.must_be_kind_of Google::Cloud::Bigtable::ColumnFamilyMap
-    column_families.must_be :frozen?
-    column_families.count.must_equal 3
+    _(column_families).must_be_kind_of Google::Cloud::Bigtable::ColumnFamilyMap
+    _(column_families).must_be :frozen?
+    _(column_families.count).must_equal 3
 
     cf1 = column_families["cf1"]
-    cf1.must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
-    cf1.gc_rule.must_be :nil?
+    _(cf1).must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
+    _(cf1.gc_rule).must_be :nil?
 
     cf2 = column_families["cf2"]
-    cf2.must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
-    cf2.gc_rule.max_versions.must_equal 5
+    _(cf2).must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
+    _(cf2.gc_rule.max_versions).must_equal 5
 
     cf3 = column_families["cf3"]
-    cf3.must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
-    cf3.gc_rule.max_age.must_equal 600
+    _(cf3).must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
+    _(cf3.gc_rule.max_age).must_equal 600
 
     table.delete
   end
@@ -110,14 +110,14 @@ describe "Instance Tables", :bigtable do
 
     it "generate consistency token and check consistency" do
       token = table.generate_consistency_token
-      token.wont_be :nil?
+      _(token).wont_be :nil?
       result = table.check_consistency(token)
-      [true, false].must_include result
+      _([true, false]).must_include result
     end
 
     it "generate consistency token and check consistency wail unitil complete" do
       result = table.wait_for_replication(timeout: 600, check_interval: 3)
-      [true, false].must_include result
+      _([true, false]).must_include result
     end
   end
 
@@ -128,14 +128,14 @@ describe "Instance Tables", :bigtable do
     it "tests permissions" do
       roles = ["bigtable.tables.delete", "bigtable.tables.get"]
       permissions = table.test_iam_permissions(roles)
-      permissions.must_be_kind_of Array
-      permissions.must_equal roles
+      _(permissions).must_be_kind_of Array
+      _(permissions).must_equal roles
     end
 
     it "allows policy to be updated on a table" do
-      table.policy.must_be_kind_of Google::Cloud::Bigtable::Policy
+      _(table.policy).must_be_kind_of Google::Cloud::Bigtable::Policy
 
-      service_account.wont_be :nil?
+      _(service_account).wont_be :nil?
 
       role = "roles/bigtable.user"
       member = "serviceAccount:#{service_account}"
@@ -144,10 +144,10 @@ describe "Instance Tables", :bigtable do
       policy.add(role, member)
       updated_policy = table.update_policy(policy)
 
-      updated_policy.role(role).wont_be :nil?
+      _(updated_policy.role(role)).wont_be :nil?
 
       role_member = table.policy.role(role).select { |m| m == member }
-      role_member.size.must_equal 1
+      _(role_member.size).must_equal 1
     end
   end
 end

--- a/google-cloud-bigtable/google-cloud-bigtable.gemspec
+++ b/google-cloud-bigtable/google-cloud-bigtable.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "grpc-google-iam-v1", "~> 0.6.9"
 
   gem.add_development_dependency "google-style", "~> 1.24.0"
-  gem.add_development_dependency "minitest", "~> 5.10"
+  gem.add_development_dependency "minitest", "~> 5.14"
   gem.add_development_dependency "minitest-focus", "~> 1.1"
   gem.add_development_dependency "minitest-rg", "~> 5.2"
   gem.add_development_dependency "redcarpet", "~> 3.0"

--- a/google-cloud-bigtable/test/google/cloud/bigtable/app_profile/delete_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/app_profile/delete_test.rb
@@ -36,7 +36,7 @@ describe Google::Cloud::Bigtable::AppProfile, :delete, :mock_bigtable do
     bigtable.service.mocked_instances = mock
 
     result = app_profile.delete
-    result.must_equal true
+    _(result).must_equal true
     mock.verify
   end
 
@@ -48,7 +48,7 @@ describe Google::Cloud::Bigtable::AppProfile, :delete, :mock_bigtable do
     bigtable.service.mocked_instances = mock
 
     result = app_profile.delete(ignore_warnings: ignore_warnings)
-    result.must_equal true
+    _(result).must_equal true
     mock.verify
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/app_profile/save_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/app_profile/save_test.rb
@@ -83,17 +83,17 @@ describe Google::Cloud::Bigtable::AppProfile, :save, :mock_bigtable do
 
     job = app_profile.save
 
-    job.must_be_kind_of Google::Cloud::Bigtable::AppProfile::Job
-    job.wont_be :done?
-    job.wont_be :error?
-    job.error.must_be :nil?
-    job.app_profile.must_be :nil?
+    _(job).must_be_kind_of Google::Cloud::Bigtable::AppProfile::Job
+    _(job).wont_be :done?
+    _(job).wont_be :error?
+    _(job.error).must_be :nil?
+    _(job.app_profile).must_be :nil?
 
     job.reload!
     app_profile = job.app_profile
 
-    app_profile.wont_be :nil?
-    app_profile.must_be_kind_of Google::Cloud::Bigtable::AppProfile
+    _(app_profile).wont_be :nil?
+    _(app_profile).must_be_kind_of Google::Cloud::Bigtable::AppProfile
 
     mock.verify
   end
@@ -122,17 +122,17 @@ describe Google::Cloud::Bigtable::AppProfile, :save, :mock_bigtable do
 
     job = app_profile.save(ignore_warnings: true)
 
-    job.must_be_kind_of Google::Cloud::Bigtable::AppProfile::Job
-    job.wont_be :done?
-    job.wont_be :error?
-    job.error.must_be :nil?
-    job.app_profile.must_be :nil?
+    _(job).must_be_kind_of Google::Cloud::Bigtable::AppProfile::Job
+    _(job).wont_be :done?
+    _(job).wont_be :error?
+    _(job.error).must_be :nil?
+    _(job.app_profile).must_be :nil?
 
     job.reload!
     app_profile = job.app_profile
 
-    app_profile.wont_be :nil?
-    app_profile.must_be_kind_of Google::Cloud::Bigtable::AppProfile
+    _(app_profile).wont_be :nil?
+    _(app_profile).must_be_kind_of Google::Cloud::Bigtable::AppProfile
 
     mock.verify
   end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/app_profile_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/app_profile_test.rb
@@ -30,15 +30,15 @@ describe Google::Cloud::Bigtable::AppProfile, :mock_bigtable do
   let(:app_profile) { Google::Cloud::Bigtable::AppProfile.from_grpc(app_profile_grpc, bigtable.service) }
 
   it "knows the identifiers" do
-    app_profile.must_be_kind_of Google::Cloud::Bigtable::AppProfile
-    app_profile.project_id.must_equal project_id
-    app_profile.instance_id.must_equal instance_id
-    app_profile.name.must_equal app_profile_id
-    app_profile.path.must_equal app_profile_path(instance_id, app_profile_id)
-    app_profile.description.must_equal description
-    app_profile.multi_cluster_routing.to_grpc.must_equal routing_policy_grpc
-    app_profile.routing_policy.to_grpc.must_equal routing_policy_grpc
-    app_profile.single_cluster_routing.must_be :nil?
+    _(app_profile).must_be_kind_of Google::Cloud::Bigtable::AppProfile
+    _(app_profile.project_id).must_equal project_id
+    _(app_profile.instance_id).must_equal instance_id
+    _(app_profile.name).must_equal app_profile_id
+    _(app_profile.path).must_equal app_profile_path(instance_id, app_profile_id)
+    _(app_profile.description).must_equal description
+    _(app_profile.multi_cluster_routing.to_grpc).must_equal routing_policy_grpc
+    _(app_profile.routing_policy.to_grpc).must_equal routing_policy_grpc
+    _(app_profile.single_cluster_routing).must_be :nil?
   end
 
   it "set multi_cluster_routing policy" do
@@ -47,13 +47,13 @@ describe Google::Cloud::Bigtable::AppProfile, :mock_bigtable do
     )
     app_profile = Google::Cloud::Bigtable::AppProfile.from_grpc(app_profile_grpc, bigtable.service)
 
-    app_profile.routing_policy.must_be :nil?
+    _(app_profile.routing_policy).must_be :nil?
 
     routing_policy = Google::Cloud::Bigtable::AppProfile.multi_cluster_routing
     app_profile.routing_policy = routing_policy
 
-    app_profile.routing_policy.must_be_kind_of Google::Cloud::Bigtable::MultiClusterRoutingUseAny
-    app_profile.routing_policy.to_grpc.must_equal routing_policy.to_grpc
+    _(app_profile.routing_policy).must_be_kind_of Google::Cloud::Bigtable::MultiClusterRoutingUseAny
+    _(app_profile.routing_policy.to_grpc).must_equal routing_policy.to_grpc
   end
 
   it "set single_cluster_routing policy" do
@@ -62,7 +62,7 @@ describe Google::Cloud::Bigtable::AppProfile, :mock_bigtable do
     )
     app_profile = Google::Cloud::Bigtable::AppProfile.from_grpc(app_profile_grpc, bigtable.service)
 
-    app_profile.routing_policy.must_be :nil?
+    _(app_profile.routing_policy).must_be :nil?
 
     routing_policy = Google::Cloud::Bigtable::AppProfile.single_cluster_routing(
       "test-cluster",
@@ -70,8 +70,8 @@ describe Google::Cloud::Bigtable::AppProfile, :mock_bigtable do
     )
     app_profile.routing_policy = routing_policy
 
-    app_profile.routing_policy.must_be_kind_of Google::Cloud::Bigtable::SingleClusterRouting
-    app_profile.routing_policy.to_grpc.must_equal routing_policy.to_grpc
+    _(app_profile.routing_policy).must_be_kind_of Google::Cloud::Bigtable::SingleClusterRouting
+    _(app_profile.routing_policy.to_grpc).must_equal routing_policy.to_grpc
   end
 
   it "reloads its state" do
@@ -83,9 +83,9 @@ describe Google::Cloud::Bigtable::AppProfile, :mock_bigtable do
 
     mock.verify
 
-    app_profile.project_id.must_equal project_id
-    app_profile.instance_id.must_equal instance_id
-    app_profile.name.must_equal app_profile_id
-    app_profile.path.must_equal app_profile_path(instance_id, app_profile_id)
+    _(app_profile.project_id).must_equal project_id
+    _(app_profile.instance_id).must_equal instance_id
+    _(app_profile.name).must_equal app_profile_id
+    _(app_profile.path).must_equal app_profile_path(instance_id, app_profile_id)
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/cluster/delete_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/cluster/delete_test.rb
@@ -37,7 +37,7 @@ describe Google::Cloud::Bigtable::Cluster, :delete, :mock_bigtable do
     bigtable.service.mocked_instances = mock
 
     result = cluster.delete
-    result.must_equal true
+    _(result).must_equal true
     mock.verify
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/cluster/save_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/cluster/save_test.rb
@@ -82,17 +82,17 @@ describe Google::Cloud::Bigtable::Cluster, :save, :mock_bigtable do
 
     job = cluster.save
 
-    job.must_be_kind_of Google::Cloud::Bigtable::Cluster::Job
-    job.wont_be :done?
-    job.wont_be :error?
-    job.error.must_be :nil?
-    job.cluster.must_be :nil?
+    _(job).must_be_kind_of Google::Cloud::Bigtable::Cluster::Job
+    _(job).wont_be :done?
+    _(job).wont_be :error?
+    _(job.error).must_be :nil?
+    _(job.cluster).must_be :nil?
 
     job.reload!
     cluster = job.cluster
 
-    cluster.wont_be :nil?
-    cluster.must_be_kind_of Google::Cloud::Bigtable::Cluster
+    _(cluster).wont_be :nil?
+    _(cluster).must_be_kind_of Google::Cloud::Bigtable::Cluster
 
     mock.verify
   end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/cluster_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/cluster_test.rb
@@ -32,19 +32,19 @@ describe Google::Cloud::Bigtable::Cluster, :mock_bigtable do
   let(:cluster) { Google::Cloud::Bigtable::Cluster.from_grpc(cluster_grpc, bigtable.service) }
 
   it "knows the identifiers" do
-    cluster.must_be_kind_of Google::Cloud::Bigtable::Cluster
-    cluster.project_id.must_equal project_id
-    cluster.instance_id.must_equal instance_id
-    cluster.cluster_id.must_equal cluster_id
-    cluster.path.must_equal cluster_path(instance_id, cluster_id)
-    cluster.nodes.must_equal nodes
-    cluster.location.must_equal location_id
-    cluster.location_path.must_equal location_path(location_id)
-    cluster.state.must_equal :READY
-    cluster.must_be :ready?
-    cluster.wont_be :creating?
-    cluster.wont_be :resizing?
-    cluster.wont_be :disabled?
+    _(cluster).must_be_kind_of Google::Cloud::Bigtable::Cluster
+    _(cluster.project_id).must_equal project_id
+    _(cluster.instance_id).must_equal instance_id
+    _(cluster.cluster_id).must_equal cluster_id
+    _(cluster.path).must_equal cluster_path(instance_id, cluster_id)
+    _(cluster.nodes).must_equal nodes
+    _(cluster.location).must_equal location_id
+    _(cluster.location_path).must_equal location_path(location_id)
+    _(cluster.state).must_equal :READY
+    _(cluster).must_be :ready?
+    _(cluster).wont_be :creating?
+    _(cluster).wont_be :resizing?
+    _(cluster).wont_be :disabled?
   end
 
   it "reloads its state" do
@@ -56,13 +56,13 @@ describe Google::Cloud::Bigtable::Cluster, :mock_bigtable do
 
     mock.verify
 
-    cluster.project_id.must_equal project_id
-    cluster.instance_id.must_equal instance_id
-    cluster.cluster_id.must_equal cluster_id
-    cluster.path.must_equal cluster_path(instance_id, cluster_id)
-    cluster.state.must_equal :READY
-    cluster.ready?.must_equal true
-    cluster.storage_type.must_equal :SSD
-    cluster.nodes.must_equal 3
+    _(cluster.project_id).must_equal project_id
+    _(cluster.instance_id).must_equal instance_id
+    _(cluster.cluster_id).must_equal cluster_id
+    _(cluster.path).must_equal cluster_path(instance_id, cluster_id)
+    _(cluster.state).must_equal :READY
+    _(cluster.ready?).must_equal true
+    _(cluster.storage_type).must_equal :SSD
+    _(cluster.nodes).must_equal 3
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/column_family/modifications_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/column_family/modifications_test.rb
@@ -64,10 +64,10 @@ describe Google::Cloud::Bigtable::ColumnFamily, :create, :mock_bigtable do
     end
 
     cf = column_families[new_cf_name]
-    cf.must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
-    cf.name.must_equal new_cf_name
-    cf.gc_rule.wont_be :nil?
-    cf.gc_rule.max_versions.must_equal 3
+    _(cf).must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
+    _(cf.name).must_equal new_cf_name
+    _(cf.gc_rule).wont_be :nil?
+    _(cf.gc_rule.max_versions).must_equal 3
 
     mock.verify
   end
@@ -100,9 +100,9 @@ describe Google::Cloud::Bigtable::ColumnFamily, :create, :mock_bigtable do
     end
 
     cf = column_families[new_cf_name]
-    cf.must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
-    cf.name.must_equal new_cf_name
-    cf.gc_rule.must_be :nil?
+    _(cf).must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
+    _(cf.name).must_equal new_cf_name
+    _(cf.gc_rule).must_be :nil?
 
     mock.verify
   end
@@ -141,10 +141,10 @@ describe Google::Cloud::Bigtable::ColumnFamily, :create, :mock_bigtable do
     end
 
     cf = column_families[cf_name]
-    cf.must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
-    cf.name.must_equal cf_name
-    cf.gc_rule.wont_be :nil?
-    cf.gc_rule.max_versions.must_equal 1
+    _(cf).must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
+    _(cf.name).must_equal cf_name
+    _(cf.gc_rule).wont_be :nil?
+    _(cf.gc_rule.max_versions).must_equal 1
 
     mock.verify
   end
@@ -181,9 +181,9 @@ describe Google::Cloud::Bigtable::ColumnFamily, :create, :mock_bigtable do
     end
 
     cf = column_families[cf_name]
-    cf.must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
-    cf.name.must_equal cf_name
-    cf.gc_rule.must_be :nil?
+    _(cf).must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
+    _(cf.name).must_equal cf_name
+    _(cf.gc_rule).must_be :nil?
 
     mock.verify
   end
@@ -212,7 +212,7 @@ describe Google::Cloud::Bigtable::ColumnFamily, :create, :mock_bigtable do
       cfm.delete(cf_name)
     end
 
-    column_families[cf_name].must_be :nil?
+    _(column_families[cf_name]).must_be :nil?
 
     mock.verify
   end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/column_family_map_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/column_family_map_test.rb
@@ -29,11 +29,11 @@ describe Google::Cloud::Bigtable::ColumnFamilyMap, :mock_bigtable do
     cfm.add cf_name, gc_rule: gc_rule
 
     cfs = cfm.to_grpc
-    cfs.length.must_equal 4
+    _(cfs.length).must_equal 4
     cf = cfs[cf_name]
-    cf.must_be_kind_of Google::Bigtable::Admin::V2::ColumnFamily
-    cf.gc_rule.must_be_kind_of Google::Bigtable::Admin::V2::GcRule
-    cf.gc_rule.must_equal gc_rule.to_grpc
+    _(cf).must_be_kind_of Google::Bigtable::Admin::V2::ColumnFamily
+    _(cf.gc_rule).must_be_kind_of Google::Bigtable::Admin::V2::GcRule
+    _(cf.gc_rule).must_equal gc_rule.to_grpc
   end
 
   it "adds a column family without gc_rule" do
@@ -42,10 +42,10 @@ describe Google::Cloud::Bigtable::ColumnFamilyMap, :mock_bigtable do
     cfm.add cf_name
 
     cfs = cfm.to_grpc
-    cfs.length.must_equal 4
+    _(cfs.length).must_equal 4
     cf = cfs[cf_name]
-    cf.must_be_kind_of Google::Bigtable::Admin::V2::ColumnFamily
-    cf.gc_rule.must_be :nil?
+    _(cf).must_be_kind_of Google::Bigtable::Admin::V2::ColumnFamily
+    _(cf.gc_rule).must_be :nil?
   end
 
   it "adds a column family with the deprecated gc_rule" do
@@ -57,18 +57,18 @@ describe Google::Cloud::Bigtable::ColumnFamilyMap, :mock_bigtable do
     end.must_output "", deprecated_gc_rule_warning
 
     cfs = cfm.to_grpc
-    cfs.length.must_equal 4
+    _(cfs.length).must_equal 4
     cf = cfs[cf_name]
-    cf.must_be_kind_of Google::Bigtable::Admin::V2::ColumnFamily
-    cf.gc_rule.must_be_kind_of Google::Bigtable::Admin::V2::GcRule
-    cf.gc_rule.must_equal gc_rule.to_grpc
+    _(cf).must_be_kind_of Google::Bigtable::Admin::V2::ColumnFamily
+    _(cf.gc_rule).must_be_kind_of Google::Bigtable::Admin::V2::GcRule
+    _(cf.gc_rule).must_equal gc_rule.to_grpc
   end
 
   it "doesn't add a column family if one already exists" do
     cf_name = cfm.names.first
 
     error = expect { cfm.add cf_name }.must_raise ArgumentError
-    error.message.must_equal "column family \"cf1\" already exists"
+    _(error.message).must_equal "column family \"cf1\" already exists"
   end
 
   it "doesn't add a column family when frozen" do
@@ -77,7 +77,7 @@ describe Google::Cloud::Bigtable::ColumnFamilyMap, :mock_bigtable do
     cfm.freeze
 
     error = expect { cfm.add cf_name }.must_raise frozen_error_class
-    error.message.must_equal "can't modify frozen Hash"
+    _(error.message).must_equal "can't modify frozen Hash"
   end
 
   it "updates a column family" do
@@ -87,11 +87,11 @@ describe Google::Cloud::Bigtable::ColumnFamilyMap, :mock_bigtable do
     cfm.update cf_name, gc_rule: gc_rule
 
     cfs = cfm.to_grpc
-    cfs.length.must_equal 3
+    _(cfs.length).must_equal 3
     cf = cfs[cf_name]
-    cf.must_be_kind_of Google::Bigtable::Admin::V2::ColumnFamily
-    cf.gc_rule.must_be_kind_of Google::Bigtable::Admin::V2::GcRule
-    cf.gc_rule.must_equal gc_rule.to_grpc
+    _(cf).must_be_kind_of Google::Bigtable::Admin::V2::ColumnFamily
+    _(cf.gc_rule).must_be_kind_of Google::Bigtable::Admin::V2::GcRule
+    _(cf.gc_rule).must_equal gc_rule.to_grpc
   end
 
   it "updates a column family without gc_rule" do
@@ -100,17 +100,17 @@ describe Google::Cloud::Bigtable::ColumnFamilyMap, :mock_bigtable do
     cfm.update cf_name
 
     cfs = cfm.to_grpc
-    cfs.length.must_equal 3
+    _(cfs.length).must_equal 3
     cf = cfs[cf_name]
-    cf.must_be_kind_of Google::Bigtable::Admin::V2::ColumnFamily
-    cf.gc_rule.must_be :nil?
+    _(cf).must_be_kind_of Google::Bigtable::Admin::V2::ColumnFamily
+    _(cf.gc_rule).must_be :nil?
   end
 
   it "doesn't update a column family if one doesn't exist" do
     cf_name = "new-cf"
 
     error = expect { cfm.update cf_name }.must_raise ArgumentError
-    error.message.must_equal "column family \"new-cf\" does not exist"
+    _(error.message).must_equal "column family \"new-cf\" does not exist"
   end
 
   it "doesn't update a column family when frozen" do
@@ -119,7 +119,7 @@ describe Google::Cloud::Bigtable::ColumnFamilyMap, :mock_bigtable do
     cfm.freeze
 
     error = expect { cfm.update cf_name }.must_raise frozen_error_class
-    error.message.must_equal "can't modify frozen Hash"
+    _(error.message).must_equal "can't modify frozen Hash"
   end
 
   it "deletes a column family" do
@@ -128,16 +128,16 @@ describe Google::Cloud::Bigtable::ColumnFamilyMap, :mock_bigtable do
     cfm.delete cf_name
 
     cfs = cfm.to_grpc
-    cfs.length.must_equal 2
+    _(cfs.length).must_equal 2
     cf = cfs[cf_name]
-    cf.must_be :nil?
+    _(cf).must_be :nil?
   end
 
   it "doesn't delete a column family if one doesn't exist" do
     cf_name = "new-cf"
 
     error = expect { cfm.delete cf_name }.must_raise ArgumentError
-    error.message.must_equal "column family \"new-cf\" does not exist"
+    _(error.message).must_equal "column family \"new-cf\" does not exist"
   end
 
   it "doesn't delete a column family when frozen" do
@@ -146,6 +146,6 @@ describe Google::Cloud::Bigtable::ColumnFamilyMap, :mock_bigtable do
     cfm.freeze
 
     error = expect { cfm.delete cf_name }.must_raise frozen_error_class
-    error.message.must_equal "can't modify frozen Hash"
+    _(error.message).must_equal "can't modify frozen Hash"
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/column_family_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/column_family_test.rb
@@ -27,11 +27,11 @@ describe Google::Cloud::Bigtable::ColumnFamily, :mock_bigtable do
       cf_name
     )
 
-    column_family.must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
-    column_family.gc_rule.wont_be :nil?
-    column_family.gc_rule.must_be_kind_of Google::Cloud::Bigtable::GcRule
-    column_family.gc_rule.max_versions.must_equal 3
-    column_family.name.must_equal cf_name
+    _(column_family).must_be_kind_of Google::Cloud::Bigtable::ColumnFamily
+    _(column_family.gc_rule).wont_be :nil?
+    _(column_family.gc_rule).must_be_kind_of Google::Cloud::Bigtable::GcRule
+    _(column_family.gc_rule.max_versions).must_equal 3
+    _(column_family.name).must_equal cf_name
   end
 
   it "set column family gc rule" do
@@ -41,10 +41,10 @@ describe Google::Cloud::Bigtable::ColumnFamily, :mock_bigtable do
       "cf"
     )
 
-    column_family.gc_rule.must_be :nil?
+    _(column_family.gc_rule).must_be :nil?
 
     column_family.gc_rule = Google::Cloud::Bigtable::GcRule.max_versions(3)
-    column_family.gc_rule.must_be_kind_of Google::Cloud::Bigtable::GcRule
-    column_family.gc_rule.max_versions.must_equal 3
+    _(column_family.gc_rule).must_be_kind_of Google::Cloud::Bigtable::GcRule
+    _(column_family.gc_rule.max_versions).must_equal 3
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/column_range_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/column_range_test.rb
@@ -22,35 +22,35 @@ describe Google::Cloud::Bigtable::ColumnRange, :column_range, :mock_bigtable do
     family_name = "cf"
     range = Google::Cloud::Bigtable::ColumnRange.new(family_name)
     grpc = range.to_grpc
-    grpc.must_be_kind_of Google::Bigtable::V2::ColumnRange
-    grpc.family_name.must_equal family_name
+    _(grpc).must_be_kind_of Google::Bigtable::V2::ColumnRange
+    _(grpc.family_name).must_equal family_name
   end
 
   describe "#from" do
     it "create inclusive from range instance" do
       from_qualifier = "from-qual-inclusive"
       range = Google::Cloud::Bigtable::ColumnRange.new("cf").from(from_qualifier)
-      range.must_be_kind_of Google::Cloud::Bigtable::ColumnRange
+      _(range).must_be_kind_of Google::Cloud::Bigtable::ColumnRange
       grpc = range.to_grpc
-      grpc.start_qualifier_closed.must_equal from_qualifier
+      _(grpc.start_qualifier_closed).must_equal from_qualifier
     end
 
     it "create exclusive from range instance" do
       from_qualifier = "from-qual-exclusive"
       range = Google::Cloud::Bigtable::ColumnRange.new("cf").from(from_qualifier, inclusive: false)
-      range.must_be_kind_of Google::Cloud::Bigtable::ColumnRange
+      _(range).must_be_kind_of Google::Cloud::Bigtable::ColumnRange
       grpc = range.to_grpc
-      grpc.start_qualifier_open.must_equal from_qualifier
+      _(grpc.start_qualifier_open).must_equal from_qualifier
     end
 
     it "create instance with from and to range" do
       from_qualifier = "from-qual"
       to_qualifier = "to-qualifier"
       range = Google::Cloud::Bigtable::ColumnRange.new("cf").from(from_qualifier).to(to_qualifier)
-      range.must_be_kind_of Google::Cloud::Bigtable::ColumnRange
+      _(range).must_be_kind_of Google::Cloud::Bigtable::ColumnRange
       grpc = range.to_grpc
-      grpc.start_qualifier_closed.must_equal from_qualifier
-      grpc.end_qualifier_open.must_equal to_qualifier
+      _(grpc.start_qualifier_closed).must_equal from_qualifier
+      _(grpc.end_qualifier_open).must_equal to_qualifier
     end
   end
 
@@ -58,27 +58,27 @@ describe Google::Cloud::Bigtable::ColumnRange, :column_range, :mock_bigtable do
     it "create exclusive to range instance" do
       to_qualifier = "to-qualifier-inclusive"
       range = Google::Cloud::Bigtable::ColumnRange.new("cf").to(to_qualifier)
-      range.must_be_kind_of Google::Cloud::Bigtable::ColumnRange
+      _(range).must_be_kind_of Google::Cloud::Bigtable::ColumnRange
       grpc = range.to_grpc
-      grpc.end_qualifier_open.must_equal to_qualifier
+      _(grpc.end_qualifier_open).must_equal to_qualifier
     end
 
     it "create inclusive to range instance" do
       to_qualifier = "to-qualifier-exclusive"
       range = Google::Cloud::Bigtable::ColumnRange.new("cf").to(to_qualifier, inclusive: true)
-      range.must_be_kind_of Google::Cloud::Bigtable::ColumnRange
+      _(range).must_be_kind_of Google::Cloud::Bigtable::ColumnRange
       grpc = range.to_grpc
-      grpc.end_qualifier_closed.must_equal to_qualifier
+      _(grpc.end_qualifier_closed).must_equal to_qualifier
     end
 
     it "create instance with from and to range" do
       from_qualifier = "from-qual"
       to_qualifier = "to-qualifier"
       range = Google::Cloud::Bigtable::ColumnRange.new("cf").to(to_qualifier).from(from_qualifier)
-      range.must_be_kind_of Google::Cloud::Bigtable::ColumnRange
+      _(range).must_be_kind_of Google::Cloud::Bigtable::ColumnRange
       grpc = range.to_grpc
-      grpc.start_qualifier_closed.must_equal from_qualifier
-      grpc.end_qualifier_open.must_equal to_qualifier
+      _(grpc.start_qualifier_closed).must_equal from_qualifier
+      _(grpc.end_qualifier_open).must_equal to_qualifier
     end
   end
 
@@ -86,19 +86,19 @@ describe Google::Cloud::Bigtable::ColumnRange, :column_range, :mock_bigtable do
     from_qualifier = "from-qual"
     to_qualifier = "to-qualifier"
     range = Google::Cloud::Bigtable::ColumnRange.new("cf").between(from_qualifier, to_qualifier)
-    range.must_be_kind_of Google::Cloud::Bigtable::ColumnRange
+    _(range).must_be_kind_of Google::Cloud::Bigtable::ColumnRange
     grpc = range.to_grpc
-    grpc.start_qualifier_closed.must_equal from_qualifier
-    grpc.end_qualifier_closed.must_equal to_qualifier
+    _(grpc.start_qualifier_closed).must_equal from_qualifier
+    _(grpc.end_qualifier_closed).must_equal to_qualifier
   end
 
   it "create instance using 'of'" do
     from_qualifier = "from-qual"
     to_qualifier = "to-qualifier"
     range = Google::Cloud::Bigtable::ColumnRange.new("cf").of(from_qualifier, to_qualifier)
-    range.must_be_kind_of Google::Cloud::Bigtable::ColumnRange
+    _(range).must_be_kind_of Google::Cloud::Bigtable::ColumnRange
     grpc = range.to_grpc
-    grpc.start_qualifier_closed.must_equal from_qualifier
-    grpc.end_qualifier_open.must_equal to_qualifier
+    _(grpc.start_qualifier_closed).must_equal from_qualifier
+    _(grpc.end_qualifier_open).must_equal to_qualifier
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/conformance_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/conformance_test.rb
@@ -67,18 +67,18 @@ class ReadRowsTest < MockBigtable
               # If cells is empty, either we are just starting, or else we have emptied `cells` from the previous row.
               # We need to fetch a row and cells against which to test the remaining `results`
               row = rows.next
-              row.key.must_equal result.row_key
+              _(row.key).must_equal result.row_key
               # The cells in a row are in a map, but the corresponding expected
               # results are in a simple array, so convert cells to array.
               cells = row.cells.values.flatten
             end
 
             cell = cells.shift # take a cell from `cells` against which to test the current `result`
-            cell.family.must_equal result.family_name
-            cell.qualifier.must_equal result.qualifier
-            cell.timestamp.must_equal result.timestamp_micros
-            cell.value.must_equal result.value
-            cell.labels.first.must_equal result.label unless result.label.empty?
+            _(cell.family).must_equal result.family_name
+            _(cell.qualifier).must_equal result.qualifier
+            _(cell.timestamp).must_equal result.timestamp_micros
+            _(cell.value).must_equal result.value
+            _(cell.labels.first).must_equal result.label unless result.label.empty?
           end
         end
       end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/convert_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/convert_test.rb
@@ -21,63 +21,63 @@ describe Google::Cloud::Bigtable::Convert, :mock_bigtable do
   describe "number_to_duration" do
     it "returns nil when given number is nil" do
       duration = Google::Cloud::Bigtable::Convert.number_to_duration(nil)
-      duration.must_be :nil?
+      _(duration).must_be :nil?
     end
 
     it "convert an integer to duration" do
       number = 100
       duration = Google::Cloud::Bigtable::Convert.number_to_duration(number)
-      duration.must_be_kind_of Google::Protobuf::Duration
-      duration.seconds.must_equal 100
-      duration.nanos.must_equal 0
+      _(duration).must_be_kind_of Google::Protobuf::Duration
+      _(duration.seconds).must_equal 100
+      _(duration.nanos).must_equal 0
     end
 
     it "converts a float numner to duration" do
       number = 100.2
       duration = Google::Cloud::Bigtable::Convert.number_to_duration(number)
-      duration.must_be_kind_of Google::Protobuf::Duration
-      duration.seconds.must_equal 100
-      duration.nanos.must_equal 200000000
+      _(duration).must_be_kind_of Google::Protobuf::Duration
+      _(duration.seconds).must_equal 100
+      _(duration.nanos).must_equal 200000000
     end
   end
 
   describe "duration_to_number" do
     it "returns nil when given duration is nil" do
       number = Google::Cloud::Bigtable::Convert.duration_to_number(nil)
-      number.must_be :nil?
+      _(number).must_be :nil?
     end
 
     it "converts duaration with seconds and return an integer" do
       seconds = 100
       duration = Google::Protobuf::Duration.new(seconds: seconds, nanos: 0)
       number = Google::Cloud::Bigtable::Convert.duration_to_number(duration)
-      number.must_equal seconds
+      _(number).must_equal seconds
     end
 
     it "converts duration with seconds and nano seconds and return a float" do
       duration = Google::Protobuf::Duration.new(seconds: 100, nanos: 200000000)
       number = Google::Cloud::Bigtable::Convert.duration_to_number(duration)
-      number.must_equal 100.2
+      _(number).must_equal 100.2
     end
 
     it "converts duration with zero second and nano seconds and return a float" do
       duration = Google::Protobuf::Duration.new(nanos: 200000000)
       number = Google::Cloud::Bigtable::Convert.duration_to_number(duration)
-      number.must_equal 0.200000000
+      _(number).must_equal 0.200000000
     end
   end
 
   describe "timestamp_to_time" do
     it "returns nil when given timestamp value is nil" do
       time = Google::Cloud::Bigtable::Convert.timestamp_to_time(nil)
-      time.must_be :nil?
+      _(time).must_be :nil?
     end
 
     it "converts timestamp with only seconds protobuf to Time" do
       seconds = 1526736908
       timestamp = Google::Protobuf::Timestamp.new(seconds: seconds)
       time = Google::Cloud::Bigtable::Convert.timestamp_to_time(timestamp)
-      time.must_equal Time.at(seconds)
+      _(time).must_equal Time.at(seconds)
     end
 
     it "converts timestamp with seconds and nano seconds protobuf to Time" do
@@ -86,15 +86,15 @@ describe Google::Cloud::Bigtable::Convert, :mock_bigtable do
       micro = nanos / 1000.0
       timestamp = Google::Protobuf::Timestamp.new(seconds: seconds, nanos: nanos)
       time = Google::Cloud::Bigtable::Convert.timestamp_to_time(timestamp)
-      time.must_be_kind_of Time
-      time.must_equal Time.at(seconds, micro)
+      _(time).must_be_kind_of Time
+      _(time).must_equal Time.at(seconds, micro)
     end
   end
 
   describe "time_to_timestamp" do
     it "returns nil when given time value is nil" do
       timestamp = Google::Cloud::Bigtable::Convert.time_to_timestamp(nil)
-      timestamp.must_be :nil?
+      _(timestamp).must_be :nil?
     end
 
     it "converts Time to protobuf Timestamp" do
@@ -103,10 +103,10 @@ describe Google::Cloud::Bigtable::Convert, :mock_bigtable do
       micro = nanos / 1000.0
       time = Time.at(seconds, micro)
       timestamp = Google::Cloud::Bigtable::Convert.time_to_timestamp(time)
-      timestamp.must_be_kind_of Google::Protobuf::Timestamp
-      timestamp.must_equal Google::Protobuf::Timestamp.new(seconds: seconds, nanos: nanos)
-      timestamp.seconds.must_equal seconds
-      timestamp.nanos.must_equal nanos
+      _(timestamp).must_be_kind_of Google::Protobuf::Timestamp
+      _(timestamp).must_equal Google::Protobuf::Timestamp.new(seconds: seconds, nanos: nanos)
+      _(timestamp.seconds).must_equal seconds
+      _(timestamp.nanos).must_equal nanos
     end
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/gc_rule_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/gc_rule_test.rb
@@ -19,13 +19,13 @@ describe Google::Cloud::Bigtable::GcRule, :mock_bigtable do
   it "creates a max age gc rule" do
     gc_rule = Google::Cloud::Bigtable::GcRule.max_age(100)
 
-    gc_rule.must_be_kind_of Google::Cloud::Bigtable::GcRule
-    gc_rule.max_age.must_equal 100
+    _(gc_rule).must_be_kind_of Google::Cloud::Bigtable::GcRule
+    _(gc_rule.max_age).must_equal 100
 
     expected_grpc = Google::Bigtable::Admin::V2::GcRule.new(
       max_age: Google::Protobuf::Duration.new(seconds: 100)
     )
-    gc_rule.to_grpc.must_equal expected_grpc
+    _(gc_rule.to_grpc).must_equal expected_grpc
   end
 
   it "updates a max age gc rule" do
@@ -33,48 +33,48 @@ describe Google::Cloud::Bigtable::GcRule, :mock_bigtable do
 
     gc_rule.max_age = 200
 
-    gc_rule.max_age.must_equal 200
+    _(gc_rule.max_age).must_equal 200
     expected_grpc = Google::Bigtable::Admin::V2::GcRule.new(
       max_age: Google::Protobuf::Duration.new(seconds: 200)
     )
-    gc_rule.to_grpc.must_equal expected_grpc
+    _(gc_rule.to_grpc).must_equal expected_grpc
   end
 
   it "updates a max age gc rule using microseconds" do
     gc_rule = Google::Cloud::Bigtable::GcRule.max_age(100.001)
 
-    gc_rule.max_age.must_equal 100.001
+    _(gc_rule.max_age).must_equal 100.001
     gc_rule.max_age = 200.999999999
 
-    gc_rule.max_age.must_equal 200.999999999
+    _(gc_rule.max_age).must_equal 200.999999999
     expected_grpc = Google::Bigtable::Admin::V2::GcRule.new(
       max_age: Google::Protobuf::Duration.new(seconds: 200, nanos: 999999999)
     )
-    gc_rule.to_grpc.must_equal expected_grpc
+    _(gc_rule.to_grpc).must_equal expected_grpc
   end
 
   it "creates a max versions gc rule" do
     gc_rule = Google::Cloud::Bigtable::GcRule.max_versions(3)
 
-    gc_rule.must_be_kind_of Google::Cloud::Bigtable::GcRule
-    gc_rule.max_versions.must_equal 3
+    _(gc_rule).must_be_kind_of Google::Cloud::Bigtable::GcRule
+    _(gc_rule.max_versions).must_equal 3
 
     expected_grpc = Google::Bigtable::Admin::V2::GcRule.new(
       max_num_versions: 3
     )
-    gc_rule.to_grpc.must_equal expected_grpc
+    _(gc_rule.to_grpc).must_equal expected_grpc
   end
 
   it "updates a max versions gc rule" do
     gc_rule = Google::Cloud::Bigtable::GcRule.max_versions(3)
 
     gc_rule.max_versions = 4
-    gc_rule.max_versions.must_equal 4
+    _(gc_rule.max_versions).must_equal 4
 
     expected_grpc = Google::Bigtable::Admin::V2::GcRule.new(
       max_num_versions: 4
     )
-    gc_rule.to_grpc.must_equal expected_grpc
+    _(gc_rule.to_grpc).must_equal expected_grpc
   end
 
   it "creates a union gc rule" do
@@ -83,22 +83,22 @@ describe Google::Cloud::Bigtable::GcRule, :mock_bigtable do
 
     gc_rule = Google::Cloud::Bigtable::GcRule.union(gc_rule_1, gc_rule_2)
 
-    gc_rule.must_be_kind_of Google::Cloud::Bigtable::GcRule
+    _(gc_rule).must_be_kind_of Google::Cloud::Bigtable::GcRule
 
     rules = gc_rule.union
-    rules.must_be_kind_of Array
-    rules.count.must_equal 2
-    rules[0].must_be_kind_of Google::Cloud::Bigtable::GcRule
-    rules[0].max_versions.must_equal 3
-    rules[1].must_be_kind_of Google::Cloud::Bigtable::GcRule
-    rules[1].max_age.must_equal 100
+    _(rules).must_be_kind_of Array
+    _(rules.count).must_equal 2
+    _(rules[0]).must_be_kind_of Google::Cloud::Bigtable::GcRule
+    _(rules[0].max_versions).must_equal 3
+    _(rules[1]).must_be_kind_of Google::Cloud::Bigtable::GcRule
+    _(rules[1].max_age).must_equal 100
 
     union_grpc = Google::Bigtable::Admin::V2::GcRule::Union.new(rules: [
       Google::Bigtable::Admin::V2::GcRule.new(max_num_versions: 3),
       Google::Bigtable::Admin::V2::GcRule.new(max_age: Google::Protobuf::Duration.new(seconds: 100))
     ])
     expected_grpc = Google::Bigtable::Admin::V2::GcRule.new(union: union_grpc)
-    gc_rule.to_grpc.must_equal expected_grpc
+    _(gc_rule.to_grpc).must_equal expected_grpc
   end
 
   it "updates a union gc rule" do
@@ -113,16 +113,16 @@ describe Google::Cloud::Bigtable::GcRule, :mock_bigtable do
 
     gc_rule.union = [gc_rule_3, gc_rule_4]
     rules = gc_rule.union
-    rules.count.must_equal 2
-    rules[0].max_versions.must_equal 4
-    rules[1].max_age.must_equal 200
+    _(rules.count).must_equal 2
+    _(rules[0].max_versions).must_equal 4
+    _(rules[1].max_age).must_equal 200
 
     union_grpc = Google::Bigtable::Admin::V2::GcRule::Union.new(rules: [
       Google::Bigtable::Admin::V2::GcRule.new(max_num_versions: 4),
       Google::Bigtable::Admin::V2::GcRule.new(max_age: Google::Protobuf::Duration.new(seconds: 200))
     ])
     expected_grpc = Google::Bigtable::Admin::V2::GcRule.new(union: union_grpc)
-    gc_rule.to_grpc.must_equal expected_grpc
+    _(gc_rule.to_grpc).must_equal expected_grpc
   end
 
   it "creates a intersection gc rule" do
@@ -132,19 +132,19 @@ describe Google::Cloud::Bigtable::GcRule, :mock_bigtable do
     gc_rule = Google::Cloud::Bigtable::GcRule.intersection(gc_rule_1, gc_rule_2)
 
     rules = gc_rule.intersection
-    rules.must_be_kind_of Array
-    rules.count.must_equal 2
-    rules[0].must_be_kind_of Google::Cloud::Bigtable::GcRule
-    rules[0].max_versions.must_equal 3
-    rules[1].must_be_kind_of Google::Cloud::Bigtable::GcRule
-    rules[1].max_age.must_equal 100
+    _(rules).must_be_kind_of Array
+    _(rules.count).must_equal 2
+    _(rules[0]).must_be_kind_of Google::Cloud::Bigtable::GcRule
+    _(rules[0].max_versions).must_equal 3
+    _(rules[1]).must_be_kind_of Google::Cloud::Bigtable::GcRule
+    _(rules[1].max_age).must_equal 100
 
     intersection_grpc = Google::Bigtable::Admin::V2::GcRule::Intersection.new(rules: [
       Google::Bigtable::Admin::V2::GcRule.new(max_num_versions: 3),
       Google::Bigtable::Admin::V2::GcRule.new(max_age: Google::Protobuf::Duration.new(seconds: 100))
     ])
     expected_grpc = Google::Bigtable::Admin::V2::GcRule.new(intersection: intersection_grpc)
-    gc_rule.to_grpc.must_equal expected_grpc
+    _(gc_rule.to_grpc).must_equal expected_grpc
   end
 
   it "updates a intersection gc rule" do
@@ -159,15 +159,15 @@ describe Google::Cloud::Bigtable::GcRule, :mock_bigtable do
 
     gc_rule.intersection = [gc_rule_3, gc_rule_4]
     rules = gc_rule.intersection
-    rules.count.must_equal 2
-    rules[0].max_versions.must_equal 4
-    rules[1].max_age.must_equal 200
+    _(rules.count).must_equal 2
+    _(rules[0].max_versions).must_equal 4
+    _(rules[1].max_age).must_equal 200
 
     intersection_grpc = Google::Bigtable::Admin::V2::GcRule::Intersection.new(rules: [
       Google::Bigtable::Admin::V2::GcRule.new(max_num_versions: 4),
       Google::Bigtable::Admin::V2::GcRule.new(max_age: Google::Protobuf::Duration.new(seconds: 200))
     ])
     expected_grpc = Google::Bigtable::Admin::V2::GcRule.new(intersection: intersection_grpc)
-    gc_rule.to_grpc.must_equal expected_grpc
+    _(gc_rule.to_grpc).must_equal expected_grpc
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/instance/app_profile_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/instance/app_profile_test.rb
@@ -37,10 +37,10 @@ describe Google::Cloud::Bigtable::Instance, :app_profile, :mock_bigtable do
 
     mock.verify
 
-    app_profile.project_id.must_equal project_id
-    app_profile.instance_id.must_equal instance_id
-    app_profile.name.must_equal app_profile_id
-    app_profile.path.must_equal app_profile_path(instance_id, app_profile_id)
+    _(app_profile.project_id).must_equal project_id
+    _(app_profile.instance_id).must_equal instance_id
+    _(app_profile.name).must_equal app_profile_id
+    _(app_profile.path).must_equal app_profile_path(instance_id, app_profile_id)
   end
 
   it "returns nil when getting an non-existent app_profile" do
@@ -56,6 +56,6 @@ describe Google::Cloud::Bigtable::Instance, :app_profile, :mock_bigtable do
     bigtable.service.mocked_instances = stub
 
     app_profile = instance.app_profile(not_found_app_profile_id)
-    app_profile.must_be :nil?
+    _(app_profile).must_be :nil?
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/instance/app_profiles_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/instance/app_profiles_test.rb
@@ -48,7 +48,7 @@ describe Google::Cloud::Bigtable::Instance, :app_profiles, :mock_bigtable do
 
     mock.verify
 
-    app_profiles.size.must_equal 3
+    _(app_profiles.size).must_equal 3
   end
 
   it "paginates app_profiles with next? and next" do
@@ -61,10 +61,10 @@ describe Google::Cloud::Bigtable::Instance, :app_profiles, :mock_bigtable do
 
     mock.verify
 
-    list.size.must_equal 3
-    list.next?.must_equal true
-    list.next.size.must_equal 2
-    list.next?.must_equal false
+    _(list.size).must_equal 3
+    _(list.next?).must_equal true
+    _(list.next.size).must_equal 2
+    _(list.next?).must_equal false
   end
 
   it "paginates app_profiles with all" do
@@ -77,7 +77,7 @@ describe Google::Cloud::Bigtable::Instance, :app_profiles, :mock_bigtable do
 
     mock.verify
 
-    app_profiles.size.must_equal 5
+    _(app_profiles.size).must_equal 5
   end
 
   it "iterates app_profiles with all using Enumerator" do
@@ -90,6 +90,6 @@ describe Google::Cloud::Bigtable::Instance, :app_profiles, :mock_bigtable do
 
     mock.verify
 
-    app_profiles.size.must_equal 5
+    _(app_profiles.size).must_equal 5
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/instance/cluster_map_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/instance/cluster_map_test.rb
@@ -23,15 +23,15 @@ describe Google::Cloud::Bigtable::Instance::ClusterMap, :mock_bigtable do
     cluster_id = "test-cluster"
 
     cluster_map = Google::Cloud::Bigtable::Instance::ClusterMap.new
-    cluster_map.must_be :empty?
+    _(cluster_map).must_be :empty?
 
     cluster_map.add(cluster_id, location, nodes: 3, storage_type: :SSD)
-    cluster_map.length.must_equal 1
+    _(cluster_map.length).must_equal 1
 
     cluster_grpc = cluster_map[cluster_id]
-    cluster_grpc.must_be_kind_of Google::Bigtable::Admin::V2::Cluster
-    cluster_grpc.location.must_equal location_path("us-east-1b")
-    cluster_grpc.serve_nodes.must_equal 3
-    cluster_grpc.default_storage_type.must_equal :SSD
+    _(cluster_grpc).must_be_kind_of Google::Bigtable::Admin::V2::Cluster
+    _(cluster_grpc.location).must_equal location_path("us-east-1b")
+    _(cluster_grpc.serve_nodes).must_equal 3
+    _(cluster_grpc.default_storage_type).must_equal :SSD
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/instance/cluster_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/instance/cluster_test.rb
@@ -45,14 +45,14 @@ describe Google::Cloud::Bigtable::Instance, :cluster, :mock_bigtable do
 
     mock.verify
 
-    cluster.project_id.must_equal project_id
-    cluster.instance_id.must_equal instance_id
-    cluster.cluster_id.must_equal cluster_id
-    cluster.path.must_equal cluster_path(instance_id, cluster_id)
-    cluster.state.must_equal :READY
-    cluster.ready?.must_equal true
-    cluster.storage_type.must_equal :SSD
-    cluster.nodes.must_equal 3
+    _(cluster.project_id).must_equal project_id
+    _(cluster.instance_id).must_equal instance_id
+    _(cluster.cluster_id).must_equal cluster_id
+    _(cluster.path).must_equal cluster_path(instance_id, cluster_id)
+    _(cluster.state).must_equal :READY
+    _(cluster.ready?).must_equal true
+    _(cluster.storage_type).must_equal :SSD
+    _(cluster.nodes).must_equal 3
   end
 
   it "returns nil when getting an non-existent cluster" do
@@ -68,6 +68,6 @@ describe Google::Cloud::Bigtable::Instance, :cluster, :mock_bigtable do
     bigtable.service.mocked_instances = stub
 
     cluster = instance.cluster(not_found_cluster_id)
-    cluster.must_be :nil?
+    _(cluster).must_be :nil?
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/instance/clusters_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/instance/clusters_test.rb
@@ -55,7 +55,7 @@ describe Google::Cloud::Bigtable::Instance, :clusters, :mock_bigtable do
 
     mock.verify
 
-    clusters.size.must_equal 3
+    _(clusters.size).must_equal 3
   end
 
   it "paginates all clusters in project" do
@@ -69,13 +69,13 @@ describe Google::Cloud::Bigtable::Instance, :clusters, :mock_bigtable do
 
     mock.verify
 
-    first_clusters.size.must_equal 3
+    _(first_clusters.size).must_equal 3
     token = first_clusters.token
-    token.wont_be :nil?
-    token.must_equal "next_page_token"
+    _(token).wont_be :nil?
+    _(token).must_equal "next_page_token"
 
-    second_clusters.size.must_equal 2
-    second_clusters.token.must_be :nil?
+    _(second_clusters.size).must_equal 2
+    _(second_clusters.token).must_be :nil?
   end
 
   it "paginates all clusters in project with next? and next" do
@@ -89,11 +89,11 @@ describe Google::Cloud::Bigtable::Instance, :clusters, :mock_bigtable do
 
     mock.verify
 
-    first_clusters.size.must_equal 3
-    first_clusters.next?.must_equal true
+    _(first_clusters.size).must_equal 3
+    _(first_clusters.next?).must_equal true
 
-    second_clusters.size.must_equal 2
-    second_clusters.next?.must_equal false
+    _(second_clusters.size).must_equal 2
+    _(second_clusters.next?).must_equal false
   end
 
   it "paginates all clusters in project with all" do
@@ -106,7 +106,7 @@ describe Google::Cloud::Bigtable::Instance, :clusters, :mock_bigtable do
 
     mock.verify
 
-    clusters.size.must_equal 5
+    _(clusters.size).must_equal 5
   end
 
   it "iterates all clusters in project with all using Enumerator" do
@@ -119,6 +119,6 @@ describe Google::Cloud::Bigtable::Instance, :clusters, :mock_bigtable do
 
     mock.verify
 
-    clusters.size.must_equal 5
+    _(clusters.size).must_equal 5
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/instance/create_app_profile_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/instance/create_app_profile_test.rb
@@ -43,11 +43,11 @@ describe Google::Cloud::Bigtable::Instance, :create_app_profile, :mock_bigtable 
     routing_policy = Google::Cloud::Bigtable::AppProfile.multi_cluster_routing
     app_profile = instance.create_app_profile app_profile_id, routing_policy, description: description
 
-    app_profile.wont_be :nil?
-    app_profile.must_be_kind_of Google::Cloud::Bigtable::AppProfile
-    app_profile.path.must_equal path
-    app_profile.description.must_equal description
-    app_profile.routing_policy.must_be_kind_of Google::Cloud::Bigtable::MultiClusterRoutingUseAny
+    _(app_profile).wont_be :nil?
+    _(app_profile).must_be_kind_of Google::Cloud::Bigtable::AppProfile
+    _(app_profile.path).must_equal path
+    _(app_profile.description).must_equal description
+    _(app_profile.routing_policy).must_be_kind_of Google::Cloud::Bigtable::MultiClusterRoutingUseAny
 
     mock.verify
   end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/instance/create_cluster_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/instance/create_cluster_test.rb
@@ -83,17 +83,17 @@ describe Google::Cloud::Bigtable::Instance, :create_cluster, :mock_bigtable do
     instance = Google::Cloud::Bigtable::Instance.from_grpc(instance_grpc, bigtable.service)
     job = instance.create_cluster(cluster_id, location_id, nodes: 3, storage_type: :SSD)
 
-    job.must_be_kind_of Google::Cloud::Bigtable::Cluster::Job
-    job.wont_be :done?
-    job.wont_be :error?
-    job.error.must_be :nil?
-    job.cluster.must_be :nil?
+    _(job).must_be_kind_of Google::Cloud::Bigtable::Cluster::Job
+    _(job).wont_be :done?
+    _(job).wont_be :error?
+    _(job.error).must_be :nil?
+    _(job.cluster).must_be :nil?
 
     job.reload!
     cluster = job.cluster
 
-    cluster.wont_be :nil?
-    cluster.must_be_kind_of Google::Cloud::Bigtable::Cluster
+    _(cluster).wont_be :nil?
+    _(cluster).must_be_kind_of Google::Cloud::Bigtable::Cluster
 
     mock.verify
   end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/instance/create_table_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/instance/create_table_test.rb
@@ -45,10 +45,10 @@ describe Google::Cloud::Bigtable::Instance, :create_table, :mock_bigtable do
     table = instance.create_table(table_id)
     mock.verify
 
-    table.project_id.must_equal project_id
-    table.instance_id.must_equal instance_id
-    table.name.must_equal table_id
-    table.path.must_equal table_path(instance_id, table_id)
+    _(table.project_id).must_equal project_id
+    _(table.instance_id).must_equal instance_id
+    _(table.name).must_equal table_id
+    _(table.path).must_equal table_path(instance_id, table_id)
   end
 
   it "creates a table with column_families arg" do
@@ -87,18 +87,18 @@ describe Google::Cloud::Bigtable::Instance, :create_table, :mock_bigtable do
 
     table = instance.create_table(table_id, column_families: cfm, granularity: :MILLIS)
 
-    table.project_id.must_equal project_id
-    table.instance_id.must_equal instance_id
-    table.name.must_equal table_id
-    table.path.must_equal table_path(instance_id, table_id)
-    table.granularity.must_equal :MILLIS
-    table.column_families.must_be_instance_of Google::Cloud::Bigtable::ColumnFamilyMap
-    table.column_families.must_be :frozen?
-    table.column_families.names.sort.must_equal column_families.keys
+    _(table.project_id).must_equal project_id
+    _(table.instance_id).must_equal instance_id
+    _(table.name).must_equal table_id
+    _(table.path).must_equal table_path(instance_id, table_id)
+    _(table.granularity).must_equal :MILLIS
+    _(table.column_families).must_be_instance_of Google::Cloud::Bigtable::ColumnFamilyMap
+    _(table.column_families).must_be :frozen?
+    _(table.column_families.names.sort).must_equal column_families.keys
     table.column_families.each do |name, cf|
-      cf.gc_rule.to_grpc.must_equal column_families[cf.name].gc_rule
+      _(cf.gc_rule.to_grpc).must_equal column_families[cf.name].gc_rule
     end
-    table.cluster_states.map(&:cluster_name).sort.must_equal cluster_states.keys
+    _(table.cluster_states.map(&:cluster_name).sort).must_equal cluster_states.keys
 
     mock.verify
   end
@@ -138,18 +138,18 @@ describe Google::Cloud::Bigtable::Instance, :create_table, :mock_bigtable do
       cfm.add('cf1', gc_rule: Google::Cloud::Bigtable::GcRule.max_versions(1))
     end
 
-    table.project_id.must_equal project_id
-    table.instance_id.must_equal instance_id
-    table.name.must_equal table_id
-    table.path.must_equal table_path(instance_id, table_id)
-    table.granularity.must_equal :MILLIS
-    table.column_families.must_be_instance_of Google::Cloud::Bigtable::ColumnFamilyMap
-    table.column_families.must_be :frozen?
-    table.column_families.names.sort.must_equal column_families.keys
+    _(table.project_id).must_equal project_id
+    _(table.instance_id).must_equal instance_id
+    _(table.name).must_equal table_id
+    _(table.path).must_equal table_path(instance_id, table_id)
+    _(table.granularity).must_equal :MILLIS
+    _(table.column_families).must_be_instance_of Google::Cloud::Bigtable::ColumnFamilyMap
+    _(table.column_families).must_be :frozen?
+    _(table.column_families.names.sort).must_equal column_families.keys
     table.column_families.each do |name, cf|
-      cf.gc_rule.to_grpc.must_equal column_families[cf.name].gc_rule
+      _(cf.gc_rule.to_grpc).must_equal column_families[cf.name].gc_rule
     end
-    table.cluster_states.map(&:cluster_name).sort.must_equal cluster_states.keys
+    _(table.cluster_states.map(&:cluster_name).sort).must_equal cluster_states.keys
 
     mock.verify
   end
@@ -187,16 +187,16 @@ describe Google::Cloud::Bigtable::Instance, :create_table, :mock_bigtable do
       cfm.add('cf1', gc_rule: Google::Cloud::Bigtable::GcRule.max_versions(1))
     end
 
-    table.project_id.must_equal project_id
-    table.instance_id.must_equal instance_id
-    table.name.must_equal table_id
-    table.path.must_equal table_path(instance_id, table_id)
-    table.granularity.must_equal :MILLIS
-    table.column_families.must_be_instance_of Google::Cloud::Bigtable::ColumnFamilyMap
-    table.column_families.must_be :frozen?
-    table.column_families.names.sort.must_equal column_families.keys
+    _(table.project_id).must_equal project_id
+    _(table.instance_id).must_equal instance_id
+    _(table.name).must_equal table_id
+    _(table.path).must_equal table_path(instance_id, table_id)
+    _(table.granularity).must_equal :MILLIS
+    _(table.column_families).must_be_instance_of Google::Cloud::Bigtable::ColumnFamilyMap
+    _(table.column_families).must_be :frozen?
+    _(table.column_families.names.sort).must_equal column_families.keys
     table.column_families.each do |name, cf|
-      cf.gc_rule.to_grpc.must_equal column_families[cf.name].gc_rule
+      _(cf.gc_rule.to_grpc).must_equal column_families[cf.name].gc_rule
     end
 
     mock.verify

--- a/google-cloud-bigtable/test/google/cloud/bigtable/instance/delete_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/instance/delete_test.rb
@@ -38,7 +38,7 @@ describe Google::Cloud::Bigtable::Instance, :delete, :mock_bigtable do
     bigtable.service.mocked_instances = mock
 
     result = instance.delete
-    result.must_equal true
+    _(result).must_equal true
     mock.verify
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/instance/iam_policy_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/instance/iam_policy_test.rb
@@ -58,14 +58,14 @@ describe Google::Cloud::Bigtable::Instance, :iam_policy, :mock_bigtable do
 
     mock.verify
 
-    policy.must_be_kind_of Google::Cloud::Bigtable::Policy
-    policy.etag.must_equal "abc"
-    policy.roles.must_be_kind_of Hash
-    policy.roles.size.must_equal 1
-    policy.roles["roles/viewer"].must_be_kind_of Array
-    policy.roles["roles/viewer"].count.must_equal 2
-    policy.roles["roles/viewer"].first.must_equal "user:viewer@example.com"
-    policy.roles["roles/viewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+    _(policy).must_be_kind_of Google::Cloud::Bigtable::Policy
+    _(policy.etag).must_equal "abc"
+    _(policy.roles).must_be_kind_of Hash
+    _(policy.roles.size).must_equal 1
+    _(policy.roles["roles/viewer"]).must_be_kind_of Array
+    _(policy.roles["roles/viewer"].count).must_equal 2
+    _(policy.roles["roles/viewer"].first).must_equal "user:viewer@example.com"
+    _(policy.roles["roles/viewer"].last).must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
   end
 
   it "update the iam policy" do
@@ -91,15 +91,15 @@ describe Google::Cloud::Bigtable::Instance, :iam_policy, :mock_bigtable do
 
     mock.verify
 
-    policy.must_be_kind_of Google::Cloud::Bigtable::Policy
-    policy.etag.must_equal "xyz"
-    policy.roles.must_be_kind_of Hash
-    policy.roles.size.must_equal 1
-    policy.roles["roles/viewer"].must_be :nil?
-    policy.roles["roles/owner"].must_be_kind_of Array
-    policy.roles["roles/owner"].count.must_equal 2
-    policy.roles["roles/owner"].first.must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
-    policy.roles["roles/owner"].last.must_equal  "user:newowner@example.com"
+    _(policy).must_be_kind_of Google::Cloud::Bigtable::Policy
+    _(policy.etag).must_equal "xyz"
+    _(policy.roles).must_be_kind_of Hash
+    _(policy.roles.size).must_equal 1
+    _(policy.roles["roles/viewer"]).must_be :nil?
+    _(policy.roles["roles/owner"]).must_be_kind_of Array
+    _(policy.roles["roles/owner"].count).must_equal 2
+    _(policy.roles["roles/owner"].first).must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
+    _(policy.roles["roles/owner"].last).must_equal  "user:newowner@example.com"
   end
 
   it "get and set policy using block" do
@@ -123,15 +123,15 @@ describe Google::Cloud::Bigtable::Instance, :iam_policy, :mock_bigtable do
 
     mock.verify
 
-    policy.must_be_kind_of Google::Cloud::Bigtable::Policy
-    policy.etag.must_equal "xyz"
-    policy.roles.must_be_kind_of Hash
-    policy.roles.size.must_equal 1
-    policy.roles["roles/viewer"].must_be :nil?
-    policy.roles["roles/owner"].must_be_kind_of Array
-    policy.roles["roles/owner"].count.must_equal 2
-    policy.roles["roles/owner"].first.must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
-    policy.roles["roles/owner"].last.must_equal  "user:newowner@example.com"
+    _(policy).must_be_kind_of Google::Cloud::Bigtable::Policy
+    _(policy.etag).must_equal "xyz"
+    _(policy.roles).must_be_kind_of Hash
+    _(policy.roles.size).must_equal 1
+    _(policy.roles["roles/viewer"]).must_be :nil?
+    _(policy.roles["roles/owner"]).must_be_kind_of Array
+    _(policy.roles["roles/owner"].count).must_equal 2
+    _(policy.roles["roles/owner"].first).must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
+    _(policy.roles["roles/owner"].last).must_equal  "user:newowner@example.com"
   end
 
   it "tests the available permissions" do
@@ -149,7 +149,7 @@ describe Google::Cloud::Bigtable::Instance, :iam_policy, :mock_bigtable do
 
    mock.verify
 
-   permissions.must_be_kind_of Array
-   permissions.must_equal ["bigtable.tables.list"]
+   _(permissions).must_be_kind_of Array
+   _(permissions).must_equal ["bigtable.tables.list"]
  end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/instance/save_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/instance/save_test.rb
@@ -78,17 +78,17 @@ describe Google::Cloud::Bigtable::Instance, :save, :mock_bigtable do
 
     job = instance.save
 
-    job.must_be_kind_of Google::Cloud::Bigtable::Instance::Job
-    job.wont_be :done?
-    job.wont_be :error?
-    job.error.must_be :nil?
-    job.instance.must_be :nil?
+    _(job).must_be_kind_of Google::Cloud::Bigtable::Instance::Job
+    _(job).wont_be :done?
+    _(job).wont_be :error?
+    _(job.error).must_be :nil?
+    _(job.instance).must_be :nil?
 
     job.reload!
     instance = job.instance
 
-    instance.wont_be :nil?
-    instance.must_be_kind_of Google::Cloud::Bigtable::Instance
+    _(instance).wont_be :nil?
+    _(instance).must_be_kind_of Google::Cloud::Bigtable::Instance
 
     mock.verify
   end
@@ -111,17 +111,17 @@ describe Google::Cloud::Bigtable::Instance, :save, :mock_bigtable do
 
     job = instance.save
 
-    job.must_be_kind_of Google::Cloud::Bigtable::Instance::Job
-    job.wont_be :done?
-    job.wont_be :error?
-    job.error.must_be :nil?
-    job.instance.must_be :nil?
+    _(job).must_be_kind_of Google::Cloud::Bigtable::Instance::Job
+    _(job).wont_be :done?
+    _(job).wont_be :error?
+    _(job.error).must_be :nil?
+    _(job.instance).must_be :nil?
 
     job.reload!
     instance = job.instance
 
-    instance.wont_be :nil?
-    instance.must_be_kind_of Google::Cloud::Bigtable::Instance
+    _(instance).wont_be :nil?
+    _(instance).must_be_kind_of Google::Cloud::Bigtable::Instance
 
     mock.verify
   end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/instance/table_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/instance/table_test.rb
@@ -46,21 +46,21 @@ describe Google::Cloud::Bigtable::Instance, :table, :mock_bigtable do
 
     mock.verify
 
-    table.project_id.must_equal project_id
-    table.instance_id.must_equal instance_id
-    table.name.must_equal table_id
-    table.path.must_equal table_path(instance_id, table_id)
-    table.granularity.must_equal :MILLIS
-    table.cluster_states.map(&:cluster_name).sort.must_equal cluster_states.keys
+    _(table.project_id).must_equal project_id
+    _(table.instance_id).must_equal instance_id
+    _(table.name).must_equal table_id
+    _(table.path).must_equal table_path(instance_id, table_id)
+    _(table.granularity).must_equal :MILLIS
+    _(table.cluster_states.map(&:cluster_name).sort).must_equal cluster_states.keys
     table.cluster_states.each do |cs|
-      cs.replication_state.must_equal :READY
+      _(cs.replication_state).must_equal :READY
     end
 
-    table.column_families.must_be_instance_of Google::Cloud::Bigtable::ColumnFamilyMap
-    table.column_families.must_be :frozen?
-    table.column_families.names.sort.must_equal column_families.keys
+    _(table.column_families).must_be_instance_of Google::Cloud::Bigtable::ColumnFamilyMap
+    _(table.column_families).must_be :frozen?
+    _(table.column_families.names.sort).must_equal column_families.keys
     table.column_families.each do |name, cf|
-      cf.gc_rule.to_grpc.must_equal column_families[cf.name].gc_rule
+      _(cf.gc_rule.to_grpc).must_equal column_families[cf.name].gc_rule
     end
   end
 
@@ -77,7 +77,7 @@ describe Google::Cloud::Bigtable::Instance, :table, :mock_bigtable do
     bigtable.service.mocked_tables = stub
 
     table = instance.table(not_found_table_id, perform_lookup: true)
-    table.must_be :nil?
+    _(table).must_be :nil?
   end
 
   it "get table object without fetching table" do
@@ -85,8 +85,8 @@ describe Google::Cloud::Bigtable::Instance, :table, :mock_bigtable do
     app_profile_id = "my-app-profile"
 
     table = instance.table(table_id, app_profile_id: app_profile_id)
-    table.must_be_kind_of Google::Cloud::Bigtable::Table
-    table.path.must_equal table_path(instance_id, table_id)
-    table.app_profile_id.must_equal app_profile_id
+    _(table).must_be_kind_of Google::Cloud::Bigtable::Table
+    _(table.path).must_equal table_path(instance_id, table_id)
+    _(table.app_profile_id).must_equal app_profile_id
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/instance/tables_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/instance/tables_test.rb
@@ -51,7 +51,7 @@ describe Google::Cloud::Bigtable::Instance, :tables, :mock_bigtable do
 
     mock.verify
 
-    tables.size.must_equal 3
+    _(tables.size).must_equal 3
   end
 
   it "paginates tables with next? and next" do
@@ -64,10 +64,10 @@ describe Google::Cloud::Bigtable::Instance, :tables, :mock_bigtable do
 
     mock.verify
 
-    list.size.must_equal 3
-    list.next?.must_equal true
-    list.next.size.must_equal 2
-    list.next?.must_equal false
+    _(list.size).must_equal 3
+    _(list.next?).must_equal true
+    _(list.next.size).must_equal 2
+    _(list.next?).must_equal false
   end
 
   it "paginates tables with all" do
@@ -80,7 +80,7 @@ describe Google::Cloud::Bigtable::Instance, :tables, :mock_bigtable do
 
     mock.verify
 
-    tables.size.must_equal 5
+    _(tables.size).must_equal 5
   end
 
   it "iterates tables with all using Enumerator" do
@@ -93,6 +93,6 @@ describe Google::Cloud::Bigtable::Instance, :tables, :mock_bigtable do
 
     mock.verify
 
-    tables.size.must_equal 5
+    _(tables.size).must_equal 5
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/instance_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/instance_test.rb
@@ -33,18 +33,18 @@ describe Google::Cloud::Bigtable::Instance, :mock_bigtable do
   end
 
   it "knows the identifiers" do
-    instance.must_be_kind_of Google::Cloud::Bigtable::Instance
-    instance.project_id.must_equal project_id
-    instance.instance_id.must_equal instance_id
-    instance.display_name.must_equal display_name
+    _(instance).must_be_kind_of Google::Cloud::Bigtable::Instance
+    _(instance.project_id).must_equal project_id
+    _(instance.instance_id).must_equal instance_id
+    _(instance.display_name).must_equal display_name
 
-    instance.state.must_equal :READY
-    instance.must_be :ready?
-    instance.wont_be :creating?
+    _(instance.state).must_equal :READY
+    _(instance).must_be :ready?
+    _(instance).wont_be :creating?
 
-    instance.type.must_equal :PRODUCTION
-    instance.must_be :production?
-    instance.wont_be :development?
+    _(instance.type).must_equal :PRODUCTION
+    _(instance).must_be :production?
+    _(instance).wont_be :development?
   end
   describe "#labels=" do
     let(:instance) do
@@ -57,19 +57,19 @@ describe Google::Cloud::Bigtable::Instance, :mock_bigtable do
 
     it "set labels using hash" do
       instance.labels = { "env" => "test1" }
-      instance.labels.to_h.must_equal({"env" => "test1"})
+      _(instance.labels.to_h).must_equal({"env" => "test1"})
 
       instance.labels = { :env => "test2" }
-      instance.labels.to_h.must_equal({"env" => "test2"})
+      _(instance.labels.to_h).must_equal({"env" => "test2"})
 
       instance.labels = { data: "users", appprofile: 12345 }
-      instance.labels.to_h.must_equal({ "data" => "users", "appprofile" => "12345" })
+      _(instance.labels.to_h).must_equal({ "data" => "users", "appprofile" => "12345" })
     end
 
     it "clear lables if labels value is nil" do
       instance.labels = { "env" => "test" }
       instance.labels = nil
-      instance.labels.length.must_equal 0
+      _(instance.labels.length).must_equal 0
     end
   end
 
@@ -82,13 +82,13 @@ describe Google::Cloud::Bigtable::Instance, :mock_bigtable do
 
     mock.verify
 
-    instance.project_id.must_equal project_id
-    instance.instance_id.must_equal instance_id
-    instance.path.must_equal instance_path(instance_id)
-    instance.display_name.must_equal "Test instance"
-    instance.state.must_equal :READY
-    instance.ready?.must_equal true
-    instance.type.must_equal :PRODUCTION
-    instance.production?.must_equal true
+    _(instance.project_id).must_equal project_id
+    _(instance.instance_id).must_equal instance_id
+    _(instance.path).must_equal instance_path(instance_id)
+    _(instance.display_name).must_equal "Test instance"
+    _(instance.state).must_equal :READY
+    _(instance.ready?).must_equal true
+    _(instance.type).must_equal :PRODUCTION
+    _(instance.production?).must_equal true
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/mutation_entry_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/mutation_entry_test.rb
@@ -22,18 +22,18 @@ describe Google::Cloud::Bigtable::MutationEntry, :mutation_entry, :mock_bigtable
 
   it "create empty instance" do
     entry = Google::Cloud::Bigtable::MutationEntry.new
-    entry.row_key.must_be :nil?
-    entry.mutations.must_be_empty
-    entry.retryable?.must_equal true
+    _(entry.row_key).must_be :nil?
+    _(entry.mutations).must_be_empty
+    _(entry.retryable?).must_equal true
   end
 
   it "create instance with only row_key" do
     entry = Google::Cloud::Bigtable::MutationEntry.new(row_key)
-    entry.row_key.must_equal row_key
+    _(entry.row_key).must_equal row_key
 
     grpc = entry.to_grpc
-    grpc.must_be_kind_of Google::Bigtable::V2::MutateRowsRequest::Entry
-    grpc.row_key.must_equal row_key
+    _(grpc).must_be_kind_of Google::Bigtable::V2::MutateRowsRequest::Entry
+    _(grpc.row_key).must_equal row_key
   end
 
   describe "#set_cell" do
@@ -44,52 +44,52 @@ describe Google::Cloud::Bigtable::MutationEntry, :mutation_entry, :mock_bigtable
     it "add set cell mutation without timestamp" do
       entry = Google::Cloud::Bigtable::MutationEntry.new(row_key)
       entry.set_cell(family, qualifier, cell_value)
-      entry.mutations.length.must_equal 1
-      entry.retryable?.must_equal true
+      _(entry.mutations.length).must_equal 1
+      _(entry.retryable?).must_equal true
 
       grpc = entry.to_grpc
       mutation = grpc.mutations.first
-      mutation.set_cell.wont_be_nil
+      _(mutation.set_cell).wont_be_nil
 
       set_cell_grpc = mutation.set_cell
-      set_cell_grpc.family_name.must_equal family
-      set_cell_grpc.column_qualifier.must_equal qualifier
-      set_cell_grpc.value.must_equal cell_value
-      set_cell_grpc.timestamp_micros.must_equal 0
+      _(set_cell_grpc.family_name).must_equal family
+      _(set_cell_grpc.column_qualifier).must_equal qualifier
+      _(set_cell_grpc.value).must_equal cell_value
+      _(set_cell_grpc.timestamp_micros).must_equal 0
     end
 
     it "add set cell mutation with timestamp" do
       timestamp = timestamp_micros
       entry = Google::Cloud::Bigtable::MutationEntry.new(row_key)
       entry.set_cell(family, qualifier, cell_value, timestamp: timestamp)
-      entry.mutations.length.must_equal 1
-      entry.retryable?.must_equal true
+      _(entry.mutations.length).must_equal 1
+      _(entry.retryable?).must_equal true
 
       grpc = entry.to_grpc
       mutation = grpc.mutations.first
-      mutation.set_cell.wont_be_nil
+      _(mutation.set_cell).wont_be_nil
 
       set_cell_grpc = mutation.set_cell
-      set_cell_grpc.family_name.must_equal family
-      set_cell_grpc.column_qualifier.must_equal qualifier
-      set_cell_grpc.value.must_equal cell_value
-      set_cell_grpc.timestamp_micros.must_equal timestamp
+      _(set_cell_grpc.family_name).must_equal family
+      _(set_cell_grpc.column_qualifier).must_equal qualifier
+      _(set_cell_grpc.value).must_equal cell_value
+      _(set_cell_grpc.timestamp_micros).must_equal timestamp
     end
 
     it "add set cell non retyable mutation with server time timestamp" do
       entry = Google::Cloud::Bigtable::MutationEntry.new(row_key)
       entry.set_cell(family, qualifier, cell_value, timestamp: -1)
-      entry.mutations.length.must_equal 1
-      entry.retryable?.must_equal false
+      _(entry.mutations.length).must_equal 1
+      _(entry.retryable?).must_equal false
     end
 
     it "convert integer value to 64 bit big endian" do
       entry = Google::Cloud::Bigtable::MutationEntry.new(row_key)
       entry.set_cell(family, qualifier, 5)
-      entry.mutations.length.must_equal 1
+      _(entry.mutations.length).must_equal 1
 
       set_cell_grpc = entry.mutations.first.set_cell
-      set_cell_grpc.value.bytes.must_equal [0, 0, 0, 0, 0, 0, 0, 5]
+      _(set_cell_grpc.value.bytes).must_equal [0, 0, 0, 0, 0, 0, 0, 5]
     end
   end
 
@@ -103,12 +103,12 @@ describe Google::Cloud::Bigtable::MutationEntry, :mutation_entry, :mock_bigtable
 
       grpc = entry.to_grpc
       mutation = grpc.mutations.first
-      mutation.delete_from_column.wont_be_nil
+      _(mutation.delete_from_column).wont_be_nil
 
       delete_cells_grpc = mutation.delete_from_column
-      delete_cells_grpc.family_name.must_equal family
-      delete_cells_grpc.column_qualifier.must_equal qualifier
-      delete_cells_grpc.time_range.must_be_nil
+      _(delete_cells_grpc.family_name).must_equal family
+      _(delete_cells_grpc.column_qualifier).must_equal qualifier
+      _(delete_cells_grpc.time_range).must_be_nil
     end
 
     it "add delete cells mutation with from timestamp" do
@@ -119,14 +119,14 @@ describe Google::Cloud::Bigtable::MutationEntry, :mutation_entry, :mock_bigtable
 
       grpc = entry.to_grpc
       mutation = grpc.mutations.first
-      mutation.delete_from_column.wont_be_nil
+      _(mutation.delete_from_column).wont_be_nil
 
       delete_cells_grpc = mutation.delete_from_column
-      delete_cells_grpc.family_name.must_equal family
-      delete_cells_grpc.column_qualifier.must_equal qualifier
-      delete_cells_grpc.time_range.wont_be_nil
-      delete_cells_grpc.time_range.start_timestamp_micros.must_equal timestamp_from
-      delete_cells_grpc.time_range.end_timestamp_micros.must_equal 0
+      _(delete_cells_grpc.family_name).must_equal family
+      _(delete_cells_grpc.column_qualifier).must_equal qualifier
+      _(delete_cells_grpc.time_range).wont_be_nil
+      _(delete_cells_grpc.time_range.start_timestamp_micros).must_equal timestamp_from
+      _(delete_cells_grpc.time_range.end_timestamp_micros).must_equal 0
     end
 
     it "add delete cells mutation with to timestamp range" do
@@ -137,14 +137,14 @@ describe Google::Cloud::Bigtable::MutationEntry, :mutation_entry, :mock_bigtable
 
       grpc = entry.to_grpc
       mutation = grpc.mutations.first
-      mutation.delete_from_column.wont_be_nil
+      _(mutation.delete_from_column).wont_be_nil
 
       delete_cells_grpc = mutation.delete_from_column
-      delete_cells_grpc.family_name.must_equal family
-      delete_cells_grpc.column_qualifier.must_equal qualifier
-      delete_cells_grpc.time_range.wont_be_nil
-      delete_cells_grpc.time_range.end_timestamp_micros.must_equal timestamp_to
-      delete_cells_grpc.time_range.start_timestamp_micros.must_equal 0
+      _(delete_cells_grpc.family_name).must_equal family
+      _(delete_cells_grpc.column_qualifier).must_equal qualifier
+      _(delete_cells_grpc.time_range).wont_be_nil
+      _(delete_cells_grpc.time_range.end_timestamp_micros).must_equal timestamp_to
+      _(delete_cells_grpc.time_range.start_timestamp_micros).must_equal 0
     end
 
     it "add delete cells mutation with timestamp range" do
@@ -156,14 +156,14 @@ describe Google::Cloud::Bigtable::MutationEntry, :mutation_entry, :mock_bigtable
 
       grpc = entry.to_grpc
       mutation = grpc.mutations.first
-      mutation.delete_from_column.wont_be_nil
+      _(mutation.delete_from_column).wont_be_nil
 
       delete_cells_grpc = mutation.delete_from_column
-      delete_cells_grpc.family_name.must_equal family
-      delete_cells_grpc.column_qualifier.must_equal qualifier
-      delete_cells_grpc.time_range.wont_be_nil
-      delete_cells_grpc.time_range.start_timestamp_micros.must_equal timestamp_from
-      delete_cells_grpc.time_range.end_timestamp_micros.must_equal timestamp_to
+      _(delete_cells_grpc.family_name).must_equal family
+      _(delete_cells_grpc.column_qualifier).must_equal qualifier
+      _(delete_cells_grpc.time_range).wont_be_nil
+      _(delete_cells_grpc.time_range.start_timestamp_micros).must_equal timestamp_from
+      _(delete_cells_grpc.time_range.end_timestamp_micros).must_equal timestamp_to
     end
   end
 
@@ -176,8 +176,8 @@ describe Google::Cloud::Bigtable::MutationEntry, :mutation_entry, :mock_bigtable
 
       grpc = entry.to_grpc
       mutation = grpc.mutations.first
-      mutation.delete_from_family.wont_be_nil
-      mutation.delete_from_family.family_name.must_equal family
+      _(mutation.delete_from_family).wont_be_nil
+      _(mutation.delete_from_family.family_name).must_equal family
     end
   end
 
@@ -188,7 +188,7 @@ describe Google::Cloud::Bigtable::MutationEntry, :mutation_entry, :mock_bigtable
 
       grpc = entry.to_grpc
       mutation = grpc.mutations.first
-      mutation.delete_from_row.wont_be_nil
+      _(mutation.delete_from_row).wont_be_nil
     end
   end
 
@@ -199,14 +199,14 @@ describe Google::Cloud::Bigtable::MutationEntry, :mutation_entry, :mock_bigtable
       .delete_cells("cf3", "field02")
       .delete_from_row
 
-    entry.mutations.length.must_equal 4
+    _(entry.mutations.length).must_equal 4
 
     grpc = entry.to_grpc
-    grpc.mutations.length.must_equal 4
+    _(grpc.mutations.length).must_equal 4
 
-    entry.mutations[0].set_cell.wont_be_nil
-    entry.mutations[1].delete_from_family.wont_be_nil
-    entry.mutations[2].delete_from_column.wont_be_nil
-    entry.mutations[3].delete_from_row.wont_be_nil
+    _(entry.mutations[0].set_cell).wont_be_nil
+    _(entry.mutations[1].delete_from_family).wont_be_nil
+    _(entry.mutations[2].delete_from_column).wont_be_nil
+    _(entry.mutations[3].delete_from_row).wont_be_nil
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/project/clusters_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/project/clusters_test.rb
@@ -47,7 +47,7 @@ describe Google::Cloud::Bigtable::Project, :clusters, :mock_bigtable do
 
     mock.verify
 
-    clusters.size.must_equal 3
+    _(clusters.size).must_equal 3
   end
 
   it "paginates all clusters in project" do
@@ -61,13 +61,13 @@ describe Google::Cloud::Bigtable::Project, :clusters, :mock_bigtable do
 
     mock.verify
 
-    first_clusters.size.must_equal 3
+    _(first_clusters.size).must_equal 3
     token = first_clusters.token
-    token.wont_be :nil?
-    token.must_equal "next_page_token"
+    _(token).wont_be :nil?
+    _(token).must_equal "next_page_token"
 
-    second_clusters.size.must_equal 2
-    second_clusters.token.must_be :nil?
+    _(second_clusters.size).must_equal 2
+    _(second_clusters.token).must_be :nil?
   end
 
   it "paginates all clusters in project with next? and next" do
@@ -81,11 +81,11 @@ describe Google::Cloud::Bigtable::Project, :clusters, :mock_bigtable do
 
     mock.verify
 
-    first_clusters.size.must_equal 3
-    first_clusters.next?.must_equal true
+    _(first_clusters.size).must_equal 3
+    _(first_clusters.next?).must_equal true
 
-    second_clusters.size.must_equal 2
-    second_clusters.next?.must_equal false
+    _(second_clusters.size).must_equal 2
+    _(second_clusters.next?).must_equal false
   end
 
   it "paginates all clusters in project with all" do
@@ -98,7 +98,7 @@ describe Google::Cloud::Bigtable::Project, :clusters, :mock_bigtable do
 
     mock.verify
 
-    clusters.size.must_equal 5
+    _(clusters.size).must_equal 5
   end
 
   it "iterates all clusters in project with all using Enumerator" do
@@ -111,6 +111,6 @@ describe Google::Cloud::Bigtable::Project, :clusters, :mock_bigtable do
 
     mock.verify
 
-    clusters.size.must_equal 5
+    _(clusters.size).must_equal 5
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/project/create_instance_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/project/create_instance_test.rb
@@ -85,17 +85,17 @@ describe Google::Cloud::Bigtable::Project, :create_instance, :mock_bigtable do
       clusters.add("test-cluster", "us-east1-b", nodes: 1)
     end
 
-    job.must_be_kind_of Google::Cloud::Bigtable::Instance::Job
-    job.wont_be :done?
-    job.wont_be :error?
-    job.error.must_be :nil?
-    job.instance.must_be :nil?
+    _(job).must_be_kind_of Google::Cloud::Bigtable::Instance::Job
+    _(job).wont_be :done?
+    _(job).wont_be :error?
+    _(job.error).must_be :nil?
+    _(job.instance).must_be :nil?
 
     job.reload!
     instance = job.instance
 
-    instance.wont_be :nil?
-    instance.must_be_kind_of Google::Cloud::Bigtable::Instance
+    _(instance).wont_be :nil?
+    _(instance).must_be_kind_of Google::Cloud::Bigtable::Instance
 
     mock.verify
   end
@@ -137,17 +137,17 @@ describe Google::Cloud::Bigtable::Project, :create_instance, :mock_bigtable do
       clusters.add("test-cluster-2", "us-east1-b", nodes: 3, storage_type: :SSD)
     end
 
-    job.must_be_kind_of Google::Cloud::Bigtable::Instance::Job
-    job.wont_be :done?
-    job.wont_be :error?
-    job.error.must_be :nil?
-    job.instance.must_be :nil?
+    _(job).must_be_kind_of Google::Cloud::Bigtable::Instance::Job
+    _(job).wont_be :done?
+    _(job).wont_be :error?
+    _(job.error).must_be :nil?
+    _(job.instance).must_be :nil?
 
     job.reload!
     instance = job.instance
 
-    instance.wont_be :nil?
-    instance.must_be_kind_of Google::Cloud::Bigtable::Instance
+    _(instance).wont_be :nil?
+    _(instance).must_be_kind_of Google::Cloud::Bigtable::Instance
 
     mock.verify
   end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/project/create_table_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/project/create_table_test.rb
@@ -61,20 +61,20 @@ describe Google::Cloud::Bigtable::Project, :create_table, :mock_bigtable do
       granularity: :MILLIS,
     )
 
-    table.project_id.must_equal project_id
-    table.instance_id.must_equal instance_id
-    table.name.must_equal table_id
-    table.path.must_equal table_path(instance_id, table_id)
-    table.granularity.must_equal :MILLIS
-    table.column_families.must_be_instance_of Google::Cloud::Bigtable::ColumnFamilyMap
-    table.column_families.must_be :frozen?
-    table.column_families.names.sort.must_equal column_families.keys
+    _(table.project_id).must_equal project_id
+    _(table.instance_id).must_equal instance_id
+    _(table.name).must_equal table_id
+    _(table.path).must_equal table_path(instance_id, table_id)
+    _(table.granularity).must_equal :MILLIS
+    _(table.column_families).must_be_instance_of Google::Cloud::Bigtable::ColumnFamilyMap
+    _(table.column_families).must_be :frozen?
+    _(table.column_families.names.sort).must_equal column_families.keys
     table.column_families.each do |name, cf|
-      cf.gc_rule.to_grpc.must_equal column_families[cf.name].gc_rule
+      _(cf.gc_rule.to_grpc).must_equal column_families[cf.name].gc_rule
     end
-    table.cluster_states.map(&:cluster_name).sort.must_equal cluster_states.keys
+    _(table.cluster_states.map(&:cluster_name).sort).must_equal cluster_states.keys
     table.cluster_states.each do |cs|
-      cs.replication_state.must_equal :READY
+      _(cs.replication_state).must_equal :READY
     end
 
     mock.verify
@@ -119,20 +119,20 @@ describe Google::Cloud::Bigtable::Project, :create_table, :mock_bigtable do
       cfm.add('cf1', gc_rule: Google::Cloud::Bigtable::GcRule.max_versions(1))
     end
 
-    table.project_id.must_equal project_id
-    table.instance_id.must_equal instance_id
-    table.name.must_equal table_id
-    table.path.must_equal table_path(instance_id, table_id)
-    table.granularity.must_equal :MILLIS
-    table.column_families.must_be_instance_of Google::Cloud::Bigtable::ColumnFamilyMap
-    table.column_families.must_be :frozen?
-    table.column_families.names.sort.must_equal column_families.keys
+    _(table.project_id).must_equal project_id
+    _(table.instance_id).must_equal instance_id
+    _(table.name).must_equal table_id
+    _(table.path).must_equal table_path(instance_id, table_id)
+    _(table.granularity).must_equal :MILLIS
+    _(table.column_families).must_be_instance_of Google::Cloud::Bigtable::ColumnFamilyMap
+    _(table.column_families).must_be :frozen?
+    _(table.column_families.names.sort).must_equal column_families.keys
     table.column_families.each do |name, cf|
-      cf.gc_rule.to_grpc.must_equal column_families[cf.name].gc_rule
+      _(cf.gc_rule.to_grpc).must_equal column_families[cf.name].gc_rule
     end
-    table.cluster_states.map(&:cluster_name).sort.must_equal cluster_states.keys
+    _(table.cluster_states.map(&:cluster_name).sort).must_equal cluster_states.keys
     table.cluster_states.each do |cs|
-      cs.replication_state.must_equal :READY
+      _(cs.replication_state).must_equal :READY
     end
 
     mock.verify
@@ -178,20 +178,20 @@ describe Google::Cloud::Bigtable::Project, :create_table, :mock_bigtable do
       cfm.add('cf1', gc_rule: Google::Cloud::Bigtable::GcRule.max_versions(1))
     end
 
-    table.project_id.must_equal project_id
-    table.instance_id.must_equal instance_id
-    table.name.must_equal table_id
-    table.path.must_equal table_path(instance_id, table_id)
-    table.granularity.must_equal :MILLIS
-    table.column_families.must_be_instance_of Google::Cloud::Bigtable::ColumnFamilyMap
-    table.column_families.must_be :frozen?
-    table.column_families.names.sort.must_equal column_families.keys
+    _(table.project_id).must_equal project_id
+    _(table.instance_id).must_equal instance_id
+    _(table.name).must_equal table_id
+    _(table.path).must_equal table_path(instance_id, table_id)
+    _(table.granularity).must_equal :MILLIS
+    _(table.column_families).must_be_instance_of Google::Cloud::Bigtable::ColumnFamilyMap
+    _(table.column_families).must_be :frozen?
+    _(table.column_families.names.sort).must_equal column_families.keys
     table.column_families.each do |name, cf|
-      cf.gc_rule.to_grpc.must_equal column_families[cf.name].gc_rule
+      _(cf.gc_rule.to_grpc).must_equal column_families[cf.name].gc_rule
     end
-    table.cluster_states.map(&:cluster_name).sort.must_equal cluster_states.keys
+    _(table.cluster_states.map(&:cluster_name).sort).must_equal cluster_states.keys
     table.cluster_states.each do |cs|
-      cs.replication_state.must_equal :READY
+      _(cs.replication_state).must_equal :READY
     end
 
     mock.verify

--- a/google-cloud-bigtable/test/google/cloud/bigtable/project/instance_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/project/instance_test.rb
@@ -37,14 +37,14 @@ describe Google::Cloud::Bigtable::Project, :instance, :mock_bigtable do
 
     mock.verify
 
-    instance.project_id.must_equal project_id
-    instance.instance_id.must_equal instance_id
-    instance.path.must_equal instance_path(instance_id)
-    instance.display_name.must_equal "Test instance"
-    instance.state.must_equal :READY
-    instance.ready?.must_equal true
-    instance.type.must_equal :PRODUCTION
-    instance.production?.must_equal true
+    _(instance.project_id).must_equal project_id
+    _(instance.instance_id).must_equal instance_id
+    _(instance.path).must_equal instance_path(instance_id)
+    _(instance.display_name).must_equal "Test instance"
+    _(instance.state).must_equal :READY
+    _(instance.ready?).must_equal true
+    _(instance.type).must_equal :PRODUCTION
+    _(instance.production?).must_equal true
   end
 
   it "returns nil when getting an non-existent instance" do
@@ -60,6 +60,6 @@ describe Google::Cloud::Bigtable::Project, :instance, :mock_bigtable do
     bigtable.service.mocked_instances = stub
 
     instance = bigtable.instance(not_found_instance_id)
-    instance.must_be :nil?
+    _(instance).must_be :nil?
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/project/instances_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/project/instances_test.rb
@@ -47,7 +47,7 @@ describe Google::Cloud::Bigtable::Project, :tables, :mock_bigtable do
 
     mock.verify
 
-    instances.size.must_equal 3
+    _(instances.size).must_equal 3
   end
 
   it "paginates instances" do
@@ -61,13 +61,13 @@ describe Google::Cloud::Bigtable::Project, :tables, :mock_bigtable do
 
     mock.verify
 
-    first_instances.size.must_equal 3
+    _(first_instances.size).must_equal 3
     token = first_instances.token
-    token.wont_be :nil?
-    token.must_equal "next_page_token"
+    _(token).wont_be :nil?
+    _(token).must_equal "next_page_token"
 
-    second_instances.size.must_equal 2
-    second_instances.token.must_be :nil?
+    _(second_instances.size).must_equal 2
+    _(second_instances.token).must_be :nil?
   end
 
   it "paginates instances with next? and next" do
@@ -81,11 +81,11 @@ describe Google::Cloud::Bigtable::Project, :tables, :mock_bigtable do
 
     mock.verify
 
-    first_instances.size.must_equal 3
-    first_instances.next?.must_equal true
+    _(first_instances.size).must_equal 3
+    _(first_instances.next?).must_equal true
 
-    second_instances.size.must_equal 2
-    second_instances.next?.must_equal false
+    _(second_instances.size).must_equal 2
+    _(second_instances.next?).must_equal false
   end
 
   it "paginates instances with all" do
@@ -98,7 +98,7 @@ describe Google::Cloud::Bigtable::Project, :tables, :mock_bigtable do
 
     mock.verify
 
-    instances.size.must_equal 5
+    _(instances.size).must_equal 5
   end
 
   it "iterates instances with all using Enumerator" do
@@ -111,6 +111,6 @@ describe Google::Cloud::Bigtable::Project, :tables, :mock_bigtable do
 
     mock.verify
 
-    instances.size.must_equal 5
+    _(instances.size).must_equal 5
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/project/table_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/project/table_test.rb
@@ -40,21 +40,21 @@ describe Google::Cloud::Bigtable::Project, :table, :mock_bigtable do
 
     mock.verify
 
-    table.project_id.must_equal project_id
-    table.instance_id.must_equal instance_id
-    table.name.must_equal table_id
-    table.path.must_equal table_path(instance_id, table_id)
-    table.granularity.must_equal :MILLIS
-    table.cluster_states.map(&:cluster_name).sort.must_equal cluster_states.keys
+    _(table.project_id).must_equal project_id
+    _(table.instance_id).must_equal instance_id
+    _(table.name).must_equal table_id
+    _(table.path).must_equal table_path(instance_id, table_id)
+    _(table.granularity).must_equal :MILLIS
+    _(table.cluster_states.map(&:cluster_name).sort).must_equal cluster_states.keys
     table.cluster_states.each do |cs|
-      cs.replication_state.must_equal :READY
+      _(cs.replication_state).must_equal :READY
     end
 
-    table.column_families.must_be_instance_of Google::Cloud::Bigtable::ColumnFamilyMap
-    table.column_families.must_be :frozen?
-    table.column_families.names.sort.must_equal column_families.keys
+    _(table.column_families).must_be_instance_of Google::Cloud::Bigtable::ColumnFamilyMap
+    _(table.column_families).must_be :frozen?
+    _(table.column_families.names.sort).must_equal column_families.keys
     table.column_families.each do |name, cf|
-      cf.gc_rule.to_grpc.must_equal column_families[cf.name].gc_rule
+      _(cf.gc_rule.to_grpc).must_equal column_families[cf.name].gc_rule
     end
   end
 
@@ -71,7 +71,7 @@ describe Google::Cloud::Bigtable::Project, :table, :mock_bigtable do
     bigtable.service.mocked_tables = stub
 
     table = bigtable.table(instance_id, not_found_table_id, perform_lookup: true)
-    table.must_be :nil?
+    _(table).must_be :nil?
   end
 
   it "load schema view on access schema fields" do
@@ -95,9 +95,9 @@ describe Google::Cloud::Bigtable::Project, :table, :mock_bigtable do
     )
 
     2.times do
-      table.column_families.wont_be :empty?
-      table.granularity.must_equal :MILLIS
-      table.cluster_states.wont_be :empty?
+      _(table.column_families).wont_be :empty?
+      _(table.granularity).must_equal :MILLIS
+      _(table.cluster_states).wont_be :empty?
     end
     mock.verify
   end
@@ -107,8 +107,8 @@ describe Google::Cloud::Bigtable::Project, :table, :mock_bigtable do
     app_profile_id = "my-app-profile"
 
     table = bigtable.table(instance_id, table_id,  app_profile_id: app_profile_id)
-    table.must_be_kind_of Google::Cloud::Bigtable::Table
-    table.path.must_equal table_path(instance_id, table_id)
-    table.app_profile_id.must_equal app_profile_id
+    _(table).must_be_kind_of Google::Cloud::Bigtable::Table
+    _(table.path).must_equal table_path(instance_id, table_id)
+    _(table.app_profile_id).must_equal app_profile_id
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/project/tables_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/project/tables_test.rb
@@ -45,7 +45,7 @@ describe Google::Cloud::Bigtable::Project, :tables, :mock_bigtable do
 
     mock.verify
 
-    tables.size.must_equal 3
+    _(tables.size).must_equal 3
   end
 
   it "paginates tables with next? and next" do
@@ -58,10 +58,10 @@ describe Google::Cloud::Bigtable::Project, :tables, :mock_bigtable do
 
     mock.verify
 
-    list.size.must_equal 3
-    list.next?.must_equal true
-    list.next.size.must_equal 2
-    list.next?.must_equal false
+    _(list.size).must_equal 3
+    _(list.next?).must_equal true
+    _(list.next.size).must_equal 2
+    _(list.next?).must_equal false
   end
 
   it "paginates tables with all" do
@@ -74,7 +74,7 @@ describe Google::Cloud::Bigtable::Project, :tables, :mock_bigtable do
 
     mock.verify
 
-    tables.size.must_equal 5
+    _(tables.size).must_equal 5
   end
 
   it "iterates tables with all using Enumerator" do
@@ -87,6 +87,6 @@ describe Google::Cloud::Bigtable::Project, :tables, :mock_bigtable do
 
     mock.verify
 
-    tables.size.must_equal 5
+    _(tables.size).must_equal 5
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/project_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/project_test.rb
@@ -17,7 +17,7 @@ require "helper"
 
 describe Google::Cloud::Bigtable::Project, :mock_bigtable do
   it "knows the project identifier" do
-    bigtable.must_be_kind_of Google::Cloud::Bigtable::Project
-    bigtable.project_id.must_equal project_id
+    _(bigtable).must_be_kind_of Google::Cloud::Bigtable::Project
+    _(bigtable.project_id).must_equal project_id
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/read_modify_write_rule_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/read_modify_write_rule_test.rb
@@ -24,8 +24,8 @@ describe Google::Cloud::Bigtable::ReadModifyWriteRule, :read_modifu_write_rue, :
   it "create instance of rule" do
     rule = Google::Cloud::Bigtable::ReadModifyWriteRule.new(family, qualifier)
     grpc = rule.to_grpc
-    grpc.family_name.must_equal family
-    grpc.column_qualifier.must_equal qualifier
+    _(grpc.family_name).must_equal family
+    _(grpc.column_qualifier).must_equal qualifier
   end
 
   it "create append rule instance" do
@@ -34,11 +34,11 @@ describe Google::Cloud::Bigtable::ReadModifyWriteRule, :read_modifu_write_rue, :
       family, qualifier, append_value
     )
 
-    rule.must_be_kind_of Google::Cloud::Bigtable::ReadModifyWriteRule
+    _(rule).must_be_kind_of Google::Cloud::Bigtable::ReadModifyWriteRule
     grpc = rule.to_grpc
-    grpc.family_name.must_equal family
-    grpc.column_qualifier.must_equal qualifier
-    grpc.append_value.must_equal append_value
+    _(grpc.family_name).must_equal family
+    _(grpc.column_qualifier).must_equal qualifier
+    _(grpc.append_value).must_equal append_value
   end
 
   it "create increment amount instance" do
@@ -47,11 +47,11 @@ describe Google::Cloud::Bigtable::ReadModifyWriteRule, :read_modifu_write_rue, :
       family, qualifier, increment_amount
     )
 
-    rule.must_be_kind_of Google::Cloud::Bigtable::ReadModifyWriteRule
+    _(rule).must_be_kind_of Google::Cloud::Bigtable::ReadModifyWriteRule
     grpc = rule.to_grpc
-    grpc.family_name.must_equal family
-    grpc.column_qualifier.must_equal qualifier
-    grpc.increment_amount.must_equal increment_amount
+    _(grpc.family_name).must_equal family
+    _(grpc.column_qualifier).must_equal qualifier
+    _(grpc.increment_amount).must_equal increment_amount
   end
 
   it "set append value field" do
@@ -60,7 +60,7 @@ describe Google::Cloud::Bigtable::ReadModifyWriteRule, :read_modifu_write_rue, :
     rule.append(value)
 
     grpc = rule.to_grpc
-    grpc.append_value.must_equal value
+    _(grpc.append_value).must_equal value
   end
 
   it "set increment value field" do
@@ -69,6 +69,6 @@ describe Google::Cloud::Bigtable::ReadModifyWriteRule, :read_modifu_write_rue, :
     rule.increment(amount)
 
     grpc = rule.to_grpc
-    grpc.increment_amount.must_equal amount
+    _(grpc.increment_amount).must_equal amount
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/row_filter/chain_filter_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/row_filter/chain_filter_test.rb
@@ -172,9 +172,9 @@ describe Google::Cloud::Bigtable::RowFilter::ChainFilter, :mock_bigtable do
     end
 
     it "range instance must be type of ValueRange" do
-      _ { proc {
+      assert_raises Google::Cloud::Bigtable::RowFilterError do
         chain_filter.value_range(Object.new)
-      } }.must_raise Google::Cloud::Bigtable::RowFilterError
+      end
     end
   end
 
@@ -196,9 +196,9 @@ describe Google::Cloud::Bigtable::RowFilter::ChainFilter, :mock_bigtable do
     end
 
     it "range instance must be type of ColumnRange" do
-      _ { proc {
+      assert_raises Google::Cloud::Bigtable::RowFilterError do
         chain_filter.column_range(Object.new)
-      } }.must_raise Google::Cloud::Bigtable::RowFilterError
+      end
     end
   end
 
@@ -212,27 +212,27 @@ describe Google::Cloud::Bigtable::RowFilter::ChainFilter, :mock_bigtable do
     end
 
     it "probability can not be greather then 1" do
-      _ { proc {
+      assert_raises Google::Cloud::Bigtable::RowFilterError do
         chain_filter.sample(1.1)
-      } }.must_raise Google::Cloud::Bigtable::RowFilterError
+      end
     end
 
     it "probability can not be equal to 1" do
-      _ { proc {
+      assert_raises Google::Cloud::Bigtable::RowFilterError do
         chain_filter.sample(1)
-      } }.must_raise Google::Cloud::Bigtable::RowFilterError
+      end
     end
 
     it "probability can not be equal to 0" do
-      _ { proc {
+      assert_raises Google::Cloud::Bigtable::RowFilterError do
         chain_filter.sample(0)
-      } }.must_raise Google::Cloud::Bigtable::RowFilterError
+      end
     end
 
     it "probability can not be less then 0" do
-      _ { proc {
+      assert_raises Google::Cloud::Bigtable::RowFilterError do
         chain_filter.sample(-0.1)
-      } }.must_raise Google::Cloud::Bigtable::RowFilterError
+      end
     end
   end
 

--- a/google-cloud-bigtable/test/google/cloud/bigtable/row_filter/chain_filter_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/row_filter/chain_filter_test.rb
@@ -26,134 +26,134 @@ describe Google::Cloud::Bigtable::RowFilter::ChainFilter, :mock_bigtable do
   let(:chain_filter) { Google::Cloud::Bigtable::RowFilter.chain }
 
   it "knows its attributes" do
-    chain_filter.must_be_kind_of Google::Cloud::Bigtable::RowFilter::ChainFilter
+    _(chain_filter).must_be_kind_of Google::Cloud::Bigtable::RowFilter::ChainFilter
     filters = chain_filter.filters
-    filters.must_be_kind_of Array
-    filters.must_be :frozen?
-    filters.must_be :empty?
+    _(filters).must_be_kind_of Array
+    _(filters).must_be :frozen?
+    _(filters).must_be :empty?
   end
 
   it "creates a sink filter" do
-    chain_filter.filters.must_be :empty?
+    _(chain_filter.filters).must_be :empty?
     chain_filter.sink
     assert_filter :sink
   end
 
   it "creates a pass filter" do
-    chain_filter.filters.must_be :empty?
+    _(chain_filter.filters).must_be :empty?
     chain_filter.pass
     assert_filter :pass_all_filter
   end
 
   it "creates a block filter" do
-    chain_filter.filters.must_be :empty?
+    _(chain_filter.filters).must_be :empty?
     chain_filter.block
     assert_filter :block_all_filter
   end
 
   it "creates a strip_value filter" do
-    chain_filter.filters.must_be :empty?
+    _(chain_filter.filters).must_be :empty?
     chain_filter.strip_value
     assert_filter :strip_value_transformer
   end
 
   it "creates a key filter" do
     regex = "user-*"
-    chain_filter.filters.must_be :empty?
+    _(chain_filter.filters).must_be :empty?
     chain_filter.key(regex)
     filter = assert_filter :row_key_regex_filter
-    filter.to_grpc.row_key_regex_filter.must_equal regex
+    _(filter.to_grpc.row_key_regex_filter).must_equal regex
   end
 
   it "creates a family filter" do
     regex = "cf-*"
-    chain_filter.filters.must_be :empty?
+    _(chain_filter.filters).must_be :empty?
     chain_filter.family(regex)
     filter = assert_filter :family_name_regex_filter
-    filter.to_grpc.family_name_regex_filter.must_equal regex
+    _(filter.to_grpc.family_name_regex_filter).must_equal regex
   end
 
   it "creates a qualifier filter" do
     regex = "field*"
-    chain_filter.filters.must_be :empty?
+    _(chain_filter.filters).must_be :empty?
     chain_filter.qualifier(regex)
     filter = assert_filter :column_qualifier_regex_filter
-    filter.to_grpc.column_qualifier_regex_filter.must_equal regex
+    _(filter.to_grpc.column_qualifier_regex_filter).must_equal regex
   end
 
   it "creates a value filter" do
     regex = "abc*"
-    chain_filter.filters.must_be :empty?
+    _(chain_filter.filters).must_be :empty?
     chain_filter.value(regex)
     filter = assert_filter :value_regex_filter
-    filter.to_grpc.value_regex_filter.must_equal regex
+    _(filter.to_grpc.value_regex_filter).must_equal regex
   end
 
   it "creates a label filter" do
     label = "test"
-    chain_filter.filters.must_be :empty?
+    _(chain_filter.filters).must_be :empty?
     chain_filter.label(label)
     filter = assert_filter :apply_label_transformer
-    filter.to_grpc.apply_label_transformer.must_equal label
+    _(filter.to_grpc.apply_label_transformer).must_equal label
   end
 
   it "creates a cells_per_row_offset filter" do
     offset = 5
-    chain_filter.filters.must_be :empty?
+    _(chain_filter.filters).must_be :empty?
     chain_filter.cells_per_row_offset(offset)
     filter = assert_filter :cells_per_row_offset_filter
-    filter.to_grpc.cells_per_row_offset_filter.must_equal offset
+    _(filter.to_grpc.cells_per_row_offset_filter).must_equal offset
   end
 
   it "creates a cells_per_row filter" do
     limit = 10
-    chain_filter.filters.must_be :empty?
+    _(chain_filter.filters).must_be :empty?
     chain_filter.cells_per_row(limit)
     filter = assert_filter :cells_per_row_limit_filter
-    filter.to_grpc.cells_per_row_limit_filter.must_equal limit
+    _(filter.to_grpc.cells_per_row_limit_filter).must_equal limit
   end
 
   it "creates a cells_per_column filter" do
     limit = 10
-    chain_filter.filters.must_be :empty?
+    _(chain_filter.filters).must_be :empty?
     chain_filter.cells_per_column(limit)
     filter = assert_filter :cells_per_column_limit_filter
-    filter.to_grpc.cells_per_column_limit_filter.must_equal limit
+    _(filter.to_grpc.cells_per_column_limit_filter).must_equal limit
   end
 
   describe "timestamp_range" do
     it "creates a timestamp_range filter" do
       from = timestamp_micros - 3000000
       to = timestamp_micros
-      chain_filter.filters.must_be :empty?
+      _(chain_filter.filters).must_be :empty?
       chain_filter.timestamp_range(from: from, to: to)
       filter = assert_filter :timestamp_range_filter
       range_grpc = Google::Bigtable::V2::TimestampRange.new(
         start_timestamp_micros: from, end_timestamp_micros: to
       )
-      filter.to_grpc.timestamp_range_filter.must_equal range_grpc
+      _(filter.to_grpc.timestamp_range_filter).must_equal range_grpc
     end
 
     it "creates a timestamp_range filter with only from range" do
       from = timestamp_micros - 3000000
-      chain_filter.filters.must_be :empty?
+      _(chain_filter.filters).must_be :empty?
       chain_filter.timestamp_range(from: from)
       filter = assert_filter :timestamp_range_filter
       range_grpc = Google::Bigtable::V2::TimestampRange.new(
         start_timestamp_micros: from
       )
-      filter.to_grpc.timestamp_range_filter.must_equal range_grpc
+      _(filter.to_grpc.timestamp_range_filter).must_equal range_grpc
     end
 
     it "creates a timestamp_range filter with only to range" do
       to = timestamp_micros
-      chain_filter.filters.must_be :empty?
+      _(chain_filter.filters).must_be :empty?
       chain_filter.timestamp_range(to: to)
       filter = assert_filter :timestamp_range_filter
       range_grpc = Google::Bigtable::V2::TimestampRange.new(
         end_timestamp_micros: to
       )
-      filter.to_grpc.timestamp_range_filter.must_equal range_grpc
+      _(filter.to_grpc.timestamp_range_filter).must_equal range_grpc
     end
   end
 
@@ -162,19 +162,19 @@ describe Google::Cloud::Bigtable::RowFilter::ChainFilter, :mock_bigtable do
       from_value = "abc"
       to_value = "xyz"
       range = Google::Cloud::Bigtable::ValueRange.new.from(from_value).to(to_value)
-      chain_filter.filters.must_be :empty?
+      _(chain_filter.filters).must_be :empty?
       chain_filter.value_range(range)
       filter = assert_filter :value_range_filter
       grpc = filter.to_grpc.value_range_filter
-      grpc.must_be_kind_of Google::Bigtable::V2::ValueRange
-      grpc.start_value_closed.must_equal from_value
-      grpc.end_value_open.must_equal to_value
+      _(grpc).must_be_kind_of Google::Bigtable::V2::ValueRange
+      _(grpc.start_value_closed).must_equal from_value
+      _(grpc.end_value_open).must_equal to_value
     end
 
     it "range instance must be type of ValueRange" do
-      proc {
+      _ { proc {
         chain_filter.value_range(Object.new)
-      }.must_raise Google::Cloud::Bigtable::RowFilterError
+      } }.must_raise Google::Cloud::Bigtable::RowFilterError
     end
   end
 
@@ -185,67 +185,67 @@ describe Google::Cloud::Bigtable::RowFilter::ChainFilter, :mock_bigtable do
       to_value = "field5"
 
       range = Google::Cloud::Bigtable::ColumnRange.new(family).from(from_value).to(to_value)
-      chain_filter.filters.must_be :empty?
+      _(chain_filter.filters).must_be :empty?
       chain_filter.column_range(range)
       filter = assert_filter :column_range_filter
       grpc = filter.to_grpc.column_range_filter
-      grpc.must_be_kind_of Google::Bigtable::V2::ColumnRange
-      grpc.family_name.must_equal family
-      grpc.start_qualifier_closed.must_equal from_value
-      grpc.end_qualifier_open.must_equal to_value
+      _(grpc).must_be_kind_of Google::Bigtable::V2::ColumnRange
+      _(grpc.family_name).must_equal family
+      _(grpc.start_qualifier_closed).must_equal from_value
+      _(grpc.end_qualifier_open).must_equal to_value
     end
 
     it "range instance must be type of ColumnRange" do
-      proc {
+      _ { proc {
         chain_filter.column_range(Object.new)
-      }.must_raise Google::Cloud::Bigtable::RowFilterError
+      } }.must_raise Google::Cloud::Bigtable::RowFilterError
     end
   end
 
   describe "#sample" do
     it "creates a sample probability filter" do
       probability = 0.5
-      chain_filter.filters.must_be :empty?
+      _(chain_filter.filters).must_be :empty?
       chain_filter.sample(probability)
       filter = assert_filter :row_sample_filter
-      filter.to_grpc.row_sample_filter.must_equal probability
+      _(filter.to_grpc.row_sample_filter).must_equal probability
     end
 
     it "probability can not be greather then 1" do
-      proc {
+      _ { proc {
         chain_filter.sample(1.1)
-      }.must_raise Google::Cloud::Bigtable::RowFilterError
+      } }.must_raise Google::Cloud::Bigtable::RowFilterError
     end
 
     it "probability can not be equal to 1" do
-      proc {
+      _ { proc {
         chain_filter.sample(1)
-      }.must_raise Google::Cloud::Bigtable::RowFilterError
+      } }.must_raise Google::Cloud::Bigtable::RowFilterError
     end
 
     it "probability can not be equal to 0" do
-      proc {
+      _ { proc {
         chain_filter.sample(0)
-      }.must_raise Google::Cloud::Bigtable::RowFilterError
+      } }.must_raise Google::Cloud::Bigtable::RowFilterError
     end
 
     it "probability can not be less then 0" do
-      proc {
+      _ { proc {
         chain_filter.sample(-0.1)
-      }.must_raise Google::Cloud::Bigtable::RowFilterError
+      } }.must_raise Google::Cloud::Bigtable::RowFilterError
     end
   end
 
   it "creates a chain filter" do
     filter = Google::Cloud::Bigtable::RowFilter.chain
-    chain_filter.filters.must_be :empty?
+    _(chain_filter.filters).must_be :empty?
     chain_filter.chain filter
     assert_filter :chain, Google::Cloud::Bigtable::RowFilter::ChainFilter
   end
 
   it "creates an interleave filter" do
     filter = Google::Cloud::Bigtable::RowFilter.interleave
-    chain_filter.filters.must_be :empty?
+    _(chain_filter.filters).must_be :empty?
     chain_filter.interleave filter
     assert_filter :interleave, Google::Cloud::Bigtable::RowFilter::InterleaveFilter
   end
@@ -253,13 +253,13 @@ describe Google::Cloud::Bigtable::RowFilter::ChainFilter, :mock_bigtable do
   it "creates a condition filter" do
     predicate = Google::Cloud::Bigtable::RowFilter.key("user-*")
     filter = Google::Cloud::Bigtable::RowFilter.condition(predicate)
-    chain_filter.filters.must_be :empty?
+    _(chain_filter.filters).must_be :empty?
     chain_filter.condition filter
     assert_filter :condition, Google::Cloud::Bigtable::RowFilter::ConditionFilter
   end
 
   def assert_filter method, type = Google::Cloud::Bigtable::RowFilter::SimpleFilter
-    chain_filter.filters.count.must_equal 1
+    _(chain_filter.filters.count).must_equal 1
     filter = chain_filter.filters.find do |f|
       t = f.to_grpc.send method
       if t.kind_of? String # may be empty string in protobuf
@@ -268,7 +268,7 @@ describe Google::Cloud::Bigtable::RowFilter::ChainFilter, :mock_bigtable do
         !t.nil?
       end
     end
-    filter.must_be_kind_of type
+    _(filter).must_be_kind_of type
     filter
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/row_filter/interleave_filter_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/row_filter/interleave_filter_test.rb
@@ -172,9 +172,9 @@ describe Google::Cloud::Bigtable::RowFilter::InterleaveFilter, :mock_bigtable do
     end
 
     it "range instance must be type of ValueRange" do
-      _ { proc {
+      assert_raises Google::Cloud::Bigtable::RowFilterError do
         interleave_filter.value_range(Object.new)
-      } }.must_raise Google::Cloud::Bigtable::RowFilterError
+      end
     end
   end
 
@@ -196,9 +196,9 @@ describe Google::Cloud::Bigtable::RowFilter::InterleaveFilter, :mock_bigtable do
     end
 
     it "range instance must be type of ColumnRange" do
-      _ { proc {
+      assert_raises Google::Cloud::Bigtable::RowFilterError do
         interleave_filter.column_range(Object.new)
-      } }.must_raise Google::Cloud::Bigtable::RowFilterError
+      end
     end
   end
 
@@ -212,27 +212,27 @@ describe Google::Cloud::Bigtable::RowFilter::InterleaveFilter, :mock_bigtable do
     end
 
     it "probability can not be greather then 1" do
-      _ { proc {
+      assert_raises Google::Cloud::Bigtable::RowFilterError do
         interleave_filter.sample(1.1)
-      } }.must_raise Google::Cloud::Bigtable::RowFilterError
+      end
     end
 
     it "probability can not be equal to 1" do
-      _ { proc {
+      assert_raises Google::Cloud::Bigtable::RowFilterError do
         interleave_filter.sample(1)
-      } }.must_raise Google::Cloud::Bigtable::RowFilterError
+      end
     end
 
     it "probability can not be equal to 0" do
-      _ { proc {
+      assert_raises Google::Cloud::Bigtable::RowFilterError do
         interleave_filter.sample(0)
-      } }.must_raise Google::Cloud::Bigtable::RowFilterError
+      end
     end
 
     it "probability can not be less then 0" do
-      _ { proc {
+      assert_raises Google::Cloud::Bigtable::RowFilterError do
         interleave_filter.sample(-0.1)
-      } }.must_raise Google::Cloud::Bigtable::RowFilterError
+      end
     end
   end
 

--- a/google-cloud-bigtable/test/google/cloud/bigtable/row_filter/interleave_filter_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/row_filter/interleave_filter_test.rb
@@ -26,134 +26,134 @@ describe Google::Cloud::Bigtable::RowFilter::InterleaveFilter, :mock_bigtable do
   let(:interleave_filter) { Google::Cloud::Bigtable::RowFilter.interleave }
 
   it "knows its attributes" do
-    interleave_filter.must_be_kind_of Google::Cloud::Bigtable::RowFilter::InterleaveFilter
+    _(interleave_filter).must_be_kind_of Google::Cloud::Bigtable::RowFilter::InterleaveFilter
     filters = interleave_filter.filters
-    filters.must_be_kind_of Array
-    filters.must_be :frozen?
-    filters.must_be :empty?
+    _(filters).must_be_kind_of Array
+    _(filters).must_be :frozen?
+    _(filters).must_be :empty?
   end
 
   it "creates a sink filter" do
-    interleave_filter.filters.must_be :empty?
+    _(interleave_filter.filters).must_be :empty?
     interleave_filter.sink
     assert_filter :sink
   end
 
   it "creates a pass filter" do
-    interleave_filter.filters.must_be :empty?
+    _(interleave_filter.filters).must_be :empty?
     interleave_filter.pass
     assert_filter :pass_all_filter
   end
 
   it "creates a block filter" do
-    interleave_filter.filters.must_be :empty?
+    _(interleave_filter.filters).must_be :empty?
     interleave_filter.block
     assert_filter :block_all_filter
   end
 
   it "creates a strip_value filter" do
-    interleave_filter.filters.must_be :empty?
+    _(interleave_filter.filters).must_be :empty?
     interleave_filter.strip_value
     assert_filter :strip_value_transformer
   end
 
   it "creates a key filter" do
     regex = "user-*"
-    interleave_filter.filters.must_be :empty?
+    _(interleave_filter.filters).must_be :empty?
     interleave_filter.key(regex)
     filter = assert_filter :row_key_regex_filter
-    filter.to_grpc.row_key_regex_filter.must_equal regex
+    _(filter.to_grpc.row_key_regex_filter).must_equal regex
   end
 
   it "creates a family filter" do
     regex = "cf-*"
-    interleave_filter.filters.must_be :empty?
+    _(interleave_filter.filters).must_be :empty?
     interleave_filter.family(regex)
     filter = assert_filter :family_name_regex_filter
-    filter.to_grpc.family_name_regex_filter.must_equal regex
+    _(filter.to_grpc.family_name_regex_filter).must_equal regex
   end
 
   it "creates a qualifier filter" do
     regex = "field*"
-    interleave_filter.filters.must_be :empty?
+    _(interleave_filter.filters).must_be :empty?
     interleave_filter.qualifier(regex)
     filter = assert_filter :column_qualifier_regex_filter
-    filter.to_grpc.column_qualifier_regex_filter.must_equal regex
+    _(filter.to_grpc.column_qualifier_regex_filter).must_equal regex
   end
 
   it "creates a value filter" do
     regex = "abc*"
-    interleave_filter.filters.must_be :empty?
+    _(interleave_filter.filters).must_be :empty?
     interleave_filter.value(regex)
     filter = assert_filter :value_regex_filter
-    filter.to_grpc.value_regex_filter.must_equal regex
+    _(filter.to_grpc.value_regex_filter).must_equal regex
   end
 
   it "creates a label filter" do
     label = "test"
-    interleave_filter.filters.must_be :empty?
+    _(interleave_filter.filters).must_be :empty?
     interleave_filter.label(label)
     filter = assert_filter :apply_label_transformer
-    filter.to_grpc.apply_label_transformer.must_equal label
+    _(filter.to_grpc.apply_label_transformer).must_equal label
   end
 
   it "creates a cells_per_row_offset filter" do
     offset = 5
-    interleave_filter.filters.must_be :empty?
+    _(interleave_filter.filters).must_be :empty?
     interleave_filter.cells_per_row_offset(offset)
     filter = assert_filter :cells_per_row_offset_filter
-    filter.to_grpc.cells_per_row_offset_filter.must_equal offset
+    _(filter.to_grpc.cells_per_row_offset_filter).must_equal offset
   end
 
   it "creates a cells_per_row filter" do
     limit = 10
-    interleave_filter.filters.must_be :empty?
+    _(interleave_filter.filters).must_be :empty?
     interleave_filter.cells_per_row(limit)
     filter = assert_filter :cells_per_row_limit_filter
-    filter.to_grpc.cells_per_row_limit_filter.must_equal limit
+    _(filter.to_grpc.cells_per_row_limit_filter).must_equal limit
   end
 
   it "creates a cells_per_column filter" do
     limit = 10
-    interleave_filter.filters.must_be :empty?
+    _(interleave_filter.filters).must_be :empty?
     interleave_filter.cells_per_column(limit)
     filter = assert_filter :cells_per_column_limit_filter
-    filter.to_grpc.cells_per_column_limit_filter.must_equal limit
+    _(filter.to_grpc.cells_per_column_limit_filter).must_equal limit
   end
 
   describe "timestamp_range" do
     it "creates a timestamp_range filter" do
       from = timestamp_micros - 3000000
       to = timestamp_micros
-      interleave_filter.filters.must_be :empty?
+      _(interleave_filter.filters).must_be :empty?
       interleave_filter.timestamp_range(from: from, to: to)
       filter = assert_filter :timestamp_range_filter
       range_grpc = Google::Bigtable::V2::TimestampRange.new(
         start_timestamp_micros: from, end_timestamp_micros: to
       )
-      filter.to_grpc.timestamp_range_filter.must_equal range_grpc
+      _(filter.to_grpc.timestamp_range_filter).must_equal range_grpc
     end
 
     it "creates a timestamp_range filter with only from range" do
       from = timestamp_micros - 3000000
-      interleave_filter.filters.must_be :empty?
+      _(interleave_filter.filters).must_be :empty?
       interleave_filter.timestamp_range(from: from)
       filter = assert_filter :timestamp_range_filter
       range_grpc = Google::Bigtable::V2::TimestampRange.new(
         start_timestamp_micros: from
       )
-      filter.to_grpc.timestamp_range_filter.must_equal range_grpc
+      _(filter.to_grpc.timestamp_range_filter).must_equal range_grpc
     end
 
     it "creates a timestamp_range filter with only to range" do
       to = timestamp_micros
-      interleave_filter.filters.must_be :empty?
+      _(interleave_filter.filters).must_be :empty?
       interleave_filter.timestamp_range(to: to)
       filter = assert_filter :timestamp_range_filter
       range_grpc = Google::Bigtable::V2::TimestampRange.new(
         end_timestamp_micros: to
       )
-      filter.to_grpc.timestamp_range_filter.must_equal range_grpc
+      _(filter.to_grpc.timestamp_range_filter).must_equal range_grpc
     end
   end
 
@@ -162,19 +162,19 @@ describe Google::Cloud::Bigtable::RowFilter::InterleaveFilter, :mock_bigtable do
       from_value = "abc"
       to_value = "xyz"
       range = Google::Cloud::Bigtable::ValueRange.new.from(from_value).to(to_value)
-      interleave_filter.filters.must_be :empty?
+      _(interleave_filter.filters).must_be :empty?
       interleave_filter.value_range(range)
       filter = assert_filter :value_range_filter
       grpc = filter.to_grpc.value_range_filter
-      grpc.must_be_kind_of Google::Bigtable::V2::ValueRange
-      grpc.start_value_closed.must_equal from_value
-      grpc.end_value_open.must_equal to_value
+      _(grpc).must_be_kind_of Google::Bigtable::V2::ValueRange
+      _(grpc.start_value_closed).must_equal from_value
+      _(grpc.end_value_open).must_equal to_value
     end
 
     it "range instance must be type of ValueRange" do
-      proc {
+      _ { proc {
         interleave_filter.value_range(Object.new)
-      }.must_raise Google::Cloud::Bigtable::RowFilterError
+      } }.must_raise Google::Cloud::Bigtable::RowFilterError
     end
   end
 
@@ -185,67 +185,67 @@ describe Google::Cloud::Bigtable::RowFilter::InterleaveFilter, :mock_bigtable do
       to_value = "field5"
 
       range = Google::Cloud::Bigtable::ColumnRange.new(family).from(from_value).to(to_value)
-      interleave_filter.filters.must_be :empty?
+      _(interleave_filter.filters).must_be :empty?
       interleave_filter.column_range(range)
       filter = assert_filter :column_range_filter
       grpc = filter.to_grpc.column_range_filter
-      grpc.must_be_kind_of Google::Bigtable::V2::ColumnRange
-      grpc.family_name.must_equal family
-      grpc.start_qualifier_closed.must_equal from_value
-      grpc.end_qualifier_open.must_equal to_value
+      _(grpc).must_be_kind_of Google::Bigtable::V2::ColumnRange
+      _(grpc.family_name).must_equal family
+      _(grpc.start_qualifier_closed).must_equal from_value
+      _(grpc.end_qualifier_open).must_equal to_value
     end
 
     it "range instance must be type of ColumnRange" do
-      proc {
+      _ { proc {
         interleave_filter.column_range(Object.new)
-      }.must_raise Google::Cloud::Bigtable::RowFilterError
+      } }.must_raise Google::Cloud::Bigtable::RowFilterError
     end
   end
 
   describe "#sample" do
     it "creates a sample probability filter" do
       probability = 0.5
-      interleave_filter.filters.must_be :empty?
+      _(interleave_filter.filters).must_be :empty?
       interleave_filter.sample(probability)
       filter = assert_filter :row_sample_filter
-      filter.to_grpc.row_sample_filter.must_equal probability
+      _(filter.to_grpc.row_sample_filter).must_equal probability
     end
 
     it "probability can not be greather then 1" do
-      proc {
+      _ { proc {
         interleave_filter.sample(1.1)
-      }.must_raise Google::Cloud::Bigtable::RowFilterError
+      } }.must_raise Google::Cloud::Bigtable::RowFilterError
     end
 
     it "probability can not be equal to 1" do
-      proc {
+      _ { proc {
         interleave_filter.sample(1)
-      }.must_raise Google::Cloud::Bigtable::RowFilterError
+      } }.must_raise Google::Cloud::Bigtable::RowFilterError
     end
 
     it "probability can not be equal to 0" do
-      proc {
+      _ { proc {
         interleave_filter.sample(0)
-      }.must_raise Google::Cloud::Bigtable::RowFilterError
+      } }.must_raise Google::Cloud::Bigtable::RowFilterError
     end
 
     it "probability can not be less then 0" do
-      proc {
+      _ { proc {
         interleave_filter.sample(-0.1)
-      }.must_raise Google::Cloud::Bigtable::RowFilterError
+      } }.must_raise Google::Cloud::Bigtable::RowFilterError
     end
   end
 
   it "creates a chain filter" do
     filter = Google::Cloud::Bigtable::RowFilter.chain
-    interleave_filter.filters.must_be :empty?
+    _(interleave_filter.filters).must_be :empty?
     interleave_filter.chain filter
     assert_filter :chain, Google::Cloud::Bigtable::RowFilter::ChainFilter
   end
 
   it "creates an interleave filter" do
     filter = Google::Cloud::Bigtable::RowFilter.interleave
-    interleave_filter.filters.must_be :empty?
+    _(interleave_filter.filters).must_be :empty?
     interleave_filter.interleave filter
     assert_filter :interleave, Google::Cloud::Bigtable::RowFilter::InterleaveFilter
   end
@@ -253,13 +253,13 @@ describe Google::Cloud::Bigtable::RowFilter::InterleaveFilter, :mock_bigtable do
   it "creates a condition filter" do
     predicate = Google::Cloud::Bigtable::RowFilter.key("user-*")
     filter = Google::Cloud::Bigtable::RowFilter.condition(predicate)
-    interleave_filter.filters.must_be :empty?
+    _(interleave_filter.filters).must_be :empty?
     interleave_filter.condition filter
     assert_filter :condition, Google::Cloud::Bigtable::RowFilter::ConditionFilter
   end
 
   def assert_filter method, type = Google::Cloud::Bigtable::RowFilter::SimpleFilter
-    interleave_filter.filters.count.must_equal 1
+    _(interleave_filter.filters.count).must_equal 1
     filter = interleave_filter.filters.find do |f|
       t = f.to_grpc.send method
       if t.kind_of? String # may be empty string in protobuf
@@ -268,7 +268,7 @@ describe Google::Cloud::Bigtable::RowFilter::InterleaveFilter, :mock_bigtable do
         !t.nil?
       end
     end
-    filter.must_be_kind_of type
+    _(filter).must_be_kind_of type
     filter
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/row_filter_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/row_filter_test.rb
@@ -26,93 +26,93 @@ describe Google::Cloud::Bigtable::RowFilter, :row_filter, :mock_bigtable do
   it "creates a sink filter" do
     filter = Google::Cloud::Bigtable::RowFilter.sink
 
-    filter.must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter
-    filter.to_grpc.sink.must_equal true
+    _(filter).must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter
+    _(filter.to_grpc.sink).must_equal true
   end
 
   it "creates a pass filter" do
     filter = Google::Cloud::Bigtable::RowFilter.pass
 
-    filter.must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter
-    filter.to_grpc.pass_all_filter.must_equal true
+    _(filter).must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter
+    _(filter.to_grpc.pass_all_filter).must_equal true
   end
 
   it "creates a block filter" do
     filter = Google::Cloud::Bigtable::RowFilter.block
 
-    filter.must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter
-    filter.to_grpc.block_all_filter.must_equal true
+    _(filter).must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter
+    _(filter.to_grpc.block_all_filter).must_equal true
   end
 
   it "creates a strip_value filter" do
     filter = Google::Cloud::Bigtable::RowFilter.strip_value
 
-    filter.must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter
-    filter.to_grpc.strip_value_transformer.must_equal true
+    _(filter).must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter
+    _(filter.to_grpc.strip_value_transformer).must_equal true
   end
 
   it "creates a key filter" do
     regex = "user-*"
     filter = Google::Cloud::Bigtable::RowFilter.key(regex)
 
-    filter.must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter
-    filter.to_grpc.row_key_regex_filter.must_equal regex
+    _(filter).must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter
+    _(filter.to_grpc.row_key_regex_filter).must_equal regex
   end
 
   it "creates a family filter" do
     regex = "cf-*"
     filter = Google::Cloud::Bigtable::RowFilter.family(regex)
 
-    filter.must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter
-    filter.to_grpc.family_name_regex_filter.must_equal regex
+    _(filter).must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter
+    _(filter.to_grpc.family_name_regex_filter).must_equal regex
   end
 
   it "creates a qualifier filter" do
     regex = "field*"
     filter = Google::Cloud::Bigtable::RowFilter.qualifier(regex)
 
-    filter.must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter
-    filter.to_grpc.column_qualifier_regex_filter.must_equal(regex)
+    _(filter).must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter
+    _(filter.to_grpc.column_qualifier_regex_filter).must_equal(regex)
   end
 
   it "creates a value filter" do
     regex = "abc*"
     filter = Google::Cloud::Bigtable::RowFilter.value(regex)
 
-    filter.must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter
-    filter.to_grpc.value_regex_filter.must_equal regex
+    _(filter).must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter
+    _(filter.to_grpc.value_regex_filter).must_equal regex
   end
 
   it "creates a label filter" do
     label = "test"
     filter = Google::Cloud::Bigtable::RowFilter.label(label)
 
-    filter.must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter
-    filter.to_grpc.apply_label_transformer.must_equal(label)
+    _(filter).must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter
+    _(filter.to_grpc.apply_label_transformer).must_equal(label)
   end
 
   it "creates a cells_per_row_offset filter" do
     offset = 5
     filter = Google::Cloud::Bigtable::RowFilter.cells_per_row_offset(offset)
 
-    filter.must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter
-    filter.to_grpc.cells_per_row_offset_filter.must_equal offset
+    _(filter).must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter
+    _(filter.to_grpc.cells_per_row_offset_filter).must_equal offset
   end
 
   it "creates a cells_per_row filter" do
     limit = 10
     filter = Google::Cloud::Bigtable::RowFilter.cells_per_row(limit)
 
-    filter.must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter
-    filter.to_grpc.cells_per_row_limit_filter.must_equal limit
+    _(filter).must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter
+    _(filter.to_grpc.cells_per_row_limit_filter).must_equal limit
   end
 
   it "creates a cells_per_column filter" do
     limit = 10
     filter = Google::Cloud::Bigtable::RowFilter.cells_per_column(limit)
 
-    filter.must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter
-    filter.to_grpc.cells_per_column_limit_filter.must_equal limit
+    _(filter).must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter
+    _(filter.to_grpc.cells_per_column_limit_filter).must_equal limit
   end
 
   describe "timestamp_range" do
@@ -122,36 +122,36 @@ describe Google::Cloud::Bigtable::RowFilter, :row_filter, :mock_bigtable do
 
       filter = Google::Cloud::Bigtable::RowFilter.timestamp_range(from: from, to: to)
 
-      filter.must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter
+      _(filter).must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter
 
       range_grpc = Google::Bigtable::V2::TimestampRange.new(
         start_timestamp_micros: from, end_timestamp_micros: to
       )
-      filter.to_grpc.timestamp_range_filter.must_equal range_grpc
+      _(filter.to_grpc.timestamp_range_filter).must_equal range_grpc
     end
 
     it "creates a timestamp_range filter with only from range" do
       from = timestamp_micros - 3000000
       filter = Google::Cloud::Bigtable::RowFilter.timestamp_range(from: from)
 
-      filter.must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter
+      _(filter).must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter
 
       range_grpc = Google::Bigtable::V2::TimestampRange.new(
         start_timestamp_micros: from
       )
-      filter.to_grpc.timestamp_range_filter.must_equal range_grpc
+      _(filter.to_grpc.timestamp_range_filter).must_equal range_grpc
     end
 
     it "creates a timestamp_range filter with only to range" do
       to = timestamp_micros
       filter = Google::Cloud::Bigtable::RowFilter.timestamp_range(to: to)
 
-      filter.must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter
+      _(filter).must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter
 
       range_grpc = Google::Bigtable::V2::TimestampRange.new(
         end_timestamp_micros: to
       )
-      filter.to_grpc.timestamp_range_filter.must_equal range_grpc
+      _(filter.to_grpc.timestamp_range_filter).must_equal range_grpc
     end
   end
 
@@ -162,18 +162,18 @@ describe Google::Cloud::Bigtable::RowFilter, :row_filter, :mock_bigtable do
       range = Google::Cloud::Bigtable::ValueRange.new.from(from_value).to(to_value)
       filter = Google::Cloud::Bigtable::RowFilter.value_range(range)
 
-      filter.must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter
+      _(filter).must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter
 
       grpc = filter.to_grpc.value_range_filter
-      grpc.must_be_kind_of Google::Bigtable::V2::ValueRange
-      grpc.start_value_closed.must_equal from_value
-      grpc.end_value_open.must_equal to_value
+      _(grpc).must_be_kind_of Google::Bigtable::V2::ValueRange
+      _(grpc.start_value_closed).must_equal from_value
+      _(grpc.end_value_open).must_equal to_value
     end
 
     it "range instance must be type of ValueRange" do
-      proc {
+      _ { proc {
         Google::Cloud::Bigtable::RowFilter.value_range(Object.new)
-      }.must_raise Google::Cloud::Bigtable::RowFilterError
+      } }.must_raise Google::Cloud::Bigtable::RowFilterError
     end
   end
 
@@ -186,19 +186,19 @@ describe Google::Cloud::Bigtable::RowFilter, :row_filter, :mock_bigtable do
       range = Google::Cloud::Bigtable::ColumnRange.new(family).from(from_value).to(to_value)
       filter = Google::Cloud::Bigtable::RowFilter.column_range(range)
 
-      filter.must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter
+      _(filter).must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter
 
       grpc = filter.to_grpc.column_range_filter
-      grpc.must_be_kind_of Google::Bigtable::V2::ColumnRange
-      grpc.family_name.must_equal family
-      grpc.start_qualifier_closed.must_equal from_value
-      grpc.end_qualifier_open.must_equal to_value
+      _(grpc).must_be_kind_of Google::Bigtable::V2::ColumnRange
+      _(grpc.family_name).must_equal family
+      _(grpc.start_qualifier_closed).must_equal from_value
+      _(grpc.end_qualifier_open).must_equal to_value
     end
 
     it "range instance must be type of ColumnRange" do
-      proc {
+      _ { proc {
         Google::Cloud::Bigtable::RowFilter.column_range(Object.new)
-      }.must_raise Google::Cloud::Bigtable::RowFilterError
+      } }.must_raise Google::Cloud::Bigtable::RowFilterError
     end
   end
 
@@ -207,90 +207,90 @@ describe Google::Cloud::Bigtable::RowFilter, :row_filter, :mock_bigtable do
       probability = 0.5
       filter = Google::Cloud::Bigtable::RowFilter.sample(probability)
 
-      filter.must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter
-      filter.to_grpc.row_sample_filter.must_equal probability
+      _(filter).must_be_kind_of Google::Cloud::Bigtable::RowFilter::SimpleFilter
+      _(filter.to_grpc.row_sample_filter).must_equal probability
     end
 
     it "probability can not be greather then 1" do
-      proc {
+      _ { proc {
         Google::Cloud::Bigtable::RowFilter.sample(1.1)
-      }.must_raise Google::Cloud::Bigtable::RowFilterError
+      } }.must_raise Google::Cloud::Bigtable::RowFilterError
     end
 
     it "probability can not be equal to 1" do
-      proc {
+      _ { proc {
         Google::Cloud::Bigtable::RowFilter.sample(1)
-      }.must_raise Google::Cloud::Bigtable::RowFilterError
+      } }.must_raise Google::Cloud::Bigtable::RowFilterError
     end
 
     it "probability can not be equal to 0" do
-      proc {
+      _ { proc {
         Google::Cloud::Bigtable::RowFilter.sample(0)
-      }.must_raise Google::Cloud::Bigtable::RowFilterError
+      } }.must_raise Google::Cloud::Bigtable::RowFilterError
     end
 
     it "probability can not be less then 0" do
-      proc {
+      _ { proc {
         Google::Cloud::Bigtable::RowFilter.sample(-0.1)
-      }.must_raise Google::Cloud::Bigtable::RowFilterError
+      } }.must_raise Google::Cloud::Bigtable::RowFilterError
     end
   end
 
   it "creates a chain filter" do
     filter = Google::Cloud::Bigtable::RowFilter.chain
-    filter.must_be_kind_of Google::Cloud::Bigtable::RowFilter::ChainFilter
+    _(filter).must_be_kind_of Google::Cloud::Bigtable::RowFilter::ChainFilter
     filters = filter.filters
-    filters.must_be_kind_of Array
-    filters.must_be :frozen?
-    filters.must_be :empty?
+    _(filters).must_be_kind_of Array
+    _(filters).must_be :frozen?
+    _(filters).must_be :empty?
 
     filter.pass.block.sink.strip_value # Add some filters to the chain.
-    filter.length.must_equal 4
+    _(filter.length).must_equal 4
 
     filters_grpc = filter.to_grpc.chain.filters
-    filters_grpc.length.must_equal 4
-    filters_grpc[0].pass_all_filter.must_equal true
-    filters_grpc[1].block_all_filter.must_equal true
-    filters_grpc[2].sink.must_equal true
-    filters_grpc[3].strip_value_transformer.must_equal true
+    _(filters_grpc.length).must_equal 4
+    _(filters_grpc[0].pass_all_filter).must_equal true
+    _(filters_grpc[1].block_all_filter).must_equal true
+    _(filters_grpc[2].sink).must_equal true
+    _(filters_grpc[3].strip_value_transformer).must_equal true
   end
 
   it "creates an interleave filter" do
     filter = Google::Cloud::Bigtable::RowFilter.interleave
-    filter.must_be_kind_of Google::Cloud::Bigtable::RowFilter::InterleaveFilter
+    _(filter).must_be_kind_of Google::Cloud::Bigtable::RowFilter::InterleaveFilter
     filters = filter.filters
-    filters.must_be_kind_of Array
-    filters.must_be :frozen?
-    filters.must_be :empty?
+    _(filters).must_be_kind_of Array
+    _(filters).must_be :frozen?
+    _(filters).must_be :empty?
 
     filter.pass.block.sink.strip_value # Add some filters to the interleave.
-    filter.length.must_equal 4
+    _(filter.length).must_equal 4
 
     filters_grpc = filter.to_grpc.interleave.filters
-    filters_grpc.length.must_equal 4
-    filters_grpc[0].pass_all_filter.must_equal true
-    filters_grpc[1].block_all_filter.must_equal true
-    filters_grpc[2].sink.must_equal true
-    filters_grpc[3].strip_value_transformer.must_equal true
+    _(filters_grpc.length).must_equal 4
+    _(filters_grpc[0].pass_all_filter).must_equal true
+    _(filters_grpc[1].block_all_filter).must_equal true
+    _(filters_grpc[2].sink).must_equal true
+    _(filters_grpc[3].strip_value_transformer).must_equal true
   end
 
   it "creates a condition filter" do
     predicate = Google::Cloud::Bigtable::RowFilter.key("user-*")
     condition = Google::Cloud::Bigtable::RowFilter.condition(predicate)
-    condition.must_be_kind_of Google::Cloud::Bigtable::RowFilter::ConditionFilter
+    _(condition).must_be_kind_of Google::Cloud::Bigtable::RowFilter::ConditionFilter
 
     on_match_filter = Google::Cloud::Bigtable::RowFilter.label("label")
     otherwise_filter = Google::Cloud::Bigtable::RowFilter.strip_value
 
     condition.on_match(on_match_filter).otherwise(otherwise_filter)
 
-    condition.to_grpc.condition.must_be_kind_of Google::Bigtable::V2::RowFilter::Condition
+    _(condition.to_grpc.condition).must_be_kind_of Google::Bigtable::V2::RowFilter::Condition
     grpc = condition.to_grpc.condition
-    grpc.predicate_filter.must_be_kind_of Google::Bigtable::V2::RowFilter
-    grpc.predicate_filter.row_key_regex_filter.must_equal "user-*"
-    grpc.true_filter.must_be_kind_of Google::Bigtable::V2::RowFilter
-    grpc.true_filter.apply_label_transformer.must_equal "label"
-    grpc.false_filter.must_be_kind_of Google::Bigtable::V2::RowFilter
-    grpc.false_filter.strip_value_transformer.must_equal true
+    _(grpc.predicate_filter).must_be_kind_of Google::Bigtable::V2::RowFilter
+    _(grpc.predicate_filter.row_key_regex_filter).must_equal "user-*"
+    _(grpc.true_filter).must_be_kind_of Google::Bigtable::V2::RowFilter
+    _(grpc.true_filter.apply_label_transformer).must_equal "label"
+    _(grpc.false_filter).must_be_kind_of Google::Bigtable::V2::RowFilter
+    _(grpc.false_filter.strip_value_transformer).must_equal true
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/row_filter_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/row_filter_test.rb
@@ -171,9 +171,9 @@ describe Google::Cloud::Bigtable::RowFilter, :row_filter, :mock_bigtable do
     end
 
     it "range instance must be type of ValueRange" do
-      _ { proc {
+      assert_raises Google::Cloud::Bigtable::RowFilterError do
         Google::Cloud::Bigtable::RowFilter.value_range(Object.new)
-      } }.must_raise Google::Cloud::Bigtable::RowFilterError
+      end
     end
   end
 
@@ -196,9 +196,9 @@ describe Google::Cloud::Bigtable::RowFilter, :row_filter, :mock_bigtable do
     end
 
     it "range instance must be type of ColumnRange" do
-      _ { proc {
+      assert_raises Google::Cloud::Bigtable::RowFilterError do
         Google::Cloud::Bigtable::RowFilter.column_range(Object.new)
-      } }.must_raise Google::Cloud::Bigtable::RowFilterError
+      end
     end
   end
 
@@ -212,27 +212,27 @@ describe Google::Cloud::Bigtable::RowFilter, :row_filter, :mock_bigtable do
     end
 
     it "probability can not be greather then 1" do
-      _ { proc {
+      assert_raises Google::Cloud::Bigtable::RowFilterError do
         Google::Cloud::Bigtable::RowFilter.sample(1.1)
-      } }.must_raise Google::Cloud::Bigtable::RowFilterError
+      end
     end
 
     it "probability can not be equal to 1" do
-      _ { proc {
+      assert_raises Google::Cloud::Bigtable::RowFilterError do
         Google::Cloud::Bigtable::RowFilter.sample(1)
-      } }.must_raise Google::Cloud::Bigtable::RowFilterError
+      end
     end
 
     it "probability can not be equal to 0" do
-      _ { proc {
+      assert_raises Google::Cloud::Bigtable::RowFilterError do
         Google::Cloud::Bigtable::RowFilter.sample(0)
-      } }.must_raise Google::Cloud::Bigtable::RowFilterError
+      end
     end
 
     it "probability can not be less then 0" do
-      _ { proc {
+      assert_raises Google::Cloud::Bigtable::RowFilterError do
         Google::Cloud::Bigtable::RowFilter.sample(-0.1)
-      } }.must_raise Google::Cloud::Bigtable::RowFilterError
+      end
     end
   end
 

--- a/google-cloud-bigtable/test/google/cloud/bigtable/row_range_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/row_range_test.rb
@@ -23,22 +23,22 @@ describe Google::Cloud::Bigtable::RowRange, :row_range, :mock_bigtable do
       from_key = "from-key-inclusive"
       range = Google::Cloud::Bigtable::RowRange.new.from(from_key)
 
-      range.must_be_kind_of Google::Cloud::Bigtable::RowRange
+      _(range).must_be_kind_of Google::Cloud::Bigtable::RowRange
 
       grpc = range.to_grpc
-      grpc.must_be_kind_of Google::Bigtable::V2::RowRange
-      grpc.start_key_closed.must_equal from_key
+      _(grpc).must_be_kind_of Google::Bigtable::V2::RowRange
+      _(grpc.start_key_closed).must_equal from_key
     end
 
     it "create exclusive from range instance" do
       from_key = "from-key-exclusive"
       range = Google::Cloud::Bigtable::RowRange.new.from(from_key, inclusive: false)
 
-      range.must_be_kind_of Google::Cloud::Bigtable::RowRange
+      _(range).must_be_kind_of Google::Cloud::Bigtable::RowRange
 
       grpc = range.to_grpc
-      grpc.must_be_kind_of Google::Bigtable::V2::RowRange
-      grpc.start_key_open.must_equal from_key
+      _(grpc).must_be_kind_of Google::Bigtable::V2::RowRange
+      _(grpc.start_key_open).must_equal from_key
     end
 
     it "create instance with from and to range" do
@@ -46,12 +46,12 @@ describe Google::Cloud::Bigtable::RowRange, :row_range, :mock_bigtable do
       to_key = "to-key"
       range = Google::Cloud::Bigtable::RowRange.new.from(from_key).to(to_key)
 
-      range.must_be_kind_of Google::Cloud::Bigtable::RowRange
+      _(range).must_be_kind_of Google::Cloud::Bigtable::RowRange
 
       grpc = range.to_grpc
-      grpc.must_be_kind_of Google::Bigtable::V2::RowRange
-      grpc.start_key_closed.must_equal from_key
-      grpc.end_key_open.must_equal to_key
+      _(grpc).must_be_kind_of Google::Bigtable::V2::RowRange
+      _(grpc.start_key_closed).must_equal from_key
+      _(grpc.end_key_open).must_equal to_key
     end
   end
 
@@ -60,22 +60,22 @@ describe Google::Cloud::Bigtable::RowRange, :row_range, :mock_bigtable do
       to_key = "to-key-inclusive"
       range = Google::Cloud::Bigtable::RowRange.new.to(to_key)
 
-      range.must_be_kind_of Google::Cloud::Bigtable::RowRange
+      _(range).must_be_kind_of Google::Cloud::Bigtable::RowRange
 
       grpc = range.to_grpc
-      grpc.must_be_kind_of Google::Bigtable::V2::RowRange
-      grpc.end_key_open.must_equal to_key
+      _(grpc).must_be_kind_of Google::Bigtable::V2::RowRange
+      _(grpc.end_key_open).must_equal to_key
     end
 
     it "create inclusive to range instance" do
       to_key = "to-key-exclusive"
       range = Google::Cloud::Bigtable::RowRange.new.to(to_key, inclusive: true)
 
-      range.must_be_kind_of Google::Cloud::Bigtable::RowRange
+      _(range).must_be_kind_of Google::Cloud::Bigtable::RowRange
 
       grpc = range.to_grpc
-      grpc.must_be_kind_of Google::Bigtable::V2::RowRange
-      grpc.end_key_closed.must_equal to_key
+      _(grpc).must_be_kind_of Google::Bigtable::V2::RowRange
+      _(grpc.end_key_closed).must_equal to_key
     end
 
     it "create instance with from and to range" do
@@ -83,12 +83,12 @@ describe Google::Cloud::Bigtable::RowRange, :row_range, :mock_bigtable do
       to_key = "to-key"
       range = Google::Cloud::Bigtable::RowRange.new.to(to_key).from(from_key)
 
-      range.must_be_kind_of Google::Cloud::Bigtable::RowRange
+      _(range).must_be_kind_of Google::Cloud::Bigtable::RowRange
 
       grpc = range.to_grpc
-      grpc.must_be_kind_of Google::Bigtable::V2::RowRange
-      grpc.start_key_closed.must_equal from_key
-      grpc.end_key_open.must_equal to_key
+      _(grpc).must_be_kind_of Google::Bigtable::V2::RowRange
+      _(grpc.start_key_closed).must_equal from_key
+      _(grpc.end_key_open).must_equal to_key
     end
   end
 
@@ -97,12 +97,12 @@ describe Google::Cloud::Bigtable::RowRange, :row_range, :mock_bigtable do
     to_key = "to-key"
     range = Google::Cloud::Bigtable::RowRange.new.between(from_key, to_key)
 
-    range.must_be_kind_of Google::Cloud::Bigtable::RowRange
+    _(range).must_be_kind_of Google::Cloud::Bigtable::RowRange
 
     grpc = range.to_grpc
-    grpc.must_be_kind_of Google::Bigtable::V2::RowRange
-    grpc.start_key_closed.must_equal from_key
-    grpc.end_key_closed.must_equal to_key
+    _(grpc).must_be_kind_of Google::Bigtable::V2::RowRange
+    _(grpc.start_key_closed).must_equal from_key
+    _(grpc.end_key_closed).must_equal to_key
   end
 
   it "create instance using of" do
@@ -110,11 +110,11 @@ describe Google::Cloud::Bigtable::RowRange, :row_range, :mock_bigtable do
     to_key = "to-key"
     range = Google::Cloud::Bigtable::RowRange.new.of(from_key, to_key)
 
-    range.must_be_kind_of Google::Cloud::Bigtable::RowRange
+    _(range).must_be_kind_of Google::Cloud::Bigtable::RowRange
 
     grpc = range.to_grpc
-    grpc.must_be_kind_of Google::Bigtable::V2::RowRange
-    grpc.start_key_closed.must_equal from_key
-    grpc.end_key_open.must_equal to_key
+    _(grpc).must_be_kind_of Google::Bigtable::V2::RowRange
+    _(grpc.start_key_closed).must_equal from_key
+    _(grpc.end_key_open).must_equal to_key
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/row_reader/read_rows_state_machine_acceptance_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/row_reader/read_rows_state_machine_acceptance_test.rb
@@ -87,9 +87,9 @@ describe Google::Cloud::Bigtable::RowsReader, :read_state_machine_acceptance, :m
 
       get_res = chunk_data_to_read_res(test_data["chunks_base64"])
       mock.expect :read_rows, get_res, [table_path(instance_id, table_id), Hash]
-      _ { proc {
+      assert_raises Google::Cloud::Bigtable::InvalidRowStateError do
         table.read_rows.each{|v| v}
-      } }.must_raise Google::Cloud::Bigtable::InvalidRowStateError
+      end
 
       mock.verify
     end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/row_reader/read_rows_state_machine_acceptance_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/row_reader/read_rows_state_machine_acceptance_test.rb
@@ -87,9 +87,9 @@ describe Google::Cloud::Bigtable::RowsReader, :read_state_machine_acceptance, :m
 
       get_res = chunk_data_to_read_res(test_data["chunks_base64"])
       mock.expect :read_rows, get_res, [table_path(instance_id, table_id), Hash]
-      proc {
+      _ { proc {
         table.read_rows.each{|v| v}
-      }.must_raise Google::Cloud::Bigtable::InvalidRowStateError
+      } }.must_raise Google::Cloud::Bigtable::InvalidRowStateError
 
       mock.verify
     end
@@ -110,12 +110,12 @@ describe Google::Cloud::Bigtable::RowsReader, :read_state_machine_acceptance, :m
       rows = table.read_rows.map{|r| r}
       families = rows.map(&:column_families).flatten.uniq.sort
 
-      families.must_equal expected_families
+      _(families).must_equal expected_families
       result = convert_rows_to_test_result(rows)
-      result.length.must_equal expected_result.length
+      _(result.length).must_equal expected_result.length
 
       result.each_with_index do |r, i|
-        r.must_equal expected_result[i]
+        _(r).must_equal expected_result[i]
       end
     end
   end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/row_reader_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/row_reader_test.rb
@@ -26,12 +26,12 @@ describe Google::Cloud::Bigtable::RowsReader, :row_reader, :mock_bigtable do
     chunk_processor.last_key = "3"
     rows_reader.instance_variable_set("@rows_count", 10)
 
-    rows_reader.last_key.must_equal "3"
+    _(rows_reader.last_key).must_equal "3"
 
     rows_limit, retry_row_set = rows_reader.retry_options(100, row_set)
 
-    rows_limit.must_equal 90
-    retry_row_set.row_keys.must_equal ["5"]
+    _(rows_limit).must_equal 90
+    _(retry_row_set.row_keys).must_equal ["5"]
   end
 
   it "add row range if row set row ranges empty" do
@@ -44,8 +44,8 @@ describe Google::Cloud::Bigtable::RowsReader, :row_reader, :mock_bigtable do
     _, retry_row_set = rows_reader.retry_options(100, row_set)
     row_ranges = retry_row_set.row_ranges
 
-    row_ranges.length.must_equal 1
-    row_ranges.first.must_equal Google::Bigtable::V2::RowRange.new(start_key_open: "3")
+    _(row_ranges.length).must_equal 1
+    _(row_ranges.first).must_equal Google::Bigtable::V2::RowRange.new(start_key_open: "3")
   end
 
   it "removed already read row ranges" do
@@ -59,8 +59,8 @@ describe Google::Cloud::Bigtable::RowsReader, :row_reader, :mock_bigtable do
     _, retry_row_set = rows_reader.retry_options(100, row_set)
     row_ranges = retry_row_set.row_ranges
 
-    row_ranges.length.must_equal 1
-    row_ranges.first.end_key_closed.must_equal "5"
+    _(row_ranges.length).must_equal 1
+    _(row_ranges.first.end_key_closed).must_equal "5"
   end
 
   it "set start key for already read row ranges" do
@@ -74,18 +74,18 @@ describe Google::Cloud::Bigtable::RowsReader, :row_reader, :mock_bigtable do
     _, retry_row_set = rows_reader.retry_options(100, row_set)
     row_ranges = retry_row_set.row_ranges
 
-    row_ranges.length.must_equal 1
-    row_ranges.first.must_equal Google::Bigtable::V2::RowRange.new(start_key_open: "3", end_key_closed: "5")
+    _(row_ranges.length).must_equal 1
+    _(row_ranges.first).must_equal Google::Bigtable::V2::RowRange.new(start_key_open: "3", end_key_closed: "5")
   end
 
   it "increment and check read is retryable" do
     rows_reader = Google::Cloud::Bigtable::RowsReader.new("dummy-table-client")
 
-    rows_reader.retryable?.must_equal true
+    _(rows_reader.retryable?).must_equal true
 
     [true, true, false].each do |expected_value|
       rows_reader.retry_count += 1
-      rows_reader.retryable?.must_equal expected_value
+      _(rows_reader.retryable?).must_equal expected_value
     end
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/sample_row_key_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/sample_row_key_test.rb
@@ -25,8 +25,8 @@ describe Google::Cloud::Bigtable::SampleRowKey, :simple_row_key, :mock_bigtable 
 
     sample_row_key = Google::Cloud::Bigtable::SampleRowKey.from_grpc(grpc)
 
-    sample_row_key.must_be_kind_of Google::Cloud::Bigtable::SampleRowKey
-    sample_row_key.key.must_equal row_key
-    sample_row_key.offset.must_equal offset
+    _(sample_row_key).must_be_kind_of Google::Cloud::Bigtable::SampleRowKey
+    _(sample_row_key.key).must_equal row_key
+    _(sample_row_key.offset).must_equal offset
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/check_and_mutate_row_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/check_and_mutate_row_test.rb
@@ -53,7 +53,7 @@ describe Google::Cloud::Bigtable::Table, :check_and_mutate_row, :mock_bigtable d
       on_match: Google::Cloud::Bigtable::MutationEntry.new.delete_cells("cf", "field1"),
       otherwise: Google::Cloud::Bigtable::MutationEntry.new.delete_from_row
     )
-    result.must_equal true
+    _(result).must_equal true
     mock.verify
   end
 
@@ -68,13 +68,13 @@ describe Google::Cloud::Bigtable::Table, :check_and_mutate_row, :mock_bigtable d
     table = bigtable.table(instance_id, table_id)
 
     row_key = "user-1"
-    proc {
+    _ { proc {
        table.check_and_mutate_row(
         row_key,
         Google::Cloud::Bigtable::RowFilter.key("user-1*"),
         on_match: Google::Cloud::Bigtable::MutationEntry.new.delete_cells("cf-BAD ", "field1"),
         otherwise: Google::Cloud::Bigtable::MutationEntry.new.delete_from_row
       )
-    }.must_raise Google::Cloud::InvalidArgumentError
+    } }.must_raise Google::Cloud::InvalidArgumentError
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/check_and_mutate_row_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/check_and_mutate_row_test.rb
@@ -68,13 +68,13 @@ describe Google::Cloud::Bigtable::Table, :check_and_mutate_row, :mock_bigtable d
     table = bigtable.table(instance_id, table_id)
 
     row_key = "user-1"
-    _ { proc {
+    assert_raises Google::Cloud::InvalidArgumentError do
        table.check_and_mutate_row(
         row_key,
         Google::Cloud::Bigtable::RowFilter.key("user-1*"),
         on_match: Google::Cloud::Bigtable::MutationEntry.new.delete_cells("cf-BAD ", "field1"),
         otherwise: Google::Cloud::Bigtable::MutationEntry.new.delete_from_row
       )
-    } }.must_raise Google::Cloud::InvalidArgumentError
+    end
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/cluster_state_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/cluster_state_test.rb
@@ -25,12 +25,12 @@ describe Google::Cloud::Bigtable::Table::ClusterState, :mock_bigtable do
       grpc, cluster_name
     )
 
-    cluster_state.must_be_kind_of Google::Cloud::Bigtable::Table::ClusterState
-    cluster_state.cluster_name.must_equal cluster_name
-    cluster_state.replication_state.must_equal :READY
-    cluster_state.ready?.must_equal true
-    cluster_state.initializing?.wont_equal true
-    cluster_state.planned_maintenance?.wont_equal true
-    cluster_state.unplanned_maintenance?.wont_equal true
+    _(cluster_state).must_be_kind_of Google::Cloud::Bigtable::Table::ClusterState
+    _(cluster_state.cluster_name).must_equal cluster_name
+    _(cluster_state.replication_state).must_equal :READY
+    _(cluster_state.ready?).must_equal true
+    _(cluster_state.initializing?).wont_equal true
+    _(cluster_state.planned_maintenance?).wont_equal true
+    _(cluster_state.unplanned_maintenance?).wont_equal true
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/column_families_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/column_families_test.rb
@@ -76,23 +76,23 @@ describe Google::Cloud::Bigtable::Table, :column_families, :mock_bigtable do
       cfm.update "cf2", gc_rule: Google::Cloud::Bigtable::GcRule.max_versions(5)
     end
 
-    column_families.must_be_instance_of Google::Cloud::Bigtable::ColumnFamilyMap
-    table.column_families.must_be :frozen?
-    column_families.names.sort.must_equal column_families_resp.keys
-    column_families["cf4"].gc_rule.to_grpc.must_equal gc_rule_1
-    column_families["cf2"].gc_rule.to_grpc.must_equal gc_rule_2
+    _(column_families).must_be_instance_of Google::Cloud::Bigtable::ColumnFamilyMap
+    _(table.column_families).must_be :frozen?
+    _(column_families.names.sort).must_equal column_families_resp.keys
+    _(column_families["cf4"].gc_rule.to_grpc).must_equal gc_rule_1
+    _(column_families["cf2"].gc_rule.to_grpc).must_equal gc_rule_2
 
-    table.column_families.must_be_instance_of Google::Cloud::Bigtable::ColumnFamilyMap
-    table.column_families.must_be :frozen?
-    table.column_families.names.sort.must_equal column_families_resp.keys
-    table.column_families["cf4"].gc_rule.to_grpc.must_equal gc_rule_1
-    table.column_families["cf2"].gc_rule.to_grpc.must_equal gc_rule_2
+    _(table.column_families).must_be_instance_of Google::Cloud::Bigtable::ColumnFamilyMap
+    _(table.column_families).must_be :frozen?
+    _(table.column_families.names.sort).must_equal column_families_resp.keys
+    _(table.column_families["cf4"].gc_rule.to_grpc).must_equal gc_rule_1
+    _(table.column_families["cf2"].gc_rule.to_grpc).must_equal gc_rule_2
 
-    table.project_id.must_equal project_id
-    table.instance_id.must_equal instance_id
-    table.name.must_equal table_id
-    table.path.must_equal table_path(instance_id, table_id)
-    table.granularity.must_equal :MILLIS
+    _(table.project_id).must_equal project_id
+    _(table.instance_id).must_equal instance_id
+    _(table.name).must_equal table_id
+    _(table.path).must_equal table_path(instance_id, table_id)
+    _(table.granularity).must_equal :MILLIS
 
     mock.verify
   end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/delete_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/delete_test.rb
@@ -40,7 +40,7 @@ describe Google::Cloud::Bigtable::Table, :delete, :mock_bigtable do
     bigtable.service.mocked_tables = mock
 
     result = table.delete
-    result.must_equal true
+    _(result).must_equal true
     mock.verify
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/drop_row_range_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/drop_row_range_test.rb
@@ -70,17 +70,18 @@ describe Google::Cloud::Bigtable::Table, :drop_rows, :mock_bigtable do
     it "drop rows all data rows with timeout option" do
       timeout_secs = 10
       stub = OpenStruct.new(
+        t: self,
         expected_table_path: table_path(instance_id, table_id),
         expected_timeout: timeout_secs * 1000
       )
 
       def stub.drop_row_range parent, args
-        _(parent).must_equal expected_table_path
-        _(args[:row_key_prefix]).must_be :nil?
-        _(args[:delete_all_data_from_table]).must_equal true
+        t._(parent).must_equal expected_table_path
+        t._(args[:row_key_prefix]).must_be :nil?
+        t._(args[:delete_all_data_from_table]).must_equal true
 
         retry_timeout = args[:options].retry_options.backoff_settings.initial_rpc_timeout_millis
-        _(retry_timeout).must_equal expected_timeout
+        t._(retry_timeout).must_equal expected_timeout
         nil
       end
       bigtable.service.mocked_tables = stub
@@ -109,17 +110,18 @@ describe Google::Cloud::Bigtable::Table, :drop_rows, :mock_bigtable do
     it "drop rows all rows with timeout" do
       timeout_secs = 10
       stub = OpenStruct.new(
+        t: self,
         expected_table_path: table_path(instance_id, table_id),
         expected_timeout: timeout_secs * 1000
       )
 
       def stub.drop_row_range parent, args
-        _(parent).must_equal expected_table_path
-        _(args[:row_key_prefix]).must_be :nil?
-        _(args[:delete_all_data_from_table]).must_equal true
+        t._(parent).must_equal expected_table_path
+        t._(args[:row_key_prefix]).must_be :nil?
+        t._(args[:delete_all_data_from_table]).must_equal true
 
         retry_timeout = args[:options].retry_options.backoff_settings.initial_rpc_timeout_millis
-        _(retry_timeout).must_equal expected_timeout
+        t._(retry_timeout).must_equal expected_timeout
         nil
       end
       bigtable.service.mocked_tables = stub
@@ -148,17 +150,18 @@ describe Google::Cloud::Bigtable::Table, :drop_rows, :mock_bigtable do
     it "delete rows by prefix with timeout" do
       timeout_secs = 10
       stub = OpenStruct.new(
+        t: self,
         expected_table_path: table_path(instance_id, table_id),
         expected_timeout: timeout_secs * 1000
       )
 
       def stub.drop_row_range parent, args
-        _(parent).must_equal expected_table_path
-        _(args[:row_key_prefix]).must_equal "user"
-        _(args[:delete_all_data_from_table]).must_be :nil?
+        t._(parent).must_equal expected_table_path
+        t._(args[:row_key_prefix]).must_equal "user"
+        t._(args[:delete_all_data_from_table]).must_be :nil?
 
         retry_timeout = args[:options].retry_options.backoff_settings.initial_rpc_timeout_millis
-        _(retry_timeout).must_equal expected_timeout
+        t._(retry_timeout).must_equal expected_timeout
         nil
       end
       bigtable.service.mocked_tables = stub

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/drop_row_range_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/drop_row_range_test.rb
@@ -48,7 +48,7 @@ describe Google::Cloud::Bigtable::Table, :drop_rows, :mock_bigtable do
       bigtable.service.mocked_tables = mock
 
       result = table.drop_row_range(row_key_prefix: "user")
-      result.must_equal true
+      _(result).must_equal true
       mock.verify
     end
 
@@ -63,7 +63,7 @@ describe Google::Cloud::Bigtable::Table, :drop_rows, :mock_bigtable do
       bigtable.service.mocked_tables = mock
 
       result = table.drop_row_range(delete_all_data: true)
-      result.must_equal true
+      _(result).must_equal true
       mock.verify
     end
 
@@ -75,18 +75,18 @@ describe Google::Cloud::Bigtable::Table, :drop_rows, :mock_bigtable do
       )
 
       def stub.drop_row_range parent, args
-        parent.must_equal expected_table_path
-        args[:row_key_prefix].must_be :nil?
-        args[:delete_all_data_from_table].must_equal true
+        _(parent).must_equal expected_table_path
+        _(args[:row_key_prefix]).must_be :nil?
+        _(args[:delete_all_data_from_table]).must_equal true
 
         retry_timeout = args[:options].retry_options.backoff_settings.initial_rpc_timeout_millis
-        retry_timeout.must_equal expected_timeout
+        _(retry_timeout).must_equal expected_timeout
         nil
       end
       bigtable.service.mocked_tables = stub
 
       result = table.drop_row_range(delete_all_data: true, timeout: timeout_secs)
-      result.must_equal true
+      _(result).must_equal true
     end
   end
 
@@ -102,7 +102,7 @@ describe Google::Cloud::Bigtable::Table, :drop_rows, :mock_bigtable do
       bigtable.service.mocked_tables = mock
 
       result = table.delete_all_rows
-      result.must_equal true
+      _(result).must_equal true
       mock.verify
     end
 
@@ -114,18 +114,18 @@ describe Google::Cloud::Bigtable::Table, :drop_rows, :mock_bigtable do
       )
 
       def stub.drop_row_range parent, args
-        parent.must_equal expected_table_path
-        args[:row_key_prefix].must_be :nil?
-        args[:delete_all_data_from_table].must_equal true
+        _(parent).must_equal expected_table_path
+        _(args[:row_key_prefix]).must_be :nil?
+        _(args[:delete_all_data_from_table]).must_equal true
 
         retry_timeout = args[:options].retry_options.backoff_settings.initial_rpc_timeout_millis
-        retry_timeout.must_equal expected_timeout
+        _(retry_timeout).must_equal expected_timeout
         nil
       end
       bigtable.service.mocked_tables = stub
 
       result = table.delete_all_rows(timeout: timeout_secs)
-      result.must_equal true
+      _(result).must_equal true
     end
   end
 
@@ -141,7 +141,7 @@ describe Google::Cloud::Bigtable::Table, :drop_rows, :mock_bigtable do
       bigtable.service.mocked_tables = mock
 
       result = table.delete_rows_by_prefix("user")
-      result.must_equal true
+      _(result).must_equal true
       mock.verify
     end
 
@@ -153,18 +153,18 @@ describe Google::Cloud::Bigtable::Table, :drop_rows, :mock_bigtable do
       )
 
       def stub.drop_row_range parent, args
-        parent.must_equal expected_table_path
-        args[:row_key_prefix].must_equal "user"
-        args[:delete_all_data_from_table].must_be :nil?
+        _(parent).must_equal expected_table_path
+        _(args[:row_key_prefix]).must_equal "user"
+        _(args[:delete_all_data_from_table]).must_be :nil?
 
         retry_timeout = args[:options].retry_options.backoff_settings.initial_rpc_timeout_millis
-        retry_timeout.must_equal expected_timeout
+        _(retry_timeout).must_equal expected_timeout
         nil
       end
       bigtable.service.mocked_tables = stub
 
       result = table.delete_rows_by_prefix("user", timeout: timeout_secs)
-      result.must_equal true
+      _(result).must_equal true
     end
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/exists_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/exists_test.rb
@@ -35,7 +35,7 @@ describe Google::Cloud::Bigtable::Table, :exists?, :mock_bigtable do
     bigtable.service.mocked_tables = mock
 
     table = bigtable.table(instance_id, table_id)
-    table.exists?.must_equal true
+    _(table.exists?).must_equal true
     mock.verify
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/iam_policy_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/iam_policy_test.rb
@@ -66,14 +66,14 @@ describe Google::Cloud::Bigtable::Table, :iam_policy, :mock_bigtable do
 
     mock.verify
 
-    policy.must_be_kind_of Google::Cloud::Bigtable::Policy
-    policy.etag.must_equal "abc"
-    policy.roles.must_be_kind_of Hash
-    policy.roles.size.must_equal 1
-    policy.roles["roles/viewer"].must_be_kind_of Array
-    policy.roles["roles/viewer"].count.must_equal 2
-    policy.roles["roles/viewer"].first.must_equal "user:viewer@example.com"
-    policy.roles["roles/viewer"].last.must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+    _(policy).must_be_kind_of Google::Cloud::Bigtable::Policy
+    _(policy.etag).must_equal "abc"
+    _(policy.roles).must_be_kind_of Hash
+    _(policy.roles.size).must_equal 1
+    _(policy.roles["roles/viewer"]).must_be_kind_of Array
+    _(policy.roles["roles/viewer"].count).must_equal 2
+    _(policy.roles["roles/viewer"].first).must_equal "user:viewer@example.com"
+    _(policy.roles["roles/viewer"].last).must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
   end
 
   it "update the iam policy" do
@@ -99,15 +99,15 @@ describe Google::Cloud::Bigtable::Table, :iam_policy, :mock_bigtable do
 
     mock.verify
 
-    policy.must_be_kind_of Google::Cloud::Bigtable::Policy
-    policy.etag.must_equal "xyz"
-    policy.roles.must_be_kind_of Hash
-    policy.roles.size.must_equal 1
-    policy.roles["roles/viewer"].must_be :nil?
-    policy.roles["roles/owner"].must_be_kind_of Array
-    policy.roles["roles/owner"].count.must_equal 2
-    policy.roles["roles/owner"].first.must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
-    policy.roles["roles/owner"].last.must_equal  "user:newowner@example.com"
+    _(policy).must_be_kind_of Google::Cloud::Bigtable::Policy
+    _(policy.etag).must_equal "xyz"
+    _(policy.roles).must_be_kind_of Hash
+    _(policy.roles.size).must_equal 1
+    _(policy.roles["roles/viewer"]).must_be :nil?
+    _(policy.roles["roles/owner"]).must_be_kind_of Array
+    _(policy.roles["roles/owner"].count).must_equal 2
+    _(policy.roles["roles/owner"].first).must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
+    _(policy.roles["roles/owner"].last).must_equal  "user:newowner@example.com"
   end
 
   it "get and set policy using block" do
@@ -131,15 +131,15 @@ describe Google::Cloud::Bigtable::Table, :iam_policy, :mock_bigtable do
 
     mock.verify
 
-    policy.must_be_kind_of Google::Cloud::Bigtable::Policy
-    policy.etag.must_equal "xyz"
-    policy.roles.must_be_kind_of Hash
-    policy.roles.size.must_equal 1
-    policy.roles["roles/viewer"].must_be :nil?
-    policy.roles["roles/owner"].must_be_kind_of Array
-    policy.roles["roles/owner"].count.must_equal 2
-    policy.roles["roles/owner"].first.must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
-    policy.roles["roles/owner"].last.must_equal  "user:newowner@example.com"
+    _(policy).must_be_kind_of Google::Cloud::Bigtable::Policy
+    _(policy.etag).must_equal "xyz"
+    _(policy.roles).must_be_kind_of Hash
+    _(policy.roles.size).must_equal 1
+    _(policy.roles["roles/viewer"]).must_be :nil?
+    _(policy.roles["roles/owner"]).must_be_kind_of Array
+    _(policy.roles["roles/owner"].count).must_equal 2
+    _(policy.roles["roles/owner"].first).must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
+    _(policy.roles["roles/owner"].last).must_equal  "user:newowner@example.com"
   end
 
   it "tests the available permissions" do
@@ -157,7 +157,7 @@ describe Google::Cloud::Bigtable::Table, :iam_policy, :mock_bigtable do
 
    mock.verify
 
-   permissions.must_be_kind_of Array
-   permissions.must_equal ["bigtable.tables.list"]
+   _(permissions).must_be_kind_of Array
+   _(permissions).must_equal ["bigtable.tables.list"]
  end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/mutate_row_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/mutate_row_test.rb
@@ -44,7 +44,7 @@ describe Google::Cloud::Bigtable::Table, :mutate_row, :mock_bigtable do
       app_profile_id: app_profile_id
     ]
 
-    table.mutate_row(entry).must_equal true
+    _(table.mutate_row(entry)).must_equal true
     mock.verify
   end
 
@@ -62,8 +62,8 @@ describe Google::Cloud::Bigtable::Table, :mutate_row, :mock_bigtable do
     entry.set_cell("cf1-BAD ", "field1", "XYZ")
 
 
-    proc {
-      table.mutate_row(entry).must_equal true
-    }.must_raise Google::Cloud::InvalidArgumentError
+    _ { proc {
+      _(table.mutate_row(entry)).must_equal true
+    } }.must_raise Google::Cloud::InvalidArgumentError
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/mutate_row_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/mutate_row_test.rb
@@ -62,8 +62,8 @@ describe Google::Cloud::Bigtable::Table, :mutate_row, :mock_bigtable do
     entry.set_cell("cf1-BAD ", "field1", "XYZ")
 
 
-    _ { proc {
+    assert_raises Google::Cloud::InvalidArgumentError do
       _(table.mutate_row(entry)).must_equal true
-    } }.must_raise Google::Cloud::InvalidArgumentError
+    end
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/mutate_rows_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/mutate_rows_test.rb
@@ -77,12 +77,12 @@ describe Google::Cloud::Bigtable::Table, :mutate_rows, :mock_bigtable do
     responses = table.mutate_rows([entry])
 
     mock.verify
-    responses.length.must_equal 1
-    responses[0].index.must_equal 0
-    responses[0].status.code.must_equal Google::Rpc::Code::OK
-    responses[0].status.description.must_equal "OK"
-    responses[0].status.message.must_equal "success"
-    responses[0].status.details.must_equal []
+    _(responses.length).must_equal 1
+    _(responses[0].index).must_equal 0
+    _(responses[0].status.code).must_equal Google::Rpc::Code::OK
+    _(responses[0].status.description).must_equal "OK"
+    _(responses[0].status.message).must_equal "success"
+    _(responses[0].status.details).must_equal []
   end
 
   it "do not retry for cell timestamp set to server time(-1)" do
@@ -110,9 +110,9 @@ describe Google::Cloud::Bigtable::Table, :mutate_rows, :mock_bigtable do
     )
     def mock.mutate_rows(parent, mutation_entries, app_profile_id: nil)
       self.retry_count += 1
-      parent.must_equal expected_table_path
-      mutation_entries.must_equal expected_req_entries
-      app_profile_id.must_equal expected_req_app_profile_id
+      _(parent).must_equal expected_table_path
+      _(mutation_entries).must_equal expected_req_entries
+      _(app_profile_id).must_equal expected_req_app_profile_id
       return expected_response
     end
 
@@ -124,13 +124,13 @@ describe Google::Cloud::Bigtable::Table, :mutate_rows, :mock_bigtable do
 
     responses = table.mutate_rows([entry])
 
-    mock.retry_count.must_equal 1
-    responses.length.must_equal 1
-    responses[0].index.must_equal 0
-    responses[0].status.code.must_equal Google::Rpc::Code::DEADLINE_EXCEEDED
-    responses[0].status.description.must_equal "DEADLINE_EXCEEDED"
-    responses[0].status.message.must_equal "failed"
-    responses[0].status.details.must_equal []
+    _(mock.retry_count).must_equal 1
+    _(responses.length).must_equal 1
+    _(responses[0].index).must_equal 0
+    _(responses[0].status.code).must_equal Google::Rpc::Code::DEADLINE_EXCEEDED
+    _(responses[0].status.description).must_equal "DEADLINE_EXCEEDED"
+    _(responses[0].status.message).must_equal "failed"
+    _(responses[0].status.details).must_equal []
   end
 
   it "retry for failed mutation with 3 times" do
@@ -166,9 +166,9 @@ describe Google::Cloud::Bigtable::Table, :mutate_rows, :mock_bigtable do
       req_retry_response: retry_responses
     )
     def mock.mutate_rows(parent, mutation_entries, app_profile_id: nil)
-      parent.must_equal expected_table_path
-      mutation_entries.must_equal req_retry_entries[self.retry_count]
-      app_profile_id.must_equal expected_req_app_profile_id
+      _(parent).must_equal expected_table_path
+      _(mutation_entries).must_equal req_retry_entries[self.retry_count]
+      _(app_profile_id).must_equal expected_req_app_profile_id
 
       res = req_retry_response[self.retry_count]
       self.retry_count += 1
@@ -184,18 +184,18 @@ describe Google::Cloud::Bigtable::Table, :mutate_rows, :mock_bigtable do
     end
     responses = table.mutate_rows(mutation_entries)
 
-    mock.retry_count.must_equal 3
-    responses.length.must_equal 2
-    responses[0].index.must_equal 0
-    responses[0].status.code.must_equal Google::Rpc::Code::OK
-    responses[0].status.description.must_equal "OK"
-    responses[0].status.message.must_equal "success"
-    responses[0].status.details.must_equal []
-    responses[1].index.must_equal 1
-    responses[1].status.code.must_equal Google::Rpc::Code::DEADLINE_EXCEEDED
-    responses[1].status.description.must_equal "DEADLINE_EXCEEDED"
-    responses[1].status.message.must_equal "failed"
-    responses[1].status.details.must_equal []
+    _(mock.retry_count).must_equal 3
+    _(responses.length).must_equal 2
+    _(responses[0].index).must_equal 0
+    _(responses[0].status.code).must_equal Google::Rpc::Code::OK
+    _(responses[0].status.description).must_equal "OK"
+    _(responses[0].status.message).must_equal "success"
+    _(responses[0].status.details).must_equal []
+    _(responses[1].index).must_equal 1
+    _(responses[1].status.code).must_equal Google::Rpc::Code::DEADLINE_EXCEEDED
+    _(responses[1].status.description).must_equal "DEADLINE_EXCEEDED"
+    _(responses[1].status.message).must_equal "failed"
+    _(responses[1].status.details).must_equal []
   end
 
   it "stop retry on success of all mutations" do
@@ -232,9 +232,9 @@ describe Google::Cloud::Bigtable::Table, :mutate_rows, :mock_bigtable do
       req_retry_response: retry_responses
     )
     def mock.mutate_rows(parent, mutation_entries, app_profile_id: nil)
-      parent.must_equal expected_table_path
-      mutation_entries.must_equal req_retry_entries[self.retry_count]
-      app_profile_id.must_equal expected_req_app_profile_id
+      _(parent).must_equal expected_table_path
+      _(mutation_entries).must_equal req_retry_entries[self.retry_count]
+      _(app_profile_id).must_equal expected_req_app_profile_id
 
       res = req_retry_response[self.retry_count]
       self.retry_count += 1
@@ -250,17 +250,17 @@ describe Google::Cloud::Bigtable::Table, :mutate_rows, :mock_bigtable do
     end
     responses = table.mutate_rows(mutation_entries)
 
-    mock.retry_count.must_equal 2
-    responses.length.must_equal 2
-    responses[0].index.must_equal 0
-    responses[0].status.code.must_equal Google::Rpc::Code::OK
-    responses[0].status.description.must_equal "OK"
-    responses[0].status.message.must_equal "success"
-    responses[0].status.details.must_equal []
-    responses[1].index.must_equal 1
-    responses[1].status.code.must_equal Google::Rpc::Code::OK
-    responses[1].status.description.must_equal "OK"
-    responses[1].status.message.must_equal "success"
-    responses[1].status.details.must_equal []
+    _(mock.retry_count).must_equal 2
+    _(responses.length).must_equal 2
+    _(responses[0].index).must_equal 0
+    _(responses[0].status.code).must_equal Google::Rpc::Code::OK
+    _(responses[0].status.description).must_equal "OK"
+    _(responses[0].status.message).must_equal "success"
+    _(responses[0].status.details).must_equal []
+    _(responses[1].index).must_equal 1
+    _(responses[1].status.code).must_equal Google::Rpc::Code::OK
+    _(responses[1].status.description).must_equal "OK"
+    _(responses[1].status.message).must_equal "success"
+    _(responses[1].status.details).must_equal []
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/read_modify_write_row_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/read_modify_write_row_test.rb
@@ -142,11 +142,11 @@ describe Google::Cloud::Bigtable::Table, :read_modify_write_row, :mock_bigtable 
 
     row_key = "user-1"
 
-    _ { proc {
+    assert_raises Google::Cloud::InvalidArgumentError do
       table.read_modify_write_row(
         row_key,
         Google::Cloud::Bigtable::ReadModifyWriteRule.append(family_name, qualifier, append_value)
       )
-    } }.must_raise Google::Cloud::InvalidArgumentError
+    end
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/read_modify_write_row_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/read_modify_write_row_test.rb
@@ -63,18 +63,18 @@ describe Google::Cloud::Bigtable::Table, :read_modify_write_row, :mock_bigtable 
     )
     mock.verify
 
-    row.must_be_kind_of Google::Cloud::Bigtable::Row
-    row.key.must_equal row_key
-    row.cells[family_name].length.must_equal 1
+    _(row).must_be_kind_of Google::Cloud::Bigtable::Row
+    _(row.key).must_equal row_key
+    _(row.cells[family_name].length).must_equal 1
 
     cell = row.cells[family_name].first
-    cell.value.must_equal cell_value
-    cell.family.must_equal family_name
-    cell.qualifier.must_equal qualifier
-    cell.timestamp.must_equal timestamp
-    cell.to_time.must_equal Time.at(timestamp/1000.0)
-    cell.to_i.must_equal 4702094672846537781
-    cell.labels.must_equal labels
+    _(cell.value).must_equal cell_value
+    _(cell.family).must_equal family_name
+    _(cell.qualifier).must_equal qualifier
+    _(cell.timestamp).must_equal timestamp
+    _(cell.to_time).must_equal Time.at(timestamp/1000.0)
+    _(cell.to_i).must_equal 4702094672846537781
+    _(cell.labels).must_equal labels
   end
 
   it "read modify and write row with multiple rule" do
@@ -118,16 +118,16 @@ describe Google::Cloud::Bigtable::Table, :read_modify_write_row, :mock_bigtable 
     )
     mock.verify
 
-    row.must_be_kind_of Google::Cloud::Bigtable::Row
-    row.key.must_equal row_key
-    row.cells[family_name].length.must_equal 2
+    _(row).must_be_kind_of Google::Cloud::Bigtable::Row
+    _(row.key).must_equal row_key
+    _(row.cells[family_name].length).must_equal 2
 
     row.cells[family_name].each_with_index do |cell, i|
-      cell.value.must_equal "#{cell_value}#{i+1}"
-      cell.family.must_equal family_name
-      cell.qualifier.must_equal qualifier
-      cell.timestamp.must_equal 0
-      cell.labels.must_equal []
+      _(cell.value).must_equal "#{cell_value}#{i+1}"
+      _(cell.family).must_equal family_name
+      _(cell.qualifier).must_equal qualifier
+      _(cell.timestamp).must_equal 0
+      _(cell.labels).must_equal []
     end
   end
 
@@ -142,11 +142,11 @@ describe Google::Cloud::Bigtable::Table, :read_modify_write_row, :mock_bigtable 
 
     row_key = "user-1"
 
-    proc {
+    _ { proc {
       table.read_modify_write_row(
         row_key,
         Google::Cloud::Bigtable::ReadModifyWriteRule.append(family_name, qualifier, append_value)
       )
-    }.must_raise Google::Cloud::InvalidArgumentError
+    } }.must_raise Google::Cloud::InvalidArgumentError
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/read_rows_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/read_rows_test.rb
@@ -189,20 +189,31 @@ describe Google::Cloud::Bigtable::Table, :read_rows, :mock_bigtable do
   end
 
   it "read rows using row keys" do
-    mock = OpenStruct.new
-
-    def mock.read_rows(parent, rows: nil, filter: nil, rows_limit: nil, app_profile_id: nil)
-      _(rows.row_keys).must_equal ["A", "B"]
-      return []
-    end
+    mock = Minitest::Mock.new
+    mock.expect :read_rows,
+                [],
+                [
+                  "projects/test/instances/test-instance/tables/test-table",
+                  { 
+                    rows: Google::Bigtable::V2::RowSet.new(
+                      row_keys: ["A", "B"],
+                      row_ranges: []
+                    ),
+                    filter: nil,
+                    rows_limit: nil,
+                    app_profile_id: nil
+                  }
+                ]
 
     bigtable.service.mocked_client = mock
     table = bigtable.table(instance_id, table_id)
     table.read_rows(keys: ["A", "B"]).map {|v| v}
+
+    mock.verify
   end
 
   it "read rows using single row range" do
-    mock = OpenStruct.new
+    mock = self
 
     def mock.read_rows(parent, rows: nil, filter: nil, rows_limit: nil, app_profile_id: nil)
       _(rows.row_ranges.length).must_equal 1
@@ -220,7 +231,7 @@ describe Google::Cloud::Bigtable::Table, :read_rows, :mock_bigtable do
   end
 
   it "read rows using multiple row ranges" do
-    mock = OpenStruct.new
+    mock = self
 
     def mock.read_rows(parent, rows: nil, filter: nil, rows_limit: nil, app_profile_id: nil)
       _(rows.row_ranges.length).must_equal 2
@@ -239,7 +250,7 @@ describe Google::Cloud::Bigtable::Table, :read_rows, :mock_bigtable do
   end
 
   it "read rows using rows limit" do
-    mock = OpenStruct.new
+    mock = self
 
     def mock.read_rows(parent, rows: nil, filter: nil, rows_limit: nil, app_profile_id: nil)
       _(rows_limit).must_equal 100
@@ -252,7 +263,7 @@ describe Google::Cloud::Bigtable::Table, :read_rows, :mock_bigtable do
   end
 
   it "read rows using rows filter" do
-    mock = OpenStruct.new
+    mock = self
 
     def mock.read_rows(parent, rows: nil, filter: nil, rows_limit: nil, app_profile_id: nil)
       _(filter).must_be_kind_of Google::Bigtable::V2::RowFilter

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/read_rows_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/read_rows_test.rb
@@ -113,7 +113,9 @@ describe Google::Cloud::Bigtable::Table, :read_rows, :mock_bigtable do
     bigtable.service.mocked_client = mock
     table = bigtable.table(instance_id, table_id)
 
-    _ { proc { table.read_rows.to_a } }.must_raise Google::Cloud::Error
+    assert_raises Google::Cloud::Error do
+      table.read_rows.to_a
+    end
     _(mock.retry_count).must_equal 3
   end
 
@@ -182,9 +184,9 @@ describe Google::Cloud::Bigtable::Table, :read_rows, :mock_bigtable do
     bigtable.service.mocked_client = mock
     table = bigtable.table(instance_id, table_id)
 
-    _ { proc {
+    assert_raises Google::Cloud::Error do
       table.read_rows.map {|v| v}
-    } }.must_raise Google::Cloud::Error
+    end
     _(mock.retry_count).must_equal 3
   end
 

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/read_rows_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/read_rows_test.rb
@@ -56,9 +56,9 @@ describe Google::Cloud::Bigtable::Table, :read_rows, :mock_bigtable do
 
     mock.verify
 
-    rows.length.must_equal 1
-    rows.first.column_families.must_equal ["A"]
-    rows.first.must_equal expected_row
+    _(rows.length).must_equal 1
+    _(rows.first.column_families).must_equal ["A"]
+    _(rows.first).must_equal expected_row
   end
 
   it "retry on retryable error" do
@@ -96,10 +96,10 @@ describe Google::Cloud::Bigtable::Table, :read_rows, :mock_bigtable do
 
     rows = table.read_rows.map {|v| v}
 
-    mock.retry_count.must_equal 1
-    rows.length.must_equal 1
-    rows.first.column_families.must_equal ["A"]
-    rows.first.must_equal expected_row
+    _(mock.retry_count).must_equal 1
+    _(rows.length).must_equal 1
+    _(rows.first.column_families).must_equal ["A"]
+    _(rows.first).must_equal expected_row
   end
 
   it "do not retry on successive 3 failure" do
@@ -113,8 +113,8 @@ describe Google::Cloud::Bigtable::Table, :read_rows, :mock_bigtable do
     bigtable.service.mocked_client = mock
     table = bigtable.table(instance_id, table_id)
 
-    proc { table.read_rows.to_a }.must_raise Google::Cloud::Error
-    mock.retry_count.must_equal 3
+    _ { proc { table.read_rows.to_a } }.must_raise Google::Cloud::Error
+    _(mock.retry_count).must_equal 3
   end
 
   it "reads rows with not successive faliure errors" do
@@ -163,11 +163,11 @@ describe Google::Cloud::Bigtable::Table, :read_rows, :mock_bigtable do
 
     rows = table.read_rows.to_a
 
-    mock_itr.counter.must_equal 2
-    rows.length.must_equal 3
+    _(mock_itr.counter).must_equal 2
+    _(rows.length).must_equal 3
 
     expected_rows.each_with_index do |r, i|
-      rows[i].key.must_equal r.key
+      _(rows[i].key).must_equal r.key
     end
   end
 
@@ -182,17 +182,17 @@ describe Google::Cloud::Bigtable::Table, :read_rows, :mock_bigtable do
     bigtable.service.mocked_client = mock
     table = bigtable.table(instance_id, table_id)
 
-    proc {
+    _ { proc {
       table.read_rows.map {|v| v}
-    }.must_raise Google::Cloud::Error
-    mock.retry_count.must_equal 3
+    } }.must_raise Google::Cloud::Error
+    _(mock.retry_count).must_equal 3
   end
 
   it "read rows using row keys" do
     mock = OpenStruct.new
 
     def mock.read_rows(parent, rows: nil, filter: nil, rows_limit: nil, app_profile_id: nil)
-      rows.row_keys.must_equal ["A", "B"]
+      _(rows.row_keys).must_equal ["A", "B"]
       return []
     end
 
@@ -205,9 +205,9 @@ describe Google::Cloud::Bigtable::Table, :read_rows, :mock_bigtable do
     mock = OpenStruct.new
 
     def mock.read_rows(parent, rows: nil, filter: nil, rows_limit: nil, app_profile_id: nil)
-      rows.row_ranges.length.must_equal 1
+      _(rows.row_ranges.length).must_equal 1
       rows.row_ranges.each do |r|
-        r.must_be_kind_of Google::Bigtable::V2::RowRange
+        _(r).must_be_kind_of Google::Bigtable::V2::RowRange
       end
       return []
     end
@@ -223,9 +223,9 @@ describe Google::Cloud::Bigtable::Table, :read_rows, :mock_bigtable do
     mock = OpenStruct.new
 
     def mock.read_rows(parent, rows: nil, filter: nil, rows_limit: nil, app_profile_id: nil)
-      rows.row_ranges.length.must_equal 2
+      _(rows.row_ranges.length).must_equal 2
       rows.row_ranges.each do |r|
-        r.must_be_kind_of Google::Bigtable::V2::RowRange
+        _(r).must_be_kind_of Google::Bigtable::V2::RowRange
       end
       return []
     end
@@ -242,7 +242,7 @@ describe Google::Cloud::Bigtable::Table, :read_rows, :mock_bigtable do
     mock = OpenStruct.new
 
     def mock.read_rows(parent, rows: nil, filter: nil, rows_limit: nil, app_profile_id: nil)
-      rows_limit.must_equal 100
+      _(rows_limit).must_equal 100
       return []
     end
 
@@ -255,7 +255,7 @@ describe Google::Cloud::Bigtable::Table, :read_rows, :mock_bigtable do
     mock = OpenStruct.new
 
     def mock.read_rows(parent, rows: nil, filter: nil, rows_limit: nil, app_profile_id: nil)
-      filter.must_be_kind_of Google::Bigtable::V2::RowFilter
+      _(filter).must_be_kind_of Google::Bigtable::V2::RowFilter
       return []
     end
 

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/replication_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/replication_test.rb
@@ -47,7 +47,7 @@ describe Google::Cloud::Bigtable::Table, :replication, :mock_bigtable do
     bigtable.service.mocked_tables = mock
 
     result = table.generate_consistency_token
-    result.must_equal token
+    _(result).must_equal token
     mock.verify
   end
 
@@ -60,7 +60,7 @@ describe Google::Cloud::Bigtable::Table, :replication, :mock_bigtable do
     bigtable.service.mocked_tables = mock
 
     result = table.check_consistency(token)
-    result.must_equal true
+    _(result).must_equal true
     mock.verify
   end
 
@@ -79,7 +79,7 @@ describe Google::Cloud::Bigtable::Table, :replication, :mock_bigtable do
     bigtable.service.mocked_tables = mock
 
     result = table.wait_for_replication
-    result.must_equal true
+    _(result).must_equal true
     mock.verify
   end
 
@@ -102,14 +102,14 @@ describe Google::Cloud::Bigtable::Table, :replication, :mock_bigtable do
     time_now = Time.now
 
     result = table.wait_for_replication(timeout: 2, check_interval: 1)
-    result.must_equal false
-    (Time.now - time_now).must_be :>=, 2
+    _(result).must_equal false
+    _((Time.now - time_now)).must_be :>=, 2
     mock.verify
   end
 
   it "wait for replication timeout can not be greater then check interval" do
-    proc {
+    _ { proc {
       table.wait_for_replication(timeout: 1, check_interval: 2)
-    }.must_raise Google::Cloud::InvalidArgumentError
+    } }.must_raise Google::Cloud::InvalidArgumentError
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/replication_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/replication_test.rb
@@ -108,8 +108,8 @@ describe Google::Cloud::Bigtable::Table, :replication, :mock_bigtable do
   end
 
   it "wait for replication timeout can not be greater then check interval" do
-    _ { proc {
+    assert_raises Google::Cloud::InvalidArgumentError do
       table.wait_for_replication(timeout: 1, check_interval: 2)
-    } }.must_raise Google::Cloud::InvalidArgumentError
+    end
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/sample_row_keys_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/sample_row_keys_test.rb
@@ -37,9 +37,9 @@ describe Google::Cloud::Bigtable::Table, :sample_row_keys, :mock_bigtable do
     ]
 
     table.sample_row_keys.each do |sample_row|
-      sample_row.must_be_kind_of Google::Cloud::Bigtable::SampleRowKey
-      sample_row.key.must_equal row_key
-      sample_row.offset.must_equal offset
+      _(sample_row).must_be_kind_of Google::Cloud::Bigtable::SampleRowKey
+      _(sample_row.key).must_equal row_key
+      _(sample_row.offset).must_equal offset
     end
     mock.verify
   end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table_test.rb
@@ -37,25 +37,25 @@ describe Google::Cloud::Bigtable::Table, :mock_bigtable do
 
   it "knows the identifiers" do
 
-    table.must_be_kind_of Google::Cloud::Bigtable::Table
-    table.project_id.must_equal project_id
-    table.instance_id.must_equal instance_id
-    table.name.must_equal table_id
-    table.path.must_equal table_path(instance_id, table_id)
+    _(table).must_be_kind_of Google::Cloud::Bigtable::Table
+    _(table.project_id).must_equal project_id
+    _(table.instance_id).must_equal instance_id
+    _(table.name).must_equal table_id
+    _(table.path).must_equal table_path(instance_id, table_id)
 
-    table.granularity.must_equal :MILLIS
-    table.granularity_millis?.must_equal true
+    _(table.granularity).must_equal :MILLIS
+    _(table.granularity_millis?).must_equal true
 
-    table.cluster_states.map(&:cluster_name).sort.must_equal cluster_states.keys
+    _(table.cluster_states.map(&:cluster_name).sort).must_equal cluster_states.keys
     table.cluster_states.each do |cs|
-      cs.replication_state.must_equal :READY
+      _(cs.replication_state).must_equal :READY
     end
 
-    table.column_families.must_be_instance_of Google::Cloud::Bigtable::ColumnFamilyMap
-    table.column_families.must_be :frozen?
-    table.column_families.names.sort.must_equal column_families.keys
+    _(table.column_families).must_be_instance_of Google::Cloud::Bigtable::ColumnFamilyMap
+    _(table.column_families).must_be :frozen?
+    _(table.column_families.names.sort).must_equal column_families.keys
     table.column_families.each do |name, cf|
-      cf.gc_rule.to_grpc.must_equal column_families[cf.name].gc_rule
+      _(cf.gc_rule.to_grpc).must_equal column_families[cf.name].gc_rule
     end
   end
 
@@ -66,37 +66,37 @@ describe Google::Cloud::Bigtable::Table, :mock_bigtable do
 
     it "create mutation entry instance" do
       mutation_entry = table.new_mutation_entry("row-1")
-      mutation_entry.must_be_kind_of Google::Cloud::Bigtable::MutationEntry
-      mutation_entry.row_key.must_equal "row-1"
+      _(mutation_entry).must_be_kind_of Google::Cloud::Bigtable::MutationEntry
+      _(mutation_entry.row_key).must_equal "row-1"
     end
 
     it "create read modify write row rule instance" do
       table = Google::Cloud::Bigtable::Table.new(Object.new, Object.new)
       rule = table.new_read_modify_write_rule("cf", "field1")
-      rule.must_be_kind_of Google::Cloud::Bigtable::ReadModifyWriteRule
-      rule.to_grpc.family_name.must_equal "cf"
-      rule.to_grpc.column_qualifier.must_equal "field1"
+      _(rule).must_be_kind_of Google::Cloud::Bigtable::ReadModifyWriteRule
+      _(rule.to_grpc.family_name).must_equal "cf"
+      _(rule.to_grpc.column_qualifier).must_equal "field1"
     end
 
     it "create value range instance" do
       range = table.new_value_range
-      range.must_be_kind_of Google::Cloud::Bigtable::ValueRange
+      _(range).must_be_kind_of Google::Cloud::Bigtable::ValueRange
     end
 
     it "create column range instance" do
       range = table.new_column_range("cf")
-      range.must_be_kind_of Google::Cloud::Bigtable::ColumnRange
-      range.family.must_equal "cf"
+      _(range).must_be_kind_of Google::Cloud::Bigtable::ColumnRange
+      _(range.family).must_equal "cf"
     end
 
     it "create row range instance" do
       range = table.new_row_range
-      range.must_be_kind_of Google::Cloud::Bigtable::RowRange
+      _(range).must_be_kind_of Google::Cloud::Bigtable::RowRange
     end
 
     it "get filter module" do
       filter = table.filter
-      filter.must_equal Google::Cloud::Bigtable::RowFilter
+      _(filter).must_equal Google::Cloud::Bigtable::RowFilter
     end
   end
 
@@ -109,17 +109,17 @@ describe Google::Cloud::Bigtable::Table, :mock_bigtable do
 
     mock.verify
 
-    table.project_id.must_equal project_id
-    table.instance_id.must_equal instance_id
-    table.name.must_equal table_id
-    table.path.must_equal table_path(instance_id, table_id)
-    table.granularity.must_equal :MILLIS
+    _(table.project_id).must_equal project_id
+    _(table.instance_id).must_equal instance_id
+    _(table.name).must_equal table_id
+    _(table.path).must_equal table_path(instance_id, table_id)
+    _(table.granularity).must_equal :MILLIS
 
-    table.column_families.must_be_instance_of Google::Cloud::Bigtable::ColumnFamilyMap
-    table.column_families.must_be :frozen?
-    table.column_families.names.sort.must_equal column_families.keys
+    _(table.column_families).must_be_instance_of Google::Cloud::Bigtable::ColumnFamilyMap
+    _(table.column_families).must_be :frozen?
+    _(table.column_families.names.sort).must_equal column_families.keys
     table.column_families.each do |name, cf|
-      cf.gc_rule.to_grpc.must_equal column_families[cf.name].gc_rule
+      _(cf.gc_rule.to_grpc).must_equal column_families[cf.name].gc_rule
     end
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/value_range_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/value_range_test.rb
@@ -23,22 +23,22 @@ describe Google::Cloud::Bigtable::ValueRange, :value_range, :mock_bigtable do
       from_value = "from-value-inclusive"
       range = Google::Cloud::Bigtable::ValueRange.new.from(from_value)
 
-      range.must_be_kind_of Google::Cloud::Bigtable::ValueRange
+      _(range).must_be_kind_of Google::Cloud::Bigtable::ValueRange
 
       grpc = range.to_grpc
-      grpc.must_be_kind_of Google::Bigtable::V2::ValueRange
-      grpc.start_value_closed.must_equal from_value
+      _(grpc).must_be_kind_of Google::Bigtable::V2::ValueRange
+      _(grpc.start_value_closed).must_equal from_value
     end
 
     it "create exclusive from range instance" do
       from_value = "from-value-exclusive"
       range = Google::Cloud::Bigtable::ValueRange.new.from(from_value, inclusive: false)
 
-      range.must_be_kind_of Google::Cloud::Bigtable::ValueRange
+      _(range).must_be_kind_of Google::Cloud::Bigtable::ValueRange
 
       grpc = range.to_grpc
-      grpc.must_be_kind_of Google::Bigtable::V2::ValueRange
-      grpc.start_value_open.must_equal from_value
+      _(grpc).must_be_kind_of Google::Bigtable::V2::ValueRange
+      _(grpc.start_value_open).must_equal from_value
     end
 
     it "create instance with from and to range" do
@@ -46,12 +46,12 @@ describe Google::Cloud::Bigtable::ValueRange, :value_range, :mock_bigtable do
       to_value = "to-value"
       range = Google::Cloud::Bigtable::ValueRange.new.from(from_value).to(to_value)
 
-      range.must_be_kind_of Google::Cloud::Bigtable::ValueRange
+      _(range).must_be_kind_of Google::Cloud::Bigtable::ValueRange
 
       grpc = range.to_grpc
-      grpc.must_be_kind_of Google::Bigtable::V2::ValueRange
-      grpc.start_value_closed.must_equal from_value
-      grpc.end_value_open.must_equal to_value
+      _(grpc).must_be_kind_of Google::Bigtable::V2::ValueRange
+      _(grpc.start_value_closed).must_equal from_value
+      _(grpc.end_value_open).must_equal to_value
     end
   end
 
@@ -60,22 +60,22 @@ describe Google::Cloud::Bigtable::ValueRange, :value_range, :mock_bigtable do
       to_value = "to-value-inclusive"
       range =Google::Cloud::Bigtable::ValueRange.new.to(to_value)
 
-      range.must_be_kind_of Google::Cloud::Bigtable::ValueRange
+      _(range).must_be_kind_of Google::Cloud::Bigtable::ValueRange
 
       grpc = range.to_grpc
-      grpc.must_be_kind_of Google::Bigtable::V2::ValueRange
-      grpc.end_value_open.must_equal to_value
+      _(grpc).must_be_kind_of Google::Bigtable::V2::ValueRange
+      _(grpc.end_value_open).must_equal to_value
     end
 
     it "create inclusive to range instance" do
       to_value = "to-value-exclusive"
       range =Google::Cloud::Bigtable::ValueRange.new.to(to_value, inclusive: true)
 
-      range.must_be_kind_of Google::Cloud::Bigtable::ValueRange
+      _(range).must_be_kind_of Google::Cloud::Bigtable::ValueRange
 
       grpc = range.to_grpc
-      grpc.must_be_kind_of Google::Bigtable::V2::ValueRange
-      grpc.end_value_closed.must_equal to_value
+      _(grpc).must_be_kind_of Google::Bigtable::V2::ValueRange
+      _(grpc.end_value_closed).must_equal to_value
     end
 
     it "create instance with from and to range" do
@@ -83,12 +83,12 @@ describe Google::Cloud::Bigtable::ValueRange, :value_range, :mock_bigtable do
       to_value = "to-value"
       range = Google::Cloud::Bigtable::ValueRange.new.to(to_value).from(from_value)
 
-      range.must_be_kind_of Google::Cloud::Bigtable::ValueRange
+      _(range).must_be_kind_of Google::Cloud::Bigtable::ValueRange
 
       grpc = range.to_grpc
-      grpc.must_be_kind_of Google::Bigtable::V2::ValueRange
-      grpc.start_value_closed.must_equal from_value
-      grpc.end_value_open.must_equal to_value
+      _(grpc).must_be_kind_of Google::Bigtable::V2::ValueRange
+      _(grpc.start_value_closed).must_equal from_value
+      _(grpc.end_value_open).must_equal to_value
     end
   end
 
@@ -97,12 +97,12 @@ describe Google::Cloud::Bigtable::ValueRange, :value_range, :mock_bigtable do
     to_value = "to-value"
     range = Google::Cloud::Bigtable::ValueRange.new.between(from_value, to_value)
 
-    range.must_be_kind_of Google::Cloud::Bigtable::ValueRange
+    _(range).must_be_kind_of Google::Cloud::Bigtable::ValueRange
 
     grpc = range.to_grpc
-    grpc.must_be_kind_of Google::Bigtable::V2::ValueRange
-    grpc.start_value_closed.must_equal from_value
-    grpc.end_value_closed.must_equal to_value
+    _(grpc).must_be_kind_of Google::Bigtable::V2::ValueRange
+    _(grpc.start_value_closed).must_equal from_value
+    _(grpc.end_value_closed).must_equal to_value
   end
 
   it "create instance using 'of'" do
@@ -110,11 +110,11 @@ describe Google::Cloud::Bigtable::ValueRange, :value_range, :mock_bigtable do
     to_value = "to-value"
     range = Google::Cloud::Bigtable::ValueRange.new.of(from_value, to_value)
 
-    range.must_be_kind_of Google::Cloud::Bigtable::ValueRange
+    _(range).must_be_kind_of Google::Cloud::Bigtable::ValueRange
 
     grpc = range.to_grpc
-    grpc.must_be_kind_of Google::Bigtable::V2::ValueRange
-    grpc.start_value_closed.must_equal from_value
-    grpc.end_value_open.must_equal to_value
+    _(grpc).must_be_kind_of Google::Bigtable::V2::ValueRange
+    _(grpc.start_value_closed).must_equal from_value
+    _(grpc.end_value_open).must_equal to_value
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable_test.rb
@@ -22,47 +22,47 @@ describe Google::Cloud do
     it "calls out to Google::Cloud.bigtable" do
       gcloud = Google::Cloud.new
       stubbed_bigtable = lambda { |project_id: nil, credentials: nil, scope: nil, timeout: nil, host: nil, client_config: nil|
-        project_id.must_be :nil?
-        credentials.must_be :nil?
-        scope.must_be :nil?
-        timeout.must_be :nil?
-        client_config.must_be :nil?
-        host.must_be :nil?
+        _(project_id).must_be :nil?
+        _(credentials).must_be :nil?
+        _(scope).must_be :nil?
+        _(timeout).must_be :nil?
+        _(client_config).must_be :nil?
+        _(host).must_be :nil?
         "bigtable-project-object-empty"
       }
       Google::Cloud.stub(:bigtable, stubbed_bigtable) do
         project = gcloud.bigtable
-        project.must_equal "bigtable-project-object-empty"
+        _(project).must_equal "bigtable-project-object-empty"
       end
     end
 
     it "passes project and credentials(keyfile) to Google::Cloud.bigtable" do
       gcloud = Google::Cloud.new "project-id", "keyfile-path"
       stubbed_bigtable = lambda  { |project_id: nil, credentials: nil, scope: nil, timeout: nil, host: nil, client_config: nil|
-        project_id.must_equal "project-id"
-        credentials.must_equal "keyfile-path"
-        scope.must_be :nil?
-        timeout.must_be :nil?
-        client_config.must_be :nil?
-        host.must_be :nil?
+        _(project_id).must_equal "project-id"
+        _(credentials).must_equal "keyfile-path"
+        _(scope).must_be :nil?
+        _(timeout).must_be :nil?
+        _(client_config).must_be :nil?
+        _(host).must_be :nil?
         "bigtable-project-object"
       }
 
       Google::Cloud.stub(:bigtable, stubbed_bigtable) do
         project = gcloud.bigtable
-        project.must_equal "bigtable-project-object"
+        _(project).must_equal "bigtable-project-object"
       end
     end
 
     it "passes project and credentials(keyfile) and options to Google::Cloud.bigtable" do
       gcloud = Google::Cloud.new "project-id", "keyfile-path"
       stubbed_bigtable = lambda { |project_id: nil, credentials: nil, scope: nil, timeout: nil, host: nil, client_config: nil|
-        project_id.must_equal "project-id"
-        credentials.must_equal "keyfile-path"
-        scope.must_equal "http://example.com/scope"
-        timeout.must_equal 60
-        client_config.must_equal("gax" => "options")
-        host.must_be :nil?
+        _(project_id).must_equal "project-id"
+        _(credentials).must_equal "keyfile-path"
+        _(scope).must_equal "http://example.com/scope"
+        _(timeout).must_equal 60
+        _(client_config).must_equal("gax" => "options")
+        _(host).must_be :nil?
         "bigtable-project-object-scoped"
       }
       Google::Cloud.stub :bigtable, stubbed_bigtable do
@@ -71,7 +71,7 @@ describe Google::Cloud do
           timeout: 60,
           client_config: { "gax" => "options" }
         )
-        project.must_equal "bigtable-project-object-scoped"
+        _(project).must_equal "bigtable-project-object-scoped"
       end
     end
   end
@@ -93,9 +93,9 @@ describe Google::Cloud do
         Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
           Google::Cloud::Bigtable::Credentials.stub(:default, default_credentials) do
             bigtable = Google::Cloud.bigtable
-            bigtable.must_be_kind_of Google::Cloud::Bigtable::Project
-            bigtable.project_id.must_equal "project-id"
-            bigtable.service.credentials.must_equal default_credentials
+            _(bigtable).must_be_kind_of Google::Cloud::Bigtable::Project
+            _(bigtable.project_id).must_equal "project-id"
+            _(bigtable.service.credentials).must_equal default_credentials
           end
         end
       end
@@ -103,16 +103,16 @@ describe Google::Cloud do
 
     it "uses provided project_id and credentials(keyfile)" do
       stubbed_credentials = lambda { |keyfile, scope: nil|
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "bigtable-credentials"
       }
       stubbed_service = lambda { |project_id, credentials, timeout: nil, host: nil, client_config: nil|
-        project_id.must_equal "project-id"
-        credentials.must_equal "bigtable-credentials"
-        timeout.must_be :nil?
-        client_config.must_be :nil?
-        host.must_be :nil?
+        _(project_id).must_equal "project-id"
+        _(credentials).must_equal "bigtable-credentials"
+        _(timeout).must_be :nil?
+        _(client_config).must_be :nil?
+        _(host).must_be :nil?
         OpenStruct.new(project_id: project_id)
       }
 
@@ -125,9 +125,9 @@ describe Google::Cloud do
                   project_id: "project-id",
                   credentials: "path/to/keyfile.json"
                 )
-                bigtable.must_be_kind_of Google::Cloud::Bigtable::Project
-                bigtable.project_id.must_equal "project-id"
-                bigtable.service.must_be_kind_of OpenStruct
+                _(bigtable).must_be_kind_of Google::Cloud::Bigtable::Project
+                _(bigtable.project_id).must_equal "project-id"
+                _(bigtable.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -153,9 +153,9 @@ describe Google::Cloud do
         Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
           Google::Cloud::Bigtable::Credentials.stub :default, default_credentials do
             bigtable = Google::Cloud::Bigtable.new
-            bigtable.must_be_kind_of Google::Cloud::Bigtable::Project
-            bigtable.project_id.must_equal "project-id"
-            bigtable.service.credentials.must_equal default_credentials
+            _(bigtable).must_be_kind_of Google::Cloud::Bigtable::Project
+            _(bigtable.project_id).must_equal "project-id"
+            _(bigtable.service.credentials).must_equal default_credentials
           end
         end
       end
@@ -163,10 +163,10 @@ describe Google::Cloud do
 
     it "uses provided endpoint" do
       stubbed_service = lambda { |project_id, credentials, timeout: nil, host: nil, client_config: nil|
-        credentials.must_equal default_credentials
-        timeout.must_be :nil?
-        client_config.must_be :nil?
-        host.must_equal "bigtable-endpoint2.example.com"
+        _(credentials).must_equal default_credentials
+        _(timeout).must_be :nil?
+        _(client_config).must_be :nil?
+        _(host).must_equal "bigtable-endpoint2.example.com"
         OpenStruct.new project_id: project_id
       }
 
@@ -174,25 +174,25 @@ describe Google::Cloud do
       ENV.stub :[], nil do
         Google::Cloud::Bigtable::Service.stub :new, stubbed_service do
           bigtable = Google::Cloud::Bigtable.new project_id: "project-id", credentials: default_credentials, endpoint: "bigtable-endpoint2.example.com"
-          bigtable.must_be_kind_of Google::Cloud::Bigtable::Project
-          bigtable.project_id.must_equal "project-id"
-          bigtable.service.must_be_kind_of OpenStruct
+          _(bigtable).must_be_kind_of Google::Cloud::Bigtable::Project
+          _(bigtable.project_id).must_equal "project-id"
+          _(bigtable.service).must_be_kind_of OpenStruct
         end
       end
     end
 
     it "uses provided project_id and credentials" do
       stubbed_credentials = lambda { |keyfile, scope: nil|
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "bigtable-credentials"
       }
       stubbed_service = lambda { |project_id, credentials, timeout: nil, host: nil, client_config: nil|
-        project_id.must_equal "project-id"
-        credentials.must_equal "bigtable-credentials"
-        timeout.must_be :nil?
-        client_config.must_be :nil?
-        host.must_be :nil?
+        _(project_id).must_equal "project-id"
+        _(credentials).must_equal "bigtable-credentials"
+        _(timeout).must_be :nil?
+        _(client_config).must_be :nil?
+        _(host).must_be :nil?
         OpenStruct.new project_id: project_id
       }
 
@@ -203,9 +203,9 @@ describe Google::Cloud do
             Google::Cloud::Bigtable::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Bigtable::Service.stub :new, stubbed_service do
                 bigtable = Google::Cloud::Bigtable.new project_id: "project-id", credentials: "path/to/keyfile.json"
-                bigtable.must_be_kind_of Google::Cloud::Bigtable::Project
-                bigtable.project_id.must_equal "project-id"
-                bigtable.service.must_be_kind_of OpenStruct
+                _(bigtable).must_be_kind_of Google::Cloud::Bigtable::Project
+                _(bigtable.project_id).must_equal "project-id"
+                _(bigtable.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -215,16 +215,16 @@ describe Google::Cloud do
 
     it "uses provided project and keyfile aliases" do
       stubbed_credentials = lambda { |keyfile, scope: nil|
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "bigtable-credentials"
       }
       stubbed_service = lambda { |project_id, credentials, timeout: nil, host: nil, client_config: nil|
-        project_id.must_equal "project-id"
-        credentials.must_equal "bigtable-credentials"
-        timeout.must_be :nil?
-        client_config.must_be :nil?
-        host.must_be :nil?
+        _(project_id).must_equal "project-id"
+        _(credentials).must_equal "bigtable-credentials"
+        _(timeout).must_be :nil?
+        _(client_config).must_be :nil?
+        _(host).must_be :nil?
         OpenStruct.new project_id: project_id
       }
 
@@ -235,9 +235,9 @@ describe Google::Cloud do
             Google::Cloud::Bigtable::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Bigtable::Service.stub :new, stubbed_service do
                 bigtable = Google::Cloud::Bigtable.new project_id: "project-id", credentials: "path/to/keyfile.json"
-                bigtable.must_be_kind_of Google::Cloud::Bigtable::Project
-                bigtable.project_id.must_equal "project-id"
-                bigtable.service.must_be_kind_of OpenStruct
+                _(bigtable).must_be_kind_of Google::Cloud::Bigtable::Project
+                _(bigtable.project_id).must_equal "project-id"
+                _(bigtable.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -254,10 +254,10 @@ describe Google::Cloud do
         Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
           Google::Cloud::Bigtable::Credentials.stub :default, default_credentials do
             bigtable = Google::Cloud::Bigtable.new
-            bigtable.must_be_kind_of Google::Cloud::Bigtable::Project
-            bigtable.project_id.must_equal "project-id"
-            bigtable.service.credentials.must_equal :this_channel_is_insecure
-            bigtable.service.host.must_equal emulator_host
+            _(bigtable).must_be_kind_of Google::Cloud::Bigtable::Project
+            _(bigtable.project_id).must_equal "project-id"
+            _(bigtable.service.credentials).must_equal :this_channel_is_insecure
+            _(bigtable.service.host).must_equal emulator_host
           end
         end
       end
@@ -271,10 +271,10 @@ describe Google::Cloud do
         Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
           Google::Cloud::Bigtable::Credentials.stub :default, default_credentials do
             bigtable = Google::Cloud::Bigtable.new emulator_host: emulator_host
-            bigtable.must_be_kind_of Google::Cloud::Bigtable::Project
-            bigtable.project_id.must_equal "project-id"
-            bigtable.service.credentials.must_equal :this_channel_is_insecure
-            bigtable.service.host.must_equal emulator_host
+            _(bigtable).must_be_kind_of Google::Cloud::Bigtable::Project
+            _(bigtable.project_id).must_equal "project-id"
+            _(bigtable.service.credentials).must_equal :this_channel_is_insecure
+            _(bigtable.service.host).must_equal emulator_host
           end
         end
       end
@@ -282,17 +282,17 @@ describe Google::Cloud do
 
     it "gets project_id from credentials" do
       stubbed_credentials = lambda { |keyfile, scope: nil|
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         OpenStruct.new project_id: "project-id"
       }
       stubbed_service = lambda { |project_id, credentials, timeout: nil, host: nil, client_config: nil|
-        project_id.must_equal "project-id"
-        credentials.must_be_kind_of OpenStruct
-        credentials.project_id.must_equal "project-id"
-        timeout.must_be :nil?
-        client_config.must_be :nil?
-        host.must_be :nil?
+        _(project_id).must_equal "project-id"
+        _(credentials).must_be_kind_of OpenStruct
+        _(credentials.project_id).must_equal "project-id"
+        _(timeout).must_be :nil?
+        _(client_config).must_be :nil?
+        _(host).must_be :nil?
         OpenStruct.new project_id: project_id
       }
       empty_env = OpenStruct.new
@@ -305,9 +305,9 @@ describe Google::Cloud do
               Google::Cloud::Bigtable::Credentials.stub :new, stubbed_credentials do
                 Google::Cloud::Bigtable::Service.stub :new, stubbed_service do
                   bigtable = Google::Cloud::Bigtable.new credentials: "path/to/keyfile.json"
-                  bigtable.must_be_kind_of Google::Cloud::Bigtable::Project
-                  bigtable.project_id.must_equal "project-id"
-                  bigtable.service.must_be_kind_of OpenStruct
+                  _(bigtable).must_be_kind_of Google::Cloud::Bigtable::Project
+                  _(bigtable.project_id).must_equal "project-id"
+                  _(bigtable.service).must_be_kind_of OpenStruct
                 end
               end
             end
@@ -331,16 +331,16 @@ describe Google::Cloud do
 
     it "uses shared config for project and keyfile" do
       stubbed_credentials = lambda { |keyfile, scope: nil|
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "bigtable-credentials"
       }
       stubbed_service = lambda { |project_id, credentials, timeout: nil, host: nil, client_config: nil|
-        project_id.must_equal "project-id"
-        credentials.must_equal "bigtable-credentials"
-        timeout.must_be :nil?
-        client_config.must_be :nil?
-        host.must_be :nil?
+        _(project_id).must_equal "project-id"
+        _(credentials).must_equal "bigtable-credentials"
+        _(timeout).must_be :nil?
+        _(client_config).must_be :nil?
+        _(host).must_be :nil?
         OpenStruct.new project_id: project_id
       }
 
@@ -357,9 +357,9 @@ describe Google::Cloud do
             Google::Cloud::Bigtable::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Bigtable::Service.stub :new, stubbed_service do
                 bigtable = Google::Cloud::Bigtable.new
-                bigtable.must_be_kind_of Google::Cloud::Bigtable::Project
-                bigtable.project_id.must_equal "project-id"
-                bigtable.service.must_be_kind_of OpenStruct
+                _(bigtable).must_be_kind_of Google::Cloud::Bigtable::Project
+                _(bigtable.project_id).must_equal "project-id"
+                _(bigtable.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -369,16 +369,16 @@ describe Google::Cloud do
 
     it "uses shared config for project_id and credentials" do
       stubbed_credentials = lambda { |keyfile, scope: nil|
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "bigtable-credentials"
       }
       stubbed_service = lambda { |project_id, credentials, timeout: nil, host: nil, client_config: nil|
-        project_id.must_equal "project-id"
-        credentials.must_equal "bigtable-credentials"
-        timeout.must_be :nil?
-        client_config.must_be :nil?
-        host.must_be :nil?
+        _(project_id).must_equal "project-id"
+        _(credentials).must_equal "bigtable-credentials"
+        _(timeout).must_be :nil?
+        _(client_config).must_be :nil?
+        _(host).must_be :nil?
         OpenStruct.new project_id: project_id
       }
 
@@ -395,9 +395,9 @@ describe Google::Cloud do
             Google::Cloud::Bigtable::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Bigtable::Service.stub :new, stubbed_service do
                 bigtable = Google::Cloud::Bigtable.new
-                bigtable.must_be_kind_of Google::Cloud::Bigtable::Project
-                bigtable.project_id.must_equal "project-id"
-                bigtable.service.must_be_kind_of OpenStruct
+                _(bigtable).must_be_kind_of Google::Cloud::Bigtable::Project
+                _(bigtable.project_id).must_equal "project-id"
+                _(bigtable.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -407,16 +407,16 @@ describe Google::Cloud do
 
     it "uses bigtable config for project and keyfile" do
       stubbed_credentials = lambda { |credentials, scope: nil|
-        credentials.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(credentials).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "bigtable-credentials"
       }
       stubbed_service = lambda { |project_id, credentials, timeout: nil, host: nil, client_config: nil|
-        project_id.must_equal "project-id"
-        credentials.must_equal "bigtable-credentials"
-        timeout.must_equal 42
-        client_config.must_equal bigtable_client_config
-        host.must_be :nil?
+        _(project_id).must_equal "project-id"
+        _(credentials).must_equal "bigtable-credentials"
+        _(timeout).must_equal 42
+        _(client_config).must_equal bigtable_client_config
+        _(host).must_be :nil?
         OpenStruct.new project_id: project_id
       }
 
@@ -435,9 +435,9 @@ describe Google::Cloud do
             Google::Cloud::Bigtable::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Bigtable::Service.stub :new, stubbed_service do
                 bigtable = Google::Cloud::Bigtable.new
-                bigtable.must_be_kind_of Google::Cloud::Bigtable::Project
-                bigtable.project_id.must_equal "project-id"
-                bigtable.service.must_be_kind_of OpenStruct
+                _(bigtable).must_be_kind_of Google::Cloud::Bigtable::Project
+                _(bigtable.project_id).must_equal "project-id"
+                _(bigtable.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -447,16 +447,16 @@ describe Google::Cloud do
 
     it "uses bigtable config for project_id and credentials" do
       stubbed_credentials = lambda { |keyfile, scope: nil|
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "bigtable-credentials"
       }
       stubbed_service = lambda { |project_id, credentials, timeout: nil, host: nil, client_config: nil|
-        project_id.must_equal "project-id"
-        credentials.must_equal "bigtable-credentials"
-        timeout.must_equal 42
-        client_config.must_equal bigtable_client_config
-        host.must_be :nil?
+        _(project_id).must_equal "project-id"
+        _(credentials).must_equal "bigtable-credentials"
+        _(timeout).must_equal 42
+        _(client_config).must_equal bigtable_client_config
+        _(host).must_be :nil?
         OpenStruct.new project_id: project_id
       }
 
@@ -475,9 +475,9 @@ describe Google::Cloud do
             Google::Cloud::Bigtable::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Bigtable::Service.stub :new, stubbed_service do
                 bigtable = Google::Cloud::Bigtable.new
-                bigtable.must_be_kind_of Google::Cloud::Bigtable::Project
-                bigtable.project_id.must_equal "project-id"
-                bigtable.service.must_be_kind_of OpenStruct
+                _(bigtable).must_be_kind_of Google::Cloud::Bigtable::Project
+                _(bigtable.project_id).must_equal "project-id"
+                _(bigtable.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -487,14 +487,14 @@ describe Google::Cloud do
 
     it "uses bigtable config for endpoint" do
       stubbed_credentials = lambda { |keyfile, scope: nil|
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "bigtable-credentials"
       }
       stubbed_service = lambda { |project_id, credentials, timeout: nil, host: nil, client_config: nil|
-        project_id.must_equal "project-id"
-        credentials.must_equal "bigtable-credentials"
-        host.must_equal "bigtable-endpoint2.example.com"
+        _(project_id).must_equal "project-id"
+        _(credentials).must_equal "bigtable-credentials"
+        _(host).must_equal "bigtable-endpoint2.example.com"
         OpenStruct.new project_id: project_id
       }
 
@@ -512,9 +512,9 @@ describe Google::Cloud do
             Google::Cloud::Bigtable::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Bigtable::Service.stub :new, stubbed_service do
                 bigtable = Google::Cloud::Bigtable.new
-                bigtable.must_be_kind_of Google::Cloud::Bigtable::Project
-                bigtable.project_id.must_equal "project-id"
-                bigtable.service.must_be_kind_of OpenStruct
+                _(bigtable).must_be_kind_of Google::Cloud::Bigtable::Project
+                _(bigtable.project_id).must_equal "project-id"
+                _(bigtable.service).must_be_kind_of OpenStruct
               end
             end
           end


### PR DESCRIPTION
Use `rubocop-minitest` gem and `bundle exec rubocop --only Minitest/GlobalExpectations -a` to autocorrect minitest warnings for Ruby 2.7.

refs: #4110
refs: #4116