### PR TITLE
chore(dns): Update minitest to 5.14

### DIFF
--- a/google-cloud-dns/.rubocop.yml
+++ b/google-cloud-dns/.rubocop.yml
@@ -1,13 +1,13 @@
-require: rubocop-minitest
-
 inherit_gem:
   google-style: google-style.yml
 
 AllCops:
   Exclude:
+    - "acceptance/**/*"
     - "google-cloud-dns.gemspec"
     - "Rakefile"
     - "support/**/*"
+    - "test/**/*"
 
 Documentation:
   Enabled: false

--- a/google-cloud-dns/.rubocop.yml
+++ b/google-cloud-dns/.rubocop.yml
@@ -1,13 +1,13 @@
+require: rubocop-minitest
+
 inherit_gem:
   google-style: google-style.yml
 
 AllCops:
   Exclude:
-    - "acceptance/**/*"
     - "google-cloud-dns.gemspec"
     - "Rakefile"
     - "support/**/*"
-    - "test/**/*"
 
 Documentation:
   Enabled: false

--- a/google-cloud-dns/Gemfile
+++ b/google-cloud-dns/Gemfile
@@ -7,3 +7,5 @@ gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-errors", path: "../google-cloud-errors"
 
 gem "rake"
+
+gem "rubocop-minitest"

--- a/google-cloud-dns/Gemfile
+++ b/google-cloud-dns/Gemfile
@@ -7,5 +7,3 @@ gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-errors", path: "../google-cloud-errors"
 
 gem "rake"
-
-gem "rubocop-minitest"

--- a/google-cloud-dns/Gemfile
+++ b/google-cloud-dns/Gemfile
@@ -7,7 +7,3 @@ gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-errors", path: "../google-cloud-errors"
 
 gem "rake"
-
-# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
-# See https://github.com/googleapis/google-cloud-ruby/issues/4110
-gem "minitest", "~> 5.11.3"

--- a/google-cloud-dns/acceptance/dns/dns_test.rb
+++ b/google-cloud-dns/acceptance/dns/dns_test.rb
@@ -49,42 +49,42 @@ describe Google::Cloud::Dns, :dns do
 
   it "lists all zones" do
     all_zones = dns.zones.all(request_limit: 3).to_a
-    all_zones.count.wont_equal 0
+    _(all_zones.count).wont_equal 0
   end
 
   it "creates and deletes a zone" do
     create_zone_name = "#{zone_name}-crtst1"
     create_zone_dns  = "crtst1.#{zone_dns}"
-    dns.zone(create_zone_name).must_be :nil?
+    _(dns.zone(create_zone_name)).must_be :nil?
     create_zone = dns.create_zone create_zone_name, create_zone_dns
-    create_zone.wont_be :nil?
-    create_zone.must_be_kind_of Google::Cloud::Dns::Zone
-    dns.zone(create_zone_name).wont_be :nil?
+    _(create_zone).wont_be :nil?
+    _(create_zone).must_be_kind_of Google::Cloud::Dns::Zone
+    _(dns.zone(create_zone_name)).wont_be :nil?
     create_zone.delete force: true
-    dns.zone(create_zone_name).must_be :nil?
+    _(dns.zone(create_zone_name)).must_be :nil?
   end
 
   it "knows its attributes" do
-    zone.name.must_equal zone_name
-    zone.dns.must_equal zone.dns
-    zone.description.must_equal ""
-    zone.id.wont_be :nil?
+    _(zone.name).must_equal zone_name
+    _(zone.dns).must_equal zone.dns
+    _(zone.description).must_equal ""
+    _(zone.id).wont_be :nil?
     zone.name_servers.each do |name_server|
-      name_server.must_include ".googledomains.com."
+      _(name_server).must_include ".googledomains.com."
     end
-    zone.name_server_set.must_be :nil?
-    zone.created_at.must_be_kind_of Time
+    _(zone.name_server_set).must_be :nil?
+    _(zone.created_at).must_be_kind_of Time
   end
 
   it "return 0 or more zones" do
-    zone.records.all.count.must_be :>=, 0
+    _(zone.records.all.count).must_be :>=, 0
   end
 
   describe "Zones" do
     it "gets the metadata for a zone" do
-      zone.name.must_equal zone_name
-      zone.dns.must_equal  zone_dns
-      zone.created_at.wont_be :nil?
+      _(zone.name).must_equal zone_name
+      _(zone.dns).must_equal  zone_dns
+      _(zone.created_at).wont_be :nil?
     end
 
     it "supports all types of records" do
@@ -103,15 +103,15 @@ describe Google::Cloud::Dns, :dns do
       end.wait_until_done!
 
       records = zone.records.all
-      records.must_include a_record
-      records.must_include aaaa_record
-      records.must_include cname_record
-      records.must_include mx_record
-      records.must_include ns_record
-      records.must_include soa_record
-      records.must_include spf_record
-      records.must_include srv_record
-      records.must_include txt_record
+      _(records).must_include a_record
+      _(records).must_include aaaa_record
+      _(records).must_include cname_record
+      _(records).must_include mx_record
+      _(records).must_include ns_record
+      _(records).must_include soa_record
+      _(records).must_include spf_record
+      _(records).must_include srv_record
+      _(records).must_include txt_record
     end
 
     it "imports records from a zone file" do
@@ -127,9 +127,9 @@ describe Google::Cloud::Dns, :dns do
         import_zone.import(tmpfile.path).wait_until_done!
 
         imported_records = import_zone.records.all
