### PR TITLE
docs: Updated the sample timeouts in the migration guide to reflect seconds

### DIFF
--- a/google-cloud-asset/MIGRATING.md
+++ b/google-cloud-asset/MIGRATING.md
@@ -74,7 +74,7 @@ timeout for all Asset V1 clients:
 ```
 Google::Cloud::Asset::V1::AssetService::Client.configure do |config|
   config.credentials = "/path/to/credentials.json"
-  config.timeout = 10_000
+  config.timeout = 10.0
 end
 ```
 
@@ -83,7 +83,7 @@ timeout for the `create_feed` call:
 
 ```
 Google::Cloud::Asset::V1::AssetService::Client.configure do |config|
-  config.rpcs.create_feed.timeout = 20_000
+  config.rpcs.create_feed.timeout = 20.0
 end
 ```
 
@@ -93,7 +93,7 @@ services globally:
 ```
 Google::Cloud::Asset.configure do |config|
   config.credentials = "/path/to/credentials.json"
-  config.timeout = 10_000
+  config.timeout = 10.0
 end
 ```
 
@@ -181,7 +181,7 @@ client = Google::Cloud::Asset.new
 
 name = "projects/my-project/feeds/my-feed"
 
-options = Google::Gax::CallOptions.new timeout: 10_000
+options = Google::Gax::CallOptions.new timeout: 10.0
 
 response = client.get_feed name, options: options
 ```
@@ -194,7 +194,7 @@ name = "projects/my-project/feeds/my-feed"
 
 # Use a hash to wrap the normal call arguments (or pass a request object), and
 # then add further keyword arguments for the call options.
-response = client.get_feed({ name: name }, timeout: 10_000)
+response = client.get_feed({ name: name }, timeout: 10.0)
 ```
 
 ### Resource Path Helpers

--- a/google-cloud-automl/MIGRATING.md
+++ b/google-cloud-automl/MIGRATING.md
@@ -75,7 +75,7 @@ timeout for all AutoML V1 clients:
 ```
 Google::Cloud::AutoML::V1::AutoML::Client.configure do |config|
   config.credentials = "/path/to/credentials.json"
-  config.timeout = 10_000
+  config.timeout = 10.0
 end
 ```
 
@@ -84,7 +84,7 @@ timeout for the `create_dataset` call:
 
 ```
 Google::Cloud::AutoML::V1::AutoML::Client.configure do |config|
-  config.rpcs.create_dataset.timeout = 20_000
+  config.rpcs.create_dataset.timeout = 20.0
 end
 ```
 
@@ -94,7 +94,7 @@ services globally:
 ```
 Google::Cloud::AutoML.configure do |config|
   config.credentials = "/path/to/credentials.json"
-  config.timeout = 10_000
+  config.timeout = 10.0
 end
 ```
 
@@ -185,7 +185,7 @@ client = Google::Cloud::AutoML::AutoML.new
 
 parent = "projects/my-project/locations/my-location"
 
-options = Google::Gax::CallOptions.new timeout: 10_000
+options = Google::Gax::CallOptions.new timeout: 10.0
 
 response = client.list_datasets parent, page_size: 10, options: options
 ```
@@ -200,7 +200,7 @@ parent = "projects/my-project/locations/my-location"
 # then add further keyword arguments for the call options.
 response = client.batch_annotate_images(
   { parent: parent, page_size: 10 },
-  timeout: 10_000
+  timeout: 10.0
 )
 ```
 

--- a/google-cloud-bigquery-data_transfer/MIGRATING.md
+++ b/google-cloud-bigquery-data_transfer/MIGRATING.md
@@ -71,7 +71,7 @@ timeout for all BigQuery DataTransfer V1 clients:
 ```
 Google::Cloud::Bigquery::DataTransfer::V1::DataTransferService::Client.configure do |config|
   config.credentials = "/path/to/credentials.json"
-  config.timeout = 10_000
+  config.timeout = 10.0
 end
 ```
 
