### PR TITLE
chore(debugger): Update minitest to 5.14

### DIFF
--- a/google-cloud-debugger/.rubocop.yml
+++ b/google-cloud-debugger/.rubocop.yml
@@ -1,9 +1,10 @@
+require: rubocop-minitest
+
 inherit_gem:
   google-style: google-style.yml
 
 AllCops:
   Exclude:
-    - "acceptance/**/*"
     - "integration/**/*"
     - "google-cloud-debugger.gemspec"
     - "lib/google/devtools/**/*"
@@ -12,7 +13,6 @@ AllCops:
     - "lib/google/cloud/debugger/v2.rb"
     - "Rakefile"
     - "support/**/*"
-    - "test/**/*"
     - "tmp/**/*"
 
 Documentation:

--- a/google-cloud-debugger/.rubocop.yml
+++ b/google-cloud-debugger/.rubocop.yml
@@ -1,10 +1,9 @@
-require: rubocop-minitest
-
 inherit_gem:
   google-style: google-style.yml
 
 AllCops:
   Exclude:
+    - "acceptance/**/*"
     - "integration/**/*"
     - "google-cloud-debugger.gemspec"
     - "lib/google/devtools/**/*"
@@ -13,6 +12,7 @@ AllCops:
     - "lib/google/cloud/debugger/v2.rb"
     - "Rakefile"
     - "support/**/*"
+    - "test/**/*"
     - "tmp/**/*"
 
 Documentation:

--- a/google-cloud-debugger/Gemfile
+++ b/google-cloud-debugger/Gemfile
@@ -9,3 +9,5 @@ gem "google-cloud-logging", path: "../google-cloud-logging"
 gem "stackdriver-core", path: "../stackdriver-core"
 
 gem "rake"
+
+gem "rubocop-minitest"

--- a/google-cloud-debugger/Gemfile
+++ b/google-cloud-debugger/Gemfile
@@ -9,5 +9,3 @@ gem "google-cloud-logging", path: "../google-cloud-logging"
 gem "stackdriver-core", path: "../stackdriver-core"
 
 gem "rake"
-
-gem "rubocop-minitest"

--- a/google-cloud-debugger/Gemfile
+++ b/google-cloud-debugger/Gemfile
@@ -9,7 +9,3 @@ gem "google-cloud-logging", path: "../google-cloud-logging"
 gem "stackdriver-core", path: "../stackdriver-core"
 
 gem "rake"
-
-# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
-# See https://github.com/googleapis/google-cloud-ruby/issues/4110
-gem "minitest", "~> 5.11.3"

--- a/google-cloud-debugger/acceptance/debugger/debugger_test.rb
+++ b/google-cloud-debugger/acceptance/debugger/debugger_test.rb
@@ -30,17 +30,17 @@ describe Google::Cloud::Debugger, :debugger do
       breakpoint.is_final_state
     end
 
-    breakpoint.must_be :is_final_state
+    _(breakpoint).must_be :is_final_state
 
     stack_frame = breakpoint.stack_frames[0]
-    stack_frame.function.must_equal "trigger_breakpoint"
-    stack_frame.locals.size.must_equal 1
-    stack_frame.locals.first.name.must_equal "local_var"
-    stack_frame.locals.first.value.must_equal "42"
+    _(stack_frame.function).must_equal "trigger_breakpoint"
+    _(stack_frame.locals.size).must_equal 1
+    _(stack_frame.locals.first.name).must_equal "local_var"
+    _(stack_frame.locals.first.value).must_equal "42"
 
-    breakpoint.evaluated_expressions.size.must_equal 1
-    breakpoint.evaluated_expressions.first.name.must_equal "local_var"
-    breakpoint.evaluated_expressions.first.value.must_equal "42"
+    _(breakpoint.evaluated_expressions.size).must_equal 1
+    _(breakpoint.evaluated_expressions.first.name).must_equal "local_var"
+    _(breakpoint.evaluated_expressions.first.value).must_equal "42"
   end
 
   it "catches and evaluates logpoint" do
@@ -66,10 +66,10 @@ describe Google::Cloud::Debugger, :debugger do
       !entries.empty?
     end
 
-    entries.wont_be :empty?
+    _(entries).wont_be :empty?
 
-    entries.first.payload.must_match "LOGPOINT"
-    entries.first.payload.must_match "local_var is 42"
-    entries.first.payload.must_match token.to_s
+    _(entries.first.payload).must_match "LOGPOINT"
+    _(entries.first.payload).must_match "local_var is 42"
+    _(entries.first.payload).must_match token.to_s
   end
 end

--- a/google-cloud-debugger/google-cloud-debugger.gemspec
+++ b/google-cloud-debugger/google-cloud-debugger.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "concurrent-ruby", "~> 1.1"
 
   gem.add_development_dependency "google-style", "~> 1.24.0"
-  gem.add_development_dependency "minitest", "~> 5.10"
+  gem.add_development_dependency "minitest", "~> 5.14"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"
   gem.add_development_dependency "minitest-focus", "~> 1.1"
   gem.add_development_dependency "minitest-rg", "~> 5.2"

--- a/google-cloud-debugger/test/google/cloud/debugger/agent_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/agent_test.rb
@@ -17,25 +17,25 @@ require "helper"
 describe Google::Cloud::Debugger::Agent, :mock_debugger do
   describe "#initialize" do
     it "initializes all the children components" do
-      agent.debuggee.must_be_kind_of Google::Cloud::Debugger::Debuggee
-      agent.tracer.must_be_kind_of Google::Cloud::Debugger::Tracer
-      agent.breakpoint_manager.must_be_kind_of Google::Cloud::Debugger::BreakpointManager
-      agent.breakpoint_manager.on_breakpoints_change.must_be_kind_of Method
-      agent.transmitter.must_be_kind_of Google::Cloud::Debugger::Transmitter
-      agent.logger.must_be_kind_of Google::Cloud::Logging::Logger
+      _(agent.debuggee).must_be_kind_of Google::Cloud::Debugger::Debuggee
+      _(agent.tracer).must_be_kind_of Google::Cloud::Debugger::Tracer
+      _(agent.breakpoint_manager).must_be_kind_of Google::Cloud::Debugger::BreakpointManager
+      _(agent.breakpoint_manager.on_breakpoints_change).must_be_kind_of Method
+      _(agent.transmitter).must_be_kind_of Google::Cloud::Debugger::Transmitter
+      _(agent.logger).must_be_kind_of Google::Cloud::Logging::Logger
     end
 
     it "the default logger shares same project_id and credentials" do
-      agent.logger.project.must_equal service.project
+      _(agent.logger.project).must_equal service.project
 
-      agent.logger.writer.logging.service.credentials.must_equal service.credentials
+      _(agent.logger.writer.logging.service.credentials).must_equal service.credentials
     end
 
     it "uses the logger passed in" do
       new_agent = Google::Cloud::Debugger::Agent.new nil, logger: "test-logger",
                                                           service_name: nil,
                                                           service_version: nil
-      new_agent.logger.must_equal "test-logger"
+      _(new_agent.logger).must_equal "test-logger"
     end
   end
 

--- a/google-cloud-debugger/test/google/cloud/debugger/backoff_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/backoff_test.rb
@@ -20,18 +20,18 @@ describe Google::Cloud::Debugger::Backoff do
   describe "#succeeded" do
     it "resets the backoff session" do
       backoff.failed
-      backoff.backing_off?.must_equal true
+      _(backoff.backing_off?).must_equal true
 
       backoff.succeeded
-      backoff.backing_off?.must_equal false
+      _(backoff.backing_off?).must_equal false
     end
   end
 
   describe "#failed" do
     it "initializes the backoff session" do
-      backoff.backing_off?.must_equal false
+      _(backoff.backing_off?).must_equal false
       backoff.failed
-      backoff.backing_off?.must_equal true
+      _(backoff.backing_off?).must_equal true
     end
 
     it "increases the backoff counter with each call" do
@@ -41,7 +41,7 @@ describe Google::Cloud::Debugger::Backoff do
       backoff.failed
       interval2 = backoff.interval
 
-      (interval2 > interval1).must_equal true
+      _((interval2 > interval1)).must_equal true
     end
   end
 end

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator/instance_c_methods_whitelist_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator/instance_c_methods_whitelist_test.rb
@@ -334,8 +334,8 @@ describe Google::Cloud::Debugger::Breakpoint::Evaluator, :instance_c_methods_whi
 
     it "doesn't allow #`" do
       result = evaluator.readonly_eval_expression binding, "`ls`"
-      result.must_be_kind_of Google::Cloud::Debugger::MutationError
-      result.message.match("#{evaluator::MUTATION_DETECTED_MSG}|#{evaluator::PROHIBITED_OPERATION_MSG}").wont_be_nil
+      _(result).must_be_kind_of Google::Cloud::Debugger::MutationError
+      _(result.message.match("#{evaluator::MUTATION_DETECTED_MSG}|#{evaluator::PROHIBITED_OPERATION_MSG}")).wont_be_nil
     end
 
     it "doesn't allow #eval" do

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/evaluator_test.rb
@@ -54,7 +54,7 @@ describe Google::Cloud::Debugger::Breakpoint::Evaluator do
       local_var = "original local var"
       expression = "local_var = 'new local var'"
       expression_triggers_mutation expression, binding
-      local_var.must_equal "original local var"
+      _(local_var).must_equal "original local var"
     end
 
     it "allows setting local variable in readonly function calls" do
@@ -65,14 +65,14 @@ describe Google::Cloud::Debugger::Breakpoint::Evaluator do
       $global_var = "original global var"
       expression = "$global_var = 'new global var'"
       expression_triggers_mutation expression, binding
-      $global_var.must_equal "original global var"
+      _($global_var).must_equal "original global var"
     end
 
     it "doesn't allow setting instance variable" do
       @instance_var = "original instance var"
       expression = "@instance_var = 'new instance var'"
       expression_triggers_mutation expression, binding
-      @instance_var.must_equal "original instance var"
+      _(@instance_var).must_equal "original instance var"
     end
 
     it "doesn't allow setting class variable" do
@@ -84,28 +84,28 @@ describe Google::Cloud::Debugger::Breakpoint::Evaluator do
       TEST_CONST  = "original constant"
       expression = "TEST_CONST = 'new constant'"
       expression_triggers_mutation expression, binding
-      TEST_CONST.must_equal "original constant"
+      _(TEST_CONST).must_equal "original constant"
     end
 
     it "doesn't allow << operator" do
       ary = [1,2]
       expression = "ary << 3"
       expression_triggers_mutation expression, binding
-      ary.size.must_equal 2
+      _(ary.size).must_equal 2
     end
 
     it "doesn't allow array set" do
       ary = [1,2]
       expression = "ary[0] = 2"
       expression_triggers_mutation expression, binding
-      ary.must_include 1
+      _(ary).must_include 1
     end
 
     it "doesn't allow hash set with string key" do
       hsh = {"abc" => 123}
       expression = "hsh['abc'] = 456"
       expression_triggers_mutation expression, binding
-      hsh["abc"].must_equal 123
+      _(hsh["abc"]).must_equal 123
     end
 
     it "doesn't allow return operation in expression" do
@@ -113,10 +113,10 @@ describe Google::Cloud::Debugger::Breakpoint::Evaluator do
       result = evaluator.readonly_eval_expression binding, expression
       if RUBY_VERSION.to_f >= 2.6
         # Ruby 2.6 raises LocalJumpError
-        result.message.must_match "unexpected return"
+        _(result.message).must_match "unexpected return"
       else
         # Ruby 2.4 and 2.5 treat this as a mutation
-        result.message.must_match evaluator::PROHIBITED_OPERATION_MSG
+        _(result.message).must_match evaluator::PROHIBITED_OPERATION_MSG
       end
     end
 
@@ -144,36 +144,36 @@ describe Google::Cloud::Debugger::Breakpoint::Evaluator do
     it "returns ZeroDivisionError" do
       expression = "1/0"
       result = evaluator.readonly_eval_expression binding, expression
-      result.must_be_kind_of ZeroDivisionError
-      result.message.must_match "divided by 0"
+      _(result).must_be_kind_of ZeroDivisionError
+      _(result.message).must_match "divided by 0"
     end
 
     it "returns NameError" do
       expression = "a_thing_that_is_not_defined"
       result = evaluator.readonly_eval_expression binding, expression
-      result.must_be_kind_of NameError
-      result.message.must_match "undefined local variable or method"
+      _(result).must_be_kind_of NameError
+      _(result.message).must_match "undefined local variable or method"
     end
 
     it "returns NoMethodError" do
       expression = "nil.blahblahblah"
       result = evaluator.readonly_eval_expression binding, expression
-      result.must_be_kind_of NoMethodError
-      result.message.must_match "undefined method"
+      _(result).must_be_kind_of NoMethodError
+      _(result.message).must_match "undefined method"
     end
 
     it "returns ArgumentError" do
       expression = "nil.send"
       result = evaluator.readonly_eval_expression binding, expression
-      result.must_be_kind_of ArgumentError
-      result.message.must_match "no method name given"
+      _(result).must_be_kind_of ArgumentError
+      _(result.message).must_match "no method name given"
     end
 
     it "errors out if evaluation takes too long" do
       expression = "infinite_loop()"
       result = evaluator.readonly_eval_expression binding, expression
-      result.must_be_kind_of Google::Cloud::Debugger::EvaluationError
-      result.message.must_match "Evaluation exceeded time limit"
+      _(result).must_be_kind_of Google::Cloud::Debugger::EvaluationError
+      _(result.message).must_match "Evaluation exceeded time limit"
     end
 
     it "does not allow direct mutating in allow_mutating_methods" do

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/source_location_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/source_location_test.rb
@@ -27,13 +27,13 @@ describe Google::Cloud::Debugger::Breakpoint::SourceLocation, :mock_debugger do
   }
 
   it "knows its attributes" do
-    source_loc.path.must_equal "my_app/my_class.rb"
-    source_loc.line.must_equal 321
+    _(source_loc.path).must_equal "my_app/my_class.rb"
+    _(source_loc.line).must_equal 321
   end
 
   it "converts to grpc" do
     grpc = source_loc.to_grpc
-    grpc.path.must_equal source_location_grpc.path
-    grpc.line.must_equal source_location_grpc.line
+    _(grpc.path).must_equal source_location_grpc.path
+    _(grpc.line).must_equal source_location_grpc.line
   end
  end

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/stack_frame_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/stack_frame_test.rb
@@ -28,10 +28,10 @@ describe Google::Cloud::Debugger::Breakpoint::StackFrame, :mock_debugger do
 
   describe ".from_grpc" do
     it "has all of the attributes" do
-      stack_frame.function.must_equal "index"
-      stack_frame.location.must_be_kind_of Google::Cloud::Debugger::Breakpoint::SourceLocation
-      stack_frame.arguments[0].must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
-      stack_frame.locals[0].must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
+      _(stack_frame.function).must_equal "index"
+      _(stack_frame.location).must_be_kind_of Google::Cloud::Debugger::Breakpoint::SourceLocation
+      _(stack_frame.arguments[0]).must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
+      _(stack_frame.locals[0]).must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
     end
   end
 
@@ -39,20 +39,20 @@ describe Google::Cloud::Debugger::Breakpoint::StackFrame, :mock_debugger do
     it "has all of the attributes" do
       grpc = stack_frame.to_grpc
 
-      grpc.function.must_equal stack_frame_grpc.function
-      grpc.location.must_equal stack_frame_grpc.location
-      grpc.arguments.must_equal stack_frame_grpc.arguments
-      grpc.locals.must_equal stack_frame_grpc.locals
+      _(grpc.function).must_equal stack_frame_grpc.function
+      _(grpc.location).must_equal stack_frame_grpc.location
+      _(grpc.arguments).must_equal stack_frame_grpc.arguments
+      _(grpc.locals).must_equal stack_frame_grpc.locals
     end
 
     it "has arguments even if missing from object" do
       stack_frame.arguments = nil
-      stack_frame.to_grpc.arguments.must_equal []
+      _(stack_frame.to_grpc.arguments).must_equal []
     end
 
     it "has locals even if missing from object" do
       stack_frame.locals = nil
-      stack_frame.to_grpc.locals.must_equal []
+      _(stack_frame.to_grpc.locals).must_equal []
     end
   end
 end

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/status_message_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/status_message_test.rb
@@ -35,9 +35,9 @@ describe Google::Cloud::Debugger::Breakpoint::StatusMessage, :mock_debugger do
 
   describe ".from_grpc" do
     it "knows all of its attributes" do
-      status_message.is_error.must_equal true
-      status_message.refers_to.must_equal Google::Cloud::Debugger::Breakpoint::StatusMessage::UNSPECIFIED
-      status_message.description.must_equal "test error message"
+      _(status_message.is_error).must_equal true
+      _(status_message.refers_to).must_equal Google::Cloud::Debugger::Breakpoint::StatusMessage::UNSPECIFIED
+      _(status_message.description).must_equal "test error message"
     end
   end
 
@@ -45,10 +45,10 @@ describe Google::Cloud::Debugger::Breakpoint::StatusMessage, :mock_debugger do
     it "exports all of the content" do
       grpc = status_message.to_grpc
 
-      grpc.must_be_kind_of Google::Devtools::Clouddebugger::V2::StatusMessage
-      grpc.is_error.must_equal true
-      grpc.refers_to.must_equal :UNSPECIFIED
-      grpc.description.format.must_equal "test error message"
+      _(grpc).must_be_kind_of Google::Devtools::Clouddebugger::V2::StatusMessage
+      _(grpc.is_error).must_equal true
+      _(grpc.refers_to).must_equal :UNSPECIFIED
+      _(grpc.description.format).must_equal "test error message"
     end
   end
 end

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/validator_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/validator_test.rb
@@ -21,36 +21,36 @@ describe Google::Cloud::Debugger::Breakpoint::Validator, :mock_debugger do
 
   describe ".validate" do
     it "return true if breakpoint is valid" do
-      validator.validate(breakpoint).must_equal true
+      _(validator.validate(breakpoint)).must_equal true
     end
 
     it "returns false if breakpoint's target file doesn't exist" do
       breakpoint.location.path = "/path/to/not-exist.rb"
 