-        imported_records.must_include import_zone.record("@", "A", 3600, "192.0.2.1")
-        imported_records.must_include import_zone.record("@", "AAAA", 3600, "2001:db8:10::1")
-        imported_records.must_include import_zone.record("@", "MX", 3600, ["10 mail.#{import_zone.dns}",
+        _(imported_records).must_include import_zone.record("@", "A", 3600, "192.0.2.1")
+        _(imported_records).must_include import_zone.record("@", "AAAA", 3600, "2001:db8:10::1")
+        _(imported_records).must_include import_zone.record("@", "MX", 3600, ["10 mail.#{import_zone.dns}",
                                                                            "20 mail2.#{import_zone.dns}",
                                                                            "50 mail3.#{import_zone.dns}"])
       end
@@ -150,11 +150,11 @@ describe Google::Cloud::Dns, :dns do
         export_zone.export tmpfile
 
         exported_zonefile = tmpfile.read
-        exported_zonefile.must_include "#{export_zone.dns} 86400 IN A 1.2.3.4"
-        exported_zonefile.must_include "#{export_zone.dns} 86400 IN AAAA 2607:f8b0:400a:801::1005"
-        exported_zonefile.must_include "redirect.#{export_zone.dns} 86400 IN CNAME example.com."
-        exported_zonefile.must_include "#{export_zone.dns} 86400 IN MX 10 mail.#{export_zone.dns}"
-        exported_zonefile.must_include "#{export_zone.dns} 86400 IN MX 20 mail2.#{export_zone.dns}"
+        _(exported_zonefile).must_include "#{export_zone.dns} 86400 IN A 1.2.3.4"
+        _(exported_zonefile).must_include "#{export_zone.dns} 86400 IN AAAA 2607:f8b0:400a:801::1005"
+        _(exported_zonefile).must_include "redirect.#{export_zone.dns} 86400 IN CNAME example.com."
+        _(exported_zonefile).must_include "#{export_zone.dns} 86400 IN MX 10 mail.#{export_zone.dns}"
+        _(exported_zonefile).must_include "#{export_zone.dns} 86400 IN MX 20 mail2.#{export_zone.dns}"
       end
     end
   end
@@ -162,53 +162,53 @@ describe Google::Cloud::Dns, :dns do
   describe "Changes" do
     it "creates a change" do
       change = zone.replace zone.dns, "A", 86400, "5.6.7.8"
-      change.must_be_kind_of Google::Cloud::Dns::Change
+      _(change).must_be_kind_of Google::Cloud::Dns::Change
       change.wait_until_done!
-      change.must_be :done?
-      change.status.must_equal "done"
+      _(change).must_be :done?
+      _(change.status).must_equal "done"
       new_a_record = change.additions.first
-      new_a_record.name.must_equal zone.dns
-      new_a_record.type.must_equal "A"
-      new_a_record.ttl.must_equal 86400
-      new_a_record.data.must_equal ["5.6.7.8"]
+      _(new_a_record.name).must_equal zone.dns
+      _(new_a_record.type).must_equal "A"
+      _(new_a_record.ttl).must_equal 86400
+      _(new_a_record.data).must_equal ["5.6.7.8"]
     end
 
     it "gets a list of changes" do
-      zone.changes.count.must_be :>=, 0
+      _(zone.changes.count).must_be :>=, 0
     end
 
     it "gets a single change" do
       all_changes = zone.changes.all
-      all_changes.count.must_be :>=, 0
+      _(all_changes.count).must_be :>=, 0
       change = zone.change all_changes.first.id
-      change.must_be_kind_of Google::Cloud::Dns::Change
+      _(change).must_be_kind_of Google::Cloud::Dns::Change
     end
   end
 
   describe "Records" do
     it "returns 0 or more records" do
-      zone.records.all.count.must_be :>=, 0
+      _(zone.records.all.count).must_be :>=, 0
     end
 
     it "retrieve records by name and type" do
       change = zone.add "retrieve.#{zone.dns}", "A", 86400, "9.10.11.12"
       change.wait_until_done!
 
-      zone.records("retrieve.#{zone.dns}", "A").all.count.must_be :>=, 1
+      _(zone.records("retrieve.#{zone.dns}", "A").all.count).must_be :>=, 1
     end
 
     it "replaces records" do
-      zone.records("replace.#{zone.dns}", "A").all.count.must_be :zero?
+      _(zone.records("replace.#{zone.dns}", "A").all.count).must_be :zero?
 
       change = zone.add "replace.#{zone.dns}", "A", 86400, "1.2.3.4"
       change.wait_until_done!
 
-      zone.records("replace.#{zone.dns}", "A").all.count.wont_be :zero?
+      _(zone.records("replace.#{zone.dns}", "A").all.count).wont_be :zero?
 
       change = zone.replace "replace.#{zone.dns}", "A", 86400, "5.6.7.8"
       change.wait_until_done!
 
-      zone.records("replace.#{zone.dns}", "A").all.count.wont_be :zero?
+      _(zone.records("replace.#{zone.dns}", "A").all.count).wont_be :zero?
     end
   end
 

--- a/google-cloud-dns/google-cloud-dns.gemspec
+++ b/google-cloud-dns/google-cloud-dns.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "zonefile", "~> 1.04"
 
   gem.add_development_dependency "google-style", "~> 1.24.0"
-  gem.add_development_dependency "minitest", "~> 5.10"
+  gem.add_development_dependency "minitest", "~> 5.14"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"
   gem.add_development_dependency "minitest-focus", "~> 1.1"
   gem.add_development_dependency "minitest-rg", "~> 5.2"

--- a/google-cloud-dns/test/google/cloud/dns/change_test.rb
+++ b/google-cloud-dns/test/google/cloud/dns/change_test.rb
@@ -22,33 +22,33 @@ describe Google::Cloud::Dns::Change, :mock_dns do
   let(:change) { Google::Cloud::Dns::Change.from_gapi done_change_gapi, zone }
 
   it "knows its attributes" do
-    change.id.must_equal "dns-change-1234567890"
-    change.additions.count.must_equal 1
-    change.additions.first.must_be_kind_of Google::Cloud::Dns::Record
-    change.deletions.count.must_equal 1
-    change.deletions.first.must_be_kind_of Google::Cloud::Dns::Record
-    change.status.must_equal "done"
-    change.must_be :done?
-    change.wont_be :pending?
+    _(change.id).must_equal "dns-change-1234567890"
+    _(change.additions.count).must_equal 1
+    _(change.additions.first).must_be_kind_of Google::Cloud::Dns::Record
+    _(change.deletions.count).must_equal 1
+    _(change.deletions.first).must_be_kind_of Google::Cloud::Dns::Record
+    _(change.status).must_equal "done"
+    _(change).must_be :done?
+    _(change).wont_be :pending?
 
     start_time = Time.new 2015, 1, 1, 0, 0, 0, 0
-    change.started_at.must_equal start_time
+    _(change.started_at).must_equal start_time
   end
 
   it "can represent a pending change" do
     pending_change = Google::Cloud::Dns::Change.from_gapi pending_change_gapi, zone
 
-    pending_change.id.must_equal "dns-change-1234567890"
-    pending_change.additions.count.must_equal 1
-    pending_change.additions.first.must_be_kind_of Google::Cloud::Dns::Record
-    pending_change.deletions.count.must_equal 1
-    pending_change.deletions.first.must_be_kind_of Google::Cloud::Dns::Record
-    pending_change.status.must_equal "pending"
-    pending_change.wont_be :done?
-    pending_change.must_be :pending?
+    _(pending_change.id).must_equal "dns-change-1234567890"
+    _(pending_change.additions.count).must_equal 1
+    _(pending_change.additions.first).must_be_kind_of Google::Cloud::Dns::Record
+    _(pending_change.deletions.count).must_equal 1
+    _(pending_change.deletions.first).must_be_kind_of Google::Cloud::Dns::Record
+    _(pending_change.status).must_equal "pending"
+    _(pending_change).wont_be :done?
+    _(pending_change).must_be :pending?
 
     start_time = Time.new 2015, 1, 1, 0, 0, 0, 0
-    pending_change.started_at.must_equal start_time
+    _(pending_change.started_at).must_equal start_time
   end
 
   it "can reload itself" do
@@ -57,13 +57,13 @@ describe Google::Cloud::Dns::Change, :mock_dns do
     mock.expect :get_change, done_change_gapi(change.id), [project, zone.id, change.id]
 
     dns.service.mocked_service = mock
-    change.must_be :done?
+    _(change).must_be :done?
     change.reload!
-    change.must_be :pending?
+    _(change).must_be :pending?
     change.reload!
     mock.verify
 
-    change.must_be :done?
+    _(change).must_be :done?
   end
 
   it "can reload itself with refresh alias" do
@@ -72,13 +72,13 @@ describe Google::Cloud::Dns::Change, :mock_dns do
     mock.expect :get_change, done_change_gapi(change.id), [project, zone.id, change.id]
 
     dns.service.mocked_service = mock
-    change.must_be :done?
+    _(change).must_be :done?
     change.refresh!
-    change.must_be :pending?
+    _(change).must_be :pending?
     change.refresh!
     mock.verify
 
-    change.must_be :done?
+    _(change).must_be :done?
   end
 
   it "can wait until done" do
@@ -97,10 +97,10 @@ describe Google::Cloud::Dns::Change, :mock_dns do
     end
 
     dns.service.mocked_service = mock
-    pending_change.must_be :pending?
+    _(pending_change).must_be :pending?
     pending_change.wait_until_done!
     mock.verify
 
-    pending_change.must_be :done?
+    _(pending_change).must_be :done?
   end
 end

--- a/google-cloud-dns/test/google/cloud/dns/importer_test.rb
+++ b/google-cloud-dns/test/google/cloud/dns/importer_test.rb
@@ -55,8 +55,8 @@ EOS
   it "imports records from zonefile file path" do
     importer = Google::Cloud::Dns::Importer.new zone, zonefile_path
     records = importer.records
-    records.size.must_be :>=, 16
-    records.each { |z| z.must_be_kind_of Google::Cloud::Dns::Record }
+    _(records.size).must_be :>=, 16
+    records.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Record }
     record_must_be records[0], "example.com.", "SOA", 3600, ["ns.example.com. username.example.com. 2007120710 1d 2h 4w 1h"]
     record_must_be records[1], "example.com.", "MX", 3600, ["10 mail.example.com.", "20 mail2.example.com.", "50 mail3"]
     record_must_be records[2], "example.com.", "A", 3600, ["192.0.2.1"]
@@ -79,8 +79,8 @@ EOS
   it "imports records from zonefile IO instance" do
     importer = Google::Cloud::Dns::Importer.new zone, zonefile_io
     records = importer.records
-    records.size.must_equal 8
-    records.each { |z| z.must_be_kind_of Google::Cloud::Dns::Record }
+    _(records.size).must_equal 8
+    records.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Record }
     record_must_be records[0], "example.com.", "SOA", 3600, ["ns1.example.com. hostmaster.example.com. 2002022401 3H 15 1w 3h"]
     record_must_be records[1], "example.com.", "MX", 86400, ["10 mail.another.com."]
     record_must_be records[2], "ns1.example.com.", "A", 86400, ["192.168.0.1"]
@@ -94,7 +94,7 @@ EOS
   it "accepts an only option string" do
     importer = Google::Cloud::Dns::Importer.new zone, zonefile_io
     records = importer.records only: "A"
-    records.size.must_equal 4
+    _(records.size).must_equal 4
     record_must_be records[0], "ns1.example.com.", "A", 86400, ["192.168.0.1"]
     record_must_be records[1], "www.example.com.", "A", 3600, ["192.168.0.2"]
     record_must_be records[2], "bill.example.com.", "A", 86400, ["192.168.0.3"]
@@ -104,7 +104,7 @@ EOS
   it "accepts an only option array" do
     importer = Google::Cloud::Dns::Importer.new zone, zonefile_io
     records = importer.records only: ["A","NS"]
-    records.size.must_equal 5
+    _(records.size).must_equal 5
     record_must_be records[0], "ns1.example.com.", "A", 86400, ["192.168.0.1"]
     record_must_be records[1], "www.example.com.", "A", 3600, ["192.168.0.2"]
     record_must_be records[2], "bill.example.com.", "A", 86400, ["192.168.0.3"]
@@ -115,7 +115,7 @@ EOS
   it "accepts an except option string" do
     importer = Google::Cloud::Dns::Importer.new zone, zonefile_io
     records = importer.records except: "A"
-    records.size.must_equal 4
+    _(records.size).must_equal 4
     record_must_be records[0], "example.com.", "SOA", 3600, ["ns1.example.com. hostmaster.example.com. 2002022401 3H 15 1w 3h"]
     record_must_be records[1], "example.com.", "MX", 86400, ["10 mail.another.com."]
     record_must_be records[2], "example.com.", "NS", 86400, ["ns1.example.com.", "ns2.smokeyjoe.com."]
@@ -125,16 +125,16 @@ EOS
   it "accepts an except option array" do
     importer = Google::Cloud::Dns::Importer.new zone, zonefile_io
     records = importer.records except: ["A","CNAME"]
-    records.size.must_equal 3
+    _(records.size).must_equal 3
     record_must_be records[0], "example.com.", "SOA", 3600, ["ns1.example.com. hostmaster.example.com. 2002022401 3H 15 1w 3h"]
     record_must_be records[1], "example.com.", "MX", 86400, ["10 mail.another.com."]
     record_must_be records[2], "example.com.", "NS", 86400, ["ns1.example.com.", "ns2.smokeyjoe.com."]
   end
 
   def record_must_be record, name, type, ttl, data
-    record.name.must_equal name
-    record.type.must_equal type
-    record.ttl.must_equal ttl
-    record.data.must_equal data
+    _(record.name).must_equal name
+    _(record.type).must_equal type
+    _(record.ttl).must_equal ttl
+    _(record.data).must_equal data
   end
 end

--- a/google-cloud-dns/test/google/cloud/dns/project_test.rb
+++ b/google-cloud-dns/test/google/cloud/dns/project_test.rb
@@ -16,7 +16,7 @@ require "helper"
 
 describe Google::Cloud::Dns::Project, :mock_dns do
   it "knows the project identifier" do
-    dns.project.must_equal project
+    _(dns.project).must_equal project
   end
 
   it "knows its quota information" do
@@ -27,14 +27,14 @@ describe Google::Cloud::Dns::Project, :mock_dns do
     dns.reload!
     mock.verify
 
-    dns.id.must_equal project
-    dns.number.must_equal 123456789
-    dns.zones_quota.must_equal 101
-    dns.records_per_zone.must_equal 1002
-    dns.additions_per_change.must_equal 103
-    dns.deletions_per_change.must_equal 104
-    dns.total_data_per_change.must_equal 8000
-    dns.data_per_record.must_equal 105
+    _(dns.id).must_equal project
+    _(dns.number).must_equal 123456789
+    _(dns.zones_quota).must_equal 101
+    _(dns.records_per_zone).must_equal 1002
+    _(dns.additions_per_change).must_equal 103
+    _(dns.deletions_per_change).must_equal 104
+    _(dns.total_data_per_change).must_equal 8000
+    _(dns.data_per_record).must_equal 105
   end
 
   it "finds a zone" do
@@ -46,8 +46,8 @@ describe Google::Cloud::Dns::Project, :mock_dns do
     zone = dns.zone found_zone
     mock.verify
 
-    zone.must_be_kind_of Google::Cloud::Dns::Zone
-    zone.name.must_equal found_zone
+    _(zone).must_be_kind_of Google::Cloud::Dns::Zone
+    _(zone.name).must_equal found_zone
   end
 
   it "returns nil when it cannot find a zone" do
@@ -58,7 +58,7 @@ describe Google::Cloud::Dns::Project, :mock_dns do
 
     dns.service.mocked_service = stub
     zone = dns.zone "example.org."
-    zone.must_be :nil?
+    _(zone).must_be :nil?
   end
 
   it "lists zones" do
@@ -70,8 +70,8 @@ describe Google::Cloud::Dns::Project, :mock_dns do
     zones = dns.zones
     mock.verify
 
-    zones.size.must_equal num_zones
-    zones.each { |z| z.must_be_kind_of Google::Cloud::Dns::Zone }
+    _(zones.size).must_equal num_zones
+    zones.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Zone }
   end
 
   it "paginates zones" do
@@ -81,17 +81,17 @@ describe Google::Cloud::Dns::Project, :mock_dns do
 
     dns.service.mocked_service = mock
     first_zones = dns.zones
