### PR TITLE
chore(error_reporting): Update minitest to 5.14

### DIFF
--- a/google-cloud-error_reporting/.rubocop.yml
+++ b/google-cloud-error_reporting/.rubocop.yml
@@ -1,16 +1,17 @@
-require: rubocop-minitest
-
 inherit_gem:
   google-style: google-style.yml
 
 AllCops:
   Exclude:
+    - "acceptance/**/*"
+    - "integration/**/*"
     - "google-cloud-error_reporting.gemspec"
     - "lib/google/devtools/**/*"
     - "lib/google/cloud/error_reporting/v1beta1/**/*"
     - "lib/google/cloud/error_reporting/v1beta1.rb"
     - "Rakefile"
     - "support/**/*"
+    - "test/**/*"
 
 Documentation:
   Enabled: false

--- a/google-cloud-error_reporting/.rubocop.yml
+++ b/google-cloud-error_reporting/.rubocop.yml
@@ -1,17 +1,16 @@
+require: rubocop-minitest
+
 inherit_gem:
   google-style: google-style.yml
 
 AllCops:
   Exclude:
-    - "acceptance/**/*"
-    - "integration/**/*"
     - "google-cloud-error_reporting.gemspec"
     - "lib/google/devtools/**/*"
     - "lib/google/cloud/error_reporting/v1beta1/**/*"
     - "lib/google/cloud/error_reporting/v1beta1.rb"
     - "Rakefile"
     - "support/**/*"
-    - "test/**/*"
 
 Documentation:
   Enabled: false

--- a/google-cloud-error_reporting/Gemfile
+++ b/google-cloud-error_reporting/Gemfile
@@ -8,7 +8,3 @@ gem "google-cloud-errors", path: "../google-cloud-errors"
 gem "stackdriver-core", path: "../stackdriver-core"
 
 gem "rake"
-
-# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
-# See https://github.com/googleapis/google-cloud-ruby/issues/4110
-gem "minitest", "~> 5.11.3"

--- a/google-cloud-error_reporting/Gemfile
+++ b/google-cloud-error_reporting/Gemfile
@@ -8,3 +8,5 @@ gem "google-cloud-errors", path: "../google-cloud-errors"
 gem "stackdriver-core", path: "../stackdriver-core"
 
 gem "rake"
+
+gem "rubocop-minitest"

--- a/google-cloud-error_reporting/Gemfile
+++ b/google-cloud-error_reporting/Gemfile
@@ -8,5 +8,3 @@ gem "google-cloud-errors", path: "../google-cloud-errors"
 gem "stackdriver-core", path: "../stackdriver-core"
 
 gem "rake"
-
-gem "rubocop-minitest"

--- a/google-cloud-error_reporting/acceptance/error_reporting/error_reporting_test.rb
+++ b/google-cloud-error_reporting/acceptance/error_reporting/error_reporting_test.rb
@@ -63,8 +63,8 @@ describe Google::Cloud::ErrorReporting, :error_reporting do
       end
     end
 
-    error_event.service_context.service.must_equal service_name
-    error_event.service_context.version.must_equal service_version
-    error_event.message.must_match token.to_s
+    _(error_event.service_context.service).must_equal service_name
+    _(error_event.service_context.version).must_equal service_version
+    _(error_event.message).must_match token.to_s
   end
 end

--- a/google-cloud-error_reporting/google-cloud-error_reporting.gemspec
+++ b/google-cloud-error_reporting/google-cloud-error_reporting.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "concurrent-ruby", "~> 1.1"
 
   gem.add_development_dependency "google-style", "~> 1.24.0"
-  gem.add_development_dependency "minitest", "~> 5.10"
+  gem.add_development_dependency "minitest", "~> 5.14"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"
   gem.add_development_dependency "minitest-focus", "~> 1.1"
   gem.add_development_dependency "minitest-rg", "~> 5.2"

--- a/google-cloud-error_reporting/integration/common_error_reporting_test.rb
+++ b/google-cloud-error_reporting/integration/common_error_reporting_test.rb
@@ -24,6 +24,6 @@ describe Google::Cloud::ErrorReporting do
 
     # TODO: Find a better way to verify response. Or even better, validate the
     # error event was indeed reported to ErrorReporting
-    response.must_match /Test error from .*: #{token}/
+    _(response).must_match /Test error from .*: #{token}/
   end
 end

--- a/google-cloud-error_reporting/test/google-cloud-error_reporting_test.rb
+++ b/google-cloud-error_reporting/test/google-cloud-error_reporting_test.rb
@@ -21,16 +21,16 @@ describe Google::Cloud do
       gcloud = Google::Cloud.new
       stubbed_error_reporting =
         ->(project, keyfile, scope: nil, timeout: nil, client_config: nil) {
-          project.must_be_nil
-          keyfile.must_be_nil
-          scope.must_be :nil?
-          timeout.must_be :nil?
-          client_config.must_be :nil?
+          _(project).must_be_nil
+          _(keyfile).must_be_nil
+          _(scope).must_be :nil?
+          _(timeout).must_be :nil?
+          _(client_config).must_be :nil?
           "fake-error_reporting-project-object"
         }
       Google::Cloud.stub :error_reporting, stubbed_error_reporting do
         project = gcloud.error_reporting
-        project.must_equal "fake-error_reporting-project-object"
+        _(project).must_equal "fake-error_reporting-project-object"
       end
     end
 
@@ -38,16 +38,16 @@ describe Google::Cloud do
       gcloud = Google::Cloud.new "test-project-id", "/path/to/a/keyfile"
       stubbed_error_reporting =
         ->(project, keyfile, scope: nil, timeout: nil, client_config: nil) {
-          project.must_equal "test-project-id"
-          keyfile.must_equal "/path/to/a/keyfile"
-          scope.must_be :nil?
-          timeout.must_be :nil?
-          client_config.must_be :nil?
+          _(project).must_equal "test-project-id"
+          _(keyfile).must_equal "/path/to/a/keyfile"
+          _(scope).must_be :nil?
+          _(timeout).must_be :nil?
+          _(client_config).must_be :nil?
           "error_reporting-project-object"
         }
       Google::Cloud.stub :error_reporting, stubbed_error_reporting do
         project = gcloud.error_reporting
-        project.must_equal "error_reporting-project-object"
+        _(project).must_equal "error_reporting-project-object"
       end
     end
 