-      validator.validate(breakpoint).must_equal false
+      _(validator.validate(breakpoint)).must_equal false
 
-      breakpoint.complete?.must_equal true
-      breakpoint.status.description.must_equal validator::FILE_NOT_FOUND_MSG
+      _(breakpoint.complete?).must_equal true
+      _(breakpoint.status.description).must_equal validator::FILE_NOT_FOUND_MSG
     end
 
     it "returns false if breakpoints target file isn't a ruby file" do
       breakpoint.location.path = "/path/to/not-ruby-file"
 
       validator.stub :verify_file_path, true do
-        validator.validate(breakpoint).must_equal false
+        _(validator.validate(breakpoint)).must_equal false
       end
 
-      breakpoint.complete?.must_equal true
-      breakpoint.status.description.must_equal validator::WRONG_FILE_TYPE_MSG
+      _(breakpoint.complete?).must_equal true
+      _(breakpoint.status.description).must_equal validator::WRONG_FILE_TYPE_MSG
     end
 
     it "returns false if breakpoint line number is too large" do
       breakpoint.location.line = 999999
 
-      validator.validate(breakpoint).must_equal false
+      _(validator.validate(breakpoint)).must_equal false
 
-      breakpoint.complete?.must_equal true
-      breakpoint.status.description.must_equal validator::INVALID_LINE_MSG
+      _(breakpoint.complete?).must_equal true
+      _(breakpoint.status.description).must_equal validator::INVALID_LINE_MSG
     end
 
     it "returns false if breakpoint is on a blank line" do
@@ -62,12 +62,12 @@ describe Google::Cloud::Debugger::Breakpoint::Validator, :mock_debugger do
 
       validator.stub :verify_file_path, true do
         validator.stub :verify_file_type, true do
-          validator.validate(breakpoint).must_equal false
+          _(validator.validate(breakpoint)).must_equal false
         end
       end
 
-      breakpoint.complete?.must_equal true
-      breakpoint.status.description.must_equal validator::INVALID_LINE_MSG
+      _(breakpoint.complete?).must_equal true
+      _(breakpoint.status.description).must_equal validator::INVALID_LINE_MSG
     end
 
     it "returns false if breakpoint is on a blank line" do
@@ -79,12 +79,12 @@ describe Google::Cloud::Debugger::Breakpoint::Validator, :mock_debugger do
 
       validator.stub :verify_file_path, true do
         validator.stub :verify_file_type, true do
-          validator.validate(breakpoint).must_equal false
+          _(validator.validate(breakpoint)).must_equal false
         end
       end
 
-      breakpoint.complete?.must_equal true
-      breakpoint.status.description.must_equal validator::INVALID_LINE_MSG
+      _(breakpoint.complete?).must_equal true
+      _(breakpoint.status.description).must_equal validator::INVALID_LINE_MSG
     end
   end
 end

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/variable_table_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/variable_table_test.rb
@@ -29,13 +29,13 @@ describe Google::Cloud::Debugger::Breakpoint::VariableTable, :mock_debugger do
       var_table_grpc = [variable_grpc, variable_grpc]
 
       var_table = Google::Cloud::Debugger::Breakpoint::VariableTable.from_grpc var_table_grpc
-      var_table.must_be_kind_of Google::Cloud::Debugger::Breakpoint::VariableTable
-      var_table.size.must_equal 2
-      var_table[0].source_var.must_be_nil
-      var_table[0].name.must_equal variable.name
-      var_table[0].type.must_equal variable.type
-      var_table[0].value.must_equal variable.value
-      var_table[0].members.must_equal variable.members
+      _(var_table).must_be_kind_of Google::Cloud::Debugger::Breakpoint::VariableTable
+      _(var_table.size).must_equal 2
+      _(var_table[0].source_var).must_be_nil
+      _(var_table[0].name).must_equal variable.name
+      _(var_table[0].type).must_equal variable.type
+      _(var_table[0].value).must_equal variable.value
+      _(var_table[0].members).must_equal variable.members
     end
   end
 
@@ -50,11 +50,11 @@ describe Google::Cloud::Debugger::Breakpoint::VariableTable, :mock_debugger do
 
       var_table_grpc = var_table.to_grpc
 
-      var_table_grpc.size.must_equal 2
-      var_table_grpc[0].name.must_equal variable_grpc.name
-      var_table_grpc[0].value.must_equal variable_grpc.value
-      var_table_grpc[0].type.must_equal variable_grpc.type
-      var_table_grpc[0].members.must_equal variable_grpc.members
+      _(var_table_grpc.size).must_equal 2
+      _(var_table_grpc[0].name).must_equal variable_grpc.name
+      _(var_table_grpc[0].value).must_equal variable_grpc.value
+      _(var_table_grpc[0].type).must_equal variable_grpc.type
+      _(var_table_grpc[0].members).must_equal variable_grpc.members
     end
   end
 
@@ -65,8 +65,8 @@ describe Google::Cloud::Debugger::Breakpoint::VariableTable, :mock_debugger do
       var_table.add "Doesn't add"
       var_table.add variable
 
-      var_table.size.must_equal 1
-      var_table.first.must_equal variable
+      _(var_table.size).must_equal 1
+      _(var_table.first).must_equal variable
     end
   end
 
@@ -80,9 +80,9 @@ describe Google::Cloud::Debugger::Breakpoint::VariableTable, :mock_debugger do
       var_table.add variable2
       var_table.add variable3
 
-      var_table.rb_var_index(4).must_equal 0
-      var_table.rb_var_index(5).must_equal 1
-      var_table.rb_var_index(6).must_equal 2
+      _(var_table.rb_var_index(4)).must_equal 0
+      _(var_table.rb_var_index(5)).must_equal 1
+      _(var_table.rb_var_index(6)).must_equal 2
     end
 
     it "returns nil if item not found" do
@@ -94,7 +94,7 @@ describe Google::Cloud::Debugger::Breakpoint::VariableTable, :mock_debugger do
       var_table.add variable2
       var_table.add variable3
 
-      var_table.rb_var_index(8).must_be_nil
+      _(var_table.rb_var_index(8)).must_be_nil
     end
   end
 end

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint/variable_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint/variable_test.rb
@@ -29,30 +29,30 @@ describe Google::Cloud::Debugger::Breakpoint::Variable, :mock_debugger do
     it "gets all the attributes" do
       grpc = variable.to_grpc
 
-      grpc.name.must_equal variable_grpc.name
-      grpc.value.must_equal variable_grpc.value
-      grpc.type.must_equal variable_grpc.type
-      grpc.members.must_equal variable_grpc.members
+      _(grpc.name).must_equal variable_grpc.name
+      _(grpc.value).must_equal variable_grpc.value
+      _(grpc.type).must_equal variable_grpc.type
+      _(grpc.members).must_equal variable_grpc.members
     end
 
     it "has members even if missing from variable" do
       variable.members = nil
       grpc = variable.to_grpc
 
-      grpc.name.must_equal variable_grpc.name
-      grpc.value.must_equal variable_grpc.value
-      grpc.members.must_equal []
+      _(grpc.name).must_equal variable_grpc.name
+      _(grpc.value).must_equal variable_grpc.value
+      _(grpc.members).must_equal []
     end
   end
 
   describe ".from_grpc" do
     it "knows its attributes" do
-      variable_grpc.name.must_equal "local_var"
-      variable_grpc.type.must_equal "Array"
-      variable_grpc.members[0].name.must_equal "[0]"
-      variable_grpc.members[0].type.must_equal "Integer"
-      variable_grpc.members[0].value.must_equal "3"
-      variable_grpc.members[0].members.must_equal []
+      _(variable_grpc.name).must_equal "local_var"
+      _(variable_grpc.type).must_equal "Array"
+      _(variable_grpc.members[0].name).must_equal "[0]"
+      _(variable_grpc.members[0].type).must_equal "Integer"
+      _(variable_grpc.members[0].value).must_equal "3"
+      _(variable_grpc.members[0].members).must_equal []
     end
 
     it "has members in grpc even if it's missing from variable" do
@@ -60,7 +60,7 @@ describe Google::Cloud::Debugger::Breakpoint::Variable, :mock_debugger do
         Google::Cloud::Debugger::Breakpoint::Variable.from_grpc variable_grpc
       variable.members = nil
       grpc = variable.to_grpc
-      grpc.members.must_equal []
+      _(grpc.members).must_equal []
     end
   end
 
@@ -69,37 +69,37 @@ describe Google::Cloud::Debugger::Breakpoint::Variable, :mock_debugger do
       grpc_ary = [variable_grpc, variable_grpc]
       ary = Google::Cloud::Debugger::Breakpoint::Variable.from_grpc_list grpc_ary
 
-      ary.size.must_equal 2
-      ary[0].name.must_equal variable.name
-      ary[0].type.must_equal variable.type
-      ary[0].value.must_equal variable.value
-      ary[0].members.wont_be_empty
+      _(ary.size).must_equal 2
+      _(ary[0].name).must_equal variable.name
+      _(ary[0].type).must_equal variable.type
+      _(ary[0].value).must_equal variable.value
+      _(ary[0].members).wont_be_empty
 
-      ary[1].name.must_equal variable.name
-      ary[1].type.must_equal variable.type
-      ary[1].value.must_equal variable.value
-      ary[1].members.wont_be_empty
+      _(ary[1].name).must_equal variable.name
+      _(ary[1].type).must_equal variable.type
+      _(ary[1].value).must_equal variable.value
+      _(ary[1].members).wont_be_empty
     end
   end
 
   describe ".buffer_full_variable" do
     it "sets a name if given" do
       var = Google::Cloud::Debugger::Breakpoint::Variable.buffer_full_variable nil, name: "test name"
-      var.name.must_equal "test name"
+      _(var.name).must_equal "test name"
     end
 
     it "returns a error variable if not given a variable table" do
       var = Google::Cloud::Debugger::Breakpoint::Variable.buffer_full_variable
 
-      var.status.is_error.must_equal true
-      var.status.description.must_equal Google::Cloud::Debugger::Breakpoint::Variable::BUFFER_FULL_MSG
+      _(var.status.is_error).must_equal true
+      _(var.status.description).must_equal Google::Cloud::Debugger::Breakpoint::Variable::BUFFER_FULL_MSG
     end
 
     it "returns a error variable if given a variable table that doesn't have the shared buffer full variable" do
       var = Google::Cloud::Debugger::Breakpoint::Variable.buffer_full_variable var_table
 
-      var.status.is_error.must_equal true
-      var.status.description.must_equal Google::Cloud::Debugger::Breakpoint::Variable::BUFFER_FULL_MSG
+      _(var.status.is_error).must_equal true
+      _(var.status.description).must_equal Google::Cloud::Debugger::Breakpoint::Variable::BUFFER_FULL_MSG
     end
 
     it "returns a reference variable to variable table's shared buffer full variable" do
@@ -107,8 +107,8 @@ describe Google::Cloud::Debugger::Breakpoint::Variable, :mock_debugger do
 
       var = Google::Cloud::Debugger::Breakpoint::Variable.buffer_full_variable var_table
 
-      var.reference_variable?.must_equal true
-      var.var_table_index.must_equal 0
+      _(var.reference_variable?).must_equal true
+      _(var.var_table_index).must_equal 0
     end
   end
 
@@ -116,50 +116,50 @@ describe Google::Cloud::Debugger::Breakpoint::Variable, :mock_debugger do
     it "returns Variable itself" do
       var = Google::Cloud::Debugger::Breakpoint::Variable.new
       var2 = Google::Cloud::Debugger::Breakpoint::Variable.from_rb_var var
-      var.object_id.must_equal var2.object_id
+      _(var.object_id).must_equal var2.object_id
     end
 
     it "converts String" do
       var = Google::Cloud::Debugger::Breakpoint::Variable.from_rb_var "test-str"
-      var.name.must_be_nil
-      var.type.must_equal "String"
-      var.value.must_equal '"test-str"'
-      var.members.must_be_empty
+      _(var.name).must_be_nil
+      _(var.type).must_equal "String"
+      _(var.value).must_equal '"test-str"'
+      _(var.members).must_be_empty
     end
 
     it "converts Nil" do
       var = Google::Cloud::Debugger::Breakpoint::Variable.from_rb_var nil
-      var.name.must_be_nil
-      var.type.must_equal "NilClass"
-      var.value.must_equal "nil"
-      var.members.must_be_empty
+      _(var.name).must_be_nil
+      _(var.type).must_equal "NilClass"
+      _(var.value).must_equal "nil"
+      _(var.members).must_be_empty
     end
 
     it "converts Symbol" do
       var = Google::Cloud::Debugger::Breakpoint::Variable.from_rb_var :key
-      var.name.must_be_nil
-      var.type.must_equal "Symbol"
-      var.value.must_equal ":key"
-      var.members.must_be_empty
+      _(var.name).must_be_nil
+      _(var.type).must_equal "Symbol"
+      _(var.value).must_equal ":key"
+      _(var.members).must_be_empty
     end
 
     it "converts Time" do
       t = Time.now
       var = Google::Cloud::Debugger::Breakpoint::Variable.from_rb_var t
-      var.name.must_be_nil
-      var.type.must_equal "Time"
-      var.value.must_equal t.inspect
-      var.members.must_be_empty
+      _(var.name).must_be_nil
+      _(var.type).must_equal "Time"
+      _(var.value).must_equal t.inspect
+      _(var.members).must_be_empty
     end
 
     it "converts empty Hash" do
       h = {}
       var = Google::Cloud::Debugger::Breakpoint::Variable.from_rb_var h
 
-      var.name.must_be_nil
-      var.type.must_equal "Hash"
-      var.members.must_be_empty
-      var.value.must_equal "{}"
+      _(var.name).must_be_nil
+      _(var.type).must_equal "Hash"
+      _(var.members).must_be_empty
+      _(var.value).must_equal "{}"
     end
 
     it "converts Hash" do
@@ -167,46 +167,46 @@ describe Google::Cloud::Debugger::Breakpoint::Variable, :mock_debugger do
       h = {k1: 1, k2: {k3: "2", k4: {k5: {k6: 3}}}}
       var = Google::Cloud::Debugger::Breakpoint::Variable.from_rb_var h
 
-      var.name.must_be_nil
-      var.value.must_be_nil
-      var.type.must_equal "Hash"
+      _(var.name).must_be_nil
+      _(var.value).must_be_nil
+      _(var.type).must_equal "Hash"
 
-      var.members.size.must_equal 2
-      var.members[0].must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
-      var.members[1].must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
+      _(var.members.size).must_equal 2
+      _(var.members[0]).must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
+      _(var.members[1]).must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
 
-      var.members[0].type.must_equal int_clsas
-      var.members[0].name.must_equal "k1"
-      var.members[0].value.must_equal "1"
+      _(var.members[0].type).must_equal int_clsas
+      _(var.members[0].name).must_equal "k1"
+      _(var.members[0].value).must_equal "1"
 
-      var.members[1].type.must_equal "Hash"
-      var.members[1].name.must_equal "k2"
-      var.members[1].value.must_be_nil
-      var.members[1].members.size.must_equal 2
+      _(var.members[1].type).must_equal "Hash"
+      _(var.members[1].name).must_equal "k2"
+      _(var.members[1].value).must_be_nil
+      _(var.members[1].members.size).must_equal 2
 
-      var.members[1].members[0].type.must_equal "String"
-      var.members[1].members[0].name.must_equal "k3"
-      var.members[1].members[0].value.must_equal '"2"'
+      _(var.members[1].members[0].type).must_equal "String"
+      _(var.members[1].members[0].name).must_equal "k3"
+      _(var.members[1].members[0].value).must_equal '"2"'
 
-      var.members[1].members[1].type.must_equal "Hash"
-      var.members[1].members[1].name.must_equal "k4"
-      var.members[1].members[1].value.must_be_nil
-      var.members[1].members[1].members.size.must_equal 1
+      _(var.members[1].members[1].type).must_equal "Hash"
+      _(var.members[1].members[1].name).must_equal "k4"
+      _(var.members[1].members[1].value).must_be_nil
+      _(var.members[1].members[1].members.size).must_equal 1
 
-      var.members[1].members[1].members[0].type.must_equal "Hash"
-      var.members[1].members[1].members[0].name.must_equal "k5"
-      var.members[1].members[1].members[0].value.must_equal({k6: 3}.to_s)
-      var.members[1].members[1].members[0].members.must_be_empty
+      _(var.members[1].members[1].members[0].type).must_equal "Hash"
+      _(var.members[1].members[1].members[0].name).must_equal "k5"
+      _(var.members[1].members[1].members[0].value).must_equal({k6: 3}.to_s)
+      _(var.members[1].members[1].members[0].members).must_be_empty
     end
 
     it "converts empty Array" do
       ary = []
       var = Google::Cloud::Debugger::Breakpoint::Variable.from_rb_var ary
 
-      var.name.must_be_nil
-      var.type.must_equal "Array"
-      var.members.must_be_empty
-      var.value.must_equal "[]"
+      _(var.name).must_be_nil
+      _(var.type).must_equal "Array"
+      _(var.members).must_be_empty
+      _(var.value).must_equal "[]"
     end
 
     it "converts Array" do
@@ -214,40 +214,40 @@ describe Google::Cloud::Debugger::Breakpoint::Variable, :mock_debugger do
       ary = [1, [[2, [4]], 3]]
       var = Google::Cloud::Debugger::Breakpoint::Variable.from_rb_var ary
 
-      var.name.must_be_nil
-      var.type.must_equal "Array"
-      var.value.must_be_nil
-      var.members.size.must_equal 2
+      _(var.name).must_be_nil
+      _(var.type).must_equal "Array"
+      _(var.value).must_be_nil
+      _(var.members.size).must_equal 2
 
-      var.members[0].type.must_equal int_class
-      var.members[0].name.must_equal "[0]"
-      var.members[0].value.must_equal "1"
-      var.members[0].members.must_be_empty
+      _(var.members[0].type).must_equal int_class
+      _(var.members[0].name).must_equal "[0]"
+      _(var.members[0].value).must_equal "1"
+      _(var.members[0].members).must_be_empty
 