-    first_zones.count.must_equal 3
-    first_zones.each { |z| z.must_be_kind_of Google::Cloud::Dns::Zone }
-    first_zones.token.wont_be :nil?
-    first_zones.token.must_equal "next_page_token"
+    _(first_zones.count).must_equal 3
+    first_zones.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Zone }
+    _(first_zones.token).wont_be :nil?
+    _(first_zones.token).must_equal "next_page_token"
 
     second_zones = dns.zones token: first_zones.token
     mock.verify
 
-    second_zones.count.must_equal 2
-    second_zones.each { |z| z.must_be_kind_of Google::Cloud::Dns::Zone }
-    second_zones.token.must_be :nil?
+    _(second_zones.count).must_equal 2
+    second_zones.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Zone }
+    _(second_zones.token).must_be :nil?
   end
 
   it "paginates zones with max set" do
@@ -102,10 +102,10 @@ describe Google::Cloud::Dns::Project, :mock_dns do
     zones = dns.zones max: 3
     mock.verify
 
-    zones.count.must_equal 3
-    zones.each { |z| z.must_be_kind_of Google::Cloud::Dns::Zone }
-    zones.token.wont_be :nil?
-    zones.token.must_equal "next_page_token"
+    _(zones.count).must_equal 3
+    zones.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Zone }
+    _(zones.token).wont_be :nil?
+    _(zones.token).must_equal "next_page_token"
   end
 
   it "paginates zones without max set" do
@@ -116,10 +116,10 @@ describe Google::Cloud::Dns::Project, :mock_dns do
     zones = dns.zones
     mock.verify
 
-    zones.count.must_equal 3
-    zones.each { |z| z.must_be_kind_of Google::Cloud::Dns::Zone }
-    zones.token.wont_be :nil?
-    zones.token.must_equal "next_page_token"
+    _(zones.count).must_equal 3
+    zones.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Zone }
+    _(zones.token).wont_be :nil?
+    _(zones.token).must_equal "next_page_token"
   end
 
   it "paginates zones with next? and next" do
@@ -129,16 +129,16 @@ describe Google::Cloud::Dns::Project, :mock_dns do
 
     dns.service.mocked_service = mock
     first_zones = dns.zones
-    first_zones.count.must_equal 3
-    first_zones.each { |z| z.must_be_kind_of Google::Cloud::Dns::Zone }
-    first_zones.next?.must_equal true
+    _(first_zones.count).must_equal 3
+    first_zones.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Zone }
+    _(first_zones.next?).must_equal true
 
     second_zones = first_zones.next
     mock.verify
 
-    second_zones.count.must_equal 2
-    second_zones.each { |z| z.must_be_kind_of Google::Cloud::Dns::Zone }
-    second_zones.next?.must_equal false
+    _(second_zones.count).must_equal 2
+    second_zones.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Zone }
+    _(second_zones.next?).must_equal false
   end
 
   it "paginates zones with next? and next and max set" do
@@ -148,16 +148,16 @@ describe Google::Cloud::Dns::Project, :mock_dns do
 
     dns.service.mocked_service = mock
     first_zones = dns.zones max: 3
-    first_zones.count.must_equal 3
-    first_zones.each { |z| z.must_be_kind_of Google::Cloud::Dns::Zone }
-    first_zones.next?.must_equal true
+    _(first_zones.count).must_equal 3
+    first_zones.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Zone }
+    _(first_zones.next?).must_equal true
 
     second_zones = first_zones.next
     mock.verify
 
-    second_zones.count.must_equal 2
-    second_zones.each { |z| z.must_be_kind_of Google::Cloud::Dns::Zone }
-    second_zones.next?.must_equal false
+    _(second_zones.count).must_equal 2
+    second_zones.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Zone }
+    _(second_zones.next?).must_equal false
   end
 
   it "paginates zones with all" do
@@ -169,8 +169,8 @@ describe Google::Cloud::Dns::Project, :mock_dns do
     zones = dns.zones.all.to_a
     mock.verify
 
-    zones.count.must_equal 5
-    zones.each { |z| z.must_be_kind_of Google::Cloud::Dns::Zone }
+    _(zones.count).must_equal 5
+    zones.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Zone }
   end
 
   it "paginates zones with all and max set" do
@@ -182,8 +182,8 @@ describe Google::Cloud::Dns::Project, :mock_dns do
     zones = dns.zones(max: 3).all.to_a
     mock.verify
 
-    zones.count.must_equal 5
-    zones.each { |z| z.must_be_kind_of Google::Cloud::Dns::Zone }
+    _(zones.count).must_equal 5
+    zones.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Zone }
   end
 
   it "iterates all zones with all using Enumerator" do
@@ -195,8 +195,8 @@ describe Google::Cloud::Dns::Project, :mock_dns do
     zones = dns.zones.all.take(5)
     mock.verify
 
-    zones.count.must_equal 5
-    zones.each { |z| z.must_be_kind_of Google::Cloud::Dns::Zone }
+    _(zones.count).must_equal 5
+    zones.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Zone }
   end
 
   it "iterates all zones with all with request_limit set" do
@@ -208,8 +208,8 @@ describe Google::Cloud::Dns::Project, :mock_dns do
     zones = dns.zones.all(request_limit: 1).to_a
     mock.verify
 
-    zones.count.must_equal 6
-    zones.each { |z| z.must_be_kind_of Google::Cloud::Dns::Zone }
+    _(zones.count).must_equal 6
+    zones.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Zone }
   end
 
   it "creates a zone" do
@@ -221,11 +221,11 @@ describe Google::Cloud::Dns::Project, :mock_dns do
     zone = dns.create_zone "example-zone", "example.net."
     mock.verify
 
-    zone.must_be_kind_of Google::Cloud::Dns::Zone
-    zone.name.must_equal "example-zone"
-    zone.dns.must_equal "example.net."
-    zone.description.must_equal ""
-    zone.name_server_set.must_be :nil?
+    _(zone).must_be_kind_of Google::Cloud::Dns::Zone
+    _(zone.name).must_equal "example-zone"
+    _(zone.dns).must_equal "example.net."
+    _(zone.description).must_equal ""
+    _(zone.name_server_set).must_be :nil?
   end
 
   it "creates a zone with a description" do
@@ -238,11 +238,11 @@ describe Google::Cloud::Dns::Project, :mock_dns do
                             description: "Example Zone Description"
     mock.verify
 
-    zone.must_be_kind_of Google::Cloud::Dns::Zone
-    zone.name.must_equal "example-zone"
-    zone.dns.must_equal "example.net."
-    zone.description.must_equal "Example Zone Description"
-    zone.name_server_set.must_be :nil?
+    _(zone).must_be_kind_of Google::Cloud::Dns::Zone
+    _(zone.name).must_equal "example-zone"
+    _(zone.dns).must_equal "example.net."
+    _(zone.description).must_equal "Example Zone Description"
+    _(zone.name_server_set).must_be :nil?
   end
 
   it "creates a zone with a name_server_set" do
@@ -255,11 +255,11 @@ describe Google::Cloud::Dns::Project, :mock_dns do
                             name_server_set: "example-set"
     mock.verify
 
-    zone.must_be_kind_of Google::Cloud::Dns::Zone
-    zone.name.must_equal "example-zone"
-    zone.dns.must_equal "example.net."
-    zone.description.must_equal ""
-    zone.name_server_set.must_equal "example-set"
+    _(zone).must_be_kind_of Google::Cloud::Dns::Zone
+    _(zone.name).must_equal "example-zone"
+    _(zone.dns).must_equal "example.net."
+    _(zone.description).must_equal ""
+    _(zone.name_server_set).must_equal "example-set"
   end
 
   it "reload! calls to the API" do

--- a/google-cloud-dns/test/google/cloud/dns/record_test.rb
+++ b/google-cloud-dns/test/google/cloud/dns/record_test.rb
@@ -24,63 +24,63 @@ describe Google::Cloud::Dns::Record, :mock_dns do
   let(:record) { Google::Cloud::Dns::Record.from_gapi record_gapi }
 
   it "knows its attributes" do
-    record.name.must_equal record_name
-    record.type.must_equal record_type
-    record.ttl.must_equal  record_ttl
-    record.data.must_equal record_data
+    _(record.name).must_equal record_name
+    _(record.type).must_equal record_type
+    _(record.ttl).must_equal  record_ttl
+    _(record.data).must_equal record_data
   end
 
   it "exports to zonefile record string" do
     zonefile_records = record.to_zonefile_records
-    zonefile_records.count.must_equal 2
-    zonefile_records.first.must_equal "#{record_name} #{record_ttl} IN #{record_type} #{record_data.first}"
-    zonefile_records.last.must_equal "#{record_name} #{record_ttl} IN #{record_type} #{record_data.last}"
+    _(zonefile_records.count).must_equal 2
+    _(zonefile_records.first).must_equal "#{record_name} #{record_ttl} IN #{record_type} #{record_data.first}"
+    _(zonefile_records.last).must_equal "#{record_name} #{record_ttl} IN #{record_type} #{record_data.last}"
   end
 
   it "knows if it is equal to other records" do
     dupe = record.dup
-    dupe.must_equal record
+    _(dupe).must_equal record
     dupe.data = ["5.6.7.8"]
-    dupe.wont_equal record
+    _(dupe).wont_equal record
   end
 
   it "duplicates all its data deeply" do
     dupe = record.dup
-    dupe.must_equal record
-    dupe.data.must_equal record.data
-    dupe.data[0].must_equal record.data[0]
+    _(dupe).must_equal record
+    _(dupe.data).must_equal record.data
+    _(dupe.data[0]).must_equal record.data[0]
 
     dupe.data[0] = "5.6.7.8"
 
-    dupe.wont_equal record
-    dupe.data.wont_equal record.data
-    dupe.data[0].wont_equal record.data[0]
+    _(dupe).wont_equal record
+    _(dupe.data).wont_equal record.data
+    _(dupe.data[0]).wont_equal record.data[0]
   end
 
   it "duplicates its data array" do
     dupe = record.dup
-    dupe.must_equal record
-    dupe.data.must_equal record.data
-    dupe.data.count.must_equal record.data.count
+    _(dupe).must_equal record
+    _(dupe.data).must_equal record.data
+    _(dupe.data.count).must_equal record.data.count
 
     dupe.data << "ns-cloud-b3.googledomains.com."
 
-    dupe.wont_equal record
-    dupe.data.wont_equal record.data
-    dupe.data.count.wont_equal record.data.count
+    _(dupe).wont_equal record
+    _(dupe.data).wont_equal record.data
+    _(dupe.data.count).wont_equal record.data.count
   end
 
   it "duplicates its data array elements" do
     dupe = record.dup
-    dupe.must_equal record
-    dupe.data.must_equal record.data
-    dupe.data[0].must_equal record.data[0]
+    _(dupe).must_equal record
+    _(dupe.data).must_equal record.data
+    _(dupe.data[0]).must_equal record.data[0]
 
     dupe.data[0].gsub! "com", "net"
 