@@ -80,7 +80,7 @@ timeout for the `get_data_source` call:
 
 ```
 Google::Cloud::Bigquery::DataTransfer::V1::DataTransferService::Client.configure do |config|
-  config.rpcs.get_data_source.timeout = 20_000
+  config.rpcs.get_data_source.timeout = 20.0
 end
 ```
 
@@ -90,7 +90,7 @@ services globally:
 ```
 Google::Cloud::Bigquery::DataTransfer.configure do |config|
   config.credentials = "/path/to/credentials.json"
-  config.timeout = 10_000
+  config.timeout = 10.0
 end
 ```
 
@@ -178,7 +178,7 @@ client = Google::Cloud::Bigquery::DataTransfer.new
 
 name = "projects/my-project/dataSources/my-source"
 
-options = Google::Gax::CallOptions.new timeout: 10_000
+options = Google::Gax::CallOptions.new timeout: 10.0
 
 response = client.get_data_source name, options: options
 ```
@@ -191,7 +191,7 @@ name = "projects/my-project/dataSources/my-source"
 
 # Use a hash to wrap the normal call arguments (or pass a request object), and
 # then add further keyword arguments for the call options.
-response = client.get_data_source({ name: name }, timeout: 10_000)
+response = client.get_data_source({ name: name }, timeout: 10.0)
 ```
 
 ### Resource Path Helpers

--- a/google-cloud-dataproc/MIGRATING.md
+++ b/google-cloud-dataproc/MIGRATING.md
@@ -74,7 +74,7 @@ timeout for all Dataproc V1 ClusterController clients:
 ```
 Google::Cloud::Dataproc::V1::ClusterController::Client.configure do |config|
   config.credentials = "/path/to/credentials.json"
-  config.timeout = 10_000
+  config.timeout = 10.0
 end
 ```
 
@@ -83,7 +83,7 @@ timeout for the `create_cluster` call:
 
 ```
 Google::Cloud::Dataproc::V1::ClusterController::Client.configure do |config|
-  config.rpcs.create_cluster.timeout = 20_000
+  config.rpcs.create_cluster.timeout = 20.0
 end
 ```
 
@@ -93,7 +93,7 @@ services globally:
 ```
 Google::Cloud::Dataproc.configure do |config|
   config.credentials = "/path/to/credentials.json"
-  config.timeout = 10_000
+  config.timeout = 10.0
 end
 ```
 
@@ -192,7 +192,7 @@ project_id = "my-project"
 region = "us-central1"
 cluster_name = "my_cluster"
 
-options = Google::Gax::CallOptions.new timeout: 10_000
+options = Google::Gax::CallOptions.new timeout: 10.0
 
 response = client.get_cluster project_id, region, cluster_name, options: options
 ```
@@ -209,7 +209,7 @@ cluster_name = "my_cluster"
 # then add further keyword arguments for the call options.
 response = client.get_feed(
     { project_id: project_id, region: region, cluster_name: cluster_name },
-    timeout: 10_000)
+    timeout: 10.0)
 ```
 
 ### Resource Path Helpers

--- a/google-cloud-dialogflow/MIGRATING.md
+++ b/google-cloud-dialogflow/MIGRATING.md
@@ -72,7 +72,7 @@ timeout for all Dialogflow V2 sessions clients:
 ```
 Google::Cloud::Dialogflow::V2::Sessions::Client.configure do |config|
   config.credentials = "/path/to/credentials.json"
-  config.timeout = 10_000
+  config.timeout = 10.0
 end
 ```
 
@@ -81,7 +81,7 @@ timeout for the `detect_intent` call:
 
 ```
 Google::Cloud::Dialogflow::V2::Sessions::Client.configure do |config|
-  config.rpcs.detect_intent.timeout = 20_000
+  config.rpcs.detect_intent.timeout = 20.0
 end
 ```
 
@@ -91,7 +91,7 @@ services globally:
 ```
 Google::Cloud::Dialogflow.configure do |config|
   config.credentials = "/path/to/credentials.json"
-  config.timeout = 10_000
+  config.timeout = 10.0
 end
 ```
 