-      var.members[1].type.must_equal "Array"
-      var.members[1].name.must_equal "[1]"
-      var.members[1].value.must_be_nil
-      var.members[1].members.size.must_equal 2
+      _(var.members[1].type).must_equal "Array"
+      _(var.members[1].name).must_equal "[1]"
+      _(var.members[1].value).must_be_nil
+      _(var.members[1].members.size).must_equal 2
 
-      var.members[1].members[0].type.must_equal "Array"
-      var.members[1].members[0].name.must_equal "[0]"
-      var.members[1].members[0].value.must_be_nil
-      var.members[1].members[0].members.size.must_equal 2
+      _(var.members[1].members[0].type).must_equal "Array"
+      _(var.members[1].members[0].name).must_equal "[0]"
+      _(var.members[1].members[0].value).must_be_nil
+      _(var.members[1].members[0].members.size).must_equal 2
 
-      var.members[1].members[0].members[0].type.must_equal int_class
-      var.members[1].members[0].members[0].name.must_equal "[0]"
-      var.members[1].members[0].members[0].value.must_equal "2"
-      var.members[1].members[0].members[0].members.must_be_empty
+      _(var.members[1].members[0].members[0].type).must_equal int_class
+      _(var.members[1].members[0].members[0].name).must_equal "[0]"
+      _(var.members[1].members[0].members[0].value).must_equal "2"
+      _(var.members[1].members[0].members[0].members).must_be_empty
 
-      var.members[1].members[0].members[1].type.must_equal "Array"
-      var.members[1].members[0].members[1].name.must_equal "[1]"
-      var.members[1].members[0].members[1].value.must_equal "[4]"
-      var.members[1].members[0].members[1].members.must_be_empty
+      _(var.members[1].members[0].members[1].type).must_equal "Array"
+      _(var.members[1].members[0].members[1].name).must_equal "[1]"
+      _(var.members[1].members[0].members[1].value).must_equal "[4]"
+      _(var.members[1].members[0].members[1].members).must_be_empty
 
-      var.members[1].members[1].type.must_equal int_class
-      var.members[1].members[1].name.must_equal "[1]"
-      var.members[1].members[1].value.must_equal "3"
-      var.members[1].members[1].members.must_be_empty
+      _(var.members[1].members[1].type).must_equal int_class
+      _(var.members[1].members[1].name).must_equal "[1]"
+      _(var.members[1].members[1].value).must_equal "3"
+      _(var.members[1].members[1].members).must_be_empty
     end
 
     it "converts custom class" do
@@ -260,15 +260,15 @@ describe Google::Cloud::Debugger::Breakpoint::Variable, :mock_debugger do
       f = Foo.new
       var = Google::Cloud::Debugger::Breakpoint::Variable.from_rb_var f
 
-      var.type.must_equal "Foo"
-      var.name.must_be_nil
-      var.value.must_be_nil
-      var.members.size.must_equal 1
+      _(var.type).must_equal "Foo"
+      _(var.name).must_be_nil
+      _(var.value).must_be_nil
+      _(var.members.size).must_equal 1
 
-      var.members[0].type.must_equal "String"
-      var.members[0].name.must_equal "@foo"
-      var.members[0].value.must_equal '"123"'
-      var.members[0].members.must_be_empty
+      _(var.members[0].type).must_equal "String"
+      _(var.members[0].name).must_equal "@foo"
+      _(var.members[0].value).must_equal '"123"'
+      _(var.members[0].members).must_be_empty
     end
 
     it "limits members count to max allowed" do
@@ -276,16 +276,16 @@ describe Google::Cloud::Debugger::Breakpoint::Variable, :mock_debugger do
       ary = (1..(max_members + 8)).to_a
       var = Google::Cloud::Debugger::Breakpoint::Variable.from_rb_var ary
 
-      var.type.must_equal "Array"
-      var.name.must_be_nil
-      var.value.must_be_nil
-      var.members.size.must_equal max_members + 1
+      _(var.type).must_equal "Array"
+      _(var.name).must_be_nil
+      _(var.value).must_be_nil
+      _(var.members.size).must_equal max_members + 1
 
-      var.members[max_members].type.must_be_nil
-      var.members[max_members].name.must_be_nil
-      var.members[max_members].value.must_be_nil
-      var.members[max_members].members.must_be_empty
-      var.members[max_members].status.description.must_match "Only first #{max_members} items were captured"
+      _(var.members[max_members].type).must_be_nil
+      _(var.members[max_members].name).must_be_nil
+      _(var.members[max_members].value).must_be_nil
+      _(var.members[max_members].members).must_be_empty
+      _(var.members[max_members].status.description).must_match "Only first #{max_members} items were captured"
     end
 
     it "limits string length to Variable::MAX_STRING_LENGTH" do
@@ -293,10 +293,10 @@ describe Google::Cloud::Debugger::Breakpoint::Variable, :mock_debugger do
       long_str = "s" * (str_max + 10)
 
       var = Google::Cloud::Debugger::Breakpoint::Variable.from_rb_var long_str
-      var.type.must_equal "String"
-      var.name.must_be_nil
-      var.value.size.must_equal str_max
-      var.members.must_be_empty
+      _(var.type).must_equal "String"
+      _(var.name).must_be_nil
+      _(var.value.size).must_equal str_max
+      _(var.members).must_be_empty
     end
 
     it "uses var_table to store repeated variables" do
@@ -305,22 +305,22 @@ describe Google::Cloud::Debugger::Breakpoint::Variable, :mock_debugger do
       int_class = 1.class.to_s
 
       var = Google::Cloud::Debugger::Breakpoint::Variable.from_rb_var ary, var_table: var_table
-      var.type.must_be_nil
-      var.var_table_index.must_equal 0
-      var.members.must_be_empty
-      var.value.must_be_nil
+      _(var.type).must_be_nil
+      _(var.var_table_index).must_equal 0
+      _(var.members).must_be_empty
+      _(var.value).must_be_nil
 
-      var_table.size.must_equal 2
-      var_table[0].type.must_equal "Array"
-      var_table[0].members.size.must_equal 2
-      var_table[0].members[0].var_table_index.must_equal 1
-      var_table[0].members[1].var_table_index.must_equal 1
+      _(var_table.size).must_equal 2
+      _(var_table[0].type).must_equal "Array"
+      _(var_table[0].members.size).must_equal 2
+      _(var_table[0].members[0].var_table_index).must_equal 1
+      _(var_table[0].members[1].var_table_index).must_equal 1
 
-      var_table[1].type.must_equal "Hash"
-      var_table[1].members.size.must_equal 1
-      var_table[1].members[0].name.must_equal "a"
-      var_table[1].members[0].type.must_equal int_class
-      var_table[1].members[0].value.must_equal "1"
+      _(var_table[1].type).must_equal "Hash"
+      _(var_table[1].members.size).must_equal 1
+      _(var_table[1].members[0].name).must_equal "a"
+      _(var_table[1].members[0].type).must_equal int_class
+      _(var_table[1].members[0].value).must_equal "1"
     end
 
     it "uses var_table for nested compound variable" do
@@ -329,28 +329,28 @@ describe Google::Cloud::Debugger::Breakpoint::Variable, :mock_debugger do
 
       var = Google::Cloud::Debugger::Breakpoint::Variable.from_rb_var ary, var_table: var_table
 
-      var.type.must_be_nil
-      var.var_table_index.must_equal 0
-      var.members.must_be_empty
-      var.value.must_be_nil
+      _(var.type).must_be_nil
+      _(var.var_table_index).must_equal 0
+      _(var.members).must_be_empty
+      _(var.value).must_be_nil
 
-      var_table.size.must_equal 2
-      var_table[0].type.must_equal "Array"
-      var_table[0].members.size.must_equal 2
-      var_table[0].members[0].name.must_equal "[0]"
-      var_table[0].members[0].type.must_equal int_class
-      var_table[0].members[0].value .must_equal "1"
+      _(var_table.size).must_equal 2
+      _(var_table[0].type).must_equal "Array"
+      _(var_table[0].members.size).must_equal 2
+      _(var_table[0].members[0].name).must_equal "[0]"
+      _(var_table[0].members[0].type).must_equal int_class
+      _(var_table[0].members[0].value) .must_equal "1"
 
-      var_table[0].members[1].name.must_equal "[1]"
-      var_table[0].members[1].type.must_be_nil
-      var_table[0].members[1].members.must_be_empty
-      var_table[0].members[1].var_table_index.must_equal 1
+      _(var_table[0].members[1].name).must_equal "[1]"
+      _(var_table[0].members[1].type).must_be_nil
+      _(var_table[0].members[1].members).must_be_empty
+      _(var_table[0].members[1].var_table_index).must_equal 1
 
-      var_table[1].type.must_equal "Array"
-      var_table[1].name.must_be_nil
-      var_table[1].members.size.must_equal 1
-      var_table[1].members[0].type.must_equal int_class
-      var_table[1].members[0].value .must_equal "2"
+      _(var_table[1].type).must_equal "Array"
+      _(var_table[1].name).must_be_nil
+      _(var_table[1].members.size).must_equal 1
+      _(var_table[1].members[0].type).must_equal int_class
+      _(var_table[1].members[0].value) .must_equal "2"
     end
 
     it "doesn't convert if given size limit is too small" do
@@ -358,9 +358,9 @@ describe Google::Cloud::Debugger::Breakpoint::Variable, :mock_debugger do
 
       var = Google::Cloud::Debugger::Breakpoint::Variable.from_rb_var nil, limit: limit
 
-      var.must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
-      var.status.is_error.must_equal true
-      var.status.description.must_equal Google::Cloud::Debugger::Breakpoint::Variable::BUFFER_FULL_MSG
+      _(var).must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
+      _(var.status.is_error).must_equal true
+      _(var.status.description).must_equal Google::Cloud::Debugger::Breakpoint::Variable::BUFFER_FULL_MSG
     end
 
     it "full converts simple variable within limit" do
@@ -368,9 +368,9 @@ describe Google::Cloud::Debugger::Breakpoint::Variable, :mock_debugger do
       str = "x" * 900
 
       var = Google::Cloud::Debugger::Breakpoint::Variable.from_rb_var str, limit: limit
-      var.type.must_equal str.class.to_s
-      var.value.must_equal str.inspect
-      (var.total_size <= limit).must_equal true
+      _(var.type).must_equal str.class.to_s
+      _(var.value).must_equal str.inspect
+      _((var.total_size <= limit)).must_equal true
     end
 
     it "limits simple variable within limit" do
@@ -378,8 +378,8 @@ describe Google::Cloud::Debugger::Breakpoint::Variable, :mock_debugger do
       str = "x" * 1100
 
       var = Google::Cloud::Debugger::Breakpoint::Variable.from_rb_var str, limit: limit
-      (var.value.size <= str.inspect.size).must_equal true
-      (var.total_size <= limit).must_equal true
+      _((var.value.size <= str.inspect.size)).must_equal true
+      _((var.total_size <= limit)).must_equal true
     end
 
     it "full converts nested compound variable within limit" do
@@ -388,38 +388,38 @@ describe Google::Cloud::Debugger::Breakpoint::Variable, :mock_debugger do
       h = {k1: 1, k2: {k3: "2", k4: {k5: {k6: 3}}}}
       var = Google::Cloud::Debugger::Breakpoint::Variable.from_rb_var h, limit: limit
 
-      var.name.must_be_nil
-      var.value.must_be_nil
-      var.type.must_equal "Hash"
+      _(var.name).must_be_nil
+      _(var.value).must_be_nil
+      _(var.type).must_equal "Hash"
 
-      var.members.size.must_equal 2
-      var.members[0].must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
-      var.members[1].must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
+      _(var.members.size).must_equal 2
+      _(var.members[0]).must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
+      _(var.members[1]).must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
 
-      var.members[0].type.must_equal int_clsas
-      var.members[0].name.must_equal "k1"
-      var.members[0].value.must_equal "1"
+      _(var.members[0].type).must_equal int_clsas
+      _(var.members[0].name).must_equal "k1"
+      _(var.members[0].value).must_equal "1"
 
-      var.members[1].type.must_equal "Hash"
-      var.members[1].name.must_equal "k2"
-      var.members[1].value.must_be_nil
-      var.members[1].members.size.must_equal 2
+      _(var.members[1].type).must_equal "Hash"
+      _(var.members[1].name).must_equal "k2"
+      _(var.members[1].value).must_be_nil
+      _(var.members[1].members.size).must_equal 2
 
-      var.members[1].members[0].type.must_equal "String"
-      var.members[1].members[0].name.must_equal "k3"
-      var.members[1].members[0].value.must_equal '"2"'
+      _(var.members[1].members[0].type).must_equal "String"
+      _(var.members[1].members[0].name).must_equal "k3"
+      _(var.members[1].members[0].value).must_equal '"2"'
 
-      var.members[1].members[1].type.must_equal "Hash"
-      var.members[1].members[1].name.must_equal "k4"
-      var.members[1].members[1].value.must_be_nil
-      var.members[1].members[1].members.size.must_equal 1
+      _(var.members[1].members[1].type).must_equal "Hash"
+      _(var.members[1].members[1].name).must_equal "k4"
+      _(var.members[1].members[1].value).must_be_nil
+      _(var.members[1].members[1].members.size).must_equal 1
 
-      var.members[1].members[1].members[0].type.must_equal "Hash"
-      var.members[1].members[1].members[0].name.must_equal "k5"
-      var.members[1].members[1].members[0].value.must_equal({k6: 3}.to_s)
-      var.members[1].members[1].members[0].members.must_be_empty
+      _(var.members[1].members[1].members[0].type).must_equal "Hash"
+      _(var.members[1].members[1].members[0].name).must_equal "k5"
+      _(var.members[1].members[1].members[0].value).must_equal({k6: 3}.to_s)
+      _(var.members[1].members[1].members[0].members).must_be_empty
 
-      (var.total_size <= limit).must_equal true
+      _((var.total_size <= limit)).must_equal true
     end
 
     it "full converts nested compound variable with variable table within limit" do
@@ -429,54 +429,54 @@ describe Google::Cloud::Debugger::Breakpoint::Variable, :mock_debugger do
       var = Google::Cloud::Debugger::Breakpoint::Variable.from_rb_var h, limit: limit,
                                                                       var_table: var_table
 
-      var.name.must_be_nil
-      var.value.must_be_nil
-      var.var_table_index.must_equal 0
-      var.members.must_be_empty
+      _(var.name).must_be_nil
+      _(var.value).must_be_nil
+      _(var.var_table_index).must_equal 0
+      _(var.members).must_be_empty
 
-      var_table.size.must_equal 3
-      var_table[0].type.must_equal "Hash"
-      var_table[0].members.size.must_equal 2
+      _(var_table.size).must_equal 3
+      _(var_table[0].type).must_equal "Hash"
+      _(var_table[0].members.size).must_equal 2
 
-      var_table[0].members[0].must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
-      var_table[0].members[1].must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
+      _(var_table[0].members[0]).must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
+      _(var_table[0].members[1]).must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
 
-      var_table[0].members[0].type.must_equal int_clsas
-      var_table[0].members[0].name.must_equal "k1"
-      var_table[0].members[0].value.must_equal "1"
-      var_table[0].members[0].var_table_index.must_be_nil
+      _(var_table[0].members[0].type).must_equal int_clsas
+      _(var_table[0].members[0].name).must_equal "k1"
+      _(var_table[0].members[0].value).must_equal "1"
+      _(var_table[0].members[0].var_table_index).must_be_nil
 
-      var_table[0].members[1].var_table_index.must_equal 1
-      var_table[0].members[1].name.must_equal "k2"
-      var_table[0].members[1].value.must_be_nil
-      var_table[0].members[1].type.must_be_nil
+      _(var_table[0].members[1].var_table_index).must_equal 1
+      _(var_table[0].members[1].name).must_equal "k2"
+      _(var_table[0].members[1].value).must_be_nil
+      _(var_table[0].members[1].type).must_be_nil
 
-      var_table[1].type.must_equal "Hash"
-      var_table[1].members.size.must_equal 2
+      _(var_table[1].type).must_equal "Hash"
+      _(var_table[1].members.size).must_equal 2
 
-      var_table[1].members[0].must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
-      var_table[1].members[1].must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
+      _(var_table[1].members[0]).must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
+      _(var_table[1].members[1]).must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
 
-      var_table[1].members[0].type.must_equal "String"
-      var_table[1].members[0].name.must_equal "k3"
-      var_table[1].members[0].value.must_equal "2".inspect
-      var_table[1].members[0].var_table_index.must_be_nil
+      _(var_table[1].members[0].type).must_equal "String"
+      _(var_table[1].members[0].name).must_equal "k3"
+      _(var_table[1].members[0].value).must_equal "2".inspect
+      _(var_table[1].members[0].var_table_index).must_be_nil
 
-      var_table[1].members[1].type.must_be_nil
-      var_table[1].members[1].name.must_equal "k4"
-      var_table[1].members[1].value.must_be_nil
-      var_table[1].members[1].var_table_index.must_equal 2
+      _(var_table[1].members[1].type).must_be_nil
+      _(var_table[1].members[1].name).must_equal "k4"
+      _(var_table[1].members[1].value).must_be_nil
+      _(var_table[1].members[1].var_table_index).must_equal 2
 
-      var_table[2].type.must_equal "Hash"
-      var_table[2].members.size.must_equal 1
+      _(var_table[2].type).must_equal "Hash"
+      _(var_table[2].members.size).must_equal 1
 
-      var_table[2].members[0].must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
+      _(var_table[2].members[0]).must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
 
-      var_table[2].members[0].type.must_equal "Hash"
-      var_table[2].members[0].name.must_equal "k5"
-      var_table[2].members[0].value.must_equal({k6: 3}.to_s)
+      _(var_table[2].members[0].type).must_equal "Hash"
+      _(var_table[2].members[0].name).must_equal "k5"
+      _(var_table[2].members[0].value).must_equal({k6: 3}.to_s)
 
-      (var.total_size <= limit).must_equal true
+      _((var.total_size <= limit)).must_equal true
     end
 
     it "limit large nested compound variable with variable table within limit size" do