@@ -55,18 +55,18 @@ describe Google::Cloud do
       gcloud = Google::Cloud.new "test-project-id", "/path/to/a/keyfile"
       stubbed_error_reporting =
         ->(project, keyfile, scope: nil, timeout: nil, client_config: nil) {
-          project.must_equal "test-project-id"
-          keyfile.must_equal "/path/to/a/keyfile"
-          scope.must_equal "http://example.com/scope"
-          timeout.must_equal 60
-          client_config.must_equal({ "gax" => "options" })
+          _(project).must_equal "test-project-id"
+          _(keyfile).must_equal "/path/to/a/keyfile"
+          _(scope).must_equal "http://example.com/scope"
+          _(timeout).must_equal 60
+          _(client_config).must_equal({ "gax" => "options" })
           "error_reporting-project-object"
         }
       Google::Cloud.stub :error_reporting, stubbed_error_reporting do
         project = gcloud.error_reporting scope: "http://example.com/scope",
                                          timeout: 60,
                                          client_config: { "gax" => "options" }
-        project.must_equal "error_reporting-project-object"
+        _(project).must_equal "error_reporting-project-object"
       end
     end
   end
@@ -76,16 +76,16 @@ describe Google::Cloud do
       gcloud = Google::Cloud.new
       stubbed_new =
         ->(project_id: nil, credentials: nil, scope: nil, timeout: nil, client_config: nil) {
-          project_id.must_be_nil
-          credentials.must_be_nil
-          scope.must_be :nil?
-          timeout.must_be :nil?
-          client_config.must_be :nil?
+          _(project_id).must_be_nil
+          _(credentials).must_be_nil
+          _(scope).must_be :nil?
+          _(timeout).must_be :nil?
+          _(client_config).must_be :nil?
           "fake-error_reporting-project-object"
         }
       Google::Cloud::ErrorReporting.stub :new, stubbed_new do
         project = gcloud.error_reporting
-        project.must_equal "fake-error_reporting-project-object"
+        _(project).must_equal "fake-error_reporting-project-object"
       end
     end
 
@@ -93,16 +93,16 @@ describe Google::Cloud do
       gcloud = Google::Cloud.new "test-project-id", "/path/to/a/keyfile"
       stubbed_new =
         ->(project_id: nil, credentials: nil, scope: nil, timeout: nil, client_config: nil) {
-          project_id.must_equal "test-project-id"
-          credentials.must_equal "/path/to/a/keyfile"
-          scope.must_be :nil?
-          timeout.must_be :nil?
-          client_config.must_be :nil?
+          _(project_id).must_equal "test-project-id"
+          _(credentials).must_equal "/path/to/a/keyfile"
+          _(scope).must_be :nil?
+          _(timeout).must_be :nil?
+          _(client_config).must_be :nil?
           "error_reporting-project-object"
         }
       Google::Cloud::ErrorReporting.stub :new, stubbed_new do
         project = gcloud.error_reporting
-        project.must_equal "error_reporting-project-object"
+        _(project).must_equal "error_reporting-project-object"
       end
     end
 
@@ -110,18 +110,18 @@ describe Google::Cloud do
       gcloud = Google::Cloud.new "test-project-id", "/path/to/a/keyfile"
       stubbed_new =
         ->(project_id: nil, credentials: nil, scope: nil, timeout: nil, client_config: nil) {
-          project_id.must_equal "test-project-id"
-          credentials.must_equal "/path/to/a/keyfile"
-          scope.must_equal "http://example.com/scope"
-          timeout.must_equal 60
-          client_config.must_equal({ "gax" => "options" })
+          _(project_id).must_equal "test-project-id"
+          _(credentials).must_equal "/path/to/a/keyfile"
+          _(scope).must_equal "http://example.com/scope"
+          _(timeout).must_equal 60
+          _(client_config).must_equal({ "gax" => "options" })
           "error_reporting-project-object"
         }
       Google::Cloud::ErrorReporting.stub :new, stubbed_new do
         project = gcloud.error_reporting scope: "http://example.com/scope",
                                          timeout: 60,
                                          client_config: { "gax" => "options" }
-        project.must_equal "error_reporting-project-object"
+        _(project).must_equal "error_reporting-project-object"
       end
     end
   end

--- a/google-cloud-error_reporting/test/google/cloud/error_reporting/error_event_test.rb
+++ b/google-cloud-error_reporting/test/google/cloud/error_reporting/error_event_test.rb
@@ -27,47 +27,47 @@ describe Google::Cloud::ErrorReporting::ErrorEvent, :mock_error_reporting do
   it "has attributes" do
     timestamp = Time.parse "2014-10-02T15:01:23.045123456Z"
 
-    error_event.event_time.must_equal timestamp
-    error_event.message.must_equal "error message"
-    error_event.service_name.must_equal "default"
-    error_event.service_version.must_equal "v1"
-    error_event.user.must_equal "testerson"
-    error_event.http_method.must_equal "GET"
-    error_event.http_url.must_equal "http://test.local/foo?bar=baz"
-    error_event.http_user_agent.must_equal "google-cloud/1.0.0"
-    error_event.http_referrer.must_equal "http://test/local/referrer"
-    error_event.http_status.must_equal 200
-    error_event.http_remote_ip.must_equal "127.0.0.1"
-    error_event.file_path.must_equal "/path/to/file.txt"
-    error_event.line_number.must_equal 5
-    error_event.function_name.must_equal "testee"
+    _(error_event.event_time).must_equal timestamp
+    _(error_event.message).must_equal "error message"
+    _(error_event.service_name).must_equal "default"
+    _(error_event.service_version).must_equal "v1"
+    _(error_event.user).must_equal "testerson"
+    _(error_event.http_method).must_equal "GET"
+    _(error_event.http_url).must_equal "http://test.local/foo?bar=baz"
+    _(error_event.http_user_agent).must_equal "google-cloud/1.0.0"
+    _(error_event.http_referrer).must_equal "http://test/local/referrer"
+    _(error_event.http_status).must_equal 200
+    _(error_event.http_remote_ip).must_equal "127.0.0.1"
+    _(error_event.file_path).must_equal "/path/to/file.txt"
+    _(error_event.line_number).must_equal 5
+    _(error_event.function_name).must_equal "testee"
   end
 
   it "works even if GRPC object doesn't have them" do
     error_event_hash.clear
 