@@ -190,7 +190,7 @@ client = Google::Cloud::Dialogflow::Sessions.new
 session = "projects/my-project/agent/sessions/my-session"
 query = { text: { text: "book a meeting room", language_code: "en-US" } }
 
-options = Google::Gax::CallOptions.new timeout: 10_000
+options = Google::Gax::CallOptions.new timeout: 10.0
 
 response = client.detect_intent session, query, options: options
 ```
@@ -206,7 +206,7 @@ query = { text: { text: "book a meeting room", language_code: "en-US" } }
 # then add further keyword arguments for the call options.
 response = client.detect_intent(
   { session: session, query_input: query },
-  timeout: 10_000
+  timeout: 10.0
 )
 ```
 

--- a/google-cloud-dlp/MIGRATING.md
+++ b/google-cloud-dlp/MIGRATING.md
@@ -73,7 +73,7 @@ timeout for all DLP V2 clients:
 ```
 Google::Cloud::Dlp::V2::DlpService::Client.configure do |config|
   config.credentials = "/path/to/credentials.json"
-  config.timeout = 10_000
+  config.timeout = 10.0
 end
 ```
 
@@ -82,7 +82,7 @@ timeout for the `redact_image` call:
 
 ```
 Google::Cloud::Dlp::V2::DlpService::Client.configure do |config|
-  config.rpcs.redact_image.timeout = 20_000
+  config.rpcs.redact_image.timeout = 20.0
 end
 ```
 
@@ -92,7 +92,7 @@ services globally:
 ```
 Google::Cloud::Dlp.configure do |config|
   config.credentials = "/path/to/credentials.json"
-  config.timeout = 10_000
+  config.timeout = 10.0
 end
 ```
 
@@ -181,7 +181,7 @@ client = Google::Cloud::Dlp.new
 
 parent = "projects/my-project"
 
-options = Google::Gax::CallOptions.new timeout: 10_000
+options = Google::Gax::CallOptions.new timeout: 10.0
 
 response = client.list_inspect_templates parent, page_size: 10, options: options
 ```
@@ -196,7 +196,7 @@ parent = "projects/my-project"
 # then add further keyword arguments for the call options.
 response = client.list_inspect_templates(
   { parent: parent, page_size: 10 },
-  timeout: 10_000
+  timeout: 10.0
 )
 ```
 

--- a/google-cloud-kms/MIGRATING.md
+++ b/google-cloud-kms/MIGRATING.md
@@ -76,7 +76,7 @@ timeout for all KMS V1 clients:
 ```
 Google::Cloud::Kms::V1::KeyManagementService::Client.configure do |config|
   config.credentials = "/path/to/credentials.json"
-  config.timeout = 10_000
+  config.timeout = 10.0
 end
 ```
 
@@ -85,7 +85,7 @@ timeout for the `list_key_rings` call:
 
 ```
 Google::Cloud::Kms::V1::KeyManagementService::Client.configure do |config|
-  config.rpcs.list_key_rings.timeout = 20_000
+  config.rpcs.list_key_rings.timeout = 20.0
 end
 ```
 
@@ -95,7 +95,7 @@ services globally:
 ```
 Google::Cloud::Kms.configure do |config|
   config.credentials = "/path/to/credentials.json"
-  config.timeout = 10_000
+  config.timeout = 10.0
 end
 ```
 
@@ -188,7 +188,7 @@ client = Google::Cloud::Kms.new
 
 parent = "projects/my-project/locations/my-location"
 
-options = Google::Gax::CallOptions.new timeout: 10_000
+options = Google::Gax::CallOptions.new timeout: 10.0
 
 response = client.list_key_rings parent, page_size: 10, options: options
 ```
@@ -203,7 +203,7 @@ parent = "projects/my-project/locations/my-location"
 # then add further keyword arguments for the call options.
 response = client.list_key_rings(
   { parent: parent, page_size: 10 },
-  timeout: 10_000
+  timeout: 10.0
 )
 ```
 