@@ -487,45 +487,45 @@ describe Google::Cloud::Debugger::Breakpoint::Variable, :mock_debugger do
       var = Google::Cloud::Debugger::Breakpoint::Variable.from_rb_var h, limit: limit,
                                                                       var_table: var_table
 
-      var.name.must_be_nil
-      var.value.must_be_nil
-      var.var_table_index.must_equal 0
-      var.members.must_be_empty
+      _(var.name).must_be_nil
+      _(var.value).must_be_nil
+      _(var.var_table_index).must_equal 0
+      _(var.members).must_be_empty
 
-      var_table.size.must_equal 2
-      var_table[0].type.must_equal "Hash"
-      var_table[0].members.size.must_equal 2
+      _(var_table.size).must_equal 2
+      _(var_table[0].type).must_equal "Hash"
+      _(var_table[0].members.size).must_equal 2
 
-      var_table[0].members[0].must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
-      var_table[0].members[1].must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
+      _(var_table[0].members[0]).must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
+      _(var_table[0].members[1]).must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
 
-      var_table[0].members[0].type.must_equal int_clsas
-      var_table[0].members[0].name.must_equal "k1"
-      var_table[0].members[0].value.must_equal "1"
-      var_table[0].members[0].var_table_index.must_be_nil
+      _(var_table[0].members[0].type).must_equal int_clsas
+      _(var_table[0].members[0].name).must_equal "k1"
+      _(var_table[0].members[0].value).must_equal "1"
+      _(var_table[0].members[0].var_table_index).must_be_nil
 
-      var_table[0].members[1].var_table_index.must_equal 1
-      var_table[0].members[1].name.must_equal "k2"
-      var_table[0].members[1].value.must_be_nil
-      var_table[0].members[1].type.must_be_nil
+      _(var_table[0].members[1].var_table_index).must_equal 1
+      _(var_table[0].members[1].name).must_equal "k2"
+      _(var_table[0].members[1].value).must_be_nil
+      _(var_table[0].members[1].type).must_be_nil
 
-      var_table[1].type.must_equal "Hash"
-      var_table[1].members.size.must_equal 2
+      _(var_table[1].type).must_equal "Hash"
+      _(var_table[1].members.size).must_equal 2
 
-      var_table[1].members[0].must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
-      var_table[1].members[1].must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
+      _(var_table[1].members[0]).must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
+      _(var_table[1].members[1]).must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
 
-      var_table[1].members[0].type.must_equal "String"
-      var_table[1].members[0].name.must_equal "k3"
-      var_table[1].members[0].value.must_match /x+\.\.\./
-      var_table[1].members[0].var_table_index.must_be_nil
+      _(var_table[1].members[0].type).must_equal "String"
+      _(var_table[1].members[0].name).must_equal "k3"
+      _(var_table[1].members[0].value).must_match /x+\.\.\./
+      _(var_table[1].members[0].var_table_index).must_be_nil
 
-      var_table[1].members[1].type.must_be_nil
-      var_table[1].members[1].name.must_be_nil
-      var_table[1].members[1].status.is_error.must_equal true
-      var_table[1].members[1].status.description.must_match /Only first . items were captured/
+      _(var_table[1].members[1].type).must_be_nil
+      _(var_table[1].members[1].name).must_be_nil
+      _(var_table[1].members[1].status.is_error).must_equal true
+      _(var_table[1].members[1].status.description).must_match /Only first . items were captured/
 
-      (var.total_size <= limit).must_equal true
+      _((var.total_size <= limit)).must_equal true
     end
 
     it "limit large nested compound variable and reuse shared buffer full variable from var_table" do
@@ -538,45 +538,45 @@ describe Google::Cloud::Debugger::Breakpoint::Variable, :mock_debugger do
       var = Google::Cloud::Debugger::Breakpoint::Variable.from_rb_var h, limit: limit,
                                                                       var_table: var_table
 
-      var.name.must_be_nil
-      var.value.must_be_nil
-      var.var_table_index.must_equal 1
-      var.members.must_be_empty
+      _(var.name).must_be_nil
+      _(var.value).must_be_nil
+      _(var.var_table_index).must_equal 1
+      _(var.members).must_be_empty
 
-      var_table.size.must_equal 3
-      var_table[1].type.must_equal "Hash"
-      var_table[1].members.size.must_equal 2
+      _(var_table.size).must_equal 3
+      _(var_table[1].type).must_equal "Hash"
+      _(var_table[1].members.size).must_equal 2
 
-      var_table[1].members[0].must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
-      var_table[1].members[1].must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
+      _(var_table[1].members[0]).must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
+      _(var_table[1].members[1]).must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
 
-      var_table[1].members[0].type.must_equal int_clsas
-      var_table[1].members[0].name.must_equal "k1"
-      var_table[1].members[0].value.must_equal "1"
-      var_table[1].members[0].var_table_index.must_be_nil
+      _(var_table[1].members[0].type).must_equal int_clsas
+      _(var_table[1].members[0].name).must_equal "k1"
+      _(var_table[1].members[0].value).must_equal "1"
+      _(var_table[1].members[0].var_table_index).must_be_nil
 
-      var_table[1].members[1].var_table_index.must_equal 2
-      var_table[1].members[1].name.must_equal "k2"
-      var_table[1].members[1].value.must_be_nil
-      var_table[1].members[1].type.must_be_nil
+      _(var_table[1].members[1].var_table_index).must_equal 2
+      _(var_table[1].members[1].name).must_equal "k2"
+      _(var_table[1].members[1].value).must_be_nil
+      _(var_table[1].members[1].type).must_be_nil
 
-      var_table[2].type.must_equal "Hash"
-      var_table[2].members.size.must_equal 2
+      _(var_table[2].type).must_equal "Hash"
+      _(var_table[2].members.size).must_equal 2
 
-      var_table[2].members[0].must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
-      var_table[2].members[1].must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
+      _(var_table[2].members[0]).must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
+      _(var_table[2].members[1]).must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
 
-      var_table[2].members[0].type.must_equal "String"
-      var_table[2].members[0].name.must_equal "k3"
-      var_table[2].members[0].value.must_match /x+\.\.\./
-      var_table[2].members[0].var_table_index.must_be_nil
+      _(var_table[2].members[0].type).must_equal "String"
+      _(var_table[2].members[0].name).must_equal "k3"
+      _(var_table[2].members[0].value).must_match /x+\.\.\./
+      _(var_table[2].members[0].var_table_index).must_be_nil
 
-      var_table[2].members[1].type.must_be_nil
-      var_table[2].members[1].name.must_be_nil
-      var_table[2].members[1].value.must_be_nil
-      var_table[2].members[1].status.description.must_match /Only first . items were captured/
+      _(var_table[2].members[1].type).must_be_nil
+      _(var_table[2].members[1].name).must_be_nil
+      _(var_table[2].members[1].value).must_be_nil
+      _(var_table[2].members[1].status.description).must_match /Only first . items were captured/
 
-      (var.total_size <= limit).must_equal true
+      _((var.total_size <= limit)).must_equal true
     end
 
     it "Adds a single buffer full variable to compound members list if limit is scessed" do
@@ -590,13 +590,13 @@ describe Google::Cloud::Debugger::Breakpoint::Variable, :mock_debugger do
       var = Google::Cloud::Debugger::Breakpoint::Variable.from_rb_var ary, limit: limit,
                                                                       var_table: var_table
 
-      var.var_table_index.must_equal 1
+      _(var.var_table_index).must_equal 1
 
-      var_table[1].members.size.must_equal 3
+      _(var_table[1].members.size).must_equal 3
 
-      var_table[1].members[0].value.must_match /x+/
-      var_table[1].members[1].value.must_match /x+/
-      var_table[1].members[2].status.description.must_match /Only first . items were captured/
+      _(var_table[1].members[0].value).must_match /x+/
+      _(var_table[1].members[1].value).must_match /x+/
+      _(var_table[1].members[2].status.description).must_match /Only first . items were captured/
     end
   end
 
@@ -604,15 +604,15 @@ describe Google::Cloud::Debugger::Breakpoint::Variable, :mock_debugger do
     it "returns true only if it's an empty variable that references another variable in variable table" do
       var = Google::Cloud::Debugger::Breakpoint::Variable.new
 
-      var.reference_variable?.must_equal false
+      _(var.reference_variable?).must_equal false
 
       var.var_table_index = 99
 
-      var.reference_variable?.must_equal true
+      _(var.reference_variable?).must_equal true
 
       var.value = "a value"
 
-      var.reference_variable?.must_equal false
+      _(var.reference_variable?).must_equal false
     end
   end
 
@@ -620,12 +620,12 @@ describe Google::Cloud::Debugger::Breakpoint::Variable, :mock_debugger do
     it "returns true if the variable itself is a buffer full error variable" do
       var = Google::Cloud::Debugger::Breakpoint::Variable.new
 
-      var.buffer_full_variable?.must_equal false
+      _(var.buffer_full_variable?).must_equal false
 
       var.set_error_state Google::Cloud::Debugger::Breakpoint::Variable::BUFFER_FULL_MSG,
                           refers_to: Google::Cloud::Debugger::Breakpoint::StatusMessage::VARIABLE_VALUE
 
-      var.buffer_full_variable?.must_equal true
+      _(var.buffer_full_variable?).must_equal true
     end
 
     it "returns true if the variable references the shared buffer full variable in variable table" do
@@ -634,15 +634,15 @@ describe Google::Cloud::Debugger::Breakpoint::Variable, :mock_debugger do
       var = Google::Cloud::Debugger::Breakpoint::Variable.new
       var.var_table_index = 0
 
-      var.buffer_full_variable?.must_equal false
+      _(var.buffer_full_variable?).must_equal false
 
       var.var_table = var_table
 
-      var.buffer_full_variable?.must_equal true
+      _(var.buffer_full_variable?).must_equal true
 
       var.value = "a value"
 
-      var.buffer_full_variable?.must_equal false
+      _(var.buffer_full_variable?).must_equal false
     end
   end
 
@@ -652,7 +652,7 @@ describe Google::Cloud::Debugger::Breakpoint::Variable, :mock_debugger do
 
       estimate_size = String.to_s.bytesize + "hello".inspect.bytesize
 
-      var.payload_size.must_equal estimate_size
+      _(var.payload_size).must_equal estimate_size
     end
 
     it "calculates the size of complex compound variable" do
@@ -662,7 +662,7 @@ describe Google::Cloud::Debugger::Breakpoint::Variable, :mock_debugger do
       estimate_size = Hash.to_s.bytesize + String.to_s.bytesize + "hash".bytesize +
                       "value".inspect.bytesize + "key".bytesize
 
-      var.payload_size.must_equal estimate_size
+      _(var.payload_size).must_equal estimate_size
     end
   end
 
@@ -672,7 +672,7 @@ describe Google::Cloud::Debugger::Breakpoint::Variable, :mock_debugger do
 
       estimate_size = String.to_s.bytesize + "hello".inspect.bytesize
 
-      var.total_size.must_equal estimate_size
+      _(var.total_size).must_equal estimate_size
     end
 
     it "calculates the size for simple variable with variable table" do
@@ -680,7 +680,7 @@ describe Google::Cloud::Debugger::Breakpoint::Variable, :mock_debugger do
 
       estimate_size = String.to_s.bytesize + "hello".inspect.bytesize
 
-      var.total_size.must_equal estimate_size
+      _(var.total_size).must_equal estimate_size
     end
 
     it "calculates the size of complex compound variable" do
@@ -692,7 +692,7 @@ describe Google::Cloud::Debugger::Breakpoint::Variable, :mock_debugger do
                     "value".inspect.bytesize + "key".bytesize
       estimate_size = nested_size * 2 + "ary".bytesize + Array.to_s.bytesize
 
-      var.total_size.must_equal estimate_size
+      _(var.total_size).must_equal estimate_size
     end
 
     it "calculates the size of complex compound variable with variable table" do
@@ -707,7 +707,7 @@ describe Google::Cloud::Debugger::Breakpoint::Variable, :mock_debugger do
       estimate_size = nested_size + "ary".bytesize +
         Array.to_s.bytesize + "[x]".bytesize * 2
 
-      var.total_size.must_equal estimate_size
+      _(var.total_size).must_equal estimate_size
     end
   end
 end

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint_manager_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint_manager_test.rb
@@ -31,14 +31,14 @@ describe Google::Cloud::Debugger::BreakpointManager, :mock_debugger do
       mocked_list_breakpoints = ->(_, _) { raise }
 
       breakpoint_manager.service.stub :list_active_breakpoints, mocked_list_breakpoints do
-        breakpoint_manager.sync_active_breakpoints(nil).must_equal false
+        _(breakpoint_manager.sync_active_breakpoints(nil)).must_equal false
       end
     end
 
     it "returns true if response.wait_expired is true" do
       mocked_response = OpenStruct.new(wait_expired: true)
       breakpoint_manager.service.stub :list_active_breakpoints, mocked_response do
-        breakpoint_manager.sync_active_breakpoints(nil).must_equal true
+        _(breakpoint_manager.sync_active_breakpoints(nil)).must_equal true
       end
     end
 
@@ -46,13 +46,13 @@ describe Google::Cloud::Debugger::BreakpointManager, :mock_debugger do
       wait_token = "a unique token"
       mocked_response = OpenStruct.new(wait_expired: false, next_wait_token: wait_token)
 
-      breakpoint_manager.wait_token.must_equal :init
+      _(breakpoint_manager.wait_token).must_equal :init
 
       breakpoint_manager.service.stub :list_active_breakpoints, mocked_response do
         breakpoint_manager.sync_active_breakpoints(nil)
       end
 
-      breakpoint_manager.wait_token.must_equal wait_token
+      _(breakpoint_manager.wait_token).must_equal wait_token
     end
 
     it "calls #update_breakpoints with a list of Google::Cloud::Debugger::Breakpoints" do
@@ -66,7 +66,7 @@ describe Google::Cloud::Debugger::BreakpointManager, :mock_debugger do
       breakpoint_manager.service.stub :list_active_breakpoints, mocked_response do
         Google::Cloud::Debugger::Breakpoint.stub :from_grpc, breakpoint1 do
           breakpoint_manager.stub :update_breakpoints, mocked_update_breakpoints do
-            breakpoint_manager.sync_active_breakpoints(nil).must_equal true
+            _(breakpoint_manager.sync_active_breakpoints(nil)).must_equal true
           end
         end
       end
@@ -82,9 +82,9 @@ describe Google::Cloud::Debugger::BreakpointManager, :mock_debugger do
         Google::Cloud::Debugger::Breakpoint.stub :from_grpc, breakpoint1 do
           app_root = "my/app/path"
           breakpoint_manager.agent.app_root = app_root
-          breakpoint_manager.sync_active_breakpoints(nil).must_equal true
+          _(breakpoint_manager.sync_active_breakpoints(nil)).must_equal true
 
-          breakpoint1.full_path.must_match app_root
+          _(breakpoint1.full_path).must_match app_root
         end
       end
     end
@@ -92,72 +92,72 @@ describe Google::Cloud::Debugger::BreakpointManager, :mock_debugger do
 
   describe "#update_breakpoints" do
     it "addes new breakpoints" do
-      breakpoint_manager.active_breakpoints.must_be_empty
-      breakpoint_manager.completed_breakpoints.must_be_empty
+      _(breakpoint_manager.active_breakpoints).must_be_empty
+      _(breakpoint_manager.completed_breakpoints).must_be_empty
 
       breakpoint_manager.update_breakpoints [breakpoint1]
 
-      breakpoint_manager.active_breakpoints.size.must_equal 1
-      breakpoint_manager.completed_breakpoints.must_be_empty
+      _(breakpoint_manager.active_breakpoints.size).must_equal 1
+      _(breakpoint_manager.completed_breakpoints).must_be_empty
 
-      breakpoint_manager.active_breakpoints.first.must_equal breakpoint1
+      _(breakpoint_manager.active_breakpoints.first).must_equal breakpoint1
     end
 
     it "doesn't add breakpoints already in @active_breakpoints" do
       breakpoint_manager.update_breakpoints [breakpoint1, breakpoint2]
 
-      breakpoint_manager.active_breakpoints.size.must_equal 2
+      _(breakpoint_manager.active_breakpoints.size).must_equal 2
 
       breakpoint_manager.update_breakpoints [breakpoint1, breakpoint2, breakpoint3]
 
-      breakpoint_manager.active_breakpoints.size.must_equal 3
+      _(breakpoint_manager.active_breakpoints.size).must_equal 3
 
-      breakpoint_manager.active_breakpoints.must_include breakpoint1
-      breakpoint_manager.active_breakpoints.must_include breakpoint2
-      breakpoint_manager.active_breakpoints.must_include breakpoint3
+      _(breakpoint_manager.active_breakpoints).must_include breakpoint1
+      _(breakpoint_manager.active_breakpoints).must_include breakpoint2
+      _(breakpoint_manager.active_breakpoints).must_include breakpoint3
     end
 
     it "removes old breakpoints not in new list" do
       breakpoint_manager.update_breakpoints [breakpoint1, breakpoint2]
 
-      breakpoint_manager.active_breakpoints.size.must_equal 2
+      _(breakpoint_manager.active_breakpoints.size).must_equal 2
 
       breakpoint_manager.update_breakpoints [breakpoint2, breakpoint3]
 
-      breakpoint_manager.active_breakpoints.size.must_equal 2
+      _(breakpoint_manager.active_breakpoints.size).must_equal 2
 
-      breakpoint_manager.active_breakpoints.must_include breakpoint2
-      breakpoint_manager.active_breakpoints.must_include breakpoint3
+      _(breakpoint_manager.active_breakpoints).must_include breakpoint2
+      _(breakpoint_manager.active_breakpoints).must_include breakpoint3
     end
 
     it "removes old breakpoints from @completed_breakpoints not in new list" do
       breakpoint_manager.update_breakpoints [breakpoint1, breakpoint2]
       breakpoint_manager.mark_off breakpoint2
 