-    error_event.message.must_be_empty
-    error_event.event_time.must_be_nil
-    error_event.service_name.must_be_nil
-    error_event.service_version.must_be_nil
-    error_event.user.must_be_nil
-    error_event.http_method.must_be_nil
-    error_event.http_url.must_be_nil
-    error_event.http_user_agent.must_be_nil
-    error_event.http_referrer.must_be_nil
-    error_event.http_status.must_be_nil
-    error_event.http_remote_ip.must_be_nil
-    error_event.file_path.must_be_nil
-    error_event.line_number.must_be_nil
-    error_event.function_name.must_be_nil
+    _(error_event.message).must_be_empty
+    _(error_event.event_time).must_be_nil
+    _(error_event.service_name).must_be_nil
+    _(error_event.service_version).must_be_nil
+    _(error_event.user).must_be_nil
+    _(error_event.http_method).must_be_nil
+    _(error_event.http_url).must_be_nil
+    _(error_event.http_user_agent).must_be_nil
+    _(error_event.http_referrer).must_be_nil
+    _(error_event.http_status).must_be_nil
+    _(error_event.http_remote_ip).must_be_nil
+    _(error_event.file_path).must_be_nil
+    _(error_event.line_number).must_be_nil
+    _(error_event.function_name).must_be_nil
   end
 
   describe "#to_grpc" do
     it "to_grpc returns a different grpc object with same attributes" do
       new_error_event_grpc = error_event.to_grpc
 
-      new_error_event_grpc.must_equal error_event_grpc
-      new_error_event_grpc.object_id.wont_equal error_event_grpc.object_id
+      _(new_error_event_grpc).must_equal error_event_grpc
+      _(new_error_event_grpc.object_id).wont_equal error_event_grpc.object_id
     end
   end
 
@@ -79,14 +79,14 @@ describe Google::Cloud::ErrorReporting::ErrorEvent, :mock_error_reporting do
     it "includes exception message when backtrace isn't present" do
       error_event =
         Google::Cloud::ErrorReporting::ErrorEvent.from_exception exception
-      error_event.message.must_equal error_message
+      _(error_event.message).must_equal error_message
     end
 
     it "includes exception message when backtrace is an empty array" do
       exception.set_backtrace([])
       error_event =
         Google::Cloud::ErrorReporting::ErrorEvent.from_exception exception
-      error_event.message.must_equal error_message
+      _(error_event.message).must_equal error_message
     end
 
     it "includes exception message and backtrace if backtrace is available" do
@@ -95,8 +95,8 @@ describe Google::Cloud::ErrorReporting::ErrorEvent, :mock_error_reporting do
 
       error_event =
         Google::Cloud::ErrorReporting::ErrorEvent.from_exception exception
-      error_event.message.must_match error_message
-      error_event.message.must_match backtrace
+      _(error_event.message).must_match error_message
+      _(error_event.message).must_match backtrace
     end
 
     it "builds an error_event with current info from exception" do
@@ -105,12 +105,12 @@ describe Google::Cloud::ErrorReporting::ErrorEvent, :mock_error_reporting do
 
       error_event =
         Google::Cloud::ErrorReporting::ErrorEvent.from_exception exception
-      error_event.message.must_match error_message
-      error_event.file_path.must_equal(
+      _(error_event.message).must_match error_message
+      _(error_event.file_path).must_equal(
         "test/test_more.rb"
       )
-      error_event.line_number.must_equal 123
-      error_event.function_name.must_equal(
+      _(error_event.line_number).must_equal 123
+      _(error_event.function_name).must_equal(
         "testee_sub"
       )
     end

--- a/google-cloud-error_reporting/test/google/cloud/error_reporting/middleware_test.rb
+++ b/google-cloud-error_reporting/test/google/cloud/error_reporting/middleware_test.rb
@@ -69,7 +69,7 @@ describe Google::Cloud::ErrorReporting::Middleware, :mock_error_reporting do
 
   describe "#initialize" do
     it "uses the error_reporting given" do
-      middleware.error_reporting.must_equal error_reporting
+      _(middleware.error_reporting).must_equal error_reporting
     end
 
     it "creates a default async_error_reporter if not given one" do
@@ -79,7 +79,7 @@ describe Google::Cloud::ErrorReporting::Middleware, :mock_error_reporting do
           middleware = Google::Cloud::ErrorReporting::Middleware.new nil,
                                                                      project_id: project_id
 
-          middleware.error_reporting.must_equal "A default reporter"
+          _(middleware.error_reporting).must_equal "A default reporter"
         end
       end
     end
@@ -88,30 +88,30 @@ describe Google::Cloud::ErrorReporting::Middleware, :mock_error_reporting do
       Google::Cloud::ErrorReporting.instance_variable_set :@default_reporter, nil
       Google::Cloud::ErrorReporting.stub :new, nil do
         mw = Google::Cloud::ErrorReporting::Middleware.new nil, project_id: project_id
-        Google::Cloud::ErrorReporting.instance_variable_get(:@default_reporter).object_id.must_equal mw.error_reporting.object_id
+        _(Google::Cloud::ErrorReporting.instance_variable_get(:@default_reporter).object_id).must_equal mw.error_reporting.object_id
       end
     end
 
     it "sets Google::Cloud::ErrorReporting.configure" do
-      Google::Cloud::ErrorReporting.configure.project_id.must_be_nil
-      Google::Cloud::ErrorReporting.configure.credentials.must_be_nil
-      Google::Cloud::ErrorReporting.configure.service_name.must_be_nil
-      Google::Cloud::ErrorReporting.configure.service_version.must_be_nil
+      _(Google::Cloud::ErrorReporting.configure.project_id).must_be_nil
+      _(Google::Cloud::ErrorReporting.configure.credentials).must_be_nil
+      _(Google::Cloud::ErrorReporting.configure.service_name).must_be_nil
+      _(Google::Cloud::ErrorReporting.configure.service_version).must_be_nil
 
       # Constructs a new Middleware, which sets Google::Cloud::ErrorReporting.configure
       middleware
 
-      Google::Cloud::ErrorReporting.configure.project_id.must_equal project_id
-      Google::Cloud::ErrorReporting.configure.credentials.must_equal credentials
-      Google::Cloud::ErrorReporting.configure.service_name.must_equal service_name
-      Google::Cloud::ErrorReporting.configure.service_version.must_equal service_version
+      _(Google::Cloud::ErrorReporting.configure.project_id).must_equal project_id
+      _(Google::Cloud::ErrorReporting.configure.credentials).must_equal credentials
+      _(Google::Cloud::ErrorReporting.configure.service_name).must_equal service_name
+      _(Google::Cloud::ErrorReporting.configure.service_version).must_equal service_version
     end
   end
 
   describe "#call" do
     it "catches exception and also raise it back up" do
       stub_report_exception = ->(_, exception) {
-        exception.message.must_equal app_exception_msg
+        _(exception.message).must_equal app_exception_msg
       }
 
       middleware.stub :report_exception, stub_report_exception do
@@ -119,7 +119,7 @@ describe Google::Cloud::ErrorReporting::Middleware, :mock_error_reporting do
           middleware.call rack_env
         end
 
-        exception.message.must_equal app_exception_msg
+        _(exception.message).must_equal app_exception_msg
       end
     end
 
@@ -128,7 +128,7 @@ describe Google::Cloud::ErrorReporting::Middleware, :mock_error_reporting do
         env['sinatra.error'] = app_exception
       }
       stub_report_exception = ->(_, exception) {
-        exception.message.must_equal app_exception_msg
+        _(exception.message).must_equal app_exception_msg
       }
 
       rack_app.stub :call, stub_call do
@@ -143,7 +143,7 @@ describe Google::Cloud::ErrorReporting::Middleware, :mock_error_reporting do
         env['rack.exception'] = app_exception
       }
       stub_report_exception = ->(_, exception) {
-        exception.message.must_equal app_exception_msg
+        _(exception.message).must_equal app_exception_msg
       }
 
       rack_app.stub :call, stub_call do