--- a/google-cloud-language/MIGRATING.md
+++ b/google-cloud-language/MIGRATING.md
@@ -71,7 +71,7 @@ timeout for all Language V1 clients:
 ```
 Google::Cloud::Language::V1::LanguageService::Client.configure do |config|
   config.credentials = "/path/to/credentials.json"
-  config.timeout = 10_000
+  config.timeout = 10.0
 end
 ```
 
@@ -80,7 +80,7 @@ timeout for the `analyze_sentiment` call:
 
 ```
 Google::Cloud::Language::V1::LanguageService::Client.configure do |config|
-  config.rpcs.analyze_sentinment.timeout = 20_000
+  config.rpcs.analyze_sentinment.timeout = 20.0
 end
 ```
 
@@ -90,7 +90,7 @@ globally:
 ```
 Google::Cloud::Language.configure do |config|
   config.credentials = "/path/to/credentials.json"
-  config.timeout = 10_000
+  config.timeout = 10.0
 end
 ```
 
@@ -193,7 +193,7 @@ document = {
   type: Google::Cloud::Language::V1::Document::Type::PLAIN_TEXT
 }
 
-options = Google::Gax::CallOptions.new timeout: 10_000
+options = Google::Gax::CallOptions.new timeout: 10.0
 
 response = client.analyze_sentiment document, options: options
 ```
@@ -212,7 +212,7 @@ encoding = Google:Cloud::Language::V1::EncodingType::UTF8
 # then add further keyword arguments for the call options.
 response = client.analyze_sentiment(
   { document: document, encoding_type: encoding },
-  timeout: 10_000
+  timeout: 10.0
 )
 ```
 

--- a/google-cloud-recaptcha_enterprise/MIGRATING.md
+++ b/google-cloud-recaptcha_enterprise/MIGRATING.md
@@ -77,7 +77,7 @@ timeout for all reCAPTCHA Enterprise V1 clients:
 ```
 Google::Cloud::RecaptchaEnterprise::V1::RecaptchaEnterpriseService::Client.configure do |config|
   config.credentials = "/path/to/credentials.json"
-  config.timeout = 10_000
+  config.timeout = 10.0
 end
 ```
 
@@ -86,7 +86,7 @@ timeout for the `create_assessment` call:
 
 ```
 Google::Cloud::RecaptchaEnterprise::V1::RecaptchaEnterpriseService::Client.configure do |config|
-  config.rpcs.create_assessment.timeout = 20_000
+  config.rpcs.create_assessment.timeout = 20.0
 end
 ```
 
@@ -96,7 +96,7 @@ services globally:
 ```
 Google::Cloud::RecaptchaEnterprise.configure do |config|
   config.credentials = "/path/to/credentials.json"
-  config.timeout = 10_000
+  config.timeout = 10.0
 end
 ```
 
@@ -185,7 +185,7 @@ client = Google::Cloud::RecaptchaEnterprise.new
 
 parent = "projects/my-project"
 
-options = Google::Gax::CallOptions.new timeout: 10_000
+options = Google::Gax::CallOptions.new timeout: 10.0
 
 response = client.list_keys parent, page_size: 10, options: options
 ```
@@ -200,7 +200,7 @@ parent = "projects/my-project"
 # then add further keyword arguments for the call options.
 response = client.list_keys(
   { parent: parent, page_size: 10 },
-  timeout: 10_000
+  timeout: 10.0
 )
 ```
 

--- a/google-cloud-redis/MIGRATING.md
+++ b/google-cloud-redis/MIGRATING.md
@@ -71,7 +71,7 @@ timeout for all Redis V1 clients:
 ```
 Google::Cloud::Redis::V1::CloudRedis::Client.configure do |config|
   config.credentials = "/path/to/credentials.json"
-  config.timeout = 10_000
+  config.timeout = 10.0
 end
 ```
 