-      breakpoint_manager.active_breakpoints.size.must_equal 1
-      breakpoint_manager.completed_breakpoints.size.must_equal 1
-      breakpoint_manager.active_breakpoints.first.must_equal breakpoint1
-      breakpoint_manager.completed_breakpoints.first.must_equal breakpoint2
+      _(breakpoint_manager.active_breakpoints.size).must_equal 1
+      _(breakpoint_manager.completed_breakpoints.size).must_equal 1
+      _(breakpoint_manager.active_breakpoints.first).must_equal breakpoint1
+      _(breakpoint_manager.completed_breakpoints.first).must_equal breakpoint2
 
       breakpoint_manager.update_breakpoints [breakpoint3]
 
-      breakpoint_manager.active_breakpoints.size.must_equal 1
-      breakpoint_manager.active_breakpoints.first.must_equal breakpoint3
-      breakpoint_manager.completed_breakpoints.must_be_empty
+      _(breakpoint_manager.active_breakpoints.size).must_equal 1
+      _(breakpoint_manager.active_breakpoints.first).must_equal breakpoint3
+      _(breakpoint_manager.completed_breakpoints).must_be_empty
     end
 
     it "doesn't add breakpoints already in @completed_breakpoints" do
       breakpoint_manager.update_breakpoints [breakpoint1]
       breakpoint_manager.mark_off breakpoint1
 
-      breakpoint_manager.active_breakpoints.must_be_empty
-      breakpoint_manager.completed_breakpoints.size.must_equal 1
+      _(breakpoint_manager.active_breakpoints).must_be_empty
+      _(breakpoint_manager.completed_breakpoints.size).must_equal 1
 
       breakpoint_manager.update_breakpoints [breakpoint1]
 
-      breakpoint_manager.active_breakpoints.must_be_empty
-      breakpoint_manager.completed_breakpoints.size.must_equal 1
-      breakpoint_manager.completed_breakpoints.must_include breakpoint1
+      _(breakpoint_manager.active_breakpoints).must_be_empty
+      _(breakpoint_manager.completed_breakpoints.size).must_equal 1
+      _(breakpoint_manager.completed_breakpoints).must_include breakpoint1
     end
 
     it "only add valid breakpoints" do
@@ -165,8 +165,8 @@ describe Google::Cloud::Debugger::BreakpointManager, :mock_debugger do
         breakpoint_manager.update_breakpoints [breakpoint1, breakpoint2]
       end
 
-      breakpoint_manager.active_breakpoints.size.must_equal 1
-      breakpoint_manager.active_breakpoints.first.must_equal breakpoint2
+      _(breakpoint_manager.active_breakpoints.size).must_equal 1
+      _(breakpoint_manager.active_breakpoints.first).must_equal breakpoint2
     end
   end
 
@@ -275,26 +275,26 @@ describe Google::Cloud::Debugger::BreakpointManager, :mock_debugger do
     it "moves a breakpoint from @active_breakpoints list to @completed_breakpoints list" do
       breakpoint_manager.update_breakpoints [breakpoint1]
 
-      breakpoint_manager.active_breakpoints.size.must_equal 1
-      breakpoint_manager.completed_breakpoints.must_be_empty
+      _(breakpoint_manager.active_breakpoints.size).must_equal 1
+      _(breakpoint_manager.completed_breakpoints).must_be_empty
 
       breakpoint_manager.mark_off breakpoint1
 
-      breakpoint_manager.active_breakpoints.must_be_empty
-      breakpoint_manager.completed_breakpoints.size.must_equal 1
-      breakpoint_manager.completed_breakpoints.must_include breakpoint1
+      _(breakpoint_manager.active_breakpoints).must_be_empty
+      _(breakpoint_manager.completed_breakpoints.size).must_equal 1
+      _(breakpoint_manager.completed_breakpoints).must_include breakpoint1
     end
 
     it "doesn't mark off a breakpoint not in @active_breakpoints" do
       breakpoint_manager.update_breakpoints [breakpoint1]
 
-      breakpoint_manager.active_breakpoints.size.must_equal 1
-      breakpoint_manager.completed_breakpoints.must_be_empty
+      _(breakpoint_manager.active_breakpoints.size).must_equal 1
+      _(breakpoint_manager.completed_breakpoints).must_be_empty
 
       breakpoint_manager.mark_off breakpoint2
 
-      breakpoint_manager.active_breakpoints.size.must_equal 1
-      breakpoint_manager.completed_breakpoints.must_be_empty
+      _(breakpoint_manager.active_breakpoints.size).must_equal 1
+      _(breakpoint_manager.completed_breakpoints).must_be_empty
     end
   end
 
@@ -308,7 +308,7 @@ describe Google::Cloud::Debugger::BreakpointManager, :mock_debugger do
         breakpoint3
       ]
 
-      breakpoint_manager.breakpoints.must_equal [breakpoint1, breakpoint2, breakpoint3]
+      _(breakpoint_manager.breakpoints).must_equal [breakpoint1, breakpoint2, breakpoint3]
     end
   end
 
@@ -322,7 +322,7 @@ describe Google::Cloud::Debugger::BreakpointManager, :mock_debugger do
         breakpoint3
       ]
 
-      breakpoint_manager.active_breakpoints.must_equal [breakpoint1, breakpoint2]
+      _(breakpoint_manager.active_breakpoints).must_equal [breakpoint1, breakpoint2]
     end
   end
 
@@ -336,28 +336,28 @@ describe Google::Cloud::Debugger::BreakpointManager, :mock_debugger do
         breakpoint3
       ]
 
-      breakpoint_manager.completed_breakpoints.must_equal [breakpoint3]
+      _(breakpoint_manager.completed_breakpoints).must_equal [breakpoint3]
     end
   end
 
   describe "#all_complete?" do
     it "returns true only if there are active breakpoints" do
-      breakpoint_manager.all_complete?.must_equal true
+      _(breakpoint_manager.all_complete?).must_equal true
       breakpoint_manager.instance_variable_set :@active_breakpoints, [
         breakpoint1,
         breakpoint2
       ]
-      breakpoint_manager.all_complete?.must_equal false
+      _(breakpoint_manager.all_complete?).must_equal false
       breakpoint_manager.instance_variable_set :@active_breakpoints, []
-      breakpoint_manager.all_complete?.must_equal true
+      _(breakpoint_manager.all_complete?).must_equal true
     end
 
     it "return true if there are only completed breakpoints" do
-      breakpoint_manager.all_complete?.must_equal true
+      _(breakpoint_manager.all_complete?).must_equal true
       breakpoint_manager.instance_variable_set :@completed_breakpoints, [
         breakpoint3
       ]
-      breakpoint_manager.all_complete?.must_equal true
+      _(breakpoint_manager.all_complete?).must_equal true
     end
   end
 
@@ -371,10 +371,10 @@ describe Google::Cloud::Debugger::BreakpointManager, :mock_debugger do
         breakpoint3
       ]
 
-      breakpoint_manager.breakpoints.wont_be_empty
+      _(breakpoint_manager.breakpoints).wont_be_empty
 
       breakpoint_manager.clear_breakpoints
-      breakpoint_manager.breakpoints.must_be_empty
+      _(breakpoint_manager.breakpoints).must_be_empty
     end
   end
 
@@ -388,8 +388,8 @@ describe Google::Cloud::Debugger::BreakpointManager, :mock_debugger do
       breakpoint_manager.agent.transmitter.stub :submit, mocked_submit do
         breakpoints = breakpoint_manager.send :filter_breakpoints, [breakpoint1, breakpoint2]
 
-        breakpoints.size.must_equal 1
-        breakpoints.first.must_equal breakpoint1
+        _(breakpoints.size).must_equal 1
+        _(breakpoints.first).must_equal breakpoint1
       end
 
       mocked_submit.verify

--- a/google-cloud-debugger/test/google/cloud/debugger/breakpoint_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/breakpoint_test.rb
@@ -36,67 +36,67 @@ describe Google::Cloud::Debugger::Breakpoint, :mock_debugger do
     it "knows all of the attributes" do
       timestamp = Time.parse "2014-10-02T15:01:23.045123456Z"
 
-      breakpoint.id.must_equal "abc123"
-      breakpoint.action.must_equal :CAPTURE
-      breakpoint.location.path.must_equal "my_app/my_class.rb"
-      breakpoint.location.line.must_equal 321
-      breakpoint.create_time.must_equal timestamp
-      breakpoint.final_time.must_equal timestamp
-      breakpoint.expressions.must_equal ["[3]"]
+      _(breakpoint.id).must_equal "abc123"
+      _(breakpoint.action).must_equal :CAPTURE
+      _(breakpoint.location.path).must_equal "my_app/my_class.rb"
+      _(breakpoint.location.line).must_equal 321
+      _(breakpoint.create_time).must_equal timestamp
+      _(breakpoint.final_time).must_equal timestamp
+      _(breakpoint.expressions).must_equal ["[3]"]
       expression_var = breakpoint.evaluated_expressions.first
-      expression_var.name.must_equal "local_var"
-      expression_var.type.must_equal "Array"
-      expression_var.members.wont_be_empty
+      _(expression_var.name).must_equal "local_var"
+      _(expression_var.type).must_equal "Array"
+      _(expression_var.members).wont_be_empty
       stack_frame = breakpoint.stack_frames.first
-      stack_frame.function.must_equal "index"
-      stack_frame.location.path.must_equal "my_app/my_class.rb"
-      stack_frame.location.line.must_equal 321
-      stack_frame.arguments.wont_be_empty
-      stack_frame.locals.wont_be_empty
-      breakpoint.condition.must_equal "i == 2"
-      breakpoint.labels.must_equal({"tag" => "hello"})
-      breakpoint.is_final_state.wont_equal true
+      _(stack_frame.function).must_equal "index"
+      _(stack_frame.location.path).must_equal "my_app/my_class.rb"
+      _(stack_frame.location.line).must_equal 321
+      _(stack_frame.arguments).wont_be_empty
+      _(stack_frame.locals).wont_be_empty
+      _(breakpoint.condition).must_equal "i == 2"
+      _(breakpoint.labels).must_equal({"tag" => "hello"})
+      _(breakpoint.is_final_state).wont_equal true
       variable_table_var = breakpoint.variable_table.first
-      variable_table_var.must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
-      variable_table_var.name.must_equal "local_var"
-      variable_table_var.type.must_equal "Array"
-      variable_table_var.members.wont_be_empty
+      _(variable_table_var).must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
+      _(variable_table_var.name).must_equal "local_var"
+      _(variable_table_var.type).must_equal "Array"
+      _(variable_table_var.members).wont_be_empty
     end
 
     it "knows all of the attributes for logpoint" do
-      logpoint.action.must_equal :LOG
-      logpoint.log_message_format.must_equal "Hello $0"
-      logpoint.expressions.must_equal ["World"]
+      _(logpoint.action).must_equal :LOG
+      _(logpoint.log_message_format).must_equal "Hello $0"
+      _(logpoint.expressions).must_equal ["World"]
     end
 
     it "has location even if missing from grpc" do
       breakpoint_hash["location"] = nil
 
-      breakpoint.location.must_be_kind_of Google::Cloud::Debugger::Breakpoint::SourceLocation
+      _(breakpoint.location).must_be_kind_of Google::Cloud::Debugger::Breakpoint::SourceLocation
     end
 
     it "has expressions even if missing from grpc" do
       breakpoint_hash["expressions"] = nil
 
-      breakpoint.expressions.must_equal []
+      _(breakpoint.expressions).must_equal []
     end
 
     it "has evaluated_expressions even if missing from grpc" do
       breakpoint_hash["evaluated_expressions"] = nil
 
-      breakpoint.evaluated_expressions.must_equal []
+      _(breakpoint.evaluated_expressions).must_equal []
     end
 
     it "has stack_frames even if missing from grpc" do
       breakpoint_hash["stack_frames"] = nil
 
-      breakpoint.stack_frames.must_equal []
+      _(breakpoint.stack_frames).must_equal []
     end
 
     it "has labels even if missing from grpc" do
       breakpoint_hash["labels"] = nil
 
-      breakpoint.labels.must_equal({})
+      _(breakpoint.labels).must_equal({})
     end
   end
 
@@ -105,39 +105,39 @@ describe Google::Cloud::Debugger::Breakpoint, :mock_debugger do
       timestamp = Time.parse "2014-10-02T15:01:23.045123456Z"
 
       grpc = breakpoint.to_grpc
-      grpc.must_be_kind_of Google::Devtools::Clouddebugger::V2::Breakpoint
+      _(grpc).must_be_kind_of Google::Devtools::Clouddebugger::V2::Breakpoint
 
-      grpc.id.must_equal "abc123"
-      grpc.create_time.seconds.must_equal timestamp.to_i
-      grpc.final_time.seconds.must_equal timestamp.to_i
-      grpc.location.path.must_equal "my_app/my_class.rb"
-      grpc.location.line.must_equal 321
-      grpc.expressions.must_equal ["[3]"]
+      _(grpc.id).must_equal "abc123"
+      _(grpc.create_time.seconds).must_equal timestamp.to_i
+      _(grpc.final_time.seconds).must_equal timestamp.to_i
+      _(grpc.location.path).must_equal "my_app/my_class.rb"
+      _(grpc.location.line).must_equal 321
+      _(grpc.expressions).must_equal ["[3]"]
       expression_var = grpc.evaluated_expressions.first
-      expression_var.name.must_equal "local_var"
-      expression_var.type.must_equal "Array"
-      expression_var.members.wont_be_empty
+      _(expression_var.name).must_equal "local_var"
+      _(expression_var.type).must_equal "Array"
+      _(expression_var.members).wont_be_empty
       stack_frame = breakpoint.stack_frames.first
-      stack_frame.function.must_equal "index"
-      stack_frame.location.path.must_equal "my_app/my_class.rb"
-      stack_frame.location.line.must_equal 321
-      stack_frame.arguments.wont_be_empty
-      stack_frame.locals.wont_be_empty
-      grpc.condition.must_equal "i == 2"
-      grpc.labels["tag"].must_equal "hello"
-      grpc.variable_table.wont_be_empty
+      _(stack_frame.function).must_equal "index"
+      _(stack_frame.location.path).must_equal "my_app/my_class.rb"
+      _(stack_frame.location.line).must_equal 321
+      _(stack_frame.arguments).wont_be_empty
+      _(stack_frame.locals).wont_be_empty
+      _(grpc.condition).must_equal "i == 2"
+      _(grpc.labels["tag"]).must_equal "hello"
+      _(grpc.variable_table).wont_be_empty
     end
   end
 
   describe "#complete" do
     it "sets @is_final_state and @final_time" do
       breakpoint.final_time = nil
-      breakpoint.is_final_state.must_equal false
+      _(breakpoint.is_final_state).must_equal false
 
       breakpoint.complete
 
-      breakpoint.is_final_state.must_equal true
-      breakpoint.final_time.must_be_kind_of Time
+      _(breakpoint.is_final_state).must_equal true
+      _(breakpoint.final_time).must_be_kind_of Time
     end
 
     it "doesn't change @final_time if already completed" do
@@ -147,29 +147,29 @@ describe Google::Cloud::Debugger::Breakpoint, :mock_debugger do
       original_final_time = breakpoint.final_time
 
       breakpoint.complete
-      breakpoint.final_time.must_equal original_final_time
+      _(breakpoint.final_time).must_equal original_final_time
     end
   end
 
   describe "#path" do
     it "gets path from location" do
-      breakpoint.path.must_equal breakpoint.location.path
+      _(breakpoint.path).must_equal breakpoint.location.path
     end
 
     it "returns nil if location doesn't exist" do
       breakpoint.location = nil
-      breakpoint.path.must_be_nil
+      _(breakpoint.path).must_be_nil
     end
   end
 
   describe "#line" do
     it "gets line from location" do
-      breakpoint.line.must_equal breakpoint.location.line
+      _(breakpoint.line).must_equal breakpoint.location.line
     end
 
     it "returns nil if location doesn't exist" do
       breakpoint.location = nil
-      breakpoint.line.must_be_nil
+      _(breakpoint.line).must_be_nil
     end
   end
 
@@ -177,12 +177,12 @@ describe Google::Cloud::Debugger::Breakpoint, :mock_debugger do
     it "returns true if condition is nil" do
       breakpoint.condition = nil
 
-      breakpoint.check_condition(nil).must_equal true
+      _(breakpoint.check_condition(nil)).must_equal true
     end
 
     it "returns true if condition is empty" do
       breakpoint.condition = ""
-      breakpoint.check_condition(nil).must_equal true
+      _(breakpoint.check_condition(nil)).must_equal true
     end
 
     it "calls breakpoint#set_error_state if Evaluator.eval_condition raises error" do
@@ -218,7 +218,7 @@ describe Google::Cloud::Debugger::Breakpoint, :mock_debugger do
     it "compares id, path, and line" do
       breakpoint2 = Google::Cloud::Debugger::Breakpoint.new("abc123", "my_app/my_class.rb", 321)
 
-      breakpoint.eql?(breakpoint2).must_equal true
+      _(breakpoint.eql?(breakpoint2)).must_equal true
     end
   end
 
@@ -244,12 +244,12 @@ describe Google::Cloud::Debugger::Breakpoint, :mock_debugger do
       error_message = "breakpoint is broken"
       status = breakpoint.set_error_state error_message, refers_to: :BREAKPOINT_CONDITION
 
-      breakpoint.status.must_equal status
-      breakpoint.status.must_be_kind_of Google::Cloud::Debugger::Breakpoint::StatusMessage
+      _(breakpoint.status).must_equal status
+      _(breakpoint.status).must_be_kind_of Google::Cloud::Debugger::Breakpoint::StatusMessage
 
-      status.description.must_equal error_message
-      status.is_error.must_equal true
-      status.refers_to.must_equal :BREAKPOINT_CONDITION
+      _(status.description).must_equal error_message
+      _(status.is_error).must_equal true
+      _(status.refers_to).must_equal :BREAKPOINT_CONDITION
     end
   end
 end