-    dupe.wont_equal record
-    dupe.data.wont_equal record.data
-    dupe.data[0].wont_equal record.data[0]
+    _(dupe).wont_equal record
+    _(dupe.data).wont_equal record.data
+    _(dupe.data[0]).wont_equal record.data[0]
   end
 
   it "is comparable in arrays" do
@@ -88,15 +88,15 @@ describe Google::Cloud::Dns::Record, :mock_dns do
                  Google::Cloud::Dns::Record.new("example.net.", "A", 86400, "localhost"),
                  Google::Cloud::Dns::Record.new("example.org.", "A", 86400, "localhost") ]
     changed = original.map(&:dup)
-    changed.must_equal original
+    _(changed).must_equal original
     changed.first.ttl = 18600
-    changed.wont_equal original
+    _(changed).wont_equal original
 
     existing = original - changed
     updated = changed - original
-    existing.count.must_equal 1
-    updated.count.must_equal 1
-    existing.first.must_equal original.first
-    updated.first.must_equal changed.first
+    _(existing.count).must_equal 1
+    _(updated.count).must_equal 1
+    _(existing.first).must_equal original.first
+    _(updated.first).must_equal changed.first
   end
 end

--- a/google-cloud-dns/test/google/cloud/dns/zone_fqdn_test.rb
+++ b/google-cloud-dns/test/google/cloud/dns/zone_fqdn_test.rb
@@ -20,29 +20,29 @@ describe Google::Cloud::Dns::Zone, :fqdn, :mock_dns do
   let(:zone) { Google::Cloud::Dns::Zone.from_gapi random_zone_gapi(zone_name, zone_dns), dns.service }
 
   it "knows a fully qualified domain name when given one" do
-    zone.fqdn("example.org.").must_equal "example.org."
+    _(zone.fqdn("example.org.")).must_equal "example.org."
   end
 
   it "creates a fully qualified domain name when not given one" do
-    zone.fqdn("example.net").must_equal "example.net."
+    _(zone.fqdn("example.net")).must_equal "example.net."
   end
 
   it "uses the zone's fully qualified domain name when given nil" do
-    zone.fqdn(nil).must_equal "example.com."
+    _(zone.fqdn(nil)).must_equal "example.com."
   end
 
   it "uses the zone's fully qualified domain name when given empty string" do
-    zone.fqdn("").must_equal "example.com."
-    zone.fqdn("  ").must_equal "example.com." # spaces
-    zone.fqdn("\t").must_equal "example.com." # tab
-    zone.fqdn("\n").must_equal "example.com." # new lines
+    _(zone.fqdn("")).must_equal "example.com."
+    _(zone.fqdn("  ")).must_equal "example.com." # spaces
+    _(zone.fqdn("\t")).must_equal "example.com." # tab
+    _(zone.fqdn("\n")).must_equal "example.com." # new lines
   end
 
   it "uses the zone's fully qualified domain name when given @" do
-    zone.fqdn("").must_equal "example.com."
+    _(zone.fqdn("")).must_equal "example.com."
   end
 
   it "prepends the zone's fully qualified domain name when given a subdomain" do
-    zone.fqdn("www").must_equal "www.example.com."
+    _(zone.fqdn("www")).must_equal "www.example.com."
   end
 end

--- a/google-cloud-dns/test/google/cloud/dns/zone_import_export_test.rb
+++ b/google-cloud-dns/test/google/cloud/dns/zone_import_export_test.rb
@@ -67,7 +67,7 @@ EOS
     zonefile = zone.to_zonefile
     mock.verify
 
-    zonefile.must_equal zone_export_expected.strip
+    _(zonefile).must_equal zone_export_expected.strip
   end
 
   it "exports records to a zonefile file" do
@@ -79,7 +79,7 @@ EOS
       zone.export tmpfile
       mock.verify
 
-      File.read(tmpfile).must_equal zone_export_expected.strip
+      _(File.read(tmpfile)).must_equal zone_export_expected.strip
     end
   end
 
@@ -102,11 +102,11 @@ EOS
     change = zone.import zonefile_io
     mock.verify
 
-    change.must_be_kind_of Google::Cloud::Dns::Change
-    change.id.must_equal "dns-change-created"
+    _(change).must_be_kind_of Google::Cloud::Dns::Change
+    _(change.id).must_equal "dns-change-created"
     record_must_be change.additions[0], to_add[0]
     record_must_be change.additions[1], to_add[1]
-    change.deletions.must_be :empty?
+    _(change.deletions).must_be :empty?
   end
 
   def list_records_gapi
@@ -122,9 +122,9 @@ EOS
   end
 
   def record_must_be actual, expected
-    actual.name.must_equal expected.name
-    actual.type.must_equal expected.type
-    actual.ttl.must_equal expected.ttl
-    actual.data.must_equal expected.data
+    _(actual.name).must_equal expected.name
+    _(actual.type).must_equal expected.type
+    _(actual.ttl).must_equal expected.ttl
+    _(actual.data).must_equal expected.data
   end
 end

--- a/google-cloud-dns/test/google/cloud/dns/zone_test.rb
+++ b/google-cloud-dns/test/google/cloud/dns/zone_test.rb
@@ -28,16 +28,16 @@ describe Google::Cloud::Dns::Zone, :mock_dns do
   let(:updated_soa) { Google::Cloud::Dns::Record.new "example.com.", "SOA", 18600, "ns-cloud-b1.googledomains.com. dns-admin.google.com. 1 21600 3600 1209600 300" }
 
   it "knows its attributes" do
-    zone.name.must_equal zone_name
-    zone.dns.must_equal zone.dns
-    zone.description.must_equal ""
-    zone.id.must_equal 123456789
-    zone.name_servers.must_equal [ "virtual-dns-1.google.example",
+    _(zone.name).must_equal zone_name
+    _(zone.dns).must_equal zone.dns
+    _(zone.description).must_equal ""
+    _(zone.id).must_equal 123456789
+    _(zone.name_servers).must_equal [ "virtual-dns-1.google.example",
                                    "virtual-dns-2.google.example" ]
-    zone.name_server_set.must_be :nil?
+    _(zone.name_server_set).must_be :nil?
 
     creation_time = Time.new 2015, 1, 1, 0, 0, 0, 0
-    zone.created_at.must_equal creation_time
+    _(zone.created_at).must_equal creation_time
   end
 
   it "can delete itself" do
@@ -101,8 +101,8 @@ describe Google::Cloud::Dns::Zone, :mock_dns do
     change = zone.change found_change
     mock.verify
 
-    change.must_be_kind_of Google::Cloud::Dns::Change
-    change.id.must_equal found_change
+    _(change).must_be_kind_of Google::Cloud::Dns::Change
+    _(change.id).must_equal found_change
   end
 
   it "returns nil when it cannot find a change" do
@@ -113,7 +113,7 @@ describe Google::Cloud::Dns::Zone, :mock_dns do
 
     dns.service.mocked_service = stub
     change = zone.change "dns-change-0987654321"
-    change.must_be :nil?
+    _(change).must_be :nil?
   end
 
   it "lists changes" do
@@ -125,8 +125,8 @@ describe Google::Cloud::Dns::Zone, :mock_dns do
     changes = zone.changes
     mock.verify
 
-    changes.size.must_equal num_changes
-    changes.each { |z| z.must_be_kind_of Google::Cloud::Dns::Change }
+    _(changes.size).must_equal num_changes
+    changes.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Change }
   end
 
   it "lists changes with max set" do
@@ -137,10 +137,10 @@ describe Google::Cloud::Dns::Zone, :mock_dns do
     changes = zone.changes max: 3
     mock.verify
 
-    changes.count.must_equal 3
-    changes.each { |z| z.must_be_kind_of Google::Cloud::Dns::Change }
-    changes.token.wont_be :nil?
-    changes.token.must_equal "next_page_token"
+    _(changes.count).must_equal 3
+    changes.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Change }
+    _(changes.token).wont_be :nil?
+    _(changes.token).must_equal "next_page_token"
   end
 
   it "lists changes with order set to asc" do
@@ -151,10 +151,10 @@ describe Google::Cloud::Dns::Zone, :mock_dns do
     changes = zone.changes order: :asc
     mock.verify
 
-    changes.count.must_equal 3
-    changes.each { |z| z.must_be_kind_of Google::Cloud::Dns::Change }
-    changes.token.wont_be :nil?
-    changes.token.must_equal "next_page_token"
+    _(changes.count).must_equal 3
+    changes.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Change }
+    _(changes.token).wont_be :nil?
+    _(changes.token).must_equal "next_page_token"
   end
 
   it "lists changes with order set to desc" do
@@ -165,10 +165,10 @@ describe Google::Cloud::Dns::Zone, :mock_dns do
     changes = zone.changes order: :desc
     mock.verify
 
-    changes.count.must_equal 3
-    changes.each { |z| z.must_be_kind_of Google::Cloud::Dns::Change }
-    changes.token.wont_be :nil?
-    changes.token.must_equal "next_page_token"
+    _(changes.count).must_equal 3
+    changes.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Change }
+    _(changes.token).wont_be :nil?
+    _(changes.token).must_equal "next_page_token"
   end
 
   it "paginates changes" do
@@ -179,17 +179,17 @@ describe Google::Cloud::Dns::Zone, :mock_dns do
     dns.service.mocked_service = mock
 
     first_changes = zone.changes
-    first_changes.count.must_equal 3
-    first_changes.each { |z| z.must_be_kind_of Google::Cloud::Dns::Change }
-    first_changes.token.wont_be :nil?
-    first_changes.token.must_equal "next_page_token"
+    _(first_changes.count).must_equal 3
+    first_changes.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Change }
+    _(first_changes.token).wont_be :nil?
+    _(first_changes.token).must_equal "next_page_token"
 
     second_changes = zone.changes token: first_changes.token
     mock.verify
 
-    second_changes.count.must_equal 2
-    second_changes.each { |z| z.must_be_kind_of Google::Cloud::Dns::Change }
-    second_changes.token.must_be :nil?
+    _(second_changes.count).must_equal 2
+    second_changes.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Change }
+    _(second_changes.token).must_be :nil?
   end
 
   it "paginates changes with next? and next" do
@@ -200,16 +200,16 @@ describe Google::Cloud::Dns::Zone, :mock_dns do
     dns.service.mocked_service = mock
 
     first_changes = zone.changes
-    first_changes.count.must_equal 3
-    first_changes.each { |z| z.must_be_kind_of Google::Cloud::Dns::Change }
-    first_changes.next?.must_equal true
+    _(first_changes.count).must_equal 3
+    first_changes.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Change }
+    _(first_changes.next?).must_equal true
 
     second_changes = first_changes.next
     mock.verify
 
-    second_changes.count.must_equal 2
-    second_changes.each { |z| z.must_be_kind_of Google::Cloud::Dns::Change }
-    second_changes.next?.must_equal false
+    _(second_changes.count).must_equal 2
+    second_changes.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Change }
+    _(second_changes.next?).must_equal false
   end
 
   it "paginates changes with next? and next and max set" do