@@ -80,7 +80,7 @@ timeout for the `list_instances` call:
 
 ```
 Google::Cloud::Redis::V1::CloudRedis::Client.configure do |config|
-  config.rpcs.list_instances.timeout = 20_000
+  config.rpcs.list_instances.timeout = 20.0
 end
 ```
 
@@ -90,7 +90,7 @@ globally:
 ```
 Google::Cloud::Redis.configure do |config|
   config.credentials = "/path/to/credentials.json"
-  config.timeout = 10_000
+  config.timeout = 10.0
 end
 ```
 
@@ -178,7 +178,7 @@ client = Google::Cloud::Redis.new
 
 parent = "projects/my-project/locations/-"
 
-options = Google::Gax::CallOptions.new timeout: 10_000
+options = Google::Gax::CallOptions.new timeout: 10.0
 
 response = client.list_instances parent, options: options
 ```
@@ -191,7 +191,7 @@ parent = "projects/my-project/locations/-"
 
 # Use a hash to wrap the normal call arguments (or pass a request object), and
 # then add further keyword arguments for the call options.
-response = client.analyze_sentiment({ parent: parent }, timeout: 10_000)
+response = client.analyze_sentiment({ parent: parent }, timeout: 10.0)
 ```
 
 ### Class Namespaces

--- a/google-cloud-security_center/MIGRATING.md
+++ b/google-cloud-security_center/MIGRATING.md
@@ -75,7 +75,7 @@ timeout for all SecurityCenter V1 clients:
 ```
 Google::Cloud::SecurityCenter::V1::SecurityCenter::Client.configure do |config|
   config.credentials = "/path/to/credentials.json"
-  config.timeout = 10_000
+  config.timeout = 10.0
 end
 ```
 
@@ -84,7 +84,7 @@ timeout for the `list_findings` call:
 
 ```
 Google::Cloud::SecurityCenter::V1::SecurityCenter::Client.configure do |config|
-  config.rpcs.list_findings.timeout = 20_000
+  config.rpcs.list_findings.timeout = 20.0
 end
 ```
 
@@ -94,7 +94,7 @@ globally:
 ```
 Google::Cloud::SecurityCenter.configure do |config|
   config.credentials = "/path/to/credentials.json"
-  config.timeout = 10_000
+  config.timeout = 10.0
 end
 ```
 
@@ -186,7 +186,7 @@ client = Google::Cloud::SecurityCenter.new
 parent = "organizations/my-org/sources/-"
 ordering = "name"
 
-options = Google::Gax::CallOptions.new timeout: 10_000
+options = Google::Gax::CallOptions.new timeout: 10.0
 
 response = client.list_findings parent, order_by: ordering, options: options
 ```
@@ -202,7 +202,7 @@ ordering = "name"
 # then add further keyword arguments for the call options.
 response = client.list_findings(
   { parent: parent, order_by: ordering },
-  timeout: 10_000
+  timeout: 10.0
 )
 ```
 

--- a/google-cloud-speech/MIGRATING.md
+++ b/google-cloud-speech/MIGRATING.md
@@ -75,7 +75,7 @@ timeout for all Speech V1 clients:
 ```
 Google::Cloud::Speech::V1::Speech::Client.configure do |config|
   config.credentials = "/path/to/credentials.json"
-  config.timeout = 10_000
+  config.timeout = 10.0
 end
 ```
 
@@ -84,7 +84,7 @@ timeout for the `recognize` call:
 
 ```
 Google::Cloud::Speech::V1::Speech::Client.configure do |config|
-  config.rpcs.recognize.timeout = 20_000
+  config.rpcs.recognize.timeout = 20.0
 end
 ```
 
@@ -94,7 +94,7 @@ services globally:
 ```
 Google::Cloud::Speech.configure do |config|
   config.credentials = "/path/to/credentials.json"
-  config.timeout = 10_000
+  config.timeout = 10.0
 end
 ```
 