--- a/google-cloud-debugger/test/google/cloud/debugger/debuggee/app_uniquifier_generator_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/debuggee/app_uniquifier_generator_test.rb
@@ -19,7 +19,7 @@ describe Google::Cloud::Debugger::Debuggee::AppUniquifierGenerator do
   describe ".generate_app_uniquifier" do
     it "uses the app_path passed it" do
       stubbed_process_directory = ->(sha = nil, path = nil, depth = 1) {
-        path.must_equal "utest_path"
+        _(path).must_equal "utest_path"
       }
       Google::Cloud::Debugger::Debuggee::AppUniquifierGenerator.stub :process_directory, stubbed_process_directory do
         Google::Cloud::Debugger::Debuggee::AppUniquifierGenerator.generate_app_uniquifier "sha", "utest_path"
@@ -28,7 +28,7 @@ describe Google::Cloud::Debugger::Debuggee::AppUniquifierGenerator do
 
     it "first defaults to use Rack::Directory.new("").root" do
       stubbed_process_directory = ->(sha = nil, path = nil, depth = 1) {
-        path.must_equal "utest_rack_path"
+        _(path).must_equal "utest_rack_path"
       }
       stubbed_rack_directory = ->(path) {
         OpenStruct.new(root: "utest_rack_path")
@@ -48,20 +48,20 @@ describe Google::Cloud::Debugger::Debuggee::AppUniquifierGenerator do
       sha = Digest::SHA1.new
       original_sha_digest = sha.to_s
       Google::Cloud::Debugger::Debuggee::AppUniquifierGenerator.process_directory sha, ".", exceeded_depth
-      sha.to_s.must_equal original_sha_digest
+      _(sha.to_s).must_equal original_sha_digest
     end
 
     it "computes sha of a directory" do
       expected_sha = Digest::SHA1.new
       sha = Digest::SHA1.new
 
-      sha.to_s.must_equal expected_sha.to_s
+      _(sha.to_s).must_equal expected_sha.to_s
 
       test_file = Pathname.new File.join(File.dirname(__FILE__), "test_dir", "test_ruby_file.rb")
       expected_sha << "#{test_file.expand_path}:#{test_file.stat.size}"
 
       Google::Cloud::Debugger::Debuggee::AppUniquifierGenerator.process_directory sha, "#{File.dirname(__FILE__)}/test_dir"
-      sha.to_s.must_equal expected_sha.to_s
+      _(sha.to_s).must_equal expected_sha.to_s
     end
   end
 end

--- a/google-cloud-debugger/test/google/cloud/debugger/debuggee_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/debuggee_test.rb
@@ -19,27 +19,27 @@ describe Google::Cloud::Debugger::Debuggee, :mock_debugger do
     it "sets debuggee id when registered successfully" do
       mocked_response = OpenStruct.new(debuggee: OpenStruct.new(id: debuggee_id))
       debuggee.service.stub :register_debuggee, mocked_response do
-        debuggee.register.must_equal true
+        _(debuggee.register).must_equal true
       end
-      debuggee.id.must_equal debuggee_id
+      _(debuggee.id).must_equal debuggee_id
     end
 
     it "revokes debuggee id if registration request raises exception" do
       mocked_register_debuggee = ->() { raise }
 
       debuggee.service.stub :register_debuggee, mocked_register_debuggee do
-        debuggee.register.must_equal false
+        _(debuggee.register).must_equal false
       end
 
-      debuggee.id.must_be_nil
+      _(debuggee.id).must_be_nil
     end
   end
 
   describe "#registered" do
     it "returns true if debuggee id isn't nil" do
-      debuggee.registered?.must_equal true
+      _(debuggee.registered?).must_equal true
       debuggee.instance_variable_set :@id, nil
-      debuggee.registered?.must_equal false
+      _(debuggee.registered?).must_equal false
     end
   end
 
@@ -47,20 +47,20 @@ describe Google::Cloud::Debugger::Debuggee, :mock_debugger do
     it "unsets debuggee id" do
       debuggee.revoke_registration
 
-      debuggee.id.must_be_nil
-      debuggee.registered?.must_equal false
+      _(debuggee.id).must_be_nil
+      _(debuggee.registered?).must_equal false
     end
   end
 
   describe "#to_grpc" do
     it "has all the attributes" do
       grpc = debuggee.to_grpc
-      grpc.id.must_equal debuggee_id
-      grpc.project.must_equal project
-      grpc.uniquifier.wont_be_nil
-      grpc.description.wont_be_nil
-      grpc.agent_version.wont_be_nil
-      grpc.labels.to_a.wont_be_empty
+      _(grpc.id).must_equal debuggee_id
+      _(grpc.project).must_equal project
+      _(grpc.uniquifier).wont_be_nil
+      _(grpc.description).wont_be_nil
+      _(grpc.agent_version).wont_be_nil
+      _(grpc.labels.to_a).wont_be_empty
     end
 
     it "uses numeric project ID if available" do
@@ -74,7 +74,7 @@ describe Google::Cloud::Debugger::Debuggee, :mock_debugger do
       mock_env = Google::Cloud::Env.new metadata_cache: metadata_cache
       debuggee.instance_variable_set :@env, mock_env
       grpc = debuggee.to_grpc
-      grpc.project.must_equal numeric_id.to_s
+      _(grpc.project).must_equal numeric_id.to_s
     end
   end
 
@@ -82,7 +82,7 @@ describe Google::Cloud::Debugger::Debuggee, :mock_debugger do
     it "returns nil if fails to read file" do
       stubbed_read = ->(_) { raise }
       File.stub :read, stubbed_read do
-        debuggee.send(:read_app_json_file, nil).must_be_nil
+        _(debuggee.send(:read_app_json_file, nil)).must_be_nil
       end
     end
 
@@ -91,7 +91,7 @@ describe Google::Cloud::Debugger::Debuggee, :mock_debugger do
 
       File.stub :read, nil do
         JSON.stub :parse, stubbed_parse do
-          debuggee.send(:read_app_json_file, nil).must_be_nil
+          _(debuggee.send(:read_app_json_file, nil)).must_be_nil
         end
       end
     end
@@ -109,8 +109,8 @@ describe Google::Cloud::Debugger::Debuggee, :mock_debugger do
       uniquifier1 = debuggee.send(:compute_uniquifier, partial_debuggee)
       uniquifier2 = debuggee.send(:compute_uniquifier, partial_debuggee)
 
-      uniquifier1.must_equal uniquifier2
-      uniquifier1.must_equal debuggee.instance_variable_get(:@computed_uniquifier)
+      _(uniquifier1).must_equal uniquifier2
+      _(uniquifier1).must_equal debuggee.instance_variable_get(:@computed_uniquifier)
     end
 
     it "calls AppUniquifierGenerator.generate_app_uniquifier if source context is missing" do

--- a/google-cloud-debugger/test/google/cloud/debugger/logpoint_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/logpoint_test.rb
@@ -30,23 +30,23 @@ describe Google::Cloud::Debugger::Logpoint, :mock_debugger do
 
   describe "#format_message" do
     it "formats basic message" do
-      logpoint.format_message("Hello World", []).must_equal "Hello World"
+      _(logpoint.format_message("Hello World", [])).must_equal "Hello World"
     end
 
     it "formats message with expressions" do
-      logpoint.format_message("Hello $0$1", ["World", :!]).must_equal "Hello \"World\":!"
+      _(logpoint.format_message("Hello $0$1", ["World", :!])).must_equal "Hello \"World\":!"
     end
 
     it "formats message with extra expressions" do
-      logpoint.format_message("Hello $0$1", ["World", :!, :zomg]).must_equal "Hello \"World\":!"
+      _(logpoint.format_message("Hello $0$1", ["World", :!, :zomg])).must_equal "Hello \"World\":!"
     end
 
     it "formats message with extra placeholder" do
-      logpoint.format_message("Hello $0$1$2", ["World", :!]).must_equal "Hello \"World\":!"
+      _(logpoint.format_message("Hello $0$1$2", ["World", :!])).must_equal "Hello \"World\":!"
     end
 
     it "doesn't substitute escaped placeholder and unescape them" do
-      logpoint.format_message("Hello 0 $0 $$0 $$$$0", ["World"]).must_equal "Hello 0 \"World\" $0 $$0"
+      _(logpoint.format_message("Hello 0 $0 $$0 $$$$0", ["World"])).must_equal "Hello 0 \"World\" $0 $$0"
     end
   end
 
@@ -54,7 +54,7 @@ describe Google::Cloud::Debugger::Logpoint, :mock_debugger do
     it "returns false if logpoint is evaluated already" do
       logpoint.complete
 
-      logpoint.evaluate([]).must_equal false
+      _(logpoint.evaluate([])).must_equal false
     end
 
     it "returns false if logpoint condition check fails" do
@@ -70,7 +70,7 @@ describe Google::Cloud::Debugger::Logpoint, :mock_debugger do
         logpoint.stub :check_condition, true do
           logpoint.evaluate([nil])
 
-          logpoint.evaluated_log_message.must_equal "test log message"
+          _(logpoint.evaluated_log_message).must_equal "test log message"
         end
       end
     end
@@ -80,7 +80,7 @@ describe Google::Cloud::Debugger::Logpoint, :mock_debugger do
 
       logpoint.evaluate []
 
-      logpoint.complete?.must_equal false
+      _(logpoint.complete?).must_equal false
     end
   end
 end

--- a/google-cloud-debugger/test/google/cloud/debugger/middleware_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/middleware_test.rb
@@ -43,18 +43,18 @@ describe Google::Cloud::Debugger::Middleware, :mock_debugger do
     it "starts pending agents" do
       Google::Cloud::Debugger::Credentials.stub :default, "/default/keyfile.json" do
         middleware
-        debugger.agent.async_running?.must_equal false
+        _(debugger.agent.async_running?).must_equal false
         Google::Cloud::Debugger::Middleware.start_agents
-        debugger.agent.async_running?.must_equal true
+        _(debugger.agent.async_running?).must_equal true
       end
     end
 
     it "causes later agents to start automatically" do
       Google::Cloud::Debugger::Credentials.stub :default, "/default/keyfile.json" do
         Google::Cloud::Debugger::Middleware.start_agents
-        debugger.agent.async_running?.must_equal false
+        _(debugger.agent.async_running?).must_equal false
         middleware
-        debugger.agent.async_running?.must_equal true
+        _(debugger.agent.async_running?).must_equal true
       end
     end
 
@@ -63,7 +63,7 @@ describe Google::Cloud::Debugger::Middleware, :mock_debugger do
         middleware
         Google::Cloud::Debugger::Middleware.start_agents
         Google::Cloud::Debugger::Middleware.start_agents
-        debugger.agent.async_running?.must_equal true
+        _(debugger.agent.async_running?).must_equal true
       end
     end
   end
@@ -93,11 +93,11 @@ describe Google::Cloud::Debugger::Middleware, :mock_debugger do
         debugger = middleware.instance_variable_get :@debugger
         env = { "rack.logger" => logger }
 
-        debugger.agent.logger.wont_equal logger
+        _(debugger.agent.logger).wont_equal logger
 
         middleware.call env
 
-        debugger.agent.logger.must_equal logger
+        _(debugger.agent.logger).must_equal logger
       end
     end
 
@@ -107,11 +107,11 @@ describe Google::Cloud::Debugger::Middleware, :mock_debugger do
         debugger = middleware.instance_variable_get :@debugger
         env = { "rack.logger" => logger }
 
-        debugger.agent.logger.wont_equal logger
+        _(debugger.agent.logger).wont_equal logger
 
         middleware.call env
 
-        debugger.agent.logger.wont_equal logger
+        _(debugger.agent.logger).wont_equal logger
       end
     end
 
@@ -124,13 +124,13 @@ describe Google::Cloud::Debugger::Middleware, :mock_debugger do
             debugger.agent.quota_manager.consume
           end
 
-          debugger.agent.quota_manager.more?.must_equal false
+          _(debugger.agent.quota_manager.more?).must_equal false
         }
 
         rack_app.stub :call, stubbed_call do
           middleware.call({})
 
-          debugger.agent.quota_manager.more?.must_equal true
+          _(debugger.agent.quota_manager.more?).must_equal true
         end
       end
     end

--- a/google-cloud-debugger/test/google/cloud/debugger/project_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/project_test.rb
@@ -16,8 +16,8 @@ require "helper"
 
 describe Google::Cloud::Debugger::Project, :mock_debugger do
   it "knows the project identifier" do
-    debugger.must_be_kind_of Google::Cloud::Debugger::Project
-    debugger.project.must_equal project
+    _(debugger).must_be_kind_of Google::Cloud::Debugger::Project
+    _(debugger.project).must_equal project
   end
 
   describe "#start" do

--- a/google-cloud-debugger/test/google/cloud/debugger/rails_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/rails_test.rb
@@ -47,10 +47,10 @@ describe Google::Cloud::Debugger::Railtie do
         Google::Cloud::Debugger::Railtie.send :consolidate_rails_config, rails_config
 
         Google::Cloud::Debugger.configure do |config|
-          config.project_id.must_equal "test-project"
-          config.credentials.must_equal "test/keyfile"
-          config.service_name.must_equal "test-module"
-          config.service_version.must_equal "test-version"
+          _(config.project_id).must_equal "test-project"
+          _(config.credentials).must_equal "test/keyfile"
+          _(config.service_name).must_equal "test-module"
+          _(config.service_version).must_equal "test-version"
         end
       end
     end
@@ -67,10 +67,10 @@ describe Google::Cloud::Debugger::Railtie do
         Google::Cloud::Debugger::Railtie.send :consolidate_rails_config, rails_config
 
         Google::Cloud::Debugger.configure do |config|
-          config.project_id.must_equal "another-test-project"
-          config.keyfile.must_equal "/another/test/keyfile"
-          config.service_name.must_equal "another-test-module"
-          config.service_version.must_equal "another-test-version"
+          _(config.project_id).must_equal "another-test-project"
+          _(config.keyfile).must_equal "/another/test/keyfile"
+          _(config.service_name).must_equal "another-test-module"
+          _(config.service_version).must_equal "another-test-version"
         end
       end
     end
@@ -80,16 +80,16 @@ describe Google::Cloud::Debugger::Railtie do
 
       Google::Cloud::Debugger::Railtie.stub :valid_credentials?, false do
         Google::Cloud::Debugger::Railtie.send :consolidate_rails_config, rails_config
-        Google::Cloud.configure.use_debugger.must_equal false
+        _(Google::Cloud.configure.use_debugger).must_equal false
       end
     end
 
     it "Set use_debugger to true if Rails is in production" do
       Google::Cloud::Debugger::Railtie.stub :valid_credentials?, true do
         Rails.env.stub :production?, true do
-          Google::Cloud.configure.use_debugger.must_be_nil
+          _(Google::Cloud.configure.use_debugger).must_be_nil
           Google::Cloud::Debugger::Railtie.send :consolidate_rails_config, rails_config
-          Google::Cloud.configure.use_debugger.must_equal true
+          _(Google::Cloud.configure.use_debugger).must_equal true
         end
       end
     end
@@ -99,7 +99,7 @@ describe Google::Cloud::Debugger::Railtie do
         Rails.env.stub :production?, true do
           Google::Cloud.configure.use_debugger = false
           Google::Cloud::Debugger::Railtie.send :consolidate_rails_config, rails_config
-          Google::Cloud.configure.use_debugger.must_equal false
+          _(Google::Cloud.configure.use_debugger).must_equal false
         end
       end
     end
@@ -110,7 +110,7 @@ describe Google::Cloud::Debugger::Railtie do
       Google::Cloud::Debugger::Railtie.stub :valid_credentials?, true do
         Rails.env.stub :production?, false do
           Google::Cloud::Debugger::Railtie.send :consolidate_rails_config, rails_config
-          Google::Cloud.configure.use_debugger.must_equal true
+          _(Google::Cloud.configure.use_debugger).must_equal true
         end
       end
     end

--- a/google-cloud-debugger/test/google/cloud/debugger/request_quota_manager_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/request_quota_manager_test.rb
@@ -20,49 +20,49 @@ describe Google::Cloud::Debugger::RequestQuotaManager, :mock_debugger do
 
   describe "#more?" do
     it "returns false when all the time quota is used up" do
-      quota_manager.more?.must_equal true
+      _(quota_manager.more?).must_equal true
 
       quota_manager.consume time: (quota_manager.time_quota + 1)
 
-      quota_manager.more?.must_equal false
+      _(quota_manager.more?).must_equal false
     end
 
     it "returns false when all the count quota is used up" do
-      quota_manager.more?.must_equal true
+      _(quota_manager.more?).must_equal true
 
       quota_manager.count_quota.times do
         quota_manager.consume
       end
 
-      quota_manager.more?.must_equal false
+      _(quota_manager.more?).must_equal false
     end
   end
 
   describe "#reset" do
     it "resets time quota" do
-      quota_manager.more?.must_equal true
+      _(quota_manager.more?).must_equal true
 
       quota_manager.consume time: (quota_manager.time_quota + 1)
 
-      quota_manager.more?.must_equal false
+      _(quota_manager.more?).must_equal false
 
       quota_manager.reset
 
-      quota_manager.more?.must_equal true
+      _(quota_manager.more?).must_equal true
     end
 
     it "resets count quota" do
-      quota_manager.more?.must_equal true
+      _(quota_manager.more?).must_equal true
 
       quota_manager.count_quota.times do
         quota_manager.consume
       end
 
-      quota_manager.more?.must_equal false
+      _(quota_manager.more?).must_equal false
 
       quota_manager.reset
 
-      quota_manager.more?.must_equal true
+      _(quota_manager.more?).must_equal true
     end
   end
 end

--- a/google-cloud-debugger/test/google/cloud/debugger/snappoint_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/snappoint_test.rb
@@ -30,8 +30,8 @@ describe Google::Cloud::Debugger::Snappoint, :mock_debugger do
     it "insert a buffer full variable into variable table" do
       snappoint = Google::Cloud::Debugger::Snappoint.new
 
-      snappoint.variable_table.size.must_equal 1
-      snappoint.variable_table[0].status.description.must_equal Google::Cloud::Debugger::Breakpoint::Variable::BUFFER_FULL_MSG
+      _(snappoint.variable_table.size).must_equal 1
+      _(snappoint.variable_table[0].status.description).must_equal Google::Cloud::Debugger::Breakpoint::Variable::BUFFER_FULL_MSG
     end
   end
 