@@ -220,16 +220,16 @@ describe Google::Cloud::Dns::Zone, :mock_dns do
     dns.service.mocked_service = mock
 
     first_changes = zone.changes max: 3
-    first_changes.count.must_equal 3
-    first_changes.each { |z| z.must_be_kind_of Google::Cloud::Dns::Change }
-    first_changes.next?.must_equal true
+    _(first_changes.count).must_equal 3
+    first_changes.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Change }
+    _(first_changes.next?).must_equal true
 
     second_changes = first_changes.next
     mock.verify
 
-    second_changes.count.must_equal 2
-    second_changes.each { |z| z.must_be_kind_of Google::Cloud::Dns::Change }
-    second_changes.next?.must_equal false
+    _(second_changes.count).must_equal 2
+    second_changes.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Change }
+    _(second_changes.next?).must_equal false
   end
 
   it "paginates changes with next? and next and order set to asc" do
@@ -240,16 +240,16 @@ describe Google::Cloud::Dns::Zone, :mock_dns do
     dns.service.mocked_service = mock
 
     first_changes = zone.changes order: :asc
-    first_changes.count.must_equal 3
-    first_changes.each { |z| z.must_be_kind_of Google::Cloud::Dns::Change }
-    first_changes.next?.must_equal true
+    _(first_changes.count).must_equal 3
+    first_changes.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Change }
+    _(first_changes.next?).must_equal true
 
     second_changes = first_changes.next
     mock.verify
 
-    second_changes.count.must_equal 2
-    second_changes.each { |z| z.must_be_kind_of Google::Cloud::Dns::Change }
-    second_changes.next?.must_equal false
+    _(second_changes.count).must_equal 2
+    second_changes.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Change }
+    _(second_changes.next?).must_equal false
   end
 
   it "paginates changes with next? and next and order set to desc" do
@@ -260,16 +260,16 @@ describe Google::Cloud::Dns::Zone, :mock_dns do
     dns.service.mocked_service = mock
 
     first_changes = zone.changes order: :desc
-    first_changes.count.must_equal 3
-    first_changes.each { |z| z.must_be_kind_of Google::Cloud::Dns::Change }
-    first_changes.next?.must_equal true
+    _(first_changes.count).must_equal 3
+    first_changes.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Change }
+    _(first_changes.next?).must_equal true
 
     second_changes = first_changes.next
     mock.verify
 
-    second_changes.count.must_equal 2
-    second_changes.each { |z| z.must_be_kind_of Google::Cloud::Dns::Change }
-    second_changes.next?.must_equal false
+    _(second_changes.count).must_equal 2
+    second_changes.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Change }
+    _(second_changes.next?).must_equal false
   end
 
   it "paginates changes with all" do
@@ -282,8 +282,8 @@ describe Google::Cloud::Dns::Zone, :mock_dns do
     changes = zone.changes.all.to_a
     mock.verify
 
-    changes.count.must_equal 5
-    changes.each { |z| z.must_be_kind_of Google::Cloud::Dns::Change }
+    _(changes.count).must_equal 5
+    changes.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Change }
   end
 
   it "paginates changes with all and max set" do
@@ -295,8 +295,8 @@ describe Google::Cloud::Dns::Zone, :mock_dns do
     changes = zone.changes(max: 3).all.to_a
     mock.verify
 
-    changes.count.must_equal 5
-    changes.each { |z| z.must_be_kind_of Google::Cloud::Dns::Change }
+    _(changes.count).must_equal 5
+    changes.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Change }
   end
 
   it "paginates changes with all and order set to asc" do
@@ -309,8 +309,8 @@ describe Google::Cloud::Dns::Zone, :mock_dns do
     changes = zone.changes(order: :asc).all.to_a
     mock.verify
 
-    changes.count.must_equal 5
-    changes.each { |z| z.must_be_kind_of Google::Cloud::Dns::Change }
+    _(changes.count).must_equal 5
+    changes.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Change }
   end
 
   it "paginates changes with all and order set to desc" do
@@ -322,8 +322,8 @@ describe Google::Cloud::Dns::Zone, :mock_dns do
     changes = zone.changes(order: :desc).all.to_a
     mock.verify
 
-    changes.count.must_equal 5
-    changes.each { |z| z.must_be_kind_of Google::Cloud::Dns::Change }
+    _(changes.count).must_equal 5
+    changes.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Change }
   end
 
   it "paginates changes with all using Enumerator" do
@@ -336,8 +336,8 @@ describe Google::Cloud::Dns::Zone, :mock_dns do
     changes = zone.changes.all.take(5)
     mock.verify
 
-    changes.count.must_equal 5
-    changes.each { |z| z.must_be_kind_of Google::Cloud::Dns::Change }
+    _(changes.count).must_equal 5
+    changes.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Change }
   end
 
   it "paginates changes with all with request_limit set" do
@@ -350,8 +350,8 @@ describe Google::Cloud::Dns::Zone, :mock_dns do
     changes = zone.changes.all(request_limit: 1).to_a
     mock.verify
 
-    changes.count.must_equal 6
-    changes.each { |z| z.must_be_kind_of Google::Cloud::Dns::Change }
+    _(changes.count).must_equal 6
+    changes.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Change }
   end
 
   it "lists records" do
@@ -363,8 +363,8 @@ describe Google::Cloud::Dns::Zone, :mock_dns do
     records = zone.records
     mock.verify
 
-    records.size.must_equal num_records
-    records.each { |z| z.must_be_kind_of Google::Cloud::Dns::Record }
+    _(records.size).must_equal num_records
+    records.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Record }
   end
 
   it "lists records with name param" do
@@ -376,8 +376,8 @@ describe Google::Cloud::Dns::Zone, :mock_dns do
     records = zone.records record_name
     mock.verify
 
-    records.size.must_equal num_records
-    records.each { |z| z.must_be_kind_of Google::Cloud::Dns::Record }
+    _(records.size).must_equal num_records
+    records.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Record }
   end
 
   it "lists records with name and type params" do
@@ -389,8 +389,8 @@ describe Google::Cloud::Dns::Zone, :mock_dns do
     records = zone.records record_name, record_type
     mock.verify
 
-    records.size.must_equal num_records
-    records.each { |z| z.must_be_kind_of Google::Cloud::Dns::Record }
+    _(records.size).must_equal num_records
+    records.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Record }
   end
 
   it "lists records with subdomain and type params" do
@@ -402,8 +402,8 @@ describe Google::Cloud::Dns::Zone, :mock_dns do
     records = zone.records "www", "A"
     mock.verify
 
-    records.size.must_equal num_records
-    records.each { |z| z.must_be_kind_of Google::Cloud::Dns::Record }
+    _(records.size).must_equal num_records
+    records.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Record }
   end
 
   it "paginates records" do
@@ -414,17 +414,17 @@ describe Google::Cloud::Dns::Zone, :mock_dns do
     dns.service.mocked_service = mock
 
     first_records = zone.records
-    first_records.count.must_equal 3
-    first_records.each { |z| z.must_be_kind_of Google::Cloud::Dns::Record }
-    first_records.token.wont_be :nil?
-    first_records.token.must_equal "next_page_token"
+    _(first_records.count).must_equal 3
+    first_records.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Record }
+    _(first_records.token).wont_be :nil?
+    _(first_records.token).must_equal "next_page_token"
 
     second_records = zone.records token: first_records.token
     mock.verify
 
-    second_records.count.must_equal 2
-    second_records.each { |z| z.must_be_kind_of Google::Cloud::Dns::Record }
-    second_records.token.must_be :nil?
+    _(second_records.count).must_equal 2
+    second_records.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Record }
+    _(second_records.token).must_be :nil?
   end
 
   it "paginates records with next? and next" do
@@ -435,16 +435,16 @@ describe Google::Cloud::Dns::Zone, :mock_dns do
     dns.service.mocked_service = mock
 
     first_records = zone.records
-    first_records.count.must_equal 3
-    first_records.each { |z| z.must_be_kind_of Google::Cloud::Dns::Record }
-    first_records.next?.must_equal true
+    _(first_records.count).must_equal 3
+    first_records.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Record }
+    _(first_records.next?).must_equal true
 
     second_records = first_records.next
     mock.verify
 
-    second_records.count.must_equal 2
-    second_records.each { |z| z.must_be_kind_of Google::Cloud::Dns::Record }
-    second_records.next?.must_equal false
+    _(second_records.count).must_equal 2
+    second_records.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Record }
+    _(second_records.next?).must_equal false
   end
 
   it "paginates records with next? and next and max set" do
@@ -455,16 +455,16 @@ describe Google::Cloud::Dns::Zone, :mock_dns do
     dns.service.mocked_service = mock
 
     first_records = zone.records max: 3
-    first_records.count.must_equal 3
-    first_records.each { |z| z.must_be_kind_of Google::Cloud::Dns::Record }
-    first_records.next?.must_equal true
+    _(first_records.count).must_equal 3
+    first_records.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Record }
+    _(first_records.next?).must_equal true
 
     second_records = first_records.next
     mock.verify
 
-    second_records.count.must_equal 2
-    second_records.each { |z| z.must_be_kind_of Google::Cloud::Dns::Record }
-    second_records.next?.must_equal false
+    _(second_records.count).must_equal 2
+    second_records.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Record }
+    _(second_records.next?).must_equal false
   end
 
   it "loads all records with all" do
@@ -477,8 +477,8 @@ describe Google::Cloud::Dns::Zone, :mock_dns do
     all_records = zone.records.all.to_a
     mock.verify
 
-    all_records.count.must_equal 5
-    all_records.each { |z| z.must_be_kind_of Google::Cloud::Dns::Record }
+    _(all_records.count).must_equal 5
+    all_records.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Record }
   end
 
   it "paginates records with all and max set" do
@@ -491,8 +491,8 @@ describe Google::Cloud::Dns::Zone, :mock_dns do
     all_records = zone.records(max: 3).all.to_a
     mock.verify
 
-    all_records.count.must_equal 5
-    all_records.each { |z| z.must_be_kind_of Google::Cloud::Dns::Record }
+    _(all_records.count).must_equal 5
+    all_records.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Record }
   end
 
   it "loads all records with all using Enumerator" do
@@ -505,8 +505,8 @@ describe Google::Cloud::Dns::Zone, :mock_dns do
     all_records = zone.records.all.take(5)
     mock.verify
 
-    all_records.count.must_equal 5
-    all_records.each { |z| z.must_be_kind_of Google::Cloud::Dns::Record }
+    _(all_records.count).must_equal 5
+    all_records.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Record }
   end
 
   it "loads all records with all with request_limit set" do
@@ -519,71 +519,71 @@ describe Google::Cloud::Dns::Zone, :mock_dns do
     all_records = zone.records.all(request_limit: 1).to_a
     mock.verify
 
-    all_records.count.must_equal 6
-    all_records.each { |z| z.must_be_kind_of Google::Cloud::Dns::Record }
+    _(all_records.count).must_equal 6
+    all_records.each { |z| _(z).must_be_kind_of Google::Cloud::Dns::Record }
   end
 
   it "can create a record" do
     record = zone.record record_name, record_type, record_ttl, record_data
 
