### PR TITLE
chore(automl): Restore previous gem version

### DIFF
--- a/google-cloud-automl/lib/google/cloud/automl/version.rb
+++ b/google-cloud-automl/lib/google/cloud/automl/version.rb
@@ -20,7 +20,7 @@
 module Google
   module Cloud
     module AutoML
-      VERSION = "0.0.1"
+      VERSION = "0.7.1"
     end
   end
 end


### PR DESCRIPTION
I accidentally overwrote the old gem version when converting AutoML to a wrapper. This PR restores it. (Found during a post-migration audit.)