@@ -166,7 +166,7 @@ describe Google::Cloud::ErrorReporting::Middleware, :mock_error_reporting do
 
     it "calls error_reporting#report to report the error" do
       stub_reporting = ->(error_event) {
-        error_event.must_be_kind_of Google::Cloud::ErrorReporting::ErrorEvent
+        _(error_event).must_be_kind_of Google::Cloud::ErrorReporting::ErrorEvent
       }
 
       middleware.error_reporting.stub :report, stub_reporting do
@@ -177,10 +177,10 @@ describe Google::Cloud::ErrorReporting::Middleware, :mock_error_reporting do
     it "calls error_reporting#report when no correct status found" do
       stub_error_reporting = MiniTest::Mock.new
       stub_error_reporting.expect :report, nil do |error_event|
-        error_event.must_be_kind_of Google::Cloud::ErrorReporting::ErrorEvent
+        _(error_event).must_be_kind_of Google::Cloud::ErrorReporting::ErrorEvent
       end
       stub_http_status = ->(exception) {
-        exception.message.must_equal app_exception_msg
+        _(exception.message).must_equal app_exception_msg
         nil
       }
 
@@ -194,7 +194,7 @@ describe Google::Cloud::ErrorReporting::Middleware, :mock_error_reporting do
     it "doesn't report if the exception maps to a HTTP code less than 500" do
       stub_reporting = ->(_) { fail "This exception should've been skipped" }
       stub_http_status = ->(exception) {
-        exception.message.must_equal app_exception_msg
+        _(exception.message).must_equal app_exception_msg
         407
       }
 
@@ -210,32 +210,32 @@ describe Google::Cloud::ErrorReporting::Middleware, :mock_error_reporting do
     it "injects service_name and service_version" do
       error_event = middleware.error_event_from_exception rack_env, app_exception
 
-      error_event.service_name.must_equal service_name
-      error_event.service_version.must_equal service_version
+      _(error_event.service_name).must_equal service_name
+      _(error_event.service_version).must_equal service_version
     end
 
     it "injects http data from Rack::Request" do
       error_event = middleware.error_event_from_exception rack_env, app_exception
 
-      error_event.http_method.must_equal "GET"
-      error_event.http_url.must_match "localhost:3000"
-      error_event.http_user_agent.must_match "chrome-1.2.3"
-      error_event.http_referrer.must_be_nil
-      error_event.http_status.must_equal 500
-      error_event.http_remote_ip.must_equal "127.0.0.1"
+      _(error_event.http_method).must_equal "GET"
+      _(error_event.http_url).must_match "localhost:3000"
+      _(error_event.http_user_agent).must_match "chrome-1.2.3"
+      _(error_event.http_referrer).must_be_nil
+      _(error_event.http_status).must_equal 500
+      _(error_event.http_remote_ip).must_equal "127.0.0.1"
     end
   end
 
   describe ".http_status" do
     it "returns right http_status code based on exception class" do
       status = middleware.send :http_status, app_exception
-      status.must_equal 500
+      _(status).must_equal 500
     end
 
     it "returns right http_status code based on exception class #2" do
       app_exception.class.stub :name, "ActionController::ParameterMissing" do
         status = middleware.send :http_status, app_exception
-        status.must_equal 400
+        _(status).must_equal 400
       end
     end
   end

--- a/google-cloud-error_reporting/test/google/cloud/error_reporting/project_test.rb
+++ b/google-cloud-error_reporting/test/google/cloud/error_reporting/project_test.rb
@@ -18,23 +18,23 @@ require "helper"
 
 describe Google::Cloud::ErrorReporting::Project, :mock_error_reporting do
   it "knows the project identifier" do
-    error_reporting.must_be_kind_of Google::Cloud::ErrorReporting::Project
-    error_reporting.project.must_equal project
+    _(error_reporting).must_be_kind_of Google::Cloud::ErrorReporting::Project
+    _(error_reporting.project).must_equal project
   end
 
   describe "#error_event" do
     it "creates an empty error_event" do
       ENV.stub :[], nil do
         error_event = error_reporting.error_event
-        error_event.must_be_kind_of Google::Cloud::ErrorReporting::ErrorEvent
+        _(error_event).must_be_kind_of Google::Cloud::ErrorReporting::ErrorEvent
 
-        error_event.service_name.must_equal "ruby"
-        error_event.service_version.must_be_nil
+        _(error_event.service_name).must_equal "ruby"
+        _(error_event.service_version).must_be_nil
 
-        error_event.message.must_be_nil
-        error_event.event_time.must_be_nil
-        error_event.user.must_be_nil
-        error_event.http_url.must_be_nil
+        _(error_event.message).must_be_nil
+        _(error_event.event_time).must_be_nil
+        _(error_event.user).must_be_nil
+        _(error_event.http_url).must_be_nil
       end
     end
 
@@ -57,15 +57,15 @@ describe Google::Cloud::ErrorReporting::Project, :mock_error_reporting do
                                                 line_number: line_number,
                                                 function_name: function_name
 
-      error_event.service_name.must_equal service_name
-      error_event.service_version.must_equal service_version
+      _(error_event.service_name).must_equal service_name
+      _(error_event.service_version).must_equal service_version
 
-      error_event.message.must_equal message
-      error_event.event_time.must_equal timestamp
-      error_event.user.must_equal user
-      error_event.file_path.must_equal file_path
-      error_event.line_number.must_equal line_number
-      error_event.function_name.must_equal function_name
+      _(error_event.message).must_equal message
+      _(error_event.event_time).must_equal timestamp
+      _(error_event.user).must_equal user
+      _(error_event.file_path).must_equal file_path
+      _(error_event.line_number).must_equal line_number
+      _(error_event.function_name).must_equal function_name
     end
   end
 