-    record.name.must_equal record_name
-    record.type.must_equal record_type
-    record.ttl.must_equal  record_ttl
-    record.data.must_equal record_data
+    _(record.name).must_equal record_name
+    _(record.type).must_equal record_type
+    _(record.ttl).must_equal  record_ttl
+    _(record.data).must_equal record_data
   end
 
   it "creates a record with a fully domain name when not given one" do
     record = zone.record "example.com", record_type, record_ttl, record_data
 
-    record.name.must_equal "example.com." # it appends "."
-    record.type.must_equal record_type
-    record.ttl.must_equal  record_ttl
-    record.data.must_equal record_data
+    _(record.name).must_equal "example.com." # it appends "."
+    _(record.type).must_equal record_type
+    _(record.ttl).must_equal  record_ttl
+    _(record.data).must_equal record_data
   end
 
   it "creates a record when given nil for the domain name" do
     record = zone.record nil, record_type, record_ttl, record_data
 
-    record.name.must_equal "example.com."
-    record.type.must_equal record_type
-    record.ttl.must_equal  record_ttl
-    record.data.must_equal record_data
+    _(record.name).must_equal "example.com."
+    _(record.type).must_equal record_type
+    _(record.ttl).must_equal  record_ttl
+    _(record.data).must_equal record_data
   end
 
   it "creates a record when given an empty string for the domain name" do
     record = zone.record "", record_type, record_ttl, record_data
 
-    record.name.must_equal "example.com."
-    record.type.must_equal record_type
-    record.ttl.must_equal  record_ttl
-    record.data.must_equal record_data
+    _(record.name).must_equal "example.com."
+    _(record.type).must_equal record_type
+    _(record.ttl).must_equal  record_ttl
+    _(record.data).must_equal record_data
   end
 
   it "creates a record when given '@' for the domain name" do
     record = zone.record "@", record_type, record_ttl, record_data
 
-    record.name.must_equal "example.com."
-    record.type.must_equal record_type
-    record.ttl.must_equal  record_ttl
-    record.data.must_equal record_data
+    _(record.name).must_equal "example.com."
+    _(record.type).must_equal record_type
+    _(record.ttl).must_equal  record_ttl
+    _(record.data).must_equal record_data
   end
 
   it "creates a record with a qualified name when given only a subdomain" do
     record = zone.record "www", record_type, record_ttl, record_data
 
-    record.name.must_equal "www.example.com."
-    record.type.must_equal record_type
-    record.ttl.must_equal  record_ttl
-    record.data.must_equal record_data
+    _(record.name).must_equal "www.example.com."
+    _(record.type).must_equal record_type
+    _(record.ttl).must_equal  record_ttl
+    _(record.data).must_equal record_data
   end
 
   it "creates a record without changing name when it is a NAPTR record" do
     record = zone.record "1.2.3.4", "NAPTR", 3600, "10 100 \"U\" \"E2U+sip\" \"!^\\+44111555(.+)$!sip:7\\1@sip.example.com!\" ."
 
-    record.name.must_equal "1.2.3.4"
-    record.type.must_equal "NAPTR"
-    record.ttl.must_equal  3600
-    record.data.must_equal ["10 100 \"U\" \"E2U+sip\" \"!^\\+44111555(.+)$!sip:7\\1@sip.example.com!\" ."]
+    _(record.name).must_equal "1.2.3.4"
+    _(record.type).must_equal "NAPTR"
+    _(record.ttl).must_equal  3600
+    _(record.data).must_equal ["10 100 \"U\" \"E2U+sip\" \"!^\\+44111555(.+)$!sip:7\\1@sip.example.com!\" ."]
   end
 
   it "adds and removes records with update" do
@@ -603,27 +603,27 @@ describe Google::Cloud::Dns::Zone, :mock_dns do
     change = zone.update to_add, to_remove
     mock.verify
 
-    change.must_be_kind_of Google::Cloud::Dns::Change
-    change.id.must_equal "dns-change-created"
-    change.additions.first.name.must_equal to_add.name
-    change.additions.first.type.must_equal to_add.type
-    change.additions.first.ttl.must_equal  to_add.ttl
-    change.additions.first.data.must_equal to_add.data
-    change.deletions.first.name.must_equal to_remove.name
-    change.deletions.first.type.must_equal to_remove.type
-    change.deletions.first.ttl.must_equal  to_remove.ttl
-    change.deletions.first.data.must_equal to_remove.data
+    _(change).must_be_kind_of Google::Cloud::Dns::Change
+    _(change.id).must_equal "dns-change-created"
+    _(change.additions.first.name).must_equal to_add.name
+    _(change.additions.first.type).must_equal to_add.type
+    _(change.additions.first.ttl).must_equal  to_add.ttl
+    _(change.additions.first.data).must_equal to_add.data
+    _(change.deletions.first.name).must_equal to_remove.name
+    _(change.deletions.first.type).must_equal to_remove.type
+    _(change.deletions.first.ttl).must_equal  to_remove.ttl
+    _(change.deletions.first.data).must_equal to_remove.data
   end
 
   it "returns nil when calling update without any records to change" do
     change = zone.update [], []
-    change.must_be :nil?
+    _(change).must_be :nil?
   end
 
   it "returns nil when calling update with records that have not changed" do
     a_record = zone.record zone.dns, "A", 18600, "0.0.0.0"
     change = zone.update a_record, a_record
-    change.must_be :nil?
+    _(change).must_be :nil?
   end
 
   it "only updates the records that have changed" do
@@ -649,16 +649,16 @@ describe Google::Cloud::Dns::Zone, :mock_dns do
     change = zone.update to_add, to_remove
     mock.verify
 
-    change.must_be_kind_of Google::Cloud::Dns::Change
-    change.id.must_equal "dns-change-created"
-    change.additions.first.name.must_equal to_add.first.name
-    change.additions.first.type.must_equal to_add.first.type
-    change.additions.first.ttl.must_equal  to_add.first.ttl
-    change.additions.first.data.must_equal to_add.first.data
-    change.deletions.first.name.must_equal to_remove.first.name
-    change.deletions.first.type.must_equal to_remove.first.type
-    change.deletions.first.ttl.must_equal  to_remove.first.ttl
-    change.deletions.first.data.must_equal to_remove.first.data
+    _(change).must_be_kind_of Google::Cloud::Dns::Change
+    _(change.id).must_equal "dns-change-created"
+    _(change.additions.first.name).must_equal to_add.first.name
+    _(change.additions.first.type).must_equal to_add.first.type
+    _(change.additions.first.ttl).must_equal  to_add.first.ttl
+    _(change.additions.first.data).must_equal to_add.first.data
+    _(change.deletions.first.name).must_equal to_remove.first.name
+    _(change.deletions.first.type).must_equal to_remove.first.type
+    _(change.deletions.first.ttl).must_equal  to_remove.first.ttl
+    _(change.deletions.first.data).must_equal to_remove.first.data
   end
 
   it "adds a record" do
@@ -678,14 +678,14 @@ describe Google::Cloud::Dns::Zone, :mock_dns do
     change = zone.add "example.net.", "A", 18600, "example.com."
     mock.verify
 
-    change.must_be_kind_of Google::Cloud::Dns::Change
-    change.id.must_equal "dns-change-created"
-    change.additions.first.name.must_equal to_add.name
-    change.additions.first.type.must_equal to_add.type
-    change.additions.first.ttl.must_equal  to_add.ttl
-    change.additions.first.data.must_equal to_add.data
-    change.additions[1].data.must_equal updated_soa.data
-    change.deletions.first.data.must_equal soa.data
+    _(change).must_be_kind_of Google::Cloud::Dns::Change
+    _(change.id).must_equal "dns-change-created"
+    _(change.additions.first.name).must_equal to_add.name
+    _(change.additions.first.type).must_equal to_add.type
+    _(change.additions.first.ttl).must_equal  to_add.ttl
+    _(change.additions.first.data).must_equal to_add.data
+    _(change.additions[1].data).must_equal updated_soa.data
+    _(change.deletions.first.data).must_equal soa.data
   end
 
   it "adds a record with a subdomain" do
@@ -705,14 +705,14 @@ describe Google::Cloud::Dns::Zone, :mock_dns do
     change = zone.add "www", "A", 18600, "example.net."
     mock.verify
 
-    change.must_be_kind_of Google::Cloud::Dns::Change
-    change.id.must_equal "dns-change-created"
-    change.additions.first.name.must_equal to_add.name
-    change.additions.first.type.must_equal to_add.type
-    change.additions.first.ttl.must_equal  to_add.ttl
-    change.additions.first.data.must_equal to_add.data
-    change.additions[1].data.must_equal updated_soa.data
-    change.deletions.first.data.must_equal soa.data
+    _(change).must_be_kind_of Google::Cloud::Dns::Change
+    _(change.id).must_equal "dns-change-created"
+    _(change.additions.first.name).must_equal to_add.name
+    _(change.additions.first.type).must_equal to_add.type
+    _(change.additions.first.ttl).must_equal  to_add.ttl
+    _(change.additions.first.data).must_equal to_add.data
+    _(change.additions[1].data).must_equal updated_soa.data
+    _(change.deletions.first.data).must_equal soa.data
   end
 
   it "updates without updating soa" do
@@ -730,13 +730,13 @@ describe Google::Cloud::Dns::Zone, :mock_dns do
     change = zone.update to_add, skip_soa: true
     mock.verify
 
-    change.must_be_kind_of Google::Cloud::Dns::Change
-    change.id.must_equal "dns-change-created"
-    change.additions.first.name.must_equal to_add.name
-    change.additions.first.type.must_equal to_add.type
-    change.additions.first.ttl.must_equal  to_add.ttl
-    change.additions.first.data.must_equal to_add.data
-    change.deletions.must_be :empty?
+    _(change).must_be_kind_of Google::Cloud::Dns::Change
+    _(change.id).must_equal "dns-change-created"
+    _(change.additions.first.name).must_equal to_add.name
+    _(change.additions.first.type).must_equal to_add.type
+    _(change.additions.first.ttl).must_equal  to_add.ttl
+    _(change.additions.first.data).must_equal to_add.data
+    _(change.deletions).must_be :empty?
   end
 
   it "updates with an integer for soa_serial" do
@@ -758,7 +758,7 @@ describe Google::Cloud::Dns::Zone, :mock_dns do
     change = zone.update to_add, [], soa_serial: 10
     mock.verify
 
-    change.additions[1].data.must_equal expected_soa.data
+    _(change.additions[1].data).must_equal expected_soa.data
   end
 
   it "updates with a lambda for soa_serial" do
@@ -780,7 +780,7 @@ describe Google::Cloud::Dns::Zone, :mock_dns do
     change = zone.update to_add, [], soa_serial: lambda { |sn| sn + 10 }
     mock.verify
 