@@ -210,7 +210,7 @@ audio = {
   uri: "gs://cloud-samples-data/speech/brooklyn_bridge.flac"
 }
 
-options = Google::Gax::CallOptions.new timeout: 10_000
+options = Google::Gax::CallOptions.new timeout: 10.0
 
 response = client.recognize config, audio, options: options
 ```
@@ -232,7 +232,7 @@ audio = {
 # then add further keyword arguments for the call options.
 response = client.batch_annotate_images(
   { config: config, audio: audio },
-  timeout: 10_000)
+  timeout: 10.0)
 ```
 
 ### Streaming Interface

--- a/google-cloud-talent/MIGRATING.md
+++ b/google-cloud-talent/MIGRATING.md
@@ -72,7 +72,7 @@ timeout for all Talent V4beta1 application service clients:
 ```
 Google::Cloud::Talent::V4beta1::ApplicationService::Client.configure do |config|
   config.credentials = "/path/to/credentials.json"
-  config.timeout = 10_000
+  config.timeout = 10.0
 end
 ```
 
@@ -81,7 +81,7 @@ timeout for the `list_applications` call:
 
 ```
 Google::Cloud::Talent::V4beta1::ApplicationService::Client.configure do |config|
-  config.rpcs.list_applications.timeout = 20_000
+  config.rpcs.list_applications.timeout = 20.0
 end
 ```
 
@@ -91,7 +91,7 @@ services globally:
 ```
 Google::Cloud::Talent.configure do |config|
   config.credentials = "/path/to/credentials.json"
-  config.timeout = 10_000
+  config.timeout = 10.0
 end
 ```
 
@@ -182,7 +182,7 @@ client = Google::Cloud::Talent::ApplicationService.new
 
 parent = "projects/my-project/tenants/my-tenant/profiles/my-profile"
 
-options = Google::Gax::CallOptions.new timeout: 10_000
+options = Google::Gax::CallOptions.new timeout: 10.0
 
 response = client.list_applications parent, page_size: 10, options: options
 ```
@@ -197,7 +197,7 @@ parent = "projects/my-project/tenants/my-tenant/profiles/my-profile"
 # then add further keyword arguments for the call options.
 response = client.list_applications(
   { parent: parent, page_size: 10 },
-  timeout: 10_000
+  timeout: 10.0
 ) 
 ```
 

--- a/google-cloud-video_intelligence/MIGRATING.md
+++ b/google-cloud-video_intelligence/MIGRATING.md
@@ -71,7 +71,7 @@ timeout for all Speech V1 clients:
 ```
 Google::Cloud::VideoIntelligence::V1::VideoIntelligenceService::Client.configure do |config|
   config.credentials = "/path/to/credentials.json"
-  config.timeout = 10_000
+  config.timeout = 10.0
 end
 ```
 
@@ -80,7 +80,7 @@ timeout for the `annotate_video` call:
 
 ```
 Google::Cloud::VideoIntelligence::V1::VideoIntelligenceService::Client.configure do |config|
-  config.rpcs.annotate_video.timeout = 20_000
+  config.rpcs.annotate_video.timeout = 20.0
 end
 ```
 
@@ -90,7 +90,7 @@ services globally:
 ```
 Google::Cloud::VideoIntelligence.configure do |config|
   config.credentials = "/path/to/credentials.json"
-  config.timeout = 10_000
+  config.timeout = 10.0
 end
 ```
 
@@ -182,7 +182,7 @@ client = Google::Cloud::VideoIntelligence.new
 features = [Google::Cloud::VideoIntelligence::V1::Feature::FACE_DETECTION]
 input_uri = "gs://my-bucket/my-video"
 
-options = Google::Gax::CallOptions.new timeout: 10_000
+options = Google::Gax::CallOptions.new timeout: 10.0
 
 response = client.annotate_video features, input_uri: input_uri, options: options
 ```
@@ -198,7 +198,7 @@ input_uri = "gs://my-bucket/my-video"
 # then add further keyword arguments for the call options.
 response = client.annotate_video(
   { features: features, input_uri: input_uri },
-  timeout: 10_000)
+  timeout: 10.0)
 ```
 
 