@@ -76,8 +76,8 @@ describe Google::Cloud::ErrorReporting::Project, :mock_error_reporting do
 
     it "injects service_name and service_version" do
       stub_report = ->(error_event) {
-        error_event.service_name.must_equal service_name
-        error_event.service_version.must_equal service_version
+        _(error_event.service_name).must_equal service_name
+        _(error_event.service_version).must_equal service_version
       }
 
       error_reporting.stub :report, stub_report do
@@ -89,8 +89,8 @@ describe Google::Cloud::ErrorReporting::Project, :mock_error_reporting do
 
     it "injects default service_name and service_version if not provided" do
       stub_report = ->(error_event) {
-        error_event.service_name.must_equal service_name
-        error_event.service_version.must_equal service_version
+        _(error_event.service_name).must_equal service_name
+        _(error_event.service_version).must_equal service_version
       }
 
       error_reporting.class.stub :default_service_name, service_name do
@@ -120,7 +120,7 @@ describe Google::Cloud::ErrorReporting::Project, :mock_error_reporting do
     it "calls Google::Cloud.env.project_id if no environment variable found" do
       Google::Cloud.env.stub :project_id, "another-project" do
         ENV.stub :[], nil do
-          Google::Cloud::ErrorReporting::Project.default_project_id.must_equal "another-project"
+          _(Google::Cloud::ErrorReporting::Project.default_project_id).must_equal "another-project"
         end
       end
     end
@@ -130,7 +130,7 @@ describe Google::Cloud::ErrorReporting::Project, :mock_error_reporting do
     it "calls Google::Cloud.env.app_engine_service_id if no environment variable found" do
       Google::Cloud.env.stub :app_engine_service_id, "another-service-id" do
         ENV.stub :[], nil do
-          Google::Cloud::ErrorReporting::Project.default_service_name.must_equal "another-service-id"
+          _(Google::Cloud::ErrorReporting::Project.default_service_name).must_equal "another-service-id"
         end
       end
     end
@@ -138,7 +138,7 @@ describe Google::Cloud::ErrorReporting::Project, :mock_error_reporting do
     it "defaults to 'ruby'" do
       Google::Cloud.env.stub :app_engine_service_id, nil do
         ENV.stub :[], nil do
-          Google::Cloud::ErrorReporting::Project.default_service_name.must_equal "ruby"
+          _(Google::Cloud::ErrorReporting::Project.default_service_name).must_equal "ruby"
         end
       end
     end
@@ -148,7 +148,7 @@ describe Google::Cloud::ErrorReporting::Project, :mock_error_reporting do
     it "calls Google::Cloud.env.app_engine_service_version if no environment variable found" do
       Google::Cloud.env.stub :app_engine_service_version, "another-service-version" do
         ENV.stub :[], nil do
-          Google::Cloud::ErrorReporting::Project.default_service_version.must_equal "another-service-version"
+          _(Google::Cloud::ErrorReporting::Project.default_service_version).must_equal "another-service-version"
         end
       end
     end

--- a/google-cloud-error_reporting/test/google/cloud/error_reporting/rails_test.rb
+++ b/google-cloud-error_reporting/test/google/cloud/error_reporting/rails_test.rb
@@ -50,11 +50,11 @@ describe Google::Cloud::ErrorReporting::Railtie do
         Google::Cloud::ErrorReporting::Railtie.send :consolidate_rails_config, rails_config
 
         Google::Cloud::ErrorReporting.configure do |config|
-          config.project_id.must_equal "test-project"
-          config.credentials.must_equal "test/keyfile"
-          config.service_name.must_equal "test-service"
-          config.service_version.must_equal "test-version"
-          config.ignore_classes.must_equal simple_ignore_classes
+          _(config.project_id).must_equal "test-project"
+          _(config.credentials).must_equal "test/keyfile"
+          _(config.service_name).must_equal "test-service"
+          _(config.service_version).must_equal "test-version"
+          _(config.ignore_classes).must_equal simple_ignore_classes
         end
       end
     end
@@ -72,11 +72,11 @@ describe Google::Cloud::ErrorReporting::Railtie do
         Google::Cloud::ErrorReporting::Railtie.send :consolidate_rails_config, rails_config
 
         Google::Cloud::ErrorReporting.configure do |config|
-          config.project_id.must_equal "another-test-project"
-          config.credentials.must_equal "/another/test/keyfile"
-          config.service_name.must_equal "another-test-service"
-          config.service_version.must_equal "another-test-version"
-          config.ignore_classes.must_equal another_ignore_classes
+          _(config.project_id).must_equal "another-test-project"
+          _(config.credentials).must_equal "/another/test/keyfile"
+          _(config.service_name).must_equal "another-test-service"
+          _(config.service_version).must_equal "another-test-version"
+          _(config.ignore_classes).must_equal another_ignore_classes
         end
       end
     end
@@ -86,16 +86,16 @@ describe Google::Cloud::ErrorReporting::Railtie do
 
       Google::Cloud::ErrorReporting::Railtie.stub :valid_credentials?, false do
         Google::Cloud::ErrorReporting::Railtie.send :consolidate_rails_config, rails_config
-        Google::Cloud.configure.use_error_reporting.must_equal false
+        _(Google::Cloud.configure.use_error_reporting).must_equal false
       end
     end
 
     it "Set use_error_reporting to true if Rails is in production" do
       Google::Cloud::ErrorReporting::Railtie.stub :valid_credentials?, true do
         Rails.env.stub :production?, true do
-          Google::Cloud.configure.use_error_reporting.must_be_nil
+          _(Google::Cloud.configure.use_error_reporting).must_be_nil
           Google::Cloud::ErrorReporting::Railtie.send :consolidate_rails_config, rails_config
-          Google::Cloud.configure.use_error_reporting.must_equal true
+          _(Google::Cloud.configure.use_error_reporting).must_equal true
         end
       end
     end
@@ -105,7 +105,7 @@ describe Google::Cloud::ErrorReporting::Railtie do
         Rails.env.stub :production?, true do
           Google::Cloud.configure.use_error_reporting = false
           Google::Cloud::ErrorReporting::Railtie.send :consolidate_rails_config, rails_config
-          Google::Cloud.configure.use_error_reporting.must_equal false
+          _(Google::Cloud.configure.use_error_reporting).must_equal false
         end
       end
     end
@@ -116,7 +116,7 @@ describe Google::Cloud::ErrorReporting::Railtie do
       Google::Cloud::ErrorReporting::Railtie.stub :valid_credentials?, true do
         Rails.env.stub :production?, false do
           Google::Cloud::ErrorReporting::Railtie.send :consolidate_rails_config, rails_config
-          Google::Cloud.configure.use_error_reporting.must_equal true
+          _(Google::Cloud.configure.use_error_reporting).must_equal true
         end
       end
     end