-    change.additions[1].data.must_equal expected_soa.data
+    _(change.additions[1].data).must_equal expected_soa.data
   end
 
   it "removes records by name and type" do
@@ -804,13 +804,13 @@ describe Google::Cloud::Dns::Zone, :mock_dns do
     change = zone.remove "example.net.", "A"
     mock.verify
 
-    change.must_be_kind_of Google::Cloud::Dns::Change
-    change.id.must_equal "dns-change-created"
-    change.additions.must_be :empty?
-    change.deletions.first.name.must_equal to_remove.name
-    change.deletions.first.type.must_equal to_remove.type
-    change.deletions.first.ttl.must_equal  to_remove.ttl
-    change.deletions.first.data.must_equal to_remove.data
+    _(change).must_be_kind_of Google::Cloud::Dns::Change
+    _(change.id).must_equal "dns-change-created"
+    _(change.additions).must_be :empty?
+    _(change.deletions.first.name).must_equal to_remove.name
+    _(change.deletions.first.type).must_equal to_remove.type
+    _(change.deletions.first.ttl).must_equal  to_remove.ttl
+    _(change.deletions.first.data).must_equal to_remove.data
   end
 
   it "removes records by subdomain name and type" do
@@ -834,13 +834,13 @@ describe Google::Cloud::Dns::Zone, :mock_dns do
     change = zone.remove "www", "A"
     mock.verify
 
-    change.must_be_kind_of Google::Cloud::Dns::Change
-    change.id.must_equal "dns-change-created"
-    change.additions.must_be :empty?
-    change.deletions.first.name.must_equal to_remove.name
-    change.deletions.first.type.must_equal to_remove.type
-    change.deletions.first.ttl.must_equal  to_remove.ttl
-    change.deletions.first.data.must_equal to_remove.data
+    _(change).must_be_kind_of Google::Cloud::Dns::Change
+    _(change.id).must_equal "dns-change-created"
+    _(change.additions).must_be :empty?
+    _(change.deletions.first.name).must_equal to_remove.name
+    _(change.deletions.first.type).must_equal to_remove.type
+    _(change.deletions.first.ttl).must_equal  to_remove.ttl
+    _(change.deletions.first.data).must_equal to_remove.data
   end
 
   it "replaces records by name and type" do
@@ -865,16 +865,16 @@ describe Google::Cloud::Dns::Zone, :mock_dns do
     change = zone.replace "example.net.", "A", 18600, "example.com."
     mock.verify
 
-    change.must_be_kind_of Google::Cloud::Dns::Change
-    change.id.must_equal "dns-change-created"
-    change.additions.first.name.must_equal to_add.name
-    change.additions.first.type.must_equal to_add.type
-    change.additions.first.ttl.must_equal  to_add.ttl
-    change.additions.first.data.must_equal to_add.data
-    change.deletions.first.name.must_equal to_remove.name
-    change.deletions.first.type.must_equal to_remove.type
-    change.deletions.first.ttl.must_equal  to_remove.ttl
-    change.deletions.first.data.must_equal to_remove.data
+    _(change).must_be_kind_of Google::Cloud::Dns::Change
+    _(change.id).must_equal "dns-change-created"
+    _(change.additions.first.name).must_equal to_add.name
+    _(change.additions.first.type).must_equal to_add.type
+    _(change.additions.first.ttl).must_equal  to_add.ttl
+    _(change.additions.first.data).must_equal to_add.data
+    _(change.deletions.first.name).must_equal to_remove.name
+    _(change.deletions.first.type).must_equal to_remove.type
+    _(change.deletions.first.ttl).must_equal  to_remove.ttl
+    _(change.deletions.first.data).must_equal to_remove.data
   end
 
   it "replaces records by subdomain and type" do
@@ -899,16 +899,16 @@ describe Google::Cloud::Dns::Zone, :mock_dns do
     change = zone.replace "www", "A", 18600, "example.net."
     mock.verify
 
-    change.must_be_kind_of Google::Cloud::Dns::Change
-    change.id.must_equal "dns-change-created"
-    change.additions.first.name.must_equal to_add.name
-    change.additions.first.type.must_equal to_add.type
-    change.additions.first.ttl.must_equal  to_add.ttl
-    change.additions.first.data.must_equal to_add.data
-    change.deletions.first.name.must_equal to_remove.name
-    change.deletions.first.type.must_equal to_remove.type
-    change.deletions.first.ttl.must_equal  to_remove.ttl
-    change.deletions.first.data.must_equal to_remove.data
+    _(change).must_be_kind_of Google::Cloud::Dns::Change
+    _(change.id).must_equal "dns-change-created"
+    _(change.additions.first.name).must_equal to_add.name
+    _(change.additions.first.type).must_equal to_add.type
+    _(change.additions.first.ttl).must_equal  to_add.ttl
+    _(change.additions.first.data).must_equal to_add.data
+    _(change.deletions.first.name).must_equal to_remove.name
+    _(change.deletions.first.type).must_equal to_remove.type
+    _(change.deletions.first.ttl).must_equal  to_remove.ttl
+    _(change.deletions.first.data).must_equal to_remove.data
   end
 
   it "modifies records by name and type" do
@@ -935,16 +935,16 @@ describe Google::Cloud::Dns::Zone, :mock_dns do
     end
     mock.verify
 
-    change.must_be_kind_of Google::Cloud::Dns::Change
-    change.id.must_equal "dns-change-created"
-    change.additions.first.name.must_equal to_add.name
-    change.additions.first.type.must_equal to_add.type
-    change.additions.first.ttl.must_equal  to_add.ttl
-    change.additions.first.data.must_equal to_add.data
-    change.deletions.first.name.must_equal to_remove.name
-    change.deletions.first.type.must_equal to_remove.type
-    change.deletions.first.ttl.must_equal  to_remove.ttl
-    change.deletions.first.data.must_equal to_remove.data
+    _(change).must_be_kind_of Google::Cloud::Dns::Change
+    _(change.id).must_equal "dns-change-created"
+    _(change.additions.first.name).must_equal to_add.name
+    _(change.additions.first.type).must_equal to_add.type
+    _(change.additions.first.ttl).must_equal  to_add.ttl
+    _(change.additions.first.data).must_equal to_add.data
+    _(change.deletions.first.name).must_equal to_remove.name
+    _(change.deletions.first.type).must_equal to_remove.type
+    _(change.deletions.first.ttl).must_equal  to_remove.ttl
+    _(change.deletions.first.data).must_equal to_remove.data
   end
 
   it "modifies records by subdomain and type" do
@@ -971,16 +971,16 @@ describe Google::Cloud::Dns::Zone, :mock_dns do
     end
     mock.verify
 
-    change.must_be_kind_of Google::Cloud::Dns::Change
-    change.id.must_equal "dns-change-created"
-    change.additions.first.name.must_equal to_add.name
-    change.additions.first.type.must_equal to_add.type
-    change.additions.first.ttl.must_equal  to_add.ttl
-    change.additions.first.data.must_equal to_add.data
-    change.deletions.first.name.must_equal to_remove.name
-    change.deletions.first.type.must_equal to_remove.type
-    change.deletions.first.ttl.must_equal  to_remove.ttl
-    change.deletions.first.data.must_equal to_remove.data
+    _(change).must_be_kind_of Google::Cloud::Dns::Change
+    _(change.id).must_equal "dns-change-created"
+    _(change.additions.first.name).must_equal to_add.name
+    _(change.additions.first.type).must_equal to_add.type
+    _(change.additions.first.ttl).must_equal  to_add.ttl
+    _(change.additions.first.data).must_equal to_add.data
+    _(change.deletions.first.name).must_equal to_remove.name
+    _(change.deletions.first.type).must_equal to_remove.type
+    _(change.deletions.first.ttl).must_equal  to_remove.ttl
+    _(change.deletions.first.data).must_equal to_remove.data
   end
 
   it "allows for multiple changes in one update using the DSL" do

--- a/google-cloud-dns/test/google/cloud/dns_test.rb
+++ b/google-cloud-dns/test/google/cloud/dns_test.rb
@@ -20,51 +20,51 @@ describe Google::Cloud do
     it "calls out to Google::Cloud.dns" do
       gcloud = Google::Cloud.new
       stubbed_dns = ->(project, keyfile, scope: nil, retries: nil, timeout: nil, host: nil) {
-        project.must_be :nil?
-        keyfile.must_be :nil?
-        scope.must_be :nil?
-        retries.must_be :nil?
-        timeout.must_be :nil?
-        host.must_be :nil?
+        _(project).must_be :nil?
+        _(keyfile).must_be :nil?
+        _(scope).must_be :nil?
+        _(retries).must_be :nil?
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
         "dns-project-object-empty"
       }
       Google::Cloud.stub :dns, stubbed_dns do
         project = gcloud.dns
-        project.must_equal "dns-project-object-empty"
+        _(project).must_equal "dns-project-object-empty"
       end
     end
 
     it "passes project and keyfile to Google::Cloud.dns" do
       gcloud = Google::Cloud.new "project-id", "keyfile-path"
       stubbed_dns = ->(project, keyfile, scope: nil, retries: nil, timeout: nil, host: nil) {
-        project.must_equal "project-id"
-        keyfile.must_equal "keyfile-path"
-        scope.must_be :nil?
-        retries.must_be :nil?
-        timeout.must_be :nil?
-        host.must_be :nil?
+        _(project).must_equal "project-id"
+        _(keyfile).must_equal "keyfile-path"
+        _(scope).must_be :nil?
+        _(retries).must_be :nil?
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
         "dns-project-object"
       }
       Google::Cloud.stub :dns, stubbed_dns do
         project = gcloud.dns
-        project.must_equal "dns-project-object"
+        _(project).must_equal "dns-project-object"
       end
     end
 
     it "passes project and keyfile and options to Google::Cloud.dns" do
       gcloud = Google::Cloud.new "project-id", "keyfile-path"
       stubbed_dns = ->(project, keyfile, scope: nil, retries: nil, timeout: nil, host: nil) {
-        project.must_equal "project-id"
-        keyfile.must_equal "keyfile-path"
-        scope.must_equal "http://example.com/scope"
-        retries.must_equal 5
-        timeout.must_equal 60
-        host.must_be :nil?
+        _(project).must_equal "project-id"
+        _(keyfile).must_equal "keyfile-path"
+        _(scope).must_equal "http://example.com/scope"
+        _(retries).must_equal 5
+        _(timeout).must_equal 60
+        _(host).must_be :nil?
         "dns-project-object-scoped"
       }
       Google::Cloud.stub :dns, stubbed_dns do
         project = gcloud.dns scope: "http://example.com/scope", retries: 5, timeout: 60
-        project.must_equal "dns-project-object-scoped"
+        _(project).must_equal "dns-project-object-scoped"
       end
     end
   end
@@ -86,9 +86,9 @@ describe Google::Cloud do
         Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
           Google::Cloud::Dns::Credentials.stub :default, default_credentials do
             dns = Google::Cloud.dns