--- a/google-cloud-vision/MIGRATING.md
+++ b/google-cloud-vision/MIGRATING.md
@@ -79,7 +79,7 @@ timeout for all Vision V1 image annotator clients:
 ```
 Google::Cloud::Vision::V1::ImageAnnotator::Client.configure do |config|
   config.credentials = "/path/to/credentials.json"
-  config.timeout = 10_000
+  config.timeout = 10.0
 end
 ```
 
@@ -88,7 +88,7 @@ timeout for the `batch_annotate_images` call:
 
 ```
 Google::Cloud::Vision::V1::ImageAnnotator::Client.configure do |config|
-  config.rpcs.batch_annotate_images.timeout = 20_000
+  config.rpcs.batch_annotate_images.timeout = 20.0
 end
 ```
 
@@ -98,7 +98,7 @@ services globally:
 ```
 Google::Cloud::Vision.configure do |config|
   config.credentials = "/path/to/credentials.json"
-  config.timeout = 10_000
+  config.timeout = 10.0
 end
 ```
 
@@ -188,7 +188,7 @@ client = Google::Cloud::Vision::ImageAnnotator.new
 
 requests = my_create_requests
 
-options = Google::Gax::CallOptions.new timeout: 10_000
+options = Google::Gax::CallOptions.new timeout: 10.0
 
 response = client.batch_annotate_images requests, options: options
 ```
@@ -201,7 +201,7 @@ requests = my_create_requests
 
 # Use a hash to wrap the normal call arguments (or pass a request object), and
 # then add further keyword arguments for the call options.
-response = client.batch_annotate_images({ requests: requests }, timeout: 10_000)
+response = client.batch_annotate_images({ requests: requests }, timeout: 10.0)
 ```
 
 ### Resource Path Helpers

--- a/google-cloud-web_risk/MIGRATING.md
+++ b/google-cloud-web_risk/MIGRATING.md
@@ -97,7 +97,7 @@ timeout for all Web Risk V1 clients:
 ```
 Google::Cloud::WebRisk::V1::WebRiskService::Client.configure do |config|
   config.credentials = "/path/to/credentials.json"
-  config.timeout = 10_000
+  config.timeout = 10.0
 end
 ```
 
@@ -106,7 +106,7 @@ timeout for the `search_uris` call:
 
 ```
 Google::Cloud::WebRisk::V1::WebRiskService::Client.configure do |config|
-  config.rpcs.search_uris.timeout = 20_000
+  config.rpcs.search_uris.timeout = 20.0
 end
 ```
 
@@ -116,7 +116,7 @@ services globally:
 ```
 Google::Cloud::WebRisk.configure do |config|
   config.credentials = "/path/to/credentials.json"
-  config.timeout = 10_000
+  config.timeout = 10.0
 end
 ```
 
@@ -208,7 +208,7 @@ client = Google::Cloud::Webrisk.new
 uri = "http://example.com"
 threat_types = [Google::Cloud::Webrisk::V1beta1::ThreatType::MALWARE]
 
-options = Google::Gax::CallOptions.new timeout: 10_000
+options = Google::Gax::CallOptions.new timeout: 10.0
 
 response = client.search_uris uri, threat_types, options: options
 ```
@@ -224,6 +224,6 @@ threat_types = [Google::Cloud::WebRisk::V1::ThreatType::MALWARE]
 # then add further keyword arguments for the call options.
 response = client.search_uris(
   { uri: uri, threat_types: threat_types },
-  timeout: 10_000
+  timeout: 10.0
 )
 ```


### PR DESCRIPTION
When I first wrote the migration guide, I had some example timeouts that assumed timeouts are expressed in milliseconds. This is incorrect; timeouts are expressed in seconds. Fixed all existing examples to reflect that so users aren't confused. (Found during a post-migration audit.)