@@ -42,8 +42,8 @@ describe Google::Cloud::Debugger::Snappoint, :mock_debugger do
       snappoint.expressions = mock_expressions
 
       stubbed_readonly_eval_expression = ->(b, e) {
-        b.must_equal mock_binding
-        e.must_equal mock_expressions.first
+        _(b).must_equal mock_binding
+        _(e).must_equal mock_expressions.first
         "Readonly Evaluated"
       }
 
@@ -58,10 +58,10 @@ describe Google::Cloud::Debugger::Snappoint, :mock_debugger do
         Google::Cloud::Debugger::Breakpoint::Variable.stub :from_rb_var, stubbed_from_var do
           snappoint.eval_expressions mock_binding
 
-          snappoint.evaluated_expressions.size.must_equal 1
-          snappoint.evaluated_expressions.first.must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
-          snappoint.evaluated_expressions.first.value.must_equal "Readonly Evaluated".inspect
-          snappoint.evaluated_expressions.first.name.must_equal mock_expressions.first
+          _(snappoint.evaluated_expressions.size).must_equal 1
+          _(snappoint.evaluated_expressions.first).must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
+          _(snappoint.evaluated_expressions.first.value).must_equal "Readonly Evaluated".inspect
+          _(snappoint.evaluated_expressions.first.name).must_equal mock_expressions.first
         end
       end
     end
@@ -71,7 +71,7 @@ describe Google::Cloud::Debugger::Snappoint, :mock_debugger do
     it "returns false if breakpoint is evaluated already" do
       snappoint.complete
 
-      snappoint.evaluate([]).must_equal false
+      _(snappoint.evaluate([])).must_equal false
     end
 
     it "returns false if condition check fails" do
@@ -84,7 +84,7 @@ describe Google::Cloud::Debugger::Snappoint, :mock_debugger do
       stubbed_eval_call_stack = ->(_) { raise }
       snappoint.stub :eval_call_stack, stubbed_eval_call_stack do
         snappoint.stub :check_condition, true do
-          snappoint.evaluate([nil]).must_equal false
+          _(snappoint.evaluate([nil])).must_equal false
         end
       end
     end
@@ -95,7 +95,7 @@ describe Google::Cloud::Debugger::Snappoint, :mock_debugger do
       snappoint.stub :eval_call_stack, nil do
         snappoint.stub :eval_expressions, stubbed_eval_expressions do
           snappoint.stub :check_condition, true do
-            snappoint.evaluate([nil]).must_equal false
+            _(snappoint.evaluate([nil])).must_equal false
           end
         end
       end
@@ -108,8 +108,8 @@ describe Google::Cloud::Debugger::Snappoint, :mock_debugger do
       snappoint.stub :check_condition, true do
         snappoint.evaluate([binding])
 
-        snappoint.evaluated_expressions.wont_be_empty
-        snappoint.stack_frames.wont_be_empty
+        _(snappoint.evaluated_expressions).wont_be_empty
+        _(snappoint.stack_frames).wont_be_empty
       end
     end
 
@@ -121,7 +121,7 @@ describe Google::Cloud::Debugger::Snappoint, :mock_debugger do
         snappoint.stub :eval_expressions, [] do
           snappoint.stub :check_condition, true do
             snappoint.stub :complete, mocked_complete do
-              snappoint.evaluate([nil]).must_equal true
+              _(snappoint.evaluate([nil])).must_equal true
             end
           end
         end
@@ -134,15 +134,15 @@ describe Google::Cloud::Debugger::Snappoint, :mock_debugger do
   describe "#eval_expressions" do
     it "set @evaluated_expressions to array of Breakpoint::Variable" do
       snappoint.eval_expressions binding
-      snappoint.evaluated_expressions.must_be_kind_of Array
-      snappoint.evaluated_expressions.all? { |var| var.is_a? Google::Cloud::Debugger::Breakpoint::Variable }.must_equal true
+      _(snappoint.evaluated_expressions).must_be_kind_of Array
+      _(snappoint.evaluated_expressions.all? { |var| var.is_a? Google::Cloud::Debugger::Breakpoint::Variable }).must_equal true
     end
 
     it "sets the Breakpoint::Variable name to the expression itself" do
       snappoint.eval_expressions binding
 
-      snappoint.evaluated_expressions.wont_be_empty
-      snappoint.evaluated_expressions.first.name.must_equal snappoint.expressions.first
+      _(snappoint.evaluated_expressions).wont_be_empty
+      _(snappoint.evaluated_expressions.first.name).must_equal snappoint.expressions.first
     end
 
     it "create a error variable if expression evaluation fails with mutation error" do
@@ -152,10 +152,10 @@ describe Google::Cloud::Debugger::Snappoint, :mock_debugger do
         snappoint.expressions = ["hello"]
         snappoint.eval_expressions binding
 
-        snappoint.evaluated_expressions.size.must_equal 1
-        snappoint.evaluated_expressions.first.must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
-        snappoint.evaluated_expressions.first.name.must_equal "hello"
-        snappoint.evaluated_expressions.first.status.refers_to.must_equal Google::Cloud::Debugger::Breakpoint::StatusMessage::VARIABLE_VALUE
+        _(snappoint.evaluated_expressions.size).must_equal 1
+        _(snappoint.evaluated_expressions.first).must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
+        _(snappoint.evaluated_expressions.first.name).must_equal "hello"
+        _(snappoint.evaluated_expressions.first.status.refers_to).must_equal Google::Cloud::Debugger::Breakpoint::StatusMessage::VARIABLE_VALUE
       end
     end
 
@@ -168,13 +168,13 @@ describe Google::Cloud::Debugger::Snappoint, :mock_debugger do
 
       snappoint.eval_expressions binding
 
-      snappoint.evaluated_expressions.size.must_equal count
+      _(snappoint.evaluated_expressions.size).must_equal count
 
       count.times do |i|
         if i < count - 1
-          snappoint.evaluated_expressions[i].value.must_match /x+/
+          _(snappoint.evaluated_expressions[i].value).must_match /x+/
         else
-          snappoint.evaluated_expressions[i].buffer_full_variable?.must_equal true
+          _(snappoint.evaluated_expressions[i].buffer_full_variable?).must_equal true
         end
       end
     end
@@ -185,7 +185,7 @@ describe Google::Cloud::Debugger::Snappoint, :mock_debugger do
       snappoint.stack_frames = []
       snappoint.eval_call_stack binding.callers
 
-      snappoint.stack_frames.all? { |sf| sf.is_a? Google::Cloud::Debugger::Breakpoint::StackFrame }.must_equal true
+      _(snappoint.stack_frames.all? { |sf| sf.is_a? Google::Cloud::Debugger::Breakpoint::StackFrame }).must_equal true
     end
 
     it "gets local variables within STACK_EVAL_DEPTH level" do
@@ -194,11 +194,11 @@ describe Google::Cloud::Debugger::Snappoint, :mock_debugger do
       snappoint.stack_frames = []
       snappoint.eval_call_stack [binding, *binding.callers]
 
-      snappoint.stack_frames.wont_be_empty
-      snappoint.stack_frames.first.locals.first.value.must_equal "test-local-var".inspect
+      _(snappoint.stack_frames).wont_be_empty
+      _(snappoint.stack_frames.first.locals.first.value).must_equal "test-local-var".inspect
       snappoint.stack_frames.each_with_index do |sf, i|
         if i >= Google::Cloud::Debugger::Snappoint::STACK_EVAL_DEPTH
-          sf.locals.must_be_empty
+          _(sf.locals).must_be_empty
         end
       end
     end
@@ -213,13 +213,13 @@ describe Google::Cloud::Debugger::Snappoint, :mock_debugger do
       snappoint.eval_expressions binding
       snappoint.eval_call_stack [binding]
 
-      snappoint.evaluated_expressions.size.must_equal count
+      _(snappoint.evaluated_expressions.size).must_equal count
 
 
-      snappoint.stack_frames.first.locals.size.must_equal 2
+      _(snappoint.stack_frames.first.locals.size).must_equal 2
       snappoint.stack_frames.first.locals.each do |var|
         if var.name == "long_str"
-          var.buffer_full_variable?.must_equal true
+          _(var.buffer_full_variable?).must_equal true
         end
       end
     end
@@ -235,7 +235,7 @@ describe Google::Cloud::Debugger::Snappoint, :mock_debugger do
 
       snappoint.evaluate [binding]
 
-      snappoint.send(:calculate_total_size).must_equal "'hello'".bytesize + String.to_s.bytesize +
+      _(snappoint.send(:calculate_total_size)).must_equal "'hello'".bytesize + String.to_s.bytesize +
                                                         "hello".inspect.bytesize + "local_var".bytesize +
                                                         "test-local-var".inspect.bytesize + String.to_s.bytesize
     end
@@ -244,9 +244,9 @@ describe Google::Cloud::Debugger::Snappoint, :mock_debugger do
   describe "#convert_variable" do
     it "convert the Ruby variable if current breakpoint is within limit" do
       var = snappoint.send :convert_variable, 1, name: "one"
-      var.must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
-      var.value.must_equal "1"
-      var.name.must_equal "one"
+      _(var).must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
+      _(var.value).must_equal "1"
+      _(var.name).must_equal "one"
     end
 
     it "returns buffer full referencing variable if current breakpoint size is full" do
@@ -255,11 +255,11 @@ describe Google::Cloud::Debugger::Snappoint, :mock_debugger do
 
         var = snappoint.send :convert_variable, 1
 
-        var.must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
-        var.value.must_be_nil
-        var.name.must_be_nil
-        var.type.must_be_nil
-        var.var_table_index.must_equal 0
+        _(var).must_be_kind_of Google::Cloud::Debugger::Breakpoint::Variable
+        _(var.value).must_be_nil
+        _(var.name).must_be_nil
+        _(var.type).must_be_nil
+        _(var.var_table_index).must_equal 0
       end
     end
   end

--- a/google-cloud-debugger/test/google/cloud/debugger/tracer/tracer_scenarios_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/tracer/tracer_scenarios_test.rb
@@ -56,7 +56,7 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
   it "catches breakpoint from function call" do
     hit = false
     stubbed_breakpoints_hit = ->(breakpoints, call_stack_bindings) do
-      breakpoints.first.must_equal breakpoint1
+      _(breakpoints.first).must_equal breakpoint1
       hit = true
     end
 
@@ -69,7 +69,7 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
       tracer.stop
     end
 
-    hit.must_equal true
+    _(hit).must_equal true
   end
 
   it "catches breakpoint called from a child thread" do
@@ -91,13 +91,13 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
       tracer.stop
     end
 
-    hit.must_equal true
+    _(hit).must_equal true
   end
 
   it "catches breakpoint from block yield" do
     hit = false
     stubbed_breakpoints_hit = ->(breakpoints, call_stack_bindings) do
-      breakpoints.first.must_equal breakpoint2
+      _(breakpoints.first).must_equal breakpoint2
       hit = true
     end
 
@@ -110,13 +110,13 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
       tracer.stop
     end
 
-    hit.must_equal true
+    _(hit).must_equal true
   end
 
   it "catches breakpoint when function interleave files" do
     hit = false
     stubbed_breakpoints_hit = ->(breakpoints, call_stack_bindings) do
-      breakpoints.first.must_equal breakpoint3
+      _(breakpoints.first).must_equal breakpoint3
       hit = true
     end
 
@@ -129,13 +129,13 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
       tracer.stop
     end
 
-    hit.must_equal true
+    _(hit).must_equal true
   end
 
   it "catches breakpoint when function interleave files#2" do
     hit = false
     stubbed_breakpoints_hit = ->(breakpoints, call_stack_bindings) do
-      breakpoints.first.must_equal breakpoint8
+      _(breakpoints.first).must_equal breakpoint8
       hit = true
     end
 
@@ -148,13 +148,13 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
       tracer.stop
     end
 
-    hit.must_equal true
+    _(hit).must_equal true
   end
 
   it "catches breakpoint when function interleave files#3" do
     hit = false
     stubbed_breakpoints_hit = ->(breakpoints, call_stack_bindings) do
-      breakpoints.first.must_equal breakpoint9
+      _(breakpoints.first).must_equal breakpoint9
       hit = true
     end
 
@@ -167,13 +167,13 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
       tracer.stop
     end
 
-    hit.must_equal true
+    _(hit).must_equal true
   end
 
   it "catches breakpoint from lambda function" do
     hit = false
     stubbed_breakpoints_hit = ->(breakpoints, call_stack_bindings) do
-      breakpoints.first.must_equal breakpoint4
+      _(breakpoints.first).must_equal breakpoint4
       hit = true
     end
 
@@ -186,13 +186,13 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
       tracer.stop
     end
 
-    hit.must_equal true
+    _(hit).must_equal true
   end
 
   it "catches breakpoint from proc" do
     hit = false
     stubbed_breakpoints_hit = ->(breakpoints, call_stack_bindings) do
-      breakpoints.first.must_equal breakpoint5
+      _(breakpoints.first).must_equal breakpoint5
       hit = true
     end
 
@@ -205,7 +205,7 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
       tracer.stop
     end
 
-    hit.must_equal true
+    _(hit).must_equal true
   end
 
   it "catches breakpoint from fiber" do
@@ -224,7 +224,7 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
       tracer.stop
     end
 
-    hit.must_equal true
+    _(hit).must_equal true
   end
 
   it "catches breakpoint from fiber after fiber yields" do
@@ -245,7 +245,7 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
       tracer.stop
     end
 
-    hit.must_equal true
+    _(hit).must_equal true
   end
 
   it "doesn't raise error when tracing dynamically defined methods" do
@@ -254,7 +254,7 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
 
     tracer.stub :breakpoints_hit, nil do
       tracer.start
-      dynamic_define_method.must_equal 42
+      _(dynamic_define_method).must_equal 42
       tracer.stop
     end
   end

--- a/google-cloud-debugger/test/google/cloud/debugger/tracer_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger/tracer_test.rb
@@ -22,7 +22,7 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
         original_hash = agent.tracer.breakpoints_cache
         new_hash = agent.tracer.update_breakpoints_cache
 
-        original_hash.object_id.wont_equal new_hash.object_id
+        _(original_hash.object_id).wont_equal new_hash.object_id
       end
     end
 
@@ -35,9 +35,9 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
       breakpoint_manager.stub :active_breakpoints, [breakpoint1, breakpoint2, breakpoint3, breakpoint4] do
         breakpoints_hash = agent.tracer.update_breakpoints_cache
 
-        breakpoints_hash["path/to/file1.rb"][123].must_equal [breakpoint1]
-        breakpoints_hash["path/to/file1.rb"][345].must_equal [breakpoint2]
-        breakpoints_hash["path/to/file2.rb"][987].must_equal [breakpoint3, breakpoint4]
+        _(breakpoints_hash["path/to/file1.rb"][123]).must_equal [breakpoint1]
+        _(breakpoints_hash["path/to/file1.rb"][345]).must_equal [breakpoint2]
+        _(breakpoints_hash["path/to/file2.rb"][987]).must_equal [breakpoint3, breakpoint4]
       end
     end
   end
@@ -61,7 +61,7 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
       breakpoint_manager.instance_variable_set :@active_breakpoints, [breakpoint]
 
       tracer.update_breakpoints_cache
-      tracer.breakpoints_cache.wont_be_empty
+      _(tracer.breakpoints_cache).wont_be_empty
 
       stubbed_evaluate = ->(_) { breakpoint.complete }
       mocked_disable_traces = Minitest::Mock.new
@@ -88,7 +88,7 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
         tracer.breakpoints_hit [breakpoint], nil
       end
 
-      breakpoint.complete?.wont_equal true
+      _(breakpoint.complete?).wont_equal true
     end
 
     it "records time used after each evaluation if there's a quota manager" do
@@ -105,7 +105,7 @@ describe Google::Cloud::Debugger::Tracer, :mock_debugger do
         tracer.breakpoints_hit [breakpoint], nil
       end
 
-      time_used.wont_equal 0
+      _(time_used).wont_equal 0
     end
   end
 

--- a/google-cloud-debugger/test/google/cloud/debugger_test.rb
+++ b/google-cloud-debugger/test/google/cloud/debugger_test.rb
@@ -21,19 +21,19 @@ describe Google::Cloud do
       gcloud = Google::Cloud.new
       stubbed_debugger = ->(project, keyfile, service_name: nil, service_version: nil,
         scope: nil, timeout: nil, client_config: nil, host: nil) {
-        project.must_be_nil
-        keyfile.must_be_nil
-        service_name.must_be_nil
-        service_version.must_be_nil
-        scope.must_be_nil
-        timeout.must_be_nil
-        client_config.must_be_nil
-        host.must_be_nil
+        _(project).must_be_nil
+        _(keyfile).must_be_nil
+        _(service_name).must_be_nil
+        _(service_version).must_be_nil
+        _(scope).must_be_nil
+        _(timeout).must_be_nil
+        _(client_config).must_be_nil
+        _(host).must_be_nil
         "debugger-project-object-empty"
       }
       Google::Cloud.stub :debugger, stubbed_debugger do
         project = gcloud.debugger
-        project.must_equal "debugger-project-object-empty"
+        _(project).must_equal "debugger-project-object-empty"
       end
     end
 
@@ -41,19 +41,19 @@ describe Google::Cloud do
       gcloud = Google::Cloud.new "project-id", "keyfile-path"
       stubbed_debugger = ->(project, keyfile, service_name: nil, service_version: nil,
         scope: nil, timeout: nil, client_config: nil, host: nil) {
-        project.must_equal "project-id"
-        keyfile.must_equal "keyfile-path"
-        service_name.must_be_nil
-        service_version.must_be_nil
-        scope.must_be_nil
-        timeout.must_be_nil
-        client_config.must_be_nil
-        host.must_be_nil
+        _(project).must_equal "project-id"
+        _(keyfile).must_equal "keyfile-path"
+        _(service_name).must_be_nil
+        _(service_version).must_be_nil
+        _(scope).must_be_nil
+        _(timeout).must_be_nil
+        _(client_config).must_be_nil
+        _(host).must_be_nil
         "debugger-project-object"
       }
       Google::Cloud.stub :debugger, stubbed_debugger do
         project = gcloud.debugger
