### PR TITLE
docs(vision): Remove migration guide note about multi-pattern resources

### DIFF
--- a/google-cloud-vision/MIGRATING.md
+++ b/google-cloud-vision/MIGRATING.md
@@ -214,8 +214,7 @@ strings passed to many calls. These helpers have changed in two ways:
   on a separate paths module that you can include elsewhere for convenience.
 * In older releases, arguments to a resource path helper are passed as
   _positional_ arguments. In the 1.0 release, they are passed as named _keyword_
-  arguments. Some helpers also support different sets of arguments, each set
-  corresponding to a different type of path.
+  arguments.
 
 Following is an example involving using a resource path helper.
 


### PR DESCRIPTION
This note about multi-pattern resource helpers was copied and pasted from another migration guide but doesn't apply to Vision. Removing it. (Found during a post-migration audit.)