@@ -140,11 +140,11 @@ describe Google::Cloud::ErrorReporting::Railtie do
         Google::Cloud::ErrorReporting::Railtie.send :consolidate_rails_config, rails_config
 
         Google::Cloud::ErrorReporting.configure do |config|
-          config.project_id.must_equal "test-project"
-          config.credentials.must_equal "test/keyfile"
-          config.service_name.must_equal "test-service"
-          config.service_version.must_equal "test-version"
-          config.ignore_classes.must_equal simple_ignore_classes
+          _(config.project_id).must_equal "test-project"
+          _(config.credentials).must_equal "test/keyfile"
+          _(config.service_name).must_equal "test-service"
+          _(config.service_version).must_equal "test-version"
+          _(config.ignore_classes).must_equal simple_ignore_classes
         end
       end
     end
@@ -162,11 +162,11 @@ describe Google::Cloud::ErrorReporting::Railtie do
         Google::Cloud::ErrorReporting::Railtie.send :consolidate_rails_config, rails_config
 
         Google::Cloud::ErrorReporting.configure do |config|
-          config.project_id.must_equal "another-test-project"
-          config.credentials.must_equal "/another/test/keyfile"
-          config.service_name.must_equal "another-test-service"
-          config.service_version.must_equal "another-test-version"
-          config.ignore_classes.must_equal another_ignore_classes
+          _(config.project_id).must_equal "another-test-project"
+          _(config.credentials).must_equal "/another/test/keyfile"
+          _(config.service_name).must_equal "another-test-service"
+          _(config.service_version).must_equal "another-test-version"
+          _(config.ignore_classes).must_equal another_ignore_classes
         end
       end
     end
@@ -176,16 +176,16 @@ describe Google::Cloud::ErrorReporting::Railtie do
 
       Google::Cloud::ErrorReporting::Railtie.stub :valid_credentials?, false do
         Google::Cloud::ErrorReporting::Railtie.send :consolidate_rails_config, rails_config
-        Google::Cloud.configure.use_error_reporting.must_equal false
+        _(Google::Cloud.configure.use_error_reporting).must_equal false
       end
     end
 
     it "Set use_error_reporting to true if Rails is in production" do
       Google::Cloud::ErrorReporting::Railtie.stub :valid_credentials?, true do
         Rails.env.stub :production?, true do
-          Google::Cloud.configure.use_error_reporting.must_be_nil
+          _(Google::Cloud.configure.use_error_reporting).must_be_nil
           Google::Cloud::ErrorReporting::Railtie.send :consolidate_rails_config, rails_config
-          Google::Cloud.configure.use_error_reporting.must_equal true
+          _(Google::Cloud.configure.use_error_reporting).must_equal true
         end
       end
     end
@@ -196,7 +196,7 @@ describe Google::Cloud::ErrorReporting::Railtie do
       Google::Cloud::ErrorReporting::Railtie.stub :valid_credentials?, true do
         Rails.env.stub :production?, false do
           Google::Cloud::ErrorReporting::Railtie.send :consolidate_rails_config, rails_config
-          Google::Cloud.configure.use_error_reporting.must_equal true
+          _(Google::Cloud.configure.use_error_reporting).must_equal true
         end
       end
     end

--- a/google-cloud-error_reporting/test/google/cloud/error_reporting_test.rb
+++ b/google-cloud-error_reporting/test/google/cloud/error_reporting_test.rb
@@ -31,9 +31,9 @@ describe Google::Cloud::ErrorReporting, :mock_error_reporting do
         Google::Cloud::ErrorReporting::Project.stub :default_project_id, "test-project-id" do
           Google::Cloud::ErrorReporting::Credentials.stub :default, default_credentials do
             error_reporting = Google::Cloud::ErrorReporting.new
-            error_reporting.must_be_kind_of Google::Cloud::ErrorReporting::Project
-            error_reporting.project.must_equal "test-project-id"
-            error_reporting.service.credentials.must_equal default_credentials
+            _(error_reporting).must_be_kind_of Google::Cloud::ErrorReporting::Project
+            _(error_reporting.project).must_equal "test-project-id"
+            _(error_reporting.service.credentials).must_equal default_credentials
           end
         end
       end
@@ -41,8 +41,8 @@ describe Google::Cloud::ErrorReporting, :mock_error_reporting do
 
     it "uses provided project_id, credentials, service, and version" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "/path/to/a/keyfile"
-        scope.must_be_nil
+        _(keyfile).must_equal "/path/to/a/keyfile"
+        _(scope).must_be_nil
         "error_reporting-credentials"
       }
 
@@ -52,9 +52,9 @@ describe Google::Cloud::ErrorReporting, :mock_error_reporting do
             Google::Cloud::ErrorReporting::Credentials.stub :new, stubbed_credentials do
               error_reporting = Google::Cloud::ErrorReporting.new project_id: "test-project-id",
                                                                   credentials: "/path/to/a/keyfile"
-              error_reporting.must_be_kind_of Google::Cloud::ErrorReporting::Project
-              error_reporting.project.must_equal "test-project-id"
-              error_reporting.service.must_be_kind_of Google::Cloud::ErrorReporting::Service
+              _(error_reporting).must_be_kind_of Google::Cloud::ErrorReporting::Project
+              _(error_reporting.project).must_equal "test-project-id"
+              _(error_reporting.service).must_be_kind_of Google::Cloud::ErrorReporting::Service
             end
           end
         end
@@ -64,11 +64,11 @@ describe Google::Cloud::ErrorReporting, :mock_error_reporting do
     it "uses provided endpoint" do
       endpoint = "errorreporting-endpoint2.example.com"
       stubbed_service = ->(project, credentials, timeout: nil, client_config: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal default_credentials
-        timeout.must_be :nil?
-        client_config.must_be :nil?
-        host.must_equal endpoint
+        _(project).must_equal "project-id"
+        _(credentials).must_equal default_credentials
+        _(timeout).must_be :nil?
+        _(client_config).must_be :nil?
+        _(host).must_equal endpoint
         OpenStruct.new project: project
       }
       ENV.stub :[], nil do
@@ -76,17 +76,17 @@ describe Google::Cloud::ErrorReporting, :mock_error_reporting do
           error_reporting = Google::Cloud::ErrorReporting.new project_id: "project-id",
                                                               endpoint: endpoint,
                                                               credentials: default_credentials