-        project.must_equal "debugger-project-object"
+        _(project).must_equal "debugger-project-object"
       end
     end
 
@@ -61,19 +61,19 @@ describe Google::Cloud do
       gcloud = Google::Cloud.new "project-id", "keyfile-path"
       stubbed_debugger = ->(project, keyfile, service_name: nil, service_version: nil,
         scope: nil, timeout: nil, client_config: nil, host: nil) {
-        project.must_equal "project-id"
-        keyfile.must_equal "keyfile-path"
-        service_name.must_equal "utest-service"
-        service_version.must_equal "vUTest"
-        scope.must_equal "http://example.com/scope"
-        timeout.must_equal 60
-        client_config.must_equal({ "gax" => "options" })
-        host.must_be_nil
+        _(project).must_equal "project-id"
+        _(keyfile).must_equal "keyfile-path"
+        _(service_name).must_equal "utest-service"
+        _(service_version).must_equal "vUTest"
+        _(scope).must_equal "http://example.com/scope"
+        _(timeout).must_equal 60
+        _(client_config).must_equal({ "gax" => "options" })
+        _(host).must_be_nil
         "debugger-project-object-scoped"
       }
       Google::Cloud.stub :debugger, stubbed_debugger do
         project = gcloud.debugger service_name: "utest-service", service_version: "vUTest", scope: "http://example.com/scope", timeout: 60, client_config: { "gax" => "options" }
-        project.must_equal "debugger-project-object-scoped"
+        _(project).must_equal "debugger-project-object-scoped"
       end
     end
   end
@@ -100,11 +100,11 @@ describe Google::Cloud do
         Google::Cloud.stub :env, stubbed_env do
           Google::Cloud::Debugger::Credentials.stub :default, default_credentials do
             debugger = Google::Cloud.debugger
-            debugger.must_be_kind_of Google::Cloud::Debugger::Project
-            debugger.project.must_equal "project-id"
-            debugger.agent.debuggee.service_name.must_equal default_service_name
-            debugger.agent.debuggee.service_version.must_equal default_service_version
-            debugger.service.credentials.must_equal default_credentials
+            _(debugger).must_be_kind_of Google::Cloud::Debugger::Project
+            _(debugger.project).must_equal "project-id"
+            _(debugger.agent.debuggee.service_name).must_equal default_service_name
+            _(debugger.agent.debuggee.service_version).must_equal default_service_version
+            _(debugger.service.credentials).must_equal default_credentials
           end
         end
       end
@@ -112,18 +112,18 @@ describe Google::Cloud do
 
     it "uses provided project_id and keyfile" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be_nil
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be_nil
         "debugger-credentials"
       }
       stubbed_service_name = "utest-service"
       stubbed_service_version = "vUTest"
       stubbed_service = ->(project, credentials, timeout: nil, client_config: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "debugger-credentials"
-        timeout.must_be_nil
-        client_config.must_be_nil
-        host.must_be_nil
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "debugger-credentials"
+        _(timeout).must_be_nil
+        _(client_config).must_be_nil
+        _(host).must_be_nil
         OpenStruct.new project: project
       }
 
@@ -134,11 +134,11 @@ describe Google::Cloud do
             Google::Cloud::Debugger::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Debugger::Service.stub :new, stubbed_service do
                 debugger = Google::Cloud.debugger "project-id", "path/to/keyfile.json", service_name: stubbed_service_name, service_version: stubbed_service_version
-                debugger.must_be_kind_of Google::Cloud::Debugger::Project
-                debugger.project.must_equal "project-id"
-                debugger.agent.debuggee.service_name.must_equal stubbed_service_name
-                debugger.agent.debuggee.service_version.must_equal stubbed_service_version
-                debugger.service.must_be_kind_of OpenStruct
+                _(debugger).must_be_kind_of Google::Cloud::Debugger::Project
+                _(debugger.project).must_equal "project-id"
+                _(debugger.agent.debuggee.service_name).must_equal stubbed_service_name
+                _(debugger.agent.debuggee.service_version).must_equal stubbed_service_version
+                _(debugger.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -149,7 +149,7 @@ describe Google::Cloud do
 
   describe ".configure" do
     it "has Google::Cloud.configure.debugger initialized already" do
-      Google::Cloud.configure.option?(:debugger).must_equal true
+      _(Google::Cloud.configure.option?(:debugger)).must_equal true
     end
 
     it "operates on the same Configuration object as Google::Cloud.configure.debugger" do
@@ -180,11 +180,11 @@ describe Google::Cloud do
         Google::Cloud.stub :env, stubbed_env do
           Google::Cloud::Debugger::Credentials.stub :default, default_credentials do
             debugger = Google::Cloud::Debugger.new
-            debugger.must_be_kind_of Google::Cloud::Debugger::Project
-            debugger.project.must_equal "project-id"
-            debugger.agent.debuggee.service_name.must_equal default_service_name
-            debugger.agent.debuggee.service_version.must_equal default_service_version
-            debugger.service.credentials.must_equal default_credentials
+            _(debugger).must_be_kind_of Google::Cloud::Debugger::Project
+            _(debugger.project).must_equal "project-id"
+            _(debugger.agent.debuggee.service_name).must_equal default_service_name
+            _(debugger.agent.debuggee.service_version).must_equal default_service_version
+            _(debugger.service.credentials).must_equal default_credentials
           end
         end
       end
@@ -192,18 +192,18 @@ describe Google::Cloud do
 
     it "uses provided project_id, credentials, service_name, and service_version" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be_nil
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be_nil
         "debugger-credentials"
       }
       stubbed_service_name = "utest-service"
       stubbed_service_version = "vUTest"
       stubbed_service = ->(project, credentials, timeout: nil, client_config: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "debugger-credentials"
-        timeout.must_be :nil?
-        client_config.must_be :nil?
-        host.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "debugger-credentials"
+        _(timeout).must_be :nil?
+        _(client_config).must_be :nil?
+        _(host).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -214,11 +214,11 @@ describe Google::Cloud do
             Google::Cloud::Debugger::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Debugger::Service.stub :new, stubbed_service do
                 debugger = Google::Cloud::Debugger.new project_id: "project-id", credentials: "path/to/keyfile.json", service_name: stubbed_service_name, service_version: stubbed_service_version
-                debugger.must_be_kind_of Google::Cloud::Debugger::Project
-                debugger.project.must_equal "project-id"
-                debugger.agent.debuggee.service_name.must_equal stubbed_service_name
-                debugger.agent.debuggee.service_version.must_equal stubbed_service_version
-                debugger.service.must_be_kind_of OpenStruct
+                _(debugger).must_be_kind_of Google::Cloud::Debugger::Project
+                _(debugger.project).must_equal "project-id"
+                _(debugger.agent.debuggee.service_name).must_equal stubbed_service_name
+                _(debugger.agent.debuggee.service_version).must_equal stubbed_service_version
+                _(debugger.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -231,11 +231,11 @@ describe Google::Cloud do
       stubbed_service_name = "utest-service"
       stubbed_service_version = "vUTest"
       stubbed_service = ->(project, credentials, timeout: nil, client_config: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal default_credentials
-        timeout.must_be :nil?
-        client_config.must_be :nil?
-        host.must_equal endpoint
+        _(project).must_equal "project-id"
+        _(credentials).must_equal default_credentials
+        _(timeout).must_be :nil?
+        _(client_config).must_be :nil?
+        _(host).must_equal endpoint
         OpenStruct.new project: project
       }
 
@@ -243,29 +243,29 @@ describe Google::Cloud do
       ENV.stub :[], nil do
         Google::Cloud::Debugger::Service.stub :new, stubbed_service do
           debugger = Google::Cloud::Debugger.new project_id: "project-id", credentials: default_credentials, endpoint: endpoint, service_name: stubbed_service_name, service_version: stubbed_service_version
-          debugger.must_be_kind_of Google::Cloud::Debugger::Project
-          debugger.project.must_equal "project-id"
-          debugger.agent.debuggee.service_name.must_equal stubbed_service_name
-          debugger.agent.debuggee.service_version.must_equal stubbed_service_version
-          debugger.service.must_be_kind_of OpenStruct
+          _(debugger).must_be_kind_of Google::Cloud::Debugger::Project
+          _(debugger.project).must_equal "project-id"
+          _(debugger.agent.debuggee.service_name).must_equal stubbed_service_name
+          _(debugger.agent.debuggee.service_version).must_equal stubbed_service_version
+          _(debugger.service).must_be_kind_of OpenStruct
         end
       end
     end
 
     it "uses provided project (alias), keyfile (alias), service_name, and service_version" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be_nil
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be_nil
         "debugger-credentials"
       }
       stubbed_service_name = "utest-service"
       stubbed_service_version = "vUTest"
       stubbed_service = ->(project, credentials, timeout: nil, client_config: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "debugger-credentials"
-        timeout.must_be :nil?
-        client_config.must_be :nil?
-        host.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "debugger-credentials"
+        _(timeout).must_be :nil?
+        _(client_config).must_be :nil?
+        _(host).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -276,11 +276,11 @@ describe Google::Cloud do
             Google::Cloud::Debugger::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Debugger::Service.stub :new, stubbed_service do
                 debugger = Google::Cloud::Debugger.new project: "project-id", keyfile: "path/to/keyfile.json", service_name: stubbed_service_name, service_version: stubbed_service_version
-                debugger.must_be_kind_of Google::Cloud::Debugger::Project
-                debugger.project.must_equal "project-id"
-                debugger.agent.debuggee.service_name.must_equal stubbed_service_name
-                debugger.agent.debuggee.service_version.must_equal stubbed_service_version
-                debugger.service.must_be_kind_of OpenStruct
+                _(debugger).must_be_kind_of Google::Cloud::Debugger::Project
+                _(debugger.project).must_equal "project-id"
+                _(debugger.agent.debuggee.service_name).must_equal stubbed_service_name
+                _(debugger.agent.debuggee.service_version).must_equal stubbed_service_version
+                _(debugger.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -290,19 +290,19 @@ describe Google::Cloud do
 
     it "gets project_id from credentials" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be_nil
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be_nil
         OpenStruct.new project_id: "project-id"
       }
       stubbed_service_name = "utest-service"
       stubbed_service_version = "vUTest"
       stubbed_service = ->(project, credentials, timeout: nil, client_config: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_be_kind_of OpenStruct
-        credentials.project_id.must_equal "project-id"
-        timeout.must_be_nil
-        client_config.must_be_nil
-        host.must_be_nil
+        _(project).must_equal "project-id"
+        _(credentials).must_be_kind_of OpenStruct
+        _(credentials.project_id).must_equal "project-id"
+        _(timeout).must_be_nil
+        _(client_config).must_be_nil
+        _(host).must_be_nil
         OpenStruct.new project: project
       }
       empty_env = OpenStruct.new
@@ -313,9 +313,9 @@ describe Google::Cloud do
               Google::Cloud::Debugger::Credentials.stub :new, stubbed_credentials do
                 Google::Cloud::Debugger::Service.stub :new, stubbed_service do
                   debugger = Google::Cloud::Debugger.new credentials: "path/to/keyfile.json"
-                  debugger.must_be_kind_of Google::Cloud::Debugger::Project
-                  debugger.project.must_equal "project-id"
-                  debugger.service.must_be_kind_of OpenStruct
+                  _(debugger).must_be_kind_of Google::Cloud::Debugger::Project
+                  _(debugger.project).must_equal "project-id"
+                  _(debugger.service).must_be_kind_of OpenStruct
                 end
               end
             end
@@ -346,16 +346,16 @@ describe Google::Cloud do
 
     it "uses shared config for project and keyfile" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "debugger-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, client_config: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "debugger-credentials"
-        timeout.must_be :nil?
-        client_config.must_be :nil?
-        host.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "debugger-credentials"
+        _(timeout).must_be :nil?
+        _(client_config).must_be :nil?
+        _(host).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -372,9 +372,9 @@ describe Google::Cloud do
             Google::Cloud::Debugger::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Debugger::Service.stub :new, stubbed_service do
                 debugger = Google::Cloud::Debugger.new
-                debugger.must_be_kind_of Google::Cloud::Debugger::Project
-                debugger.project.must_equal "project-id"
-                debugger.service.must_be_kind_of OpenStruct
+                _(debugger).must_be_kind_of Google::Cloud::Debugger::Project
+                _(debugger.project).must_equal "project-id"
+                _(debugger.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -384,16 +384,16 @@ describe Google::Cloud do
 
     it "uses shared config for project_id and credentials" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "debugger-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, client_config: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "debugger-credentials"
-        timeout.must_be :nil?
-        client_config.must_be :nil?
-        host.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "debugger-credentials"
+        _(timeout).must_be :nil?
+        _(client_config).must_be :nil?
+        _(host).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -410,9 +410,9 @@ describe Google::Cloud do
             Google::Cloud::Debugger::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Debugger::Service.stub :new, stubbed_service do
                 debugger = Google::Cloud::Debugger.new
-                debugger.must_be_kind_of Google::Cloud::Debugger::Project
-                debugger.project.must_equal "project-id"
-                debugger.service.must_be_kind_of OpenStruct
+                _(debugger).must_be_kind_of Google::Cloud::Debugger::Project
+                _(debugger.project).must_equal "project-id"
+                _(debugger.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -422,15 +422,15 @@ describe Google::Cloud do
 
     it "uses debugger config for project and keyfile" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "debugger-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, client_config: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "debugger-credentials"
-        timeout.must_equal 42
-        client_config.must_equal debugger_client_config
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "debugger-credentials"
+        _(timeout).must_equal 42
+        _(client_config).must_equal debugger_client_config
         OpenStruct.new project: project
       }
 
@@ -449,9 +449,9 @@ describe Google::Cloud do
             Google::Cloud::Debugger::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Debugger::Service.stub :new, stubbed_service do
                 debugger = Google::Cloud::Debugger.new
-                debugger.must_be_kind_of Google::Cloud::Debugger::Project
-                debugger.project.must_equal "project-id"
-                debugger.service.must_be_kind_of OpenStruct
+                _(debugger).must_be_kind_of Google::Cloud::Debugger::Project
+                _(debugger.project).must_equal "project-id"
+                _(debugger.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -462,11 +462,11 @@ describe Google::Cloud do
     it "uses debugger config for endpoint" do
       endpoint = "debugger-endpoint2.example.com"
       stubbed_service = ->(project, credentials, timeout: nil, client_config: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal default_credentials
-        timeout.must_be :nil?
-        client_config.must_be :nil?
-        host.must_equal endpoint
+        _(project).must_equal "project-id"
+        _(credentials).must_equal default_credentials
+        _(timeout).must_be :nil?
+        _(client_config).must_be :nil?
+        _(host).must_equal endpoint
         OpenStruct.new project: project
       }
 
@@ -480,24 +480,24 @@ describe Google::Cloud do
 
         Google::Cloud::Debugger::Service.stub :new, stubbed_service do
           debugger = Google::Cloud::Debugger.new project: "project-id", credentials: default_credentials, endpoint: endpoint
-          debugger.must_be_kind_of Google::Cloud::Debugger::Project
-          debugger.project.must_equal "project-id"
-          debugger.service.must_be_kind_of OpenStruct
+          _(debugger).must_be_kind_of Google::Cloud::Debugger::Project
+          _(debugger.project).must_equal "project-id"
+          _(debugger.service).must_be_kind_of OpenStruct
         end
       end
     end
 
     it "uses debugger config for project_id and credentials" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "debugger-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, client_config: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "debugger-credentials"
-        timeout.must_equal 42
-        client_config.must_equal debugger_client_config
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "debugger-credentials"
+        _(timeout).must_equal 42
+        _(client_config).must_equal debugger_client_config
         OpenStruct.new project: project
       }
 
@@ -516,9 +516,9 @@ describe Google::Cloud do
             Google::Cloud::Debugger::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Debugger::Service.stub :new, stubbed_service do
                 debugger = Google::Cloud::Debugger.new
-                debugger.must_be_kind_of Google::Cloud::Debugger::Project
-                debugger.project.must_equal "project-id"
-                debugger.service.must_be_kind_of OpenStruct
+                _(debugger).must_be_kind_of Google::Cloud::Debugger::Project
+                _(debugger.project).must_equal "project-id"
+                _(debugger.service).must_be_kind_of OpenStruct
               end
             end
           end

--- a/google-cloud-debugger/test/helper.rb
+++ b/google-cloud-debugger/test/helper.rb
@@ -151,24 +151,24 @@ class EvaluatorSpec < Minitest::Spec
 
   def expression_must_equal expression, expected, binding = binding()
     result = evaluator.readonly_eval_expression binding, expression
-    result.must_equal expected
+    _(result).must_equal expected
   end
 
   def expression_must_be_kind_of expression, expected, binding = binding()
     result = evaluator.readonly_eval_expression binding, expression
-    result.must_be_kind_of expected
+    _(result).must_be_kind_of expected
   end
 
   def expression_prohibited expression, binding = binding()
     result = evaluator.readonly_eval_expression binding, expression
-    result.must_be_kind_of Google::Cloud::Debugger::MutationError
-    result.message.must_match Google::Cloud::Debugger::Breakpoint::Evaluator::PROHIBITED_OPERATION_MSG
+    _(result).must_be_kind_of Google::Cloud::Debugger::MutationError
+    _(result.message).must_match Google::Cloud::Debugger::Breakpoint::Evaluator::PROHIBITED_OPERATION_MSG
   end
 
   def expression_triggers_mutation expression, binding = binding()
     result = evaluator.readonly_eval_expression binding, expression
-    result.must_be_kind_of Google::Cloud::Debugger::MutationError
-    result.message.must_match Google::Cloud::Debugger::Breakpoint::Evaluator::MUTATION_DETECTED_MSG
+    _(result).must_be_kind_of Google::Cloud::Debugger::MutationError
+    _(result.message).must_match Google::Cloud::Debugger::Breakpoint::Evaluator::MUTATION_DETECTED_MSG
   end
 end
 


### PR DESCRIPTION
Use `rubocop-minitest` gem and `bundle exec rubocop --only Minitest/GlobalExpectations -a` to autocorrect minitest warnings for Ruby 2.7.

refs: #4110
refs: #4116