-            dns.must_be_kind_of Google::Cloud::Dns::Project
-            dns.project.must_equal "project-id"
-            dns.service.credentials.must_equal default_credentials
+            _(dns).must_be_kind_of Google::Cloud::Dns::Project
+            _(dns.project).must_equal "project-id"
+            _(dns.service.credentials).must_equal default_credentials
           end
         end
       end
@@ -96,16 +96,16 @@ describe Google::Cloud do
 
     it "uses provided project_id and keyfile" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "dns-credentials"
       }
       stubbed_service = ->(project, credentials, retries: nil, timeout: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "dns-credentials"
-        retries.must_be :nil?
-        timeout.must_be :nil?
-        host.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "dns-credentials"
+        _(retries).must_be :nil?
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -116,9 +116,9 @@ describe Google::Cloud do
             Google::Cloud::Dns::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Dns::Service.stub :new, stubbed_service do
                 dns = Google::Cloud.dns "project-id", "path/to/keyfile.json"
-                dns.must_be_kind_of Google::Cloud::Dns::Project
-                dns.project.must_equal "project-id"
-                dns.service.must_be_kind_of OpenStruct
+                _(dns).must_be_kind_of Google::Cloud::Dns::Project
+                _(dns.project).must_equal "project-id"
+                _(dns.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -144,9 +144,9 @@ describe Google::Cloud do
         Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
           Google::Cloud::Dns::Credentials.stub :default, default_credentials do
             dns = Google::Cloud::Dns.new
-            dns.must_be_kind_of Google::Cloud::Dns::Project
-            dns.project.must_equal "project-id"
-            dns.service.credentials.must_equal default_credentials
+            _(dns).must_be_kind_of Google::Cloud::Dns::Project
+            _(dns.project).must_equal "project-id"
+            _(dns.service.credentials).must_equal default_credentials
           end
         end
       end
@@ -154,16 +154,16 @@ describe Google::Cloud do
 
     it "uses provided project_id and credentials" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "dns-credentials"
       }
       stubbed_service = ->(project, credentials, retries: nil, timeout: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "dns-credentials"
-        retries.must_be :nil?
-        timeout.must_be :nil?
-        host.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "dns-credentials"
+        _(retries).must_be :nil?
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -174,9 +174,9 @@ describe Google::Cloud do
             Google::Cloud::Dns::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Dns::Service.stub :new, stubbed_service do
                 dns = Google::Cloud::Dns.new project_id: "project-id", credentials: "path/to/keyfile.json"
-                dns.must_be_kind_of Google::Cloud::Dns::Project
-                dns.project.must_equal "project-id"
-                dns.service.must_be_kind_of OpenStruct
+                _(dns).must_be_kind_of Google::Cloud::Dns::Project
+                _(dns.project).must_equal "project-id"
+                _(dns.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -186,16 +186,16 @@ describe Google::Cloud do
 
     it "uses provided project and keyfile aliases" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "dns-credentials"
       }
       stubbed_service = ->(project, credentials, retries: nil, timeout: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "dns-credentials"
-        retries.must_be :nil?
-        timeout.must_be :nil?
-        host.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "dns-credentials"
+        _(retries).must_be :nil?
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -206,9 +206,9 @@ describe Google::Cloud do
             Google::Cloud::Dns::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Dns::Service.stub :new, stubbed_service do
                 dns = Google::Cloud::Dns.new project: "project-id", keyfile: "path/to/keyfile.json"
-                dns.must_be_kind_of Google::Cloud::Dns::Project
-                dns.project.must_equal "project-id"
-                dns.service.must_be_kind_of OpenStruct
+                _(dns).must_be_kind_of Google::Cloud::Dns::Project
+                _(dns.project).must_equal "project-id"
+                _(dns.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -218,17 +218,17 @@ describe Google::Cloud do
 
     it "gets project_id from credentials" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         OpenStruct.new project_id: "project-id"
       }
       stubbed_service = ->(project, credentials, retries: nil, timeout: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_be_kind_of OpenStruct
-        credentials.project_id.must_equal "project-id"
-        retries.must_be :nil?
-        timeout.must_be :nil?
-        host.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_be_kind_of OpenStruct
+        _(credentials.project_id).must_equal "project-id"
+        _(retries).must_be :nil?
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
         OpenStruct.new project: project
       }
       empty_env = OpenStruct.new
@@ -241,9 +241,9 @@ describe Google::Cloud do
               Google::Cloud::Dns::Credentials.stub :new, stubbed_credentials do
                 Google::Cloud::Dns::Service.stub :new, stubbed_service do
                   dns = Google::Cloud::Dns.new credentials: "path/to/keyfile.json"
-                  dns.must_be_kind_of Google::Cloud::Dns::Project
-                  dns.project.must_equal "project-id"
-                  dns.service.must_be_kind_of OpenStruct
+                  _(dns).must_be_kind_of Google::Cloud::Dns::Project
+                  _(dns.project).must_equal "project-id"
+                  _(dns.service).must_be_kind_of OpenStruct
                 end
               end
             end
@@ -254,11 +254,11 @@ describe Google::Cloud do
 
     it "uses provided endpoint" do
       stubbed_service = ->(project, credentials, retries: nil, timeout: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal default_credentials
-        retries.must_be :nil?
-        timeout.must_be :nil?
-        host.must_equal "dns-endpoint2.example.com"
+        _(project).must_equal "project-id"
+        _(credentials).must_equal default_credentials
+        _(retries).must_be :nil?
+        _(timeout).must_be :nil?
+        _(host).must_equal "dns-endpoint2.example.com"
         OpenStruct.new project: project
       }
 
@@ -267,9 +267,9 @@ describe Google::Cloud do
         Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
           Google::Cloud::Dns::Service.stub :new, stubbed_service do
             dns = Google::Cloud::Dns.new credentials: default_credentials, endpoint: "dns-endpoint2.example.com"
-            dns.must_be_kind_of Google::Cloud::Dns::Project
-            dns.project.must_equal "project-id"
-            dns.service.must_be_kind_of OpenStruct
+            _(dns).must_be_kind_of Google::Cloud::Dns::Project
+            _(dns.project).must_equal "project-id"
+            _(dns.service).must_be_kind_of OpenStruct
           end
         end
       end
@@ -285,16 +285,16 @@ describe Google::Cloud do
 
     it "uses shared config for project and keyfile" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "dns-credentials"
       }
       stubbed_service = ->(project, credentials, retries: nil, timeout: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "dns-credentials"
-        retries.must_be :nil?
-        timeout.must_be :nil?
-        host.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "dns-credentials"
+        _(retries).must_be :nil?
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -311,9 +311,9 @@ describe Google::Cloud do
             Google::Cloud::Dns::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Dns::Service.stub :new, stubbed_service do
                 dns = Google::Cloud::Dns.new
-                dns.must_be_kind_of Google::Cloud::Dns::Project
-                dns.project.must_equal "project-id"
-                dns.service.must_be_kind_of OpenStruct
+                _(dns).must_be_kind_of Google::Cloud::Dns::Project
+                _(dns.project).must_equal "project-id"
+                _(dns.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -323,16 +323,16 @@ describe Google::Cloud do
 
     it "uses shared config for project_id and credentials" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "dns-credentials"
       }
       stubbed_service = ->(project, credentials, retries: nil, timeout: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "dns-credentials"
-        retries.must_be :nil?
-        timeout.must_be :nil?
-        host.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "dns-credentials"
+        _(retries).must_be :nil?
+        _(timeout).must_be :nil?
+        _(host).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -349,9 +349,9 @@ describe Google::Cloud do
             Google::Cloud::Dns::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Dns::Service.stub :new, stubbed_service do
                 dns = Google::Cloud::Dns.new
-                dns.must_be_kind_of Google::Cloud::Dns::Project
-                dns.project.must_equal "project-id"
-                dns.service.must_be_kind_of OpenStruct
+                _(dns).must_be_kind_of Google::Cloud::Dns::Project
+                _(dns.project).must_equal "project-id"
+                _(dns.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -361,16 +361,16 @@ describe Google::Cloud do
 
     it "uses dns config for project and keyfile" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "dns-credentials"
       }
       stubbed_service = ->(project, credentials, retries: nil, timeout: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "dns-credentials"
-        retries.must_equal 3
-        timeout.must_equal 42
-        host.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "dns-credentials"
+        _(retries).must_equal 3
+        _(timeout).must_equal 42
+        _(host).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -389,9 +389,9 @@ describe Google::Cloud do
             Google::Cloud::Dns::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Dns::Service.stub :new, stubbed_service do
                 dns = Google::Cloud::Dns.new
-                dns.must_be_kind_of Google::Cloud::Dns::Project
-                dns.project.must_equal "project-id"
-                dns.service.must_be_kind_of OpenStruct
+                _(dns).must_be_kind_of Google::Cloud::Dns::Project
+                _(dns.project).must_equal "project-id"
+                _(dns.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -401,16 +401,16 @@ describe Google::Cloud do
 
     it "uses dns config for project_id and credentials" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "dns-credentials"
       }
       stubbed_service = ->(project, credentials, retries: nil, timeout: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "dns-credentials"
-        retries.must_equal 3
-        timeout.must_equal 42
-        host.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "dns-credentials"
+        _(retries).must_equal 3
+        _(timeout).must_equal 42
+        _(host).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -429,9 +429,9 @@ describe Google::Cloud do
             Google::Cloud::Dns::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Dns::Service.stub :new, stubbed_service do
                 dns = Google::Cloud::Dns.new
-                dns.must_be_kind_of Google::Cloud::Dns::Project
-                dns.project.must_equal "project-id"
-                dns.service.must_be_kind_of OpenStruct
+                _(dns).must_be_kind_of Google::Cloud::Dns::Project
+                _(dns.project).must_equal "project-id"
+                _(dns.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -441,16 +441,16 @@ describe Google::Cloud do
 
     it "uses dns config for endpoint" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "dns-credentials"
       }
       stubbed_service = ->(project, credentials, retries: nil, timeout: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "dns-credentials"
-        retries.must_equal 3
-        timeout.must_equal 42
-        host.must_equal "dns-endpoint2.example.com"
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "dns-credentials"
+        _(retries).must_equal 3
+        _(timeout).must_equal 42
+        _(host).must_equal "dns-endpoint2.example.com"
         OpenStruct.new project: project
       }
 
@@ -470,9 +470,9 @@ describe Google::Cloud do
             Google::Cloud::Dns::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Dns::Service.stub :new, stubbed_service do
                 dns = Google::Cloud::Dns.new
-                dns.must_be_kind_of Google::Cloud::Dns::Project
-                dns.project.must_equal "project-id"
-                dns.service.must_be_kind_of OpenStruct
+                _(dns).must_be_kind_of Google::Cloud::Dns::Project
+                _(dns.project).must_equal "project-id"
+                _(dns.service).must_be_kind_of OpenStruct
               end
             end
           end


### PR DESCRIPTION
Use `rubocop-minitest` gem and `bundle exec rubocop --only Minitest/GlobalExpectations -a` to autocorrect minitest warnings for Ruby 2.7.

refs: #4110
refs: #4116