-          error_reporting.must_be_kind_of Google::Cloud::ErrorReporting::Project
-          error_reporting.project.must_equal "project-id"
-          error_reporting.service.must_be_kind_of OpenStruct
+          _(error_reporting).must_be_kind_of Google::Cloud::ErrorReporting::Project
+          _(error_reporting.project).must_equal "project-id"
+          _(error_reporting.service).must_be_kind_of OpenStruct
         end
       end
     end
 
     it "uses provided project (alias), keyfile (alias), service, and version" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "/path/to/a/keyfile"
-        scope.must_be_nil
+        _(keyfile).must_equal "/path/to/a/keyfile"
+        _(scope).must_be_nil
         "error_reporting-credentials"
       }
 
@@ -96,9 +96,9 @@ describe Google::Cloud::ErrorReporting, :mock_error_reporting do
             Google::Cloud::ErrorReporting::Credentials.stub :new, stubbed_credentials do
               error_reporting = Google::Cloud::ErrorReporting.new project: "test-project-id",
                                                                   keyfile: "/path/to/a/keyfile"
-              error_reporting.must_be_kind_of Google::Cloud::ErrorReporting::Project
-              error_reporting.project.must_equal "test-project-id"
-              error_reporting.service.must_be_kind_of Google::Cloud::ErrorReporting::Service
+              _(error_reporting).must_be_kind_of Google::Cloud::ErrorReporting::Project
+              _(error_reporting.project).must_equal "test-project-id"
+              _(error_reporting.service).must_be_kind_of Google::Cloud::ErrorReporting::Service
             end
           end
         end
@@ -111,14 +111,14 @@ describe Google::Cloud::ErrorReporting, :mock_error_reporting do
           Google::Cloud::ErrorReporting.new project: ""
         end
 
-        exception.message.must_equal "project_id is missing"
+        _(exception.message).must_equal "project_id is missing"
       end
     end
   end
 
   describe ".configure" do
     it "has Google::Cloud.configure.error_reporting initialized already" do
-      Google::Cloud.configure.option?(:error_reporting).must_equal true
+      _(Google::Cloud.configure.option?(:error_reporting)).must_equal true
     end
 
     it "operates on the same Configuration object as Google::Cloud.configure.error_reporting" do
@@ -131,14 +131,14 @@ describe Google::Cloud::ErrorReporting, :mock_error_reporting do
 
     before {
       Google::Cloud::ErrorReporting.instance_variable_set :@default_reporter, nil
-      Google::Cloud::ErrorReporting.instance_variable_get(:@default_reporter).must_be_nil
+      _(Google::Cloud::ErrorReporting.instance_variable_get(:@default_reporter)).must_be_nil
     }
 
     after {
       Google::Cloud.configure.reset!
       Google::Cloud::ErrorReporting.configure.reset!
       Google::Cloud::ErrorReporting.instance_variable_set :@default_reporter, nil
-      Google::Cloud::ErrorReporting.instance_variable_get(:@default_reporter).must_be_nil
+      _(Google::Cloud::ErrorReporting.instance_variable_get(:@default_reporter)).must_be_nil
     }
 
     it "doesn't call Project#report_exception if Google::Cloud.configure.use_error_reporting is false" do
@@ -156,8 +156,8 @@ describe Google::Cloud::ErrorReporting, :mock_error_reporting do
     it "calls Project#report with the given service_name and service_version" do
       mocked_client = Minitest::Mock.new
       mocked_client.expect :report, nil do |event|
-        event.service_name.must_equal "test-service-name"
-        event.service_version.must_equal "test-service-version"
+        _(event.service_name).must_equal "test-service-name"
+        _(event.service_version).must_equal "test-service-version"
       end
 
       Google::Cloud::ErrorReporting.stub :default_reporter, mocked_client do
@@ -175,8 +175,8 @@ describe Google::Cloud::ErrorReporting, :mock_error_reporting do
       end
       mocked_client = Minitest::Mock.new
       mocked_client.expect :report, nil do |event|
-        event.service_name.must_equal "test-service-name"
-        event.service_version.must_equal "test-service-version"
+        _(event.service_name).must_equal "test-service-name"
+        _(event.service_version).must_equal "test-service-version"
       end
 
       Google::Cloud::ErrorReporting.stub :default_reporter, mocked_client do
@@ -191,11 +191,11 @@ describe Google::Cloud::ErrorReporting, :mock_error_reporting do
       end
       mocked_client = Minitest::Mock.new
       mocked_client.expect :report, nil do |event|
-        event.service_name.must_equal "test-service-name"
-        event.service_version.must_equal "test-service-version"
-        event.file_path.must_equal "error_reporting.rb"
-        event.line_number.must_equal 123
-        event.function_name.must_equal "report"
+        _(event.service_name).must_equal "test-service-name"
+        _(event.service_version).must_equal "test-service-version"
+        _(event.file_path).must_equal "error_reporting.rb"
+        _(event.line_number).must_equal 123
+        _(event.function_name).must_equal "report"
       end
 
       Google::Cloud::ErrorReporting.stub :default_reporter, mocked_client do
@@ -219,8 +219,8 @@ describe Google::Cloud::ErrorReporting, :mock_error_reporting do
       end
 
       stubbed_new = ->(args) {
-        args[:project_id].must_equal "test-project-id"
-        args[:credentials].must_equal "test-keyfile"
+        _(args[:project_id]).must_equal "test-project-id"
+        _(args[:credentials]).must_equal "test-keyfile"
       }
 
       Google::Cloud::ErrorReporting.stub :new, stubbed_new do
@@ -235,8 +235,8 @@ describe Google::Cloud::ErrorReporting, :mock_error_reporting do
       end
 
       stubbed_new = ->(args) {
-        args[:project_id].must_equal "test-project-id"
-        args[:credentials].must_equal "test-keyfile"
+        _(args[:project_id]).must_equal "test-project-id"
+        _(args[:credentials]).must_equal "test-keyfile"
       }
 
       Google::Cloud::ErrorReporting.stub :new, stubbed_new do
@@ -251,8 +251,8 @@ describe Google::Cloud::ErrorReporting, :mock_error_reporting do
       end
 
       stubbed_new = ->(args) {
-        args[:project_id].must_equal "test-project-id"
-        args[:credentials].must_equal "test-keyfile"
+        _(args[:project_id]).must_equal "test-project-id"
+        _(args[:credentials]).must_equal "test-keyfile"
       }
 
       Google::Cloud::ErrorReporting.stub :new, stubbed_new do
@@ -267,8 +267,8 @@ describe Google::Cloud::ErrorReporting, :mock_error_reporting do
       end
 
       stubbed_new = ->(args) {
-        args[:project_id].must_equal "test-project-id"
-        args[:credentials].must_equal "test-keyfile"
+        _(args[:project_id]).must_equal "test-project-id"
+        _(args[:credentials]).must_equal "test-keyfile"
       }
 
       Google::Cloud::ErrorReporting.stub :new, stubbed_new do
@@ -287,7 +287,7 @@ describe Google::Cloud::ErrorReporting, :mock_error_reporting do
       Google::Cloud::ErrorReporting::AsyncErrorReporter.stub :new, stubbed_async_reporter do
         Google::Cloud::ErrorReporting.stub :new, nil do
           first_client = Google::Cloud::ErrorReporting.default_reporter
-          Google::Cloud::ErrorReporting.default_reporter.must_equal first_client
+          _(Google::Cloud::ErrorReporting.default_reporter).must_equal first_client
         end
       end
     end
@@ -314,16 +314,16 @@ describe Google::Cloud::ErrorReporting, :mock_error_reporting do
 
     it "uses shared config for project and keyfile" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "error_reporting-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, client_config: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "error_reporting-credentials"
-        timeout.must_be :nil?
-        client_config.must_be :nil?
-        host.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "error_reporting-credentials"
+        _(timeout).must_be :nil?
+        _(client_config).must_be :nil?
+        _(host).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -340,9 +340,9 @@ describe Google::Cloud::ErrorReporting, :mock_error_reporting do
             Google::Cloud::ErrorReporting::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::ErrorReporting::Service.stub :new, stubbed_service do
                 error_reporting = Google::Cloud::ErrorReporting.new
-                error_reporting.must_be_kind_of Google::Cloud::ErrorReporting::Project
-                error_reporting.project.must_equal "project-id"
-                error_reporting.service.must_be_kind_of OpenStruct
+                _(error_reporting).must_be_kind_of Google::Cloud::ErrorReporting::Project
+                _(error_reporting.project).must_equal "project-id"
+                _(error_reporting.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -352,16 +352,16 @@ describe Google::Cloud::ErrorReporting, :mock_error_reporting do
 
     it "uses shared config for project_id and credentials" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "error_reporting-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, client_config: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "error_reporting-credentials"
-        timeout.must_be :nil?
-        client_config.must_be :nil?
-        host.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "error_reporting-credentials"
+        _(timeout).must_be :nil?
+        _(client_config).must_be :nil?
+        _(host).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -378,9 +378,9 @@ describe Google::Cloud::ErrorReporting, :mock_error_reporting do
             Google::Cloud::ErrorReporting::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::ErrorReporting::Service.stub :new, stubbed_service do
                 error_reporting = Google::Cloud::ErrorReporting.new
-                error_reporting.must_be_kind_of Google::Cloud::ErrorReporting::Project
-                error_reporting.project.must_equal "project-id"
-                error_reporting.service.must_be_kind_of OpenStruct
+                _(error_reporting).must_be_kind_of Google::Cloud::ErrorReporting::Project
+                _(error_reporting.project).must_equal "project-id"
+                _(error_reporting.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -390,16 +390,16 @@ describe Google::Cloud::ErrorReporting, :mock_error_reporting do
 
     it "uses error_reporting config for project and keyfile" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "error_reporting-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, client_config: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "error_reporting-credentials"
-        timeout.must_equal 42
-        client_config.must_equal error_reporting_client_config
-        host.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "error_reporting-credentials"
+        _(timeout).must_equal 42
+        _(client_config).must_equal error_reporting_client_config
+        _(host).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -418,9 +418,9 @@ describe Google::Cloud::ErrorReporting, :mock_error_reporting do
             Google::Cloud::ErrorReporting::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::ErrorReporting::Service.stub :new, stubbed_service do
                 error_reporting = Google::Cloud::ErrorReporting.new
-                error_reporting.must_be_kind_of Google::Cloud::ErrorReporting::Project
-                error_reporting.project.must_equal "project-id"
-                error_reporting.service.must_be_kind_of OpenStruct
+                _(error_reporting).must_be_kind_of Google::Cloud::ErrorReporting::Project
+                _(error_reporting.project).must_equal "project-id"
+                _(error_reporting.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -431,11 +431,11 @@ describe Google::Cloud::ErrorReporting, :mock_error_reporting do
     it "uses error_reporting config for endpoint" do
       endpoint = "errorreporting-endpoint2.example.com"
       stubbed_service = ->(project, credentials, timeout: nil, client_config: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal default_credentials
-        timeout.must_be :nil?
-        client_config.must_be :nil?
-        host.must_equal endpoint
+        _(project).must_equal "project-id"
+        _(credentials).must_equal default_credentials
+        _(timeout).must_be :nil?
+        _(client_config).must_be :nil?
+        _(host).must_equal endpoint
         OpenStruct.new project: project
       }
 
@@ -449,25 +449,25 @@ describe Google::Cloud::ErrorReporting, :mock_error_reporting do
 
         Google::Cloud::ErrorReporting::Service.stub :new, stubbed_service do
           error_reporting = Google::Cloud::ErrorReporting.new project: "project-id", credentials: default_credentials, endpoint: endpoint
-          error_reporting.must_be_kind_of Google::Cloud::ErrorReporting::Project
-          error_reporting.project.must_equal "project-id"
-          error_reporting.service.must_be_kind_of OpenStruct
+          _(error_reporting).must_be_kind_of Google::Cloud::ErrorReporting::Project
+          _(error_reporting.project).must_equal "project-id"
+          _(error_reporting.service).must_be_kind_of OpenStruct
         end
       end
     end
 
     it "uses error_reporting config for project_id and credentials" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "error_reporting-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, client_config: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "error_reporting-credentials"
-        timeout.must_equal 42
-        client_config.must_equal error_reporting_client_config
-        host.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "error_reporting-credentials"
+        _(timeout).must_equal 42
+        _(client_config).must_equal error_reporting_client_config
+        _(host).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -486,9 +486,9 @@ describe Google::Cloud::ErrorReporting, :mock_error_reporting do
             Google::Cloud::ErrorReporting::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::ErrorReporting::Service.stub :new, stubbed_service do
                 error_reporting = Google::Cloud::ErrorReporting.new
-                error_reporting.must_be_kind_of Google::Cloud::ErrorReporting::Project
-                error_reporting.project.must_equal "project-id"
-                error_reporting.service.must_be_kind_of OpenStruct
+                _(error_reporting).must_be_kind_of Google::Cloud::ErrorReporting::Project
+                _(error_reporting.project).must_equal "project-id"
+                _(error_reporting.service).must_be_kind_of OpenStruct
               end
             end
           end


### PR DESCRIPTION
Use `rubocop-minitest` gem and `bundle exec rubocop --only Minitest/GlobalExpectations -a` to autocorrect minitest warnings for Ruby 2.7.

refs: #4110
refs: #4116