### PR TITLE
chore(logging): Update minitest to 5.14

### DIFF
--- a/google-cloud-logging/.rubocop.yml
+++ b/google-cloud-logging/.rubocop.yml
@@ -1,16 +1,17 @@
-require: rubocop-minitest
-
 inherit_gem:
   google-style: google-style.yml
 
 AllCops:
   Exclude:
+    - "acceptance/**/*"
+    - "integration/**/*"
     - "google-cloud-logging.gemspec"
     - "lib/google/logging/**/*"
     - "lib/google/cloud/logging/v2.rb"
     - "lib/google/cloud/logging/v2/**/*"
     - "Rakefile"
     - "support/**/*"
+    - "test/**/*"
 
 Documentation:
   Enabled: false

--- a/google-cloud-logging/.rubocop.yml
+++ b/google-cloud-logging/.rubocop.yml
@@ -1,17 +1,16 @@
+require: rubocop-minitest
+
 inherit_gem:
   google-style: google-style.yml
 
 AllCops:
   Exclude:
-    - "acceptance/**/*"
-    - "integration/**/*"
     - "google-cloud-logging.gemspec"
     - "lib/google/logging/**/*"
     - "lib/google/cloud/logging/v2.rb"
     - "lib/google/cloud/logging/v2/**/*"
     - "Rakefile"
     - "support/**/*"
-    - "test/**/*"
 
 Documentation:
   Enabled: false

--- a/google-cloud-logging/Gemfile
+++ b/google-cloud-logging/Gemfile
@@ -11,3 +11,5 @@ gem "stackdriver-core", path: "../stackdriver-core"
 
 gem "minitest-reporters", "~> 1.3.5", require: false
 gem "rake"
+
+gem "rubocop-minitest"

--- a/google-cloud-logging/Gemfile
+++ b/google-cloud-logging/Gemfile
@@ -11,5 +11,3 @@ gem "stackdriver-core", path: "../stackdriver-core"
 
 gem "minitest-reporters", "~> 1.3.5", require: false
 gem "rake"
-
-gem "rubocop-minitest"

--- a/google-cloud-logging/Gemfile
+++ b/google-cloud-logging/Gemfile
@@ -11,7 +11,3 @@ gem "stackdriver-core", path: "../stackdriver-core"
 
 gem "minitest-reporters", "~> 1.3.5", require: false
 gem "rake"
-
-# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
-# See https://github.com/googleapis/google-cloud-ruby/issues/4110
-gem "minitest", "~> 5.11.3"

--- a/google-cloud-logging/acceptance/logging/logging_test.rb
+++ b/google-cloud-logging/acceptance/logging/logging_test.rb
@@ -25,44 +25,44 @@ describe Google::Cloud::Logging, :logging do
                                  pubsub_dest,
                                  filter: "severity = ALERT"
 
-      sink.name.must_equal "#{prefix}-sink"
-      sink.destination.must_equal pubsub_dest
-      sink.filter.must_equal "severity = ALERT"
+      _(sink.name).must_equal "#{prefix}-sink"
+      _(sink.destination).must_equal pubsub_dest
+      _(sink.filter).must_equal "severity = ALERT"
 
       sink.filter = "severity >= WARNING"
 
       sink.save
 
-      sink.name.must_equal "#{prefix}-sink"
-      sink.destination.must_equal pubsub_dest
-      sink.filter.must_equal "severity >= WARNING"
+      _(sink.name).must_equal "#{prefix}-sink"
+      _(sink.destination).must_equal pubsub_dest
+      _(sink.filter).must_equal "severity >= WARNING"
 
       sink.refresh!
 
-      sink.name.must_equal "#{prefix}-sink"
-      sink.destination.must_equal pubsub_dest
-      sink.filter.must_equal "severity >= WARNING"
+      _(sink.name).must_equal "#{prefix}-sink"
+      _(sink.destination).must_equal pubsub_dest
+      _(sink.filter).must_equal "severity >= WARNING"
 
       dup_sink = logging.sink "#{prefix}-sink"
 
-      dup_sink.name.must_equal "#{prefix}-sink"
-      dup_sink.destination.must_equal pubsub_dest
-      dup_sink.filter.must_equal "severity >= WARNING"
+      _(dup_sink.name).must_equal "#{prefix}-sink"
+      _(dup_sink.destination).must_equal pubsub_dest
+      _(dup_sink.filter).must_equal "severity >= WARNING"
 
-      logging.sinks.wont_be :empty?
-      logging.sinks(max: 1).length.must_equal 1
+      _(logging.sinks).wont_be :empty?
+      _(logging.sinks(max: 1).length).must_equal 1
 
       sink.delete
 
-      logging.sink("#{prefix}-sink").must_be :nil?
+      _(logging.sink("#{prefix}-sink")).must_be :nil?
     end
 
     it "lists sinks" do
       pubsub_dest = "pubsub.googleapis.com/projects/#{logging.project}/topics/#{prefix}-topic"
       sink = logging.create_sink "#{prefix}-list-sink", pubsub_dest
 
-      logging.sinks.wont_be :empty?
-      logging.sinks(max: 1).length.must_equal 1
+      _(logging.sinks).wont_be :empty?
+      _(logging.sinks(max: 1).length).must_equal 1
 
       sink.delete
     end
@@ -74,37 +74,37 @@ describe Google::Cloud::Logging, :logging do
                                      "severity = ALERT",
                                      description: "Metric for acceptance tsets"
 
-      metric.name.must_equal "#{prefix}-metric"
-      metric.description.must_equal "Metric for acceptance tsets"
-      metric.filter.must_equal "severity = ALERT"
+      _(metric.name).must_equal "#{prefix}-metric"
+      _(metric.description).must_equal "Metric for acceptance tsets"
+      _(metric.filter).must_equal "severity = ALERT"
 
       metric.description = "Metric for acceptance tests"
       metric.filter = "severity >= WARNING"
 
       metric.save
 
-      metric.name.must_equal "#{prefix}-metric"
-      metric.description.must_equal "Metric for acceptance tests"
-      metric.filter.must_equal "severity >= WARNING"
+      _(metric.name).must_equal "#{prefix}-metric"
+      _(metric.description).must_equal "Metric for acceptance tests"
+      _(metric.filter).must_equal "severity >= WARNING"
 
       metric.refresh!
 
-      metric.name.must_equal "#{prefix}-metric"
-      metric.description.must_equal "Metric for acceptance tests"
-      metric.filter.must_equal "severity >= WARNING"
+      _(metric.name).must_equal "#{prefix}-metric"
+      _(metric.description).must_equal "Metric for acceptance tests"
+      _(metric.filter).must_equal "severity >= WARNING"
 
       dup_metric = logging.metric "#{prefix}-metric"
 
-      dup_metric.name.must_equal "#{prefix}-metric"
-      dup_metric.description.must_equal "Metric for acceptance tests"
-      dup_metric.filter.must_equal "severity >= WARNING"
+      _(dup_metric.name).must_equal "#{prefix}-metric"
+      _(dup_metric.description).must_equal "Metric for acceptance tests"
+      _(dup_metric.filter).must_equal "severity >= WARNING"
 
-      logging.metrics.wont_be :empty?
-      logging.metrics(max: 1).length.must_equal 1
+      _(logging.metrics).wont_be :empty?
+      _(logging.metrics(max: 1).length).must_equal 1
 
       metric.delete
 
-      logging.metric("#{prefix}-metric").must_be :nil?
+      _(logging.metric("#{prefix}-metric")).must_be :nil?
     end
   end
 
@@ -134,11 +134,11 @@ describe Google::Cloud::Logging, :logging do
         sleep delay
         delay += 1
       end
-      entries.wont_be_empty
-      logging.entries(max: 1).length.must_equal 1
+      _(entries).wont_be_empty
+      _(logging.entries(max: 1).length).must_equal 1
 
-      logging.logs.wont_be :empty?
-      logging.logs(max: 1).length.must_equal 1
+      _(logging.logs).wont_be :empty?
+      _(logging.logs(max: 1).length).must_equal 1
     end
   end
 
@@ -167,12 +167,12 @@ describe Google::Cloud::Logging, :logging do
       skip "Removed due to inconsistent failure by the service to retrieve written_entries. Reinstate when service stabilizes."
       written_entries = entries_via_backoff("symbol").map &:payload
 
-      written_entries.must_include "Danger Will Robinson (:debug)!"
-      written_entries.must_include "Danger Will Robinson (:info)!"
-      written_entries.must_include "Danger Will Robinson (:warn)!"
-      written_entries.must_include "Danger Will Robinson (:error)!"
-      written_entries.must_include "Danger Will Robinson (:fatal)!"
-      written_entries.must_include "Danger Will Robinson (:unknown)!"
+      _(written_entries).must_include "Danger Will Robinson (:debug)!"
+      _(written_entries).must_include "Danger Will Robinson (:info)!"
+      _(written_entries).must_include "Danger Will Robinson (:warn)!"
+      _(written_entries).must_include "Danger Will Robinson (:error)!"
+      _(written_entries).must_include "Danger Will Robinson (:fatal)!"
+      _(written_entries).must_include "Danger Will Robinson (:unknown)!"
     end
 
     it "writes to a log with add and a string" do
@@ -191,12 +191,12 @@ describe Google::Cloud::Logging, :logging do
       skip "Removed due to inconsistent failure by the service to retrieve written_entries. Reinstate when service stabilizes."
       written_entries = entries_via_backoff("string").map &:payload
 
-      written_entries.must_include "Danger Will Robinson ('debug')!"
-      written_entries.must_include "Danger Will Robinson ('info')!"
-      written_entries.must_include "Danger Will Robinson ('warn')!"
-      written_entries.must_include "Danger Will Robinson ('error')!"
-      written_entries.must_include "Danger Will Robinson ('fatal')!"
-      written_entries.must_include "Danger Will Robinson ('unknown')!"
+      _(written_entries).must_include "Danger Will Robinson ('debug')!"
+      _(written_entries).must_include "Danger Will Robinson ('info')!"
+      _(written_entries).must_include "Danger Will Robinson ('warn')!"
+      _(written_entries).must_include "Danger Will Robinson ('error')!"
+      _(written_entries).must_include "Danger Will Robinson ('fatal')!"
+      _(written_entries).must_include "Danger Will Robinson ('unknown')!"
     end
 
     it "writes to a log with add and a constant" do
@@ -215,12 +215,12 @@ describe Google::Cloud::Logging, :logging do
       skip "Removed due to inconsistent failure by the service to retrieve written_entries. Reinstate when service stabilizes."
       written_entries = entries_via_backoff("constant").map &:payload
 
-      written_entries.must_include "Danger Will Robinson (DEBUG)!"
-      written_entries.must_include "Danger Will Robinson (INFO)!"
-      written_entries.must_include "Danger Will Robinson (WARN)!"
-      written_entries.must_include "Danger Will Robinson (ERROR)!"
-      written_entries.must_include "Danger Will Robinson (FATAL)!"
-      written_entries.must_include "Danger Will Robinson (UNKNOWN)!"
+      _(written_entries).must_include "Danger Will Robinson (DEBUG)!"
+      _(written_entries).must_include "Danger Will Robinson (INFO)!"
+      _(written_entries).must_include "Danger Will Robinson (WARN)!"
+      _(written_entries).must_include "Danger Will Robinson (ERROR)!"
+      _(written_entries).must_include "Danger Will Robinson (FATAL)!"
+      _(written_entries).must_include "Danger Will Robinson (UNKNOWN)!"
     end
 
     it "writes to a log with named functions" do
@@ -239,12 +239,12 @@ describe Google::Cloud::Logging, :logging do
       skip "Removed due to inconsistent failure by the service to retrieve written_entries. Reinstate when service stabilizes."
       written_entries = entries_via_backoff("method").map &:payload
 
-      written_entries.must_include "Danger Will Robinson (debug)!"
-      written_entries.must_include "Danger Will Robinson (info)!"
-      written_entries.must_include "Danger Will Robinson (warn)!"
-      written_entries.must_include "Danger Will Robinson (error)!"
-      written_entries.must_include "Danger Will Robinson (fatal)!"
-      written_entries.must_include "Danger Will Robinson (unknown)!"
+      _(written_entries).must_include "Danger Will Robinson (debug)!"
+      _(written_entries).must_include "Danger Will Robinson (info)!"
+      _(written_entries).must_include "Danger Will Robinson (warn)!"
+      _(written_entries).must_include "Danger Will Robinson (error)!"
+      _(written_entries).must_include "Danger Will Robinson (fatal)!"
+      _(written_entries).must_include "Danger Will Robinson (unknown)!"
     end
 
     def entries_via_backoff type
@@ -286,12 +286,12 @@ describe Google::Cloud::Logging, :logging do
       skip "Removed due to inconsistent failure by the service to retrieve written_entries. Reinstate when service stabilizes."
       written_entries = entries_via_backoff("symbol").map &:payload
 
-      written_entries.must_include "Danger Will Robinson (:debug)!"
-      written_entries.must_include "Danger Will Robinson (:info)!"
-      written_entries.must_include "Danger Will Robinson (:warn)!"
-      written_entries.must_include "Danger Will Robinson (:error)!"
-      written_entries.must_include "Danger Will Robinson (:fatal)!"
-      written_entries.must_include "Danger Will Robinson (:unknown)!"
+      _(written_entries).must_include "Danger Will Robinson (:debug)!"
+      _(written_entries).must_include "Danger Will Robinson (:info)!"
+      _(written_entries).must_include "Danger Will Robinson (:warn)!"
+      _(written_entries).must_include "Danger Will Robinson (:error)!"
+      _(written_entries).must_include "Danger Will Robinson (:fatal)!"
+      _(written_entries).must_include "Danger Will Robinson (:unknown)!"
     end
 
     it "writes to a log with add and a string" do
@@ -310,12 +310,12 @@ describe Google::Cloud::Logging, :logging do
       skip "Removed due to inconsistent failure by the service to retrieve written_entries. Reinstate when service stabilizes."
       written_entries = entries_via_backoff("string").map &:payload
 
-      written_entries.must_include "Danger Will Robinson ('debug')!"
-      written_entries.must_include "Danger Will Robinson ('info')!"
-      written_entries.must_include "Danger Will Robinson ('warn')!"
-      written_entries.must_include "Danger Will Robinson ('error')!"
-      written_entries.must_include "Danger Will Robinson ('fatal')!"
-      written_entries.must_include "Danger Will Robinson ('unknown')!"
+      _(written_entries).must_include "Danger Will Robinson ('debug')!"
+      _(written_entries).must_include "Danger Will Robinson ('info')!"
+      _(written_entries).must_include "Danger Will Robinson ('warn')!"
+      _(written_entries).must_include "Danger Will Robinson ('error')!"
+      _(written_entries).must_include "Danger Will Robinson ('fatal')!"
+      _(written_entries).must_include "Danger Will Robinson ('unknown')!"
     end
 
     it "writes to a log with add and a constant" do
@@ -334,12 +334,12 @@ describe Google::Cloud::Logging, :logging do
       skip "Removed due to inconsistent failure by the service to retrieve written_entries. Reinstate when service stabilizes."
       written_entries = entries_via_backoff("constant").map &:payload
 
-      written_entries.must_include "Danger Will Robinson (DEBUG)!"
-      written_entries.must_include "Danger Will Robinson (INFO)!"
-      written_entries.must_include "Danger Will Robinson (WARN)!"
-      written_entries.must_include "Danger Will Robinson (ERROR)!"
-      written_entries.must_include "Danger Will Robinson (FATAL)!"
-      written_entries.must_include "Danger Will Robinson (UNKNOWN)!"
+      _(written_entries).must_include "Danger Will Robinson (DEBUG)!"
+      _(written_entries).must_include "Danger Will Robinson (INFO)!"
+      _(written_entries).must_include "Danger Will Robinson (WARN)!"
+      _(written_entries).must_include "Danger Will Robinson (ERROR)!"
+      _(written_entries).must_include "Danger Will Robinson (FATAL)!"
+      _(written_entries).must_include "Danger Will Robinson (UNKNOWN)!"
     end
 
     it "writes to a log with named functions" do
@@ -358,12 +358,12 @@ describe Google::Cloud::Logging, :logging do
       skip "Removed due to inconsistent failure by the service to retrieve written_entries. Reinstate when service stabilizes."
       written_entries = entries_via_backoff("method").map &:payload
 
-      written_entries.must_include "Danger Will Robinson (debug)!"
-      written_entries.must_include "Danger Will Robinson (info)!"
-      written_entries.must_include "Danger Will Robinson (warn)!"
-      written_entries.must_include "Danger Will Robinson (error)!"
-      written_entries.must_include "Danger Will Robinson (fatal)!"
-      written_entries.must_include "Danger Will Robinson (unknown)!"
+      _(written_entries).must_include "Danger Will Robinson (debug)!"
+      _(written_entries).must_include "Danger Will Robinson (info)!"
+      _(written_entries).must_include "Danger Will Robinson (warn)!"
+      _(written_entries).must_include "Danger Will Robinson (error)!"
+      _(written_entries).must_include "Danger Will Robinson (fatal)!"
+      _(written_entries).must_include "Danger Will Robinson (unknown)!"
     end
 
     def entries_via_backoff type

--- a/google-cloud-logging/google-cloud-logging.gemspec
+++ b/google-cloud-logging/google-cloud-logging.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "concurrent-ruby", "~> 1.1"
 
   gem.add_development_dependency "google-style", "~> 1.24.0"
-  gem.add_development_dependency "minitest", "~> 5.10"
+  gem.add_development_dependency "minitest", "~> 5.14"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"
   gem.add_development_dependency "minitest-focus", "~> 1.1"
   gem.add_development_dependency "minitest-rg", "~> 5.2"

--- a/google-cloud-logging/integration/common_logging_test.rb
+++ b/google-cloud-logging/integration/common_logging_test.rb
@@ -27,8 +27,8 @@ describe Google::Cloud::Logging do
       end
     end
 
-    response["logger_class"].must_equal "Google::Cloud::Logging::Logger"
-    response["writer_class"].must_equal "Google::Cloud::Logging::AsyncWriter"
+    _(response["logger_class"]).must_equal "Google::Cloud::Logging::Logger"
+    _(response["writer_class"]).must_equal "Google::Cloud::Logging::AsyncWriter"
   end
 
   it "submits logs on GAE" do
@@ -45,7 +45,7 @@ describe Google::Cloud::Logging do
       logs.length == 1
     end
 
-    logs.length.must_equal 1
+    _(logs.length).must_equal 1
   end
 end
 

--- a/google-cloud-logging/integration/gae/logging_test.rb
+++ b/google-cloud-logging/integration/gae/logging_test.rb
@@ -27,9 +27,9 @@ describe Google::Cloud::Logging do
       end
     end
 
-    response["monitored_resource"]["type"].must_equal "gae_app"
-    response["monitored_resource"]["labels"]["module_id"].wont_be_nil
-    response["monitored_resource"]["labels"]["version_id"].wont_be_nil
+    _(response["monitored_resource"]["type"]).must_equal "gae_app"
+    _(response["monitored_resource"]["labels"]["module_id"]).wont_be_nil
+    _(response["monitored_resource"]["labels"]["version_id"]).wont_be_nil
   end
 
   it "injects trace_id into each log entry" do
@@ -46,6 +46,6 @@ describe Google::Cloud::Logging do
       logs.length == 1
     end
 
-    logs[0]["labels"]["traceId"].wont_be_nil
+    _(logs[0]["labels"]["traceId"]).wont_be_nil
   end
 end

--- a/google-cloud-logging/integration/gke/logging_test.rb
+++ b/google-cloud-logging/integration/gke/logging_test.rb
@@ -27,8 +27,8 @@ describe Google::Cloud::Logging do
       end
     end
 
-    response["monitored_resource"]["type"].must_equal "container"
-    response["monitored_resource"]["labels"]["cluster_name"].wont_be_nil
-    response["monitored_resource"]["labels"]["namespace_id"].wont_be_nil
+    _(response["monitored_resource"]["type"]).must_equal "container"
+    _(response["monitored_resource"]["labels"]["cluster_name"]).wont_be_nil
+    _(response["monitored_resource"]["labels"]["namespace_id"]).wont_be_nil
   end
 end

--- a/google-cloud-logging/test/google/cloud/logging/async_writer/logger_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/async_writer/logger_test.rb
@@ -24,11 +24,11 @@ describe Google::Cloud::Logging::AsyncWriter, :logger, :mock_logging do
 
     async = logging.async_writer
     logger = async.logger log_name, resource, labels
-    logger.must_be_kind_of Google::Cloud::Logging::Logger
-    logger.log_name.must_equal log_name
-    logger.resource.must_equal resource
-    logger.labels.must_equal labels
-    logger.writer.must_be_kind_of Google::Cloud::Logging::AsyncWriter
+    _(logger).must_be_kind_of Google::Cloud::Logging::Logger
+    _(logger.log_name).must_equal log_name
+    _(logger.resource).must_equal resource
+    _(logger.labels).must_equal labels
+    _(logger.writer).must_be_kind_of Google::Cloud::Logging::AsyncWriter
   end
 
   it "creates a ruby logger object with labels using symbols" do
@@ -40,11 +40,11 @@ describe Google::Cloud::Logging::AsyncWriter, :logger, :mock_logging do
 
     async = logging.async_writer
     logger = async.logger log_name, resource, labels
-    logger.must_be_kind_of Google::Cloud::Logging::Logger
-    logger.log_name.must_equal log_name
-    logger.resource.must_equal resource
-    logger.labels.must_equal labels
-    logger.writer.must_be_kind_of Google::Cloud::Logging::AsyncWriter
+    _(logger).must_be_kind_of Google::Cloud::Logging::Logger
+    _(logger.log_name).must_equal log_name
+    _(logger.resource).must_equal resource
+    _(logger.labels).must_equal labels
+    _(logger.writer).must_be_kind_of Google::Cloud::Logging::AsyncWriter
   end
 
   it "creates a ruby logger object without labels" do
@@ -55,10 +55,10 @@ describe Google::Cloud::Logging::AsyncWriter, :logger, :mock_logging do
 
     async = logging.async_writer
     logger = async.logger log_name, resource
-    logger.must_be_kind_of Google::Cloud::Logging::Logger
-    logger.log_name.must_equal log_name
-    logger.resource.must_equal resource
-    logger.labels.must_be :empty?
-    logger.writer.must_be_kind_of Google::Cloud::Logging::AsyncWriter
+    _(logger).must_be_kind_of Google::Cloud::Logging::Logger
+    _(logger.log_name).must_equal log_name
+    _(logger.resource).must_equal resource
+    _(logger.labels).must_be :empty?
+    _(logger.writer).must_be_kind_of Google::Cloud::Logging::AsyncWriter
   end
 end

--- a/google-cloud-logging/test/google/cloud/logging/async_writer_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/async_writer_test.rb
@@ -127,7 +127,7 @@ describe Google::Cloud::Logging::AsyncWriter, :mock_logging do
       async_writer.instance_variable_get(:@batch).nil?
     }
 
-    wait_result.must_equal :completed
+    _(wait_result).must_equal :completed
 
     async_writer.wait! 1
 

--- a/google-cloud-logging/test/google/cloud/logging/convert/hash_to_struct_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/convert/hash_to_struct_test.rb
@@ -19,166 +19,166 @@ describe Google::Cloud::Logging::Convert, :hash_to_struct do
   it "converts empty hash" do
     hash = {}
     struct = Google::Cloud::Logging::Convert.hash_to_struct hash
-    struct.must_be_kind_of Google::Protobuf::Struct
-    struct.fields.must_be_kind_of Google::Protobuf::Map
-    struct.fields.keys.must_be :empty?
+    _(struct).must_be_kind_of Google::Protobuf::Struct
+    _(struct.fields).must_be_kind_of Google::Protobuf::Map
+    _(struct.fields.keys).must_be :empty?
   end
 
   it "converts simple hash" do
     hash = { "foo" => "bar" }
     struct = Google::Cloud::Logging::Convert.hash_to_struct hash
-    struct.must_be_kind_of Google::Protobuf::Struct
-    struct.fields.must_be_kind_of Google::Protobuf::Map
-    struct.fields.keys.wont_be :empty?
+    _(struct).must_be_kind_of Google::Protobuf::Struct
+    _(struct.fields).must_be_kind_of Google::Protobuf::Map
+    _(struct.fields.keys).wont_be :empty?
     bar_value = struct.fields["foo"]
-    bar_value.must_be_kind_of Google::Protobuf::Value
-    bar_value.kind.must_equal :string_value
-    bar_value.string_value.must_equal "bar"
+    _(bar_value).must_be_kind_of Google::Protobuf::Value
+    _(bar_value.kind).must_equal :string_value
+    _(bar_value.string_value).must_equal "bar"
   end
 
   it "converts simple hash of symbols" do
     hash = { foo: :bar }
     struct = Google::Cloud::Logging::Convert.hash_to_struct hash
-    struct.must_be_kind_of Google::Protobuf::Struct
-    struct.fields.must_be_kind_of Google::Protobuf::Map
-    struct.fields.keys.wont_be :empty?
+    _(struct).must_be_kind_of Google::Protobuf::Struct
+    _(struct.fields).must_be_kind_of Google::Protobuf::Map
+    _(struct.fields.keys).wont_be :empty?
     bar_value = struct.fields["foo"]
-    bar_value.must_be_kind_of Google::Protobuf::Value
-    bar_value.kind.must_equal :string_value
-    bar_value.string_value.must_equal "bar"
+    _(bar_value).must_be_kind_of Google::Protobuf::Value
+    _(bar_value.kind).must_equal :string_value
+    _(bar_value.string_value).must_equal "bar"
   end
 
   it "converts hash with nil value" do
     hash = { "foo" => nil }
     struct = Google::Cloud::Logging::Convert.hash_to_struct hash
-    struct.must_be_kind_of Google::Protobuf::Struct
-    struct.fields.must_be_kind_of Google::Protobuf::Map
-    struct.fields.keys.wont_be :empty?
+    _(struct).must_be_kind_of Google::Protobuf::Struct
+    _(struct.fields).must_be_kind_of Google::Protobuf::Map
+    _(struct.fields.keys).wont_be :empty?
     nil_value = struct.fields["foo"]
-    nil_value.must_be_kind_of Google::Protobuf::Value
-    nil_value.kind.must_equal :null_value
-    nil_value.null_value.must_equal :NULL_VALUE
+    _(nil_value).must_be_kind_of Google::Protobuf::Value
+    _(nil_value.kind).must_equal :null_value
+    _(nil_value.null_value).must_equal :NULL_VALUE
   end
 
   it "converts hash with int value" do
     hash = { "foo" => 123 }
     struct = Google::Cloud::Logging::Convert.hash_to_struct hash
-    struct.must_be_kind_of Google::Protobuf::Struct
-    struct.fields.must_be_kind_of Google::Protobuf::Map
-    struct.fields.keys.wont_be :empty?
+    _(struct).must_be_kind_of Google::Protobuf::Struct
+    _(struct.fields).must_be_kind_of Google::Protobuf::Map
+    _(struct.fields.keys).wont_be :empty?
     int_value = struct.fields["foo"]
-    int_value.must_be_kind_of Google::Protobuf::Value
-    int_value.kind.must_equal :number_value
-    int_value.number_value.must_equal 123.0
+    _(int_value).must_be_kind_of Google::Protobuf::Value
+    _(int_value.kind).must_equal :number_value
+    _(int_value.number_value).must_equal 123.0
   end
 
   it "converts hash with float value" do
     hash = { "foo" => 456.789 }
     struct = Google::Cloud::Logging::Convert.hash_to_struct hash
-    struct.must_be_kind_of Google::Protobuf::Struct
-    struct.fields.must_be_kind_of Google::Protobuf::Map
-    struct.fields.keys.wont_be :empty?
+    _(struct).must_be_kind_of Google::Protobuf::Struct
+    _(struct.fields).must_be_kind_of Google::Protobuf::Map
+    _(struct.fields.keys).wont_be :empty?
     float_value = struct.fields["foo"]
-    float_value.must_be_kind_of Google::Protobuf::Value
-    float_value.kind.must_equal :number_value
-    float_value.number_value.must_equal 456.789
+    _(float_value).must_be_kind_of Google::Protobuf::Value
+    _(float_value.kind).must_equal :number_value
+    _(float_value.number_value).must_equal 456.789
   end
 
   it "converts hash with true value" do
     hash = { "foo" => true }
     struct = Google::Cloud::Logging::Convert.hash_to_struct hash
-    struct.must_be_kind_of Google::Protobuf::Struct
-    struct.fields.must_be_kind_of Google::Protobuf::Map
-    struct.fields.keys.wont_be :empty?
+    _(struct).must_be_kind_of Google::Protobuf::Struct
+    _(struct.fields).must_be_kind_of Google::Protobuf::Map
+    _(struct.fields.keys).wont_be :empty?
     true_value = struct.fields["foo"]
-    true_value.must_be_kind_of Google::Protobuf::Value
-    true_value.kind.must_equal :bool_value
-    true_value.bool_value.must_equal true
+    _(true_value).must_be_kind_of Google::Protobuf::Value
+    _(true_value.kind).must_equal :bool_value
+    _(true_value.bool_value).must_equal true
   end
 
   it "converts hash with false value" do
     hash = { "foo" => false }
     struct = Google::Cloud::Logging::Convert.hash_to_struct hash
-    struct.must_be_kind_of Google::Protobuf::Struct
-    struct.fields.must_be_kind_of Google::Protobuf::Map
-    struct.fields.keys.wont_be :empty?
+    _(struct).must_be_kind_of Google::Protobuf::Struct
+    _(struct.fields).must_be_kind_of Google::Protobuf::Map
+    _(struct.fields.keys).wont_be :empty?
     false_value = struct.fields["foo"]
-    false_value.must_be_kind_of Google::Protobuf::Value
-    false_value.kind.must_equal :bool_value
-    false_value.bool_value.must_equal false
+    _(false_value).must_be_kind_of Google::Protobuf::Value
+    _(false_value.kind).must_equal :bool_value
+    _(false_value.bool_value).must_equal false
   end
 
   it "converts hash with hash value" do
     hash = { "foo" => { bar: :baz } }
     struct = Google::Cloud::Logging::Convert.hash_to_struct hash
-    struct.must_be_kind_of Google::Protobuf::Struct
-    struct.fields.must_be_kind_of Google::Protobuf::Map
-    struct.fields.keys.wont_be :empty?
+    _(struct).must_be_kind_of Google::Protobuf::Struct
+    _(struct.fields).must_be_kind_of Google::Protobuf::Map
+    _(struct.fields.keys).wont_be :empty?
     hash_value = struct.fields["foo"]
-    hash_value.must_be_kind_of Google::Protobuf::Value
-    hash_value.kind.must_equal :struct_value
-    hash_value.struct_value.fields.must_be_kind_of Google::Protobuf::Map
-    hash_value.struct_value.fields["bar"].must_be_kind_of Google::Protobuf::Value
-    hash_value.struct_value.fields["bar"].kind.must_equal :string_value
-    hash_value.struct_value.fields["bar"].string_value.must_equal "baz"
+    _(hash_value).must_be_kind_of Google::Protobuf::Value
+    _(hash_value.kind).must_equal :struct_value
+    _(hash_value.struct_value.fields).must_be_kind_of Google::Protobuf::Map
+    _(hash_value.struct_value.fields["bar"]).must_be_kind_of Google::Protobuf::Value
+    _(hash_value.struct_value.fields["bar"].kind).must_equal :string_value
+    _(hash_value.struct_value.fields["bar"].string_value).must_equal "baz"
   end
 
   it "converts hash with array value" do
     hash = { "foo" => ["hello", "world"] }
     struct = Google::Cloud::Logging::Convert.hash_to_struct hash
-    struct.must_be_kind_of Google::Protobuf::Struct
-    struct.fields.must_be_kind_of Google::Protobuf::Map
-    struct.fields.keys.wont_be :empty?
+    _(struct).must_be_kind_of Google::Protobuf::Struct
+    _(struct.fields).must_be_kind_of Google::Protobuf::Map
+    _(struct.fields.keys).wont_be :empty?
     array_value = struct.fields["foo"]
-    array_value.must_be_kind_of Google::Protobuf::Value
-    array_value.kind.must_equal :list_value
-    array_value.list_value.must_be_kind_of Google::Protobuf::ListValue
-    array_value.list_value.values.wont_be :empty?
-    array_value.list_value.values.first.must_equal Google::Protobuf::Value.new(string_value: "hello")
-    array_value.list_value.values.last.must_equal Google::Protobuf::Value.new(string_value: "world")
+    _(array_value).must_be_kind_of Google::Protobuf::Value
+    _(array_value.kind).must_equal :list_value
+    _(array_value.list_value).must_be_kind_of Google::Protobuf::ListValue
+    _(array_value.list_value.values).wont_be :empty?
+    _(array_value.list_value.values.first).must_equal Google::Protobuf::Value.new(string_value: "hello")
+    _(array_value.list_value.values.last).must_equal Google::Protobuf::Value.new(string_value: "world")
   end
 
   it "converts complex hash" do
     hash = { foo: nil, bar: true, baz: :bif, pi: 3.14, meta: { foo: :bar }, msg: ["hello", "world"] }
     struct = Google::Cloud::Logging::Convert.hash_to_struct hash
-    struct.must_be_kind_of Google::Protobuf::Struct
-    struct.fields.must_be_kind_of Google::Protobuf::Map
-    struct.fields.keys.wont_be :empty?
+    _(struct).must_be_kind_of Google::Protobuf::Struct
+    _(struct.fields).must_be_kind_of Google::Protobuf::Map
+    _(struct.fields.keys).wont_be :empty?
 
     nil_value = struct.fields["foo"]
-    nil_value.must_be_kind_of Google::Protobuf::Value
-    nil_value.kind.must_equal :null_value
-    nil_value.null_value.must_equal :NULL_VALUE
+    _(nil_value).must_be_kind_of Google::Protobuf::Value
+    _(nil_value.kind).must_equal :null_value
+    _(nil_value.null_value).must_equal :NULL_VALUE
 
     true_value = struct.fields["bar"]
-    true_value.must_be_kind_of Google::Protobuf::Value
-    true_value.kind.must_equal :bool_value
-    true_value.bool_value.must_equal true
+    _(true_value).must_be_kind_of Google::Protobuf::Value
+    _(true_value.kind).must_equal :bool_value
+    _(true_value.bool_value).must_equal true
 
     string_value = struct.fields["baz"]
-    string_value.must_be_kind_of Google::Protobuf::Value
-    string_value.kind.must_equal :string_value
-    string_value.string_value.must_equal "bif"
+    _(string_value).must_be_kind_of Google::Protobuf::Value
+    _(string_value.kind).must_equal :string_value
+    _(string_value.string_value).must_equal "bif"
 
     num_value = struct.fields["pi"]
-    num_value.must_be_kind_of Google::Protobuf::Value
-    num_value.kind.must_equal :number_value
-    num_value.number_value.must_equal 3.14
+    _(num_value).must_be_kind_of Google::Protobuf::Value
+    _(num_value.kind).must_equal :number_value
+    _(num_value.number_value).must_equal 3.14
 
     hash_value = struct.fields["meta"]
-    hash_value.must_be_kind_of Google::Protobuf::Value
-    hash_value.kind.must_equal :struct_value
-    hash_value.struct_value.fields.must_be_kind_of Google::Protobuf::Map
-    hash_value.struct_value.fields["foo"].must_be_kind_of Google::Protobuf::Value
-    hash_value.struct_value.fields["foo"].kind.must_equal :string_value
-    hash_value.struct_value.fields["foo"].string_value.must_equal "bar"
+    _(hash_value).must_be_kind_of Google::Protobuf::Value
+    _(hash_value.kind).must_equal :struct_value
+    _(hash_value.struct_value.fields).must_be_kind_of Google::Protobuf::Map
+    _(hash_value.struct_value.fields["foo"]).must_be_kind_of Google::Protobuf::Value
+    _(hash_value.struct_value.fields["foo"].kind).must_equal :string_value
+    _(hash_value.struct_value.fields["foo"].string_value).must_equal "bar"
 
     array_value = struct.fields["msg"]
-    array_value.must_be_kind_of Google::Protobuf::Value
-    array_value.kind.must_equal :list_value
-    array_value.list_value.must_be_kind_of Google::Protobuf::ListValue
-    array_value.list_value.values.wont_be :empty?
-    array_value.list_value.values.first.must_equal Google::Protobuf::Value.new(string_value: "hello")
-    array_value.list_value.values.last.must_equal Google::Protobuf::Value.new(string_value: "world")
+    _(array_value).must_be_kind_of Google::Protobuf::Value
+    _(array_value.kind).must_equal :list_value
+    _(array_value.list_value).must_be_kind_of Google::Protobuf::ListValue
+    _(array_value.list_value.values).wont_be :empty?
+    _(array_value.list_value.values.first).must_equal Google::Protobuf::Value.new(string_value: "hello")
+    _(array_value.list_value.values.last).must_equal Google::Protobuf::Value.new(string_value: "world")
   end
 end

--- a/google-cloud-logging/test/google/cloud/logging/convert/object_to_value_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/convert/object_to_value_test.rb
@@ -25,31 +25,31 @@ describe Google::Cloud::Logging::Convert, :object_to_value do
 
   it "converts nil object" do
     value = Google::Cloud::Logging::Convert.object_to_value nil
-    value.must_equal null_value
+    _(value).must_equal null_value
   end
 
   it "converts true object" do
     value = Google::Cloud::Logging::Convert.object_to_value true
-    value.must_equal true_value
+    _(value).must_equal true_value
   end
 
   it "converts string object" do
     value = Google::Cloud::Logging::Convert.object_to_value "bif"
-    value.must_equal string_value
+    _(value).must_equal string_value
   end
 
   it "converts num object" do
     value = Google::Cloud::Logging::Convert.object_to_value 3.14
-    value.must_equal num_value
+    _(value).must_equal num_value
   end
 
   it "converts struct object" do
     value = Google::Cloud::Logging::Convert.object_to_value({ "foo" => "bar" })
-    value.must_equal struct_value
+    _(value).must_equal struct_value
   end
 
   it "converts list object" do
     value = Google::Cloud::Logging::Convert.object_to_value ["hello", "world"]
-    value.must_equal list_value
+    _(value).must_equal list_value
   end
 end

--- a/google-cloud-logging/test/google/cloud/logging/entry/http_request_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/entry/http_request_test.rb
@@ -19,46 +19,46 @@ describe Google::Cloud::Logging::Entry::HttpRequest, :mock_logging do
   let(:http_request) { Google::Cloud::Logging::Entry::HttpRequest.from_grpc http_request_grpc }
 
   it "has attributes" do
-    http_request.request_method.must_equal "GET"
-    http_request.url.must_equal "http://test.local/foo?bar=baz"
-    http_request.size.must_equal 123
-    http_request.status.must_equal 200
-    http_request.response_size.must_equal 456
-    http_request.user_agent.must_equal "google-cloud/1.0.0"
-    http_request.remote_ip.must_equal "127.0.0.1"
-    http_request.referer.must_equal "http://test.local/referer"
-    http_request.cache_hit.must_equal false
-    http_request.validated.must_equal false
+    _(http_request.request_method).must_equal "GET"
+    _(http_request.url).must_equal "http://test.local/foo?bar=baz"
+    _(http_request.size).must_equal 123
+    _(http_request.status).must_equal 200
+    _(http_request.response_size).must_equal 456
+    _(http_request.user_agent).must_equal "google-cloud/1.0.0"
+    _(http_request.remote_ip).must_equal "127.0.0.1"
+    _(http_request.referer).must_equal "http://test.local/referer"
+    _(http_request.cache_hit).must_equal false
+    _(http_request.validated).must_equal false
   end
 
   it "method alias (deprecated)" do
-    http_request.request_method.must_equal "GET"
-    http_request.method.must_equal http_request.request_method
+    _(http_request.request_method).must_equal "GET"
+    _(http_request.method).must_equal http_request.request_method
 
     http_request.method = "POST"
 
-    http_request.request_method.must_equal "POST"
-    http_request.method.must_equal http_request.request_method
+    _(http_request.request_method).must_equal "POST"
+    _(http_request.method).must_equal http_request.request_method
   end
 
   it "method alias doesn't stomp on Object#method" do
     actual_method = http_request.method :validated=
-    actual_method.must_be_kind_of Method
-    actual_method.name.must_equal :validated=
+    _(actual_method).must_be_kind_of Method
+    _(actual_method.name).must_equal :validated=
 
     # This is the real method object, which can be used.
-    http_request.validated.must_equal false
+    _(http_request.validated).must_equal false
     actual_method.to_proc.call true
-    http_request.validated.must_equal true
+    _(http_request.validated).must_equal true
   end
 
   it "method alias being passed nil calls Object#method" do
-    http_request.request_method.must_equal "GET"
-    http_request.method.must_equal http_request.request_method
+    _(http_request.request_method).must_equal "GET"
+    _(http_request.method).must_equal http_request.request_method
 
     err = expect do
       http_request.method nil
     end.must_raise TypeError
-    err.message.must_include "nil is not a symbol"
+    _(err.message).must_include "nil is not a symbol"
   end
 end

--- a/google-cloud-logging/test/google/cloud/logging/entry/operation_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/entry/operation_test.rb
@@ -19,9 +19,9 @@ describe Google::Cloud::Logging::Entry::Operation, :mock_logging do
   let(:operation) { Google::Cloud::Logging::Entry::Operation.from_grpc operation_grpc }
 
   it "has attributes" do
-    operation.id.must_equal "xyz789"
-    operation.producer.must_equal "MyApp.MyClass#my_method"
-    operation.first.must_equal false
-    operation.last.must_equal false
+    _(operation.id).must_equal "xyz789"
+    _(operation.producer).must_equal "MyApp.MyClass#my_method"
+    _(operation.first).must_equal false
+    _(operation.last).must_equal false
   end
 end

--- a/google-cloud-logging/test/google/cloud/logging/entry/severity_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/entry/severity_test.rb
@@ -20,245 +20,245 @@ describe Google::Cloud::Logging::Entry, :severity, :mock_logging do
 
   it "has the correct helpers for DEFAULT" do
     entry.severity = :DEFAULT
-    entry.must_be :default?
-    entry.wont_be :debug?
-    entry.wont_be :info?
-    entry.wont_be :notice?
-    entry.wont_be :warning?
-    entry.wont_be :error?
-    entry.wont_be :critical?
-    entry.wont_be :alert?
-    entry.wont_be :emergency?
+    _(entry).must_be :default?
+    _(entry).wont_be :debug?
+    _(entry).wont_be :info?
+    _(entry).wont_be :notice?
+    _(entry).wont_be :warning?
+    _(entry).wont_be :error?
+    _(entry).wont_be :critical?
+    _(entry).wont_be :alert?
+    _(entry).wont_be :emergency?
   end
 
   it "has the correct helpers for DEBUG" do
     entry.severity = :DEBUG
-    entry.wont_be :default?
-    entry.must_be :debug?
-    entry.wont_be :info?
-    entry.wont_be :notice?
-    entry.wont_be :warning?
-    entry.wont_be :error?
-    entry.wont_be :critical?
-    entry.wont_be :alert?
-    entry.wont_be :emergency?
+    _(entry).wont_be :default?
+    _(entry).must_be :debug?
+    _(entry).wont_be :info?
+    _(entry).wont_be :notice?
+    _(entry).wont_be :warning?
+    _(entry).wont_be :error?
+    _(entry).wont_be :critical?
+    _(entry).wont_be :alert?
+    _(entry).wont_be :emergency?
   end
 
   it "has the correct helpers for INFO" do
     entry.severity = :INFO
-    entry.wont_be :default?
-    entry.wont_be :debug?
-    entry.must_be :info?
-    entry.wont_be :notice?
-    entry.wont_be :warning?
-    entry.wont_be :error?
-    entry.wont_be :critical?
-    entry.wont_be :alert?
-    entry.wont_be :emergency?
+    _(entry).wont_be :default?
+    _(entry).wont_be :debug?
+    _(entry).must_be :info?
+    _(entry).wont_be :notice?
+    _(entry).wont_be :warning?
+    _(entry).wont_be :error?
+    _(entry).wont_be :critical?
+    _(entry).wont_be :alert?
+    _(entry).wont_be :emergency?
   end
 
   it "has the correct helpers for NOTICE" do
     entry.severity = :NOTICE
-    entry.wont_be :default?
-    entry.wont_be :debug?
-    entry.wont_be :info?
-    entry.must_be :notice?
-    entry.wont_be :warning?
-    entry.wont_be :error?
-    entry.wont_be :critical?
-    entry.wont_be :alert?
-    entry.wont_be :emergency?
+    _(entry).wont_be :default?
+    _(entry).wont_be :debug?
+    _(entry).wont_be :info?
+    _(entry).must_be :notice?
+    _(entry).wont_be :warning?
+    _(entry).wont_be :error?
+    _(entry).wont_be :critical?
+    _(entry).wont_be :alert?
+    _(entry).wont_be :emergency?
   end
 
   it "has the correct helpers for WARNING" do
     entry.severity = :WARNING
-    entry.wont_be :default?
-    entry.wont_be :debug?
-    entry.wont_be :info?
-    entry.wont_be :notice?
-    entry.must_be :warning?
-    entry.wont_be :error?
-    entry.wont_be :critical?
-    entry.wont_be :alert?
-    entry.wont_be :emergency?
+    _(entry).wont_be :default?
+    _(entry).wont_be :debug?
+    _(entry).wont_be :info?
+    _(entry).wont_be :notice?
+    _(entry).must_be :warning?
+    _(entry).wont_be :error?
+    _(entry).wont_be :critical?
+    _(entry).wont_be :alert?
+    _(entry).wont_be :emergency?
   end
 
   it "has the correct helpers for ERROR" do
     entry.severity = :ERROR
-    entry.wont_be :default?
-    entry.wont_be :debug?
-    entry.wont_be :info?
-    entry.wont_be :notice?
-    entry.wont_be :warning?
-    entry.must_be :error?
-    entry.wont_be :critical?
-    entry.wont_be :alert?
-    entry.wont_be :emergency?
+    _(entry).wont_be :default?
+    _(entry).wont_be :debug?
+    _(entry).wont_be :info?
+    _(entry).wont_be :notice?
+    _(entry).wont_be :warning?
+    _(entry).must_be :error?
+    _(entry).wont_be :critical?
+    _(entry).wont_be :alert?
+    _(entry).wont_be :emergency?
   end
 
   it "has the correct helpers for CRITICAL" do
     entry.severity = :CRITICAL
-    entry.wont_be :default?
-    entry.wont_be :debug?
-    entry.wont_be :info?
-    entry.wont_be :notice?
-    entry.wont_be :warning?
-    entry.wont_be :error?
-    entry.must_be :critical?
-    entry.wont_be :alert?
-    entry.wont_be :emergency?
+    _(entry).wont_be :default?
+    _(entry).wont_be :debug?
+    _(entry).wont_be :info?
+    _(entry).wont_be :notice?
+    _(entry).wont_be :warning?
+    _(entry).wont_be :error?
+    _(entry).must_be :critical?
+    _(entry).wont_be :alert?
+    _(entry).wont_be :emergency?
   end
 
   it "has the correct helpers for ALERT" do
     entry.severity = :ALERT
-    entry.wont_be :default?
-    entry.wont_be :debug?
-    entry.wont_be :info?
-    entry.wont_be :notice?
-    entry.wont_be :warning?
-    entry.wont_be :error?
-    entry.wont_be :critical?
-    entry.must_be :alert?
-    entry.wont_be :emergency?
+    _(entry).wont_be :default?
+    _(entry).wont_be :debug?
+    _(entry).wont_be :info?
+    _(entry).wont_be :notice?
+    _(entry).wont_be :warning?
+    _(entry).wont_be :error?
+    _(entry).wont_be :critical?
+    _(entry).must_be :alert?
+    _(entry).wont_be :emergency?
   end
 
   it "has the correct helpers for EMERGENCY" do
     entry.severity = :EMERGENCY
-    entry.wont_be :default?
-    entry.wont_be :debug?
-    entry.wont_be :info?
-    entry.wont_be :notice?
-    entry.wont_be :warning?
-    entry.wont_be :error?
-    entry.wont_be :critical?
-    entry.wont_be :alert?
-    entry.must_be :emergency?
+    _(entry).wont_be :default?
+    _(entry).wont_be :debug?
+    _(entry).wont_be :info?
+    _(entry).wont_be :notice?
+    _(entry).wont_be :warning?
+    _(entry).wont_be :error?
+    _(entry).wont_be :critical?
+    _(entry).wont_be :alert?
+    _(entry).must_be :emergency?
   end
 
   it "allows DEFAULT to be set" do
     entry.severity = :DEBUG
-    entry.wont_be :default?
+    _(entry).wont_be :default?
     entry.default!
-    entry.must_be :default?
-    entry.wont_be :debug?
-    entry.wont_be :info?
-    entry.wont_be :notice?
-    entry.wont_be :warning?
-    entry.wont_be :error?
-    entry.wont_be :critical?
-    entry.wont_be :alert?
-    entry.wont_be :emergency?
+    _(entry).must_be :default?
+    _(entry).wont_be :debug?
+    _(entry).wont_be :info?
+    _(entry).wont_be :notice?
+    _(entry).wont_be :warning?
+    _(entry).wont_be :error?
+    _(entry).wont_be :critical?
+    _(entry).wont_be :alert?
+    _(entry).wont_be :emergency?
   end
 
   it "allows DEBUG to be set" do
-    entry.wont_be :debug?
+    _(entry).wont_be :debug?
     entry.debug!
-    entry.wont_be :default?
-    entry.must_be :debug?
-    entry.wont_be :info?
-    entry.wont_be :notice?
-    entry.wont_be :warning?
-    entry.wont_be :error?
-    entry.wont_be :critical?
-    entry.wont_be :alert?
-    entry.wont_be :emergency?
+    _(entry).wont_be :default?
+    _(entry).must_be :debug?
+    _(entry).wont_be :info?
+    _(entry).wont_be :notice?
+    _(entry).wont_be :warning?
+    _(entry).wont_be :error?
+    _(entry).wont_be :critical?
+    _(entry).wont_be :alert?
+    _(entry).wont_be :emergency?
   end
 
   it "allows INFO to be set" do
-    entry.wont_be :info?
+    _(entry).wont_be :info?
     entry.info!
-    entry.wont_be :default?
-    entry.wont_be :debug?
-    entry.must_be :info?
-    entry.wont_be :notice?
-    entry.wont_be :warning?
-    entry.wont_be :error?
-    entry.wont_be :critical?
-    entry.wont_be :alert?
-    entry.wont_be :emergency?
+    _(entry).wont_be :default?
+    _(entry).wont_be :debug?
+    _(entry).must_be :info?
+    _(entry).wont_be :notice?
+    _(entry).wont_be :warning?
+    _(entry).wont_be :error?
+    _(entry).wont_be :critical?
+    _(entry).wont_be :alert?
+    _(entry).wont_be :emergency?
   end
 
   it "allows NOTICE to be set" do
-    entry.wont_be :notice?
+    _(entry).wont_be :notice?
     entry.notice!
-    entry.wont_be :default?
-    entry.wont_be :debug?
-    entry.wont_be :info?
-    entry.must_be :notice?
-    entry.wont_be :warning?
-    entry.wont_be :error?
-    entry.wont_be :critical?
-    entry.wont_be :alert?
-    entry.wont_be :emergency?
+    _(entry).wont_be :default?
+    _(entry).wont_be :debug?
+    _(entry).wont_be :info?
+    _(entry).must_be :notice?
+    _(entry).wont_be :warning?
+    _(entry).wont_be :error?
+    _(entry).wont_be :critical?
+    _(entry).wont_be :alert?
+    _(entry).wont_be :emergency?
   end
 
   it "allows WARNING to be set" do
-    entry.wont_be :warning?
+    _(entry).wont_be :warning?
     entry.warning!
-    entry.wont_be :default?
-    entry.wont_be :debug?
-    entry.wont_be :info?
-    entry.wont_be :notice?
-    entry.must_be :warning?
-    entry.wont_be :error?
-    entry.wont_be :critical?
-    entry.wont_be :alert?
-    entry.wont_be :emergency?
+    _(entry).wont_be :default?
+    _(entry).wont_be :debug?
+    _(entry).wont_be :info?
+    _(entry).wont_be :notice?
+    _(entry).must_be :warning?
+    _(entry).wont_be :error?
+    _(entry).wont_be :critical?
+    _(entry).wont_be :alert?
+    _(entry).wont_be :emergency?
   end
 
   it "allows ERROR to be set" do
-    entry.wont_be :error?
+    _(entry).wont_be :error?
     entry.error!
-    entry.wont_be :default?
-    entry.wont_be :debug?
-    entry.wont_be :info?
-    entry.wont_be :notice?
-    entry.wont_be :warning?
-    entry.must_be :error?
-    entry.wont_be :critical?
-    entry.wont_be :alert?
-    entry.wont_be :emergency?
+    _(entry).wont_be :default?
+    _(entry).wont_be :debug?
+    _(entry).wont_be :info?
+    _(entry).wont_be :notice?
+    _(entry).wont_be :warning?
+    _(entry).must_be :error?
+    _(entry).wont_be :critical?
+    _(entry).wont_be :alert?
+    _(entry).wont_be :emergency?
   end
 
   it "allows CRITICAL to be set" do
-    entry.wont_be :critical?
+    _(entry).wont_be :critical?
     entry.critical!
-    entry.wont_be :default?
-    entry.wont_be :debug?
-    entry.wont_be :info?
-    entry.wont_be :notice?
-    entry.wont_be :warning?
-    entry.wont_be :error?
-    entry.must_be :critical?
-    entry.wont_be :alert?
-    entry.wont_be :emergency?
+    _(entry).wont_be :default?
+    _(entry).wont_be :debug?
+    _(entry).wont_be :info?
+    _(entry).wont_be :notice?
+    _(entry).wont_be :warning?
+    _(entry).wont_be :error?
+    _(entry).must_be :critical?
+    _(entry).wont_be :alert?
+    _(entry).wont_be :emergency?
   end
 
   it "allows ALERT to be set" do
-    entry.wont_be :alert?
+    _(entry).wont_be :alert?
     entry.alert!
-    entry.wont_be :default?
-    entry.wont_be :debug?
-    entry.wont_be :info?
-    entry.wont_be :notice?
-    entry.wont_be :warning?
-    entry.wont_be :error?
-    entry.wont_be :critical?
-    entry.must_be :alert?
-    entry.wont_be :emergency?
+    _(entry).wont_be :default?
+    _(entry).wont_be :debug?
+    _(entry).wont_be :info?
+    _(entry).wont_be :notice?
+    _(entry).wont_be :warning?
+    _(entry).wont_be :error?
+    _(entry).wont_be :critical?
+    _(entry).must_be :alert?
+    _(entry).wont_be :emergency?
   end
 
   it "allows EMERGENCY to be set" do
-    entry.wont_be :emergency?
+    _(entry).wont_be :emergency?
     entry.emergency!
-    entry.wont_be :default?
-    entry.wont_be :debug?
-    entry.wont_be :info?
-    entry.wont_be :notice?
-    entry.wont_be :warning?
-    entry.wont_be :error?
-    entry.wont_be :critical?
-    entry.wont_be :alert?
-    entry.must_be :emergency?
+    _(entry).wont_be :default?
+    _(entry).wont_be :debug?
+    _(entry).wont_be :info?
+    _(entry).wont_be :notice?
+    _(entry).wont_be :warning?
+    _(entry).wont_be :error?
+    _(entry).wont_be :critical?
+    _(entry).wont_be :alert?
+    _(entry).must_be :emergency?
   end
 end

--- a/google-cloud-logging/test/google/cloud/logging/entry/to_grpc_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/entry/to_grpc_test.rb
@@ -23,25 +23,25 @@ describe Google::Cloud::Logging::Entry, :to_grpc, :mock_logging do
   end
 
   it "returns the correct data when empty" do
-    entry.must_be :empty?
+    _(entry).must_be :empty?
     # empty even though insert_id has a value
-    entry.insert_id.must_equal default_insert_id
+    _(entry.insert_id).must_equal default_insert_id
 
     grpc = entry.to_grpc
 
-    grpc.log_name.must_be :empty?
-    grpc.resource.must_be :nil?
-    grpc.severity.must_equal :DEFAULT
-    grpc.timestamp.must_be :nil?
-    grpc.insert_id.must_equal default_insert_id
-    Google::Cloud::Logging::Convert.map_to_hash(grpc.labels).must_be :empty?
-    grpc.text_payload.must_be :empty?
-    grpc.json_payload.must_be :nil?
-    grpc.proto_payload.must_be :nil?
-    grpc.http_request.must_be :nil?
-    grpc.operation.must_be :nil?
-    grpc.trace.must_be :empty?
-    grpc.source_location.must_be :nil?
+    _(grpc.log_name).must_be :empty?
+    _(grpc.resource).must_be :nil?
+    _(grpc.severity).must_equal :DEFAULT
+    _(grpc.timestamp).must_be :nil?
+    _(grpc.insert_id).must_equal default_insert_id
+    _(Google::Cloud::Logging::Convert.map_to_hash(grpc.labels)).must_be :empty?
+    _(grpc.text_payload).must_be :empty?
+    _(grpc.json_payload).must_be :nil?
+    _(grpc.proto_payload).must_be :nil?
+    _(grpc.http_request).must_be :nil?
+    _(grpc.operation).must_be :nil?
+    _(grpc.trace).must_be :empty?
+    _(grpc.source_location).must_be :nil?
   end
 
   it "returns the correct data when data is added" do
@@ -83,41 +83,41 @@ describe Google::Cloud::Logging::Entry, :to_grpc, :mock_logging do
 
     grpc = entry.to_grpc
 
-    grpc.log_name.must_equal "projects/test/logs/testlog"
+    _(grpc.log_name).must_equal "projects/test/logs/testlog"
 
-    grpc.resource.type.must_equal        "webapp_server"
-    Google::Cloud::Logging::Convert.map_to_hash(grpc.resource.labels).must_equal({ "description" => "The server is running in test",
+    _(grpc.resource.type).must_equal        "webapp_server"
+    _(Google::Cloud::Logging::Convert.map_to_hash(grpc.resource.labels)).must_equal({ "description" => "The server is running in test",
                                                                      "env"         => "test",
                                                                      "valueType"   => "STRING" })
 
-    grpc.severity.must_equal :ERROR
-    grpc.timestamp.must_equal Google::Protobuf::Timestamp.new(seconds: Time.parse("2016-01-02T03:04:05Z").to_i)
-    grpc.insert_id.must_equal "insert123"
-    Google::Cloud::Logging::Convert.map_to_hash(grpc.labels).must_equal("env" => "test", "fizz" => "buzz")
-    grpc.text_payload.must_equal "payload"
-    grpc.json_payload.must_be :nil?
-    grpc.proto_payload.must_be :nil?
+    _(grpc.severity).must_equal :ERROR
+    _(grpc.timestamp).must_equal Google::Protobuf::Timestamp.new(seconds: Time.parse("2016-01-02T03:04:05Z").to_i)
+    _(grpc.insert_id).must_equal "insert123"
+    _(Google::Cloud::Logging::Convert.map_to_hash(grpc.labels)).must_equal("env" => "test", "fizz" => "buzz")
+    _(grpc.text_payload).must_equal "payload"
+    _(grpc.json_payload).must_be :nil?
+    _(grpc.proto_payload).must_be :nil?
 
-    grpc.http_request.request_method.must_equal "POST"
-    grpc.http_request.request_url.must_equal "http://test.local/fizz?buzz"
-    grpc.http_request.request_size.must_equal 456
-    grpc.http_request.status.must_equal 201
-    grpc.http_request.response_size.must_equal 345
-    grpc.http_request.user_agent.must_equal "google-cloud/1.0.0"
-    grpc.http_request.remote_ip.must_equal "127.0.0.1"
-    grpc.http_request.referer.must_equal "http://test.local/referer"
-    grpc.http_request.cache_hit.must_equal true
-    grpc.http_request.cache_validated_with_origin_server.must_equal false
+    _(grpc.http_request.request_method).must_equal "POST"
+    _(grpc.http_request.request_url).must_equal "http://test.local/fizz?buzz"
+    _(grpc.http_request.request_size).must_equal 456
+    _(grpc.http_request.status).must_equal 201
+    _(grpc.http_request.response_size).must_equal 345
+    _(grpc.http_request.user_agent).must_equal "google-cloud/1.0.0"
+    _(grpc.http_request.remote_ip).must_equal "127.0.0.1"
+    _(grpc.http_request.referer).must_equal "http://test.local/referer"
+    _(grpc.http_request.cache_hit).must_equal true
+    _(grpc.http_request.cache_validated_with_origin_server).must_equal false
 
-    grpc.operation.id.must_equal "abc123"
-    grpc.operation.producer.must_equal "NewApp.NewClass#new_method"
-    grpc.operation.first.must_equal true
-    grpc.operation.last.must_equal false
+    _(grpc.operation.id).must_equal "abc123"
+    _(grpc.operation.producer).must_equal "NewApp.NewClass#new_method"
+    _(grpc.operation.first).must_equal true
+    _(grpc.operation.last).must_equal false
 
-    grpc.trace.must_equal "projects/my-projectid/traces/06796866738c859f2f19b7cfb3214824"
+    _(grpc.trace).must_equal "projects/my-projectid/traces/06796866738c859f2f19b7cfb3214824"
 
-    grpc.source_location.file.must_equal "my_app/my_class.rb"
-    grpc.source_location.line.must_equal 123
-    grpc.source_location.function.must_equal "#my_method"
+    _(grpc.source_location.file).must_equal "my_app/my_class.rb"
+    _(grpc.source_location.line).must_equal 123
+    _(grpc.source_location.function).must_equal "#my_method"
   end
 end

--- a/google-cloud-logging/test/google/cloud/logging/entry_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/entry_test.rb
@@ -20,20 +20,20 @@ describe Google::Cloud::Logging::Entry, :mock_logging do
   let(:entry) { Google::Cloud::Logging::Entry.from_grpc entry_grpc }
 
   it "knows its attributes" do
-    entry.log_name.must_equal             entry_hash[:log_name]
-    entry.resource.must_be_kind_of        Google::Cloud::Logging::Resource
-    entry.timestamp.to_i.must_equal       Time.parse("2014-10-02T15:01:23.045123456Z").to_i
-    entry.severity.must_equal             entry_hash[:severity]
-    entry.insert_id.must_equal            entry_hash[:insert_id]
-    entry.labels.must_be_kind_of          Hash
-    entry.labels["env"].must_equal        "production"
-    entry.labels["foo"].must_equal        "bar"
-    entry.payload.must_equal              "payload"
-    entry.http_request.must_be_kind_of    Google::Cloud::Logging::Entry::HttpRequest
-    entry.operation.must_be_kind_of       Google::Cloud::Logging::Entry::Operation
-    entry.trace.must_equal                "projects/my-projectid/traces/06796866738c859f2f19b7cfb3214824"
-    entry.source_location.must_be_kind_of       Google::Cloud::Logging::Entry::SourceLocation
-    entry.trace_sampled.must_equal        true
+    _(entry.log_name).must_equal             entry_hash[:log_name]
+    _(entry.resource).must_be_kind_of        Google::Cloud::Logging::Resource
+    _(entry.timestamp.to_i).must_equal       Time.parse("2014-10-02T15:01:23.045123456Z").to_i
+    _(entry.severity).must_equal             entry_hash[:severity]
+    _(entry.insert_id).must_equal            entry_hash[:insert_id]
+    _(entry.labels).must_be_kind_of          Hash
+    _(entry.labels["env"]).must_equal        "production"
+    _(entry.labels["foo"]).must_equal        "bar"
+    _(entry.payload).must_equal              "payload"
+    _(entry.http_request).must_be_kind_of    Google::Cloud::Logging::Entry::HttpRequest
+    _(entry.operation).must_be_kind_of       Google::Cloud::Logging::Entry::Operation
+    _(entry.trace).must_equal                "projects/my-projectid/traces/06796866738c859f2f19b7cfb3214824"
+    _(entry.source_location).must_be_kind_of       Google::Cloud::Logging::Entry::SourceLocation
+    _(entry.trace_sampled).must_equal        true
   end
 
   it "timestamp gives the correct time when a timestamp is present" do
@@ -41,121 +41,121 @@ describe Google::Cloud::Logging::Entry, :mock_logging do
     entry_grpc.timestamp.seconds = custom_timestamp.to_i
     entry_grpc.timestamp.nanos = custom_timestamp.nsec
     entry = Google::Cloud::Logging::Entry.from_grpc entry_grpc
-    entry.timestamp.wont_be :nil?
-    entry.timestamp.must_equal custom_timestamp
+    _(entry.timestamp).wont_be :nil?
+    _(entry.timestamp).must_equal custom_timestamp
   end
 
   it "timestamp returns nil when not present" do
     entry_hash[:timestamp] = nil
-    entry.timestamp.must_be :nil?
+    _(entry.timestamp).must_be :nil?
   end
 
   it "timestamp gives nil when no timestamp is present" do
     entry.timestamp = nil
-    entry.timestamp.must_be :nil?
+    _(entry.timestamp).must_be :nil?
   end
 
   it "labels will return a Hash even when missing from the Google API object" do
     entry_hash[:labels] = nil
-    entry.labels.must_be_kind_of Hash
-    entry.labels.must_be :empty?
+    _(entry.labels).must_be_kind_of Hash
+    _(entry.labels).must_be :empty?
   end
 
   it "can have a JSON payload" do
     entry.payload = { "pay" => "load" }
-    entry.payload.must_be_kind_of Hash
-    entry.payload["pay"].must_equal "load"
+    _(entry.payload).must_be_kind_of Hash
+    _(entry.payload["pay"]).must_equal "load"
   end
 
   it "can have a ProtoBuf payload" do
     proto = Google::Protobuf::Any.new type_url: "example.com/Greeter/SayHello",
                                       value: "\n\fHello world!".encode("ASCII-8BIT")
     entry.payload = proto
-    entry.payload.must_be_kind_of Google::Protobuf::Any
+    _(entry.payload).must_be_kind_of Google::Protobuf::Any
     grpc = entry.to_grpc
-    grpc.proto_payload.must_be_kind_of Google::Protobuf::Any
-    grpc.proto_payload.must_equal          proto
-    grpc.proto_payload.type_url.must_equal proto.type_url
-    grpc.proto_payload.value.must_equal    proto.value
+    _(grpc.proto_payload).must_be_kind_of Google::Protobuf::Any
+    _(grpc.proto_payload).must_equal          proto
+    _(grpc.proto_payload.type_url).must_equal proto.type_url
+    _(grpc.proto_payload.value).must_equal    proto.value
   end
 
   it "has the correct resource attributes" do
-    entry.resource.type.must_equal entry_hash[:resource][:type]
-    entry.resource.labels.keys.sort.must_equal   entry_hash[:resource][:labels].keys.sort
-    entry.resource.labels.values.sort.must_equal entry_hash[:resource][:labels].values.sort
+    _(entry.resource.type).must_equal entry_hash[:resource][:type]
+    _(entry.resource.labels.keys.sort).must_equal   entry_hash[:resource][:labels].keys.sort
+    _(entry.resource.labels.values.sort).must_equal entry_hash[:resource][:labels].values.sort
   end
 
   it "has a resource even if the Google API object doesn't have it" do
     entry_hash.delete :resource
 
-    entry.resource.wont_be :nil?
-    entry.resource.must_be_kind_of Google::Cloud::Logging::Resource
-    entry.resource.type.must_be :nil?
-    entry.resource.labels.must_be_kind_of Hash
-    entry.resource.labels.must_be :empty?
+    _(entry.resource).wont_be :nil?
+    _(entry.resource).must_be_kind_of Google::Cloud::Logging::Resource
+    _(entry.resource.type).must_be :nil?
+    _(entry.resource.labels).must_be_kind_of Hash
+    _(entry.resource.labels).must_be :empty?
   end
 
   it "has the correct http_request attributes" do
-    entry.http_request.request_method.must_equal "GET"
-    entry.http_request.url.must_equal "http://test.local/foo?bar=baz"
-    entry.http_request.size.must_equal 123
-    entry.http_request.status.must_equal 200
-    entry.http_request.response_size.must_equal 456
-    entry.http_request.user_agent.must_equal "google-cloud/1.0.0"
-    entry.http_request.remote_ip.must_equal "127.0.0.1"
-    entry.http_request.referer.must_equal "http://test.local/referer"
-    entry.http_request.cache_hit.must_equal false
-    entry.http_request.validated.must_equal false
+    _(entry.http_request.request_method).must_equal "GET"
+    _(entry.http_request.url).must_equal "http://test.local/foo?bar=baz"
+    _(entry.http_request.size).must_equal 123
+    _(entry.http_request.status).must_equal 200
+    _(entry.http_request.response_size).must_equal 456
+    _(entry.http_request.user_agent).must_equal "google-cloud/1.0.0"
+    _(entry.http_request.remote_ip).must_equal "127.0.0.1"
+    _(entry.http_request.referer).must_equal "http://test.local/referer"
+    _(entry.http_request.cache_hit).must_equal false
+    _(entry.http_request.validated).must_equal false
   end
 
   it "has an http_request even if the Google API object doesn't have it" do
     entry_hash.delete :http_request
 
-    entry.http_request.wont_be :nil?
-    entry.http_request.must_be_kind_of Google::Cloud::Logging::Entry::HttpRequest
-    entry.http_request.request_method.must_be :nil?
-    entry.http_request.url.must_be :nil?
-    entry.http_request.size.must_be :nil?
-    entry.http_request.status.must_be :nil?
-    entry.http_request.response_size.must_be :nil?
-    entry.http_request.user_agent.must_be :nil?
-    entry.http_request.remote_ip.must_be :nil?
-    entry.http_request.referer.must_be :nil?
-    entry.http_request.cache_hit.must_be :nil?
-    entry.http_request.validated.must_be :nil?
+    _(entry.http_request).wont_be :nil?
+    _(entry.http_request).must_be_kind_of Google::Cloud::Logging::Entry::HttpRequest
+    _(entry.http_request.request_method).must_be :nil?
+    _(entry.http_request.url).must_be :nil?
+    _(entry.http_request.size).must_be :nil?
+    _(entry.http_request.status).must_be :nil?
+    _(entry.http_request.response_size).must_be :nil?
+    _(entry.http_request.user_agent).must_be :nil?
+    _(entry.http_request.remote_ip).must_be :nil?
+    _(entry.http_request.referer).must_be :nil?
+    _(entry.http_request.cache_hit).must_be :nil?
+    _(entry.http_request.validated).must_be :nil?
   end
 
   it "has the correct operation attributes" do
-    entry.operation.id.must_equal "xyz789"
-    entry.operation.producer.must_equal "MyApp.MyClass#my_method"
-    entry.operation.first.must_equal false
-    entry.operation.last.must_equal false
+    _(entry.operation.id).must_equal "xyz789"
+    _(entry.operation.producer).must_equal "MyApp.MyClass#my_method"
+    _(entry.operation.first).must_equal false
+    _(entry.operation.last).must_equal false
   end
 
   it "has an operation even if the Google API object doesn't have it" do
     entry_hash.delete :operation
 
-    entry.operation.wont_be :nil?
-    entry.operation.must_be_kind_of Google::Cloud::Logging::Entry::Operation
-    entry.operation.id.must_be :nil?
-    entry.operation.producer.must_be :nil?
-    entry.operation.first.must_be :nil?
-    entry.operation.last.must_be :nil?
+    _(entry.operation).wont_be :nil?
+    _(entry.operation).must_be_kind_of Google::Cloud::Logging::Entry::Operation
+    _(entry.operation.id).must_be :nil?
+    _(entry.operation.producer).must_be :nil?
+    _(entry.operation.first).must_be :nil?
+    _(entry.operation.last).must_be :nil?
   end
 
   it "has the correct source location attributes" do
-    entry.source_location.file.must_equal "my_app/my_class.rb"
-    entry.source_location.line.must_equal 321
-    entry.source_location.function.must_equal "#my_method"
+    _(entry.source_location.file).must_equal "my_app/my_class.rb"
+    _(entry.source_location.line).must_equal 321
+    _(entry.source_location.function).must_equal "#my_method"
   end
 
   it "has a source location even if the Google API object doesn't have it" do
     entry_hash.delete :source_location
 
-    entry.source_location.wont_be :nil?
-    entry.source_location.must_be_kind_of Google::Cloud::Logging::Entry::SourceLocation
-    entry.source_location.file.must_be :nil?
-    entry.source_location.line.must_be :nil?
-    entry.source_location.function.must_be :nil?
+    _(entry.source_location).wont_be :nil?
+    _(entry.source_location).must_be_kind_of Google::Cloud::Logging::Entry::SourceLocation
+    _(entry.source_location.file).must_be :nil?
+    _(entry.source_location.line).must_be :nil?
+    _(entry.source_location.function).must_be :nil?
   end
 end

--- a/google-cloud-logging/test/google/cloud/logging/logger/debug_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/debug_test.rb
@@ -53,11 +53,11 @@ describe Google::Cloud::Logging::Logger, :debug, :mock_logging do
   end
 
   it "knows its log level using helper methods" do
-    logger.must_be :debug?
-    logger.must_be :info?
-    logger.must_be :warn?
-    logger.must_be :error?
-    logger.must_be :fatal?
+    _(logger).must_be :debug?
+    _(logger).must_be :info?
+    _(logger).must_be :warn?
+    _(logger).must_be :error?
+    _(logger).must_be :fatal?
   end
 
   it "creates a log entry with #debug" do

--- a/google-cloud-logging/test/google/cloud/logging/logger/error_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/error_test.rb
@@ -53,11 +53,11 @@ describe Google::Cloud::Logging::Logger, :error, :mock_logging do
   end
 
   it "knows its log level using helper methods" do
-    logger.wont_be :debug?
-    logger.wont_be :info?
-    logger.wont_be :warn?
-    logger.must_be :error?
-    logger.must_be :fatal?
+    _(logger).wont_be :debug?
+    _(logger).wont_be :info?
+    _(logger).wont_be :warn?
+    _(logger).must_be :error?
+    _(logger).must_be :fatal?
   end
 
   it "does not create a log entry with #debug" do

--- a/google-cloud-logging/test/google/cloud/logging/logger/fatal_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/fatal_test.rb
@@ -53,11 +53,11 @@ describe Google::Cloud::Logging::Logger, :fatal, :mock_logging do
   end
 
   it "knows its log level using helper methods" do
-    logger.wont_be :debug?
-    logger.wont_be :info?
-    logger.wont_be :warn?
-    logger.wont_be :error?
-    logger.must_be :fatal?
+    _(logger).wont_be :debug?
+    _(logger).wont_be :info?
+    _(logger).wont_be :warn?
+    _(logger).wont_be :error?
+    _(logger).must_be :fatal?
   end
 
   it "does not create a log entry with #debug" do

--- a/google-cloud-logging/test/google/cloud/logging/logger/info_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/info_test.rb
@@ -53,11 +53,11 @@ describe Google::Cloud::Logging::Logger, :info, :mock_logging do
   end
 
   it "knows its log level using helper methods" do
-    logger.wont_be :debug?
-    logger.must_be :info?
-    logger.must_be :warn?
-    logger.must_be :error?
-    logger.must_be :fatal?
+    _(logger).wont_be :debug?
+    _(logger).must_be :info?
+    _(logger).must_be :warn?
+    _(logger).must_be :error?
+    _(logger).must_be :fatal?
   end
 
   it "does not create a log entry with #debug" do

--- a/google-cloud-logging/test/google/cloud/logging/logger/unknown_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/unknown_test.rb
@@ -53,11 +53,11 @@ describe Google::Cloud::Logging::Logger, :unknown, :mock_logging do
   end
 
   it "knows its log level using helper methods" do
-    logger.wont_be :debug?
-    logger.wont_be :info?
-    logger.wont_be :warn?
-    logger.wont_be :error?
-    logger.wont_be :fatal?
+    _(logger).wont_be :debug?
+    _(logger).wont_be :info?
+    _(logger).wont_be :warn?
+    _(logger).wont_be :error?
+    _(logger).wont_be :fatal?
   end
 
   it "does not create a log entry with #debug" do

--- a/google-cloud-logging/test/google/cloud/logging/logger/warn_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/warn_test.rb
@@ -53,11 +53,11 @@ describe Google::Cloud::Logging::Logger, :warn, :mock_logging do
   end
 
   it "knows its log level using helper methods" do
-    logger.wont_be :debug?
-    logger.wont_be :info?
-    logger.must_be :warn?
-    logger.must_be :error?
-    logger.must_be :fatal?
+    _(logger).wont_be :debug?
+    _(logger).wont_be :info?
+    _(logger).must_be :warn?
+    _(logger).must_be :error?
+    _(logger).must_be :fatal?
   end
 
   it "does not create a log entry with #debug" do

--- a/google-cloud-logging/test/google/cloud/logging/logger_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger_test.rb
@@ -60,8 +60,8 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
 
   it "@labels instance variable is default to empty hash if not given" do
     logger = Google::Cloud::Logging::Logger.new logging, log_name, resource
-    logger.labels.must_be_kind_of Hash
-    logger.labels.must_be :empty?
+    _(logger.labels).must_be_kind_of Hash
+    _(logger.labels).must_be :empty?
   end
 
   it "creates a DEBUG log entry with #debug" do
@@ -174,7 +174,7 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
 
     it "associates given info to current Thread ID" do
       logger.add_request_info info: request_info
-      logger.request_info.must_equal request_info
+      _(logger.request_info).must_equal request_info
     end
 
     it "passes request info to log writes" do
@@ -280,27 +280,27 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
   end
 
   it "recognizes formatter attribute even though it doesn't care" do
-    logger.formatter.wont_be_nil
+    _(logger.formatter).wont_be_nil
     formatter = ::Logger::Formatter.new
     formatter.datetime_format = "meow"
     logger.formatter = formatter
-    logger.formatter.must_equal formatter
+    _(logger.formatter).must_equal formatter
   end
 
   it "recognizes datetime_format attribute even though it doesn't care" do
-    logger.datetime_format.must_equal ""
+    _(logger.datetime_format).must_equal ""
     logger.datetime_format = "meow"
-    logger.datetime_format.must_equal "meow"
+    _(logger.datetime_format).must_equal "meow"
   end
 
   describe "log_name attribute" do
     it "is aliased as progname" do
       new_log_name = "another_web_app_log"
-      logger.log_name.must_equal log_name
-      logger.progname.must_equal log_name
+      _(logger.log_name).must_equal log_name
+      _(logger.progname).must_equal log_name
       logger.progname = new_log_name
-      logger.log_name.must_equal new_log_name
-      logger.progname.must_equal new_log_name
+      _(logger.log_name).must_equal new_log_name
+      _(logger.progname).must_equal new_log_name
     end
 
     it "is reflected in log writes" do
@@ -319,11 +319,11 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
 
   describe "level attribute" do
     it "is aliased as sev_threshold" do
-      logger.level.must_equal ::Logger::DEBUG
-      logger.sev_threshold.must_equal ::Logger::DEBUG
+      _(logger.level).must_equal ::Logger::DEBUG
+      _(logger.sev_threshold).must_equal ::Logger::DEBUG
       logger.sev_threshold = ::Logger::ERROR
-      logger.level.must_equal ::Logger::ERROR
-      logger.sev_threshold.must_equal ::Logger::ERROR
+      _(logger.level).must_equal ::Logger::ERROR
+      _(logger.sev_threshold).must_equal ::Logger::ERROR
     end
 
     it "controls log writes" do
@@ -345,7 +345,7 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
       mocked_write_entry.expect :call, nil, [::Logger::INFO, "Correct info message"]
       mocked_write_entry.expect :call, nil, [::Logger::FATAL, "Correct fatal message"]
 
-      logger.level.must_equal ::Logger::DEBUG
+      _(logger.level).must_equal ::Logger::DEBUG
 
       logger.stub :write_entry, mocked_write_entry do
         logger.info "Correct info message"
@@ -353,11 +353,11 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
           logger.info "Wrong info message"
           logger.fatal "Correct fatal message"
 
-          logger.level.must_equal ::Logger::FATAL
+          _(logger.level).must_equal ::Logger::FATAL
         end
       end
 
-      logger.level.must_equal ::Logger::DEBUG
+      _(logger.level).must_equal ::Logger::DEBUG
 
       mocked_write_entry.verify
     end

--- a/google-cloud-logging/test/google/cloud/logging/metric_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/metric_test.rb
@@ -20,9 +20,9 @@ describe Google::Cloud::Logging::Metric, :mock_logging do
   let(:metric) { Google::Cloud::Logging::Metric.from_grpc metric_grpc, logging.service }
 
   it "knows its attributes" do
-    metric.name.must_equal        metric_hash[:name]
-    metric.description.must_equal metric_hash[:description]
-    metric.filter.must_equal      metric_hash[:filter]
+    _(metric.name).must_equal        metric_hash[:name]
+    _(metric.description).must_equal metric_hash[:description]
+    _(metric.filter).must_equal      metric_hash[:filter]
   end
 
   it "can save itself" do
@@ -43,9 +43,9 @@ describe Google::Cloud::Logging::Metric, :mock_logging do
 
     mock.verify
 
-    metric.must_be_kind_of Google::Cloud::Logging::Metric
-    metric.description.must_equal new_metric_description
-    metric.filter.must_equal new_metric_filter
+    _(metric).must_be_kind_of Google::Cloud::Logging::Metric
+    _(metric.description).must_equal new_metric_description
+    _(metric.filter).must_equal new_metric_filter
   end
 
   it "can refresh itself" do

--- a/google-cloud-logging/test/google/cloud/logging/middleware_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/middleware_test.rb
@@ -72,11 +72,11 @@ describe Google::Cloud::Logging::Middleware, :mock_logging do
         end
       end
 
-      middleware.logger.must_be_kind_of Google::Cloud::Logging::Logger
+      _(middleware.logger).must_be_kind_of Google::Cloud::Logging::Logger
     end
 
     it "uses the logger provided if given" do
-      middleware.logger.must_equal logger
+      _(middleware.logger).must_equal logger
     end
 
     it "invokes the on_init callback when provided" do
@@ -95,7 +95,7 @@ describe Google::Cloud::Logging::Middleware, :mock_logging do
   describe "#call" do
     it "sets env[\"rack.logger\"] to the given logger" do
       stubbed_call = ->(env) {
-        env["rack.logger"].must_equal logger
+        _(env["rack.logger"]).must_equal logger
       }
       rack_app.stub :call, stubbed_call do
         middleware.call rack_env
@@ -104,8 +104,8 @@ describe Google::Cloud::Logging::Middleware, :mock_logging do
 
     it "calls logger.add_request_info to track trace_id" do
       stubbed_add_request_info = ->(args) {
-        args[:trace_id].must_equal trace_id
-        args[:env].must_equal rack_env
+        _(args[:trace_id]).must_equal trace_id
+        _(args[:env]).must_equal rack_env
       }
       logger.stub :add_request_info, stubbed_add_request_info do
         middleware.call rack_env
@@ -116,7 +116,7 @@ describe Google::Cloud::Logging::Middleware, :mock_logging do
       ["/healthz", "/_ah/health"].each do |path|
         rack_env = { "PATH_INFO" => path }
         stubbed_add_request_info = ->(args) {
-          args[:log_name].must_equal "ruby_health_check_log"
+          _(args[:log_name]).must_equal "ruby_health_check_log"
         }
         logger.stub :add_request_info, stubbed_add_request_info do
           middleware.call rack_env
@@ -136,7 +136,7 @@ describe Google::Cloud::Logging::Middleware, :mock_logging do
           assert_raises StandardError do
             middleware.call rack_env
           end
-          method_called.must_equal true
+          _(method_called).must_equal true
         end
       end
     end
@@ -150,22 +150,22 @@ describe Google::Cloud::Logging::Middleware, :mock_logging do
     it "returns resource of right type if given parameters" do
       Google::Cloud::Logging::Middleware.stub :default_monitored_resource, default_rc do
         rc = Google::Cloud::Logging::Middleware.build_monitored_resource custom_type, custom_labels
-        rc.type.must_equal custom_type
-        rc.labels.must_equal custom_labels
+        _(rc.type).must_equal custom_type
+        _(rc.labels).must_equal custom_labels
       end
     end
 
     it "returns default monitored resource if only given type" do
       Google::Cloud::Logging::Middleware.stub :default_monitored_resource, default_rc do
         rc = Google::Cloud::Logging::Middleware.build_monitored_resource custom_type
-        rc.must_equal default_rc
+        _(rc).must_equal default_rc
       end
     end
 
     it "returns default monitored resource if only given labels" do
       Google::Cloud::Logging::Middleware.stub :default_monitored_resource, default_rc do
         rc = Google::Cloud::Logging::Middleware.build_monitored_resource nil, custom_labels
-        rc.must_equal default_rc
+        _(rc).must_equal default_rc
       end
     end
   end
@@ -174,28 +174,28 @@ describe Google::Cloud::Logging::Middleware, :mock_logging do
     it "returns resource of type gae_app if app_engine? is true" do
       Google::Cloud.stub :env, OpenStruct.new(:app_engine? => true, :container_engine? => false, :compute_engine? => true) do
         rc = Google::Cloud::Logging::Middleware.build_monitored_resource
-        rc.type.must_equal "gae_app"
+        _(rc.type).must_equal "gae_app"
       end
     end
 
     it "returns resource of type container if container_engine? is true" do
       Google::Cloud.stub :env, OpenStruct.new(:app_engine? => false, :container_engine? => true, :compute_engine? => true) do
         rc = Google::Cloud::Logging::Middleware.build_monitored_resource
-        rc.type.must_equal "container"
+        _(rc.type).must_equal "container"
       end
     end
 
     it "returns resource of type gce_instance if compute_engine? is true" do
       Google::Cloud.stub :env, OpenStruct.new(:app_engine? => false, :container_engine? => false, :compute_engine? => true) do
         rc = Google::Cloud::Logging::Middleware.build_monitored_resource
-        rc.type.must_equal "gce_instance"
+        _(rc.type).must_equal "gce_instance"
       end
     end
 
     it "returns resource of type global if not on GCP" do
       Google::Cloud.stub :env, OpenStruct.new(:app_engine? => false, :container_engine? => false, :compute_engine? => false) do
         rc = Google::Cloud::Logging::Middleware.build_monitored_resource
-        rc.type.must_equal "global"
+        _(rc.type).must_equal "global"
       end
     end
   end

--- a/google-cloud-logging/test/google/cloud/logging/project/async_writer_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/async_writer_test.rb
@@ -17,25 +17,25 @@ require "helper"
 describe Google::Cloud::Logging::Project, :async_writer, :mock_logging do
   it "creates an async writer object" do
     async = logging.async_writer
-    async.must_be_kind_of Google::Cloud::Logging::AsyncWriter
-    async.logging.must_be_same_as logging
-    async.max_count.must_equal 10000
-    async.max_bytes.must_equal 10000000
-    async.max_queue.must_equal 100
-    async.interval.must_equal 5
-    async.threads.must_equal 10
-    async.must_be :started?
+    _(async).must_be_kind_of Google::Cloud::Logging::AsyncWriter
+    _(async.logging).must_be_same_as logging
+    _(async.max_count).must_equal 10000
+    _(async.max_bytes).must_equal 10000000
+    _(async.max_queue).must_equal 100
+    _(async.interval).must_equal 5
+    _(async.threads).must_equal 10
+    _(async).must_be :started?
   end
 
   it "creates an async writer object with custom options" do
     async = logging.async_writer max_batch_count: 42, max_batch_bytes: 5000000, max_queue_size: 123, interval:10, threads: 1
-    async.must_be_kind_of Google::Cloud::Logging::AsyncWriter
-    async.logging.must_be_same_as logging
-    async.max_count.must_equal 42
-    async.max_bytes.must_equal 5000000
-    async.max_queue.must_equal 123
-    async.interval.must_equal 10
-    async.threads.must_equal 1
-    async.must_be :started?
+    _(async).must_be_kind_of Google::Cloud::Logging::AsyncWriter
+    _(async.logging).must_be_same_as logging
+    _(async.max_count).must_equal 42
+    _(async.max_bytes).must_equal 5000000
+    _(async.max_queue).must_equal 123
+    _(async.interval).must_equal 10
+    _(async.threads).must_equal 1
+    _(async).must_be :started?
   end
 end

--- a/google-cloud-logging/test/google/cloud/logging/project/list_entries_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/list_entries_test.rb
@@ -28,8 +28,8 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
 
     mock.verify
 
-    entries.each { |m| m.must_be_kind_of Google::Cloud::Logging::Entry }
-    entries.size.must_equal num_entries
+    entries.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::Entry }
+    _(entries.size).must_equal num_entries
   end
 
   it "lists entries with find_entries alias" do
@@ -45,8 +45,8 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
 
     mock.verify
 
-    entries.each { |m| m.must_be_kind_of Google::Cloud::Logging::Entry }
-    entries.size.must_equal num_entries
+    entries.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::Entry }
+    _(entries.size).must_equal num_entries
   end
 
   it "paginates entries" do
@@ -63,14 +63,14 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
 
     mock.verify
 
-    first_entries.each { |m| m.must_be_kind_of Google::Cloud::Logging::Entry }
-    first_entries.count.must_equal 3
-    first_entries.token.wont_be :nil?
-    first_entries.token.must_equal "next_page_token"
+    first_entries.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::Entry }
+    _(first_entries.count).must_equal 3
+    _(first_entries.token).wont_be :nil?
+    _(first_entries.token).must_equal "next_page_token"
 
-    second_entries.each { |m| m.must_be_kind_of Google::Cloud::Logging::Entry }
-    second_entries.count.must_equal 2
-    second_entries.token.must_be :nil?
+    second_entries.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::Entry }
+    _(second_entries.count).must_equal 2
+    _(second_entries.token).must_be :nil?
   end
 
   it "paginates entries with criteria" do
@@ -92,28 +92,28 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
 
     mock.verify
 
-    first_entries.each { |m| m.must_be_kind_of Google::Cloud::Logging::Entry }
-    first_entries.count.must_equal 3
-    first_entries.token.wont_be :nil?
-    first_entries.token.must_equal "next_page_token"
+    first_entries.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::Entry }
+    _(first_entries.count).must_equal 3
+    _(first_entries.token).wont_be :nil?
+    _(first_entries.token).must_equal "next_page_token"
 
     # ensure the correct values are propogated to the ivars
-    first_entries.instance_variable_get(:@projects).must_equal ["project1", "project2", "project3"],
-    first_entries.instance_variable_get(:@resources).must_be_nil
-    first_entries.instance_variable_get(:@filter).must_equal 'resource.type:"gce_"'
-    first_entries.instance_variable_get(:@order).must_equal "timestamp"
-    first_entries.instance_variable_get(:@max).must_be_nil
+    _(first_entries.instance_variable_get(:@projects)).must_equal ["project1", "project2", "project3"],
+    _(first_entries.instance_variable_get(:@resources)).must_be_nil
+    _(first_entries.instance_variable_get(:@filter)).must_equal 'resource.type:"gce_"'
+    _(first_entries.instance_variable_get(:@order)).must_equal "timestamp"
+    _(first_entries.instance_variable_get(:@max)).must_be_nil
 
-    second_entries.each { |m| m.must_be_kind_of Google::Cloud::Logging::Entry }
-    second_entries.count.must_equal 2
-    second_entries.token.must_be :nil?
+    second_entries.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::Entry }
+    _(second_entries.count).must_equal 2
+    _(second_entries.token).must_be :nil?
 
     # ensure the correct values are propogated to the ivars
-    second_entries.instance_variable_get(:@projects).must_equal ["project1", "project2", "project3"],
-    second_entries.instance_variable_get(:@resources).must_be_nil
-    second_entries.instance_variable_get(:@filter).must_equal 'resource.type:"gce_"'
-    second_entries.instance_variable_get(:@order).must_equal "timestamp"
-    second_entries.instance_variable_get(:@max).must_be_nil
+    _(second_entries.instance_variable_get(:@projects)).must_equal ["project1", "project2", "project3"],
+    _(second_entries.instance_variable_get(:@resources)).must_be_nil
+    _(second_entries.instance_variable_get(:@filter)).must_equal 'resource.type:"gce_"'
+    _(second_entries.instance_variable_get(:@order)).must_equal "timestamp"
+    _(second_entries.instance_variable_get(:@max)).must_be_nil
   end
 
   it "paginates entries using next? and next" do
@@ -130,13 +130,13 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
 
     mock.verify
 
-    first_entries.each { |m| m.must_be_kind_of Google::Cloud::Logging::Entry }
-    first_entries.count.must_equal 3
-    first_entries.next?.must_equal true #must_be :next?
+    first_entries.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::Entry }
+    _(first_entries.count).must_equal 3
+    _(first_entries.next?).must_equal true #must_be :next?
 
-    second_entries.each { |m| m.must_be_kind_of Google::Cloud::Logging::Entry }
-    second_entries.count.must_equal 2
-    second_entries.next?.must_equal false #wont_be :next?
+    second_entries.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::Entry }
+    _(second_entries.count).must_equal 2
+    _(second_entries.next?).must_equal false #wont_be :next?
   end
 
   it "paginates entries with criteria using next? and next" do
@@ -155,29 +155,29 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
 
     mock.verify
 
-    first_entries.each { |m| m.must_be_kind_of Google::Cloud::Logging::Entry }
-    first_entries.count.must_equal 3
-    first_entries.next?.must_equal true #must_be :next?
-    first_entries.token.must_equal "next_page_token"
+    first_entries.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::Entry }
+    _(first_entries.count).must_equal 3
+    _(first_entries.next?).must_equal true #must_be :next?
+    _(first_entries.token).must_equal "next_page_token"
 
     # ensure the correct values are propogated to the ivars
-    first_entries.instance_variable_get(:@projects).must_equal ["project1", "project2", "project3"],
-    first_entries.instance_variable_get(:@resources).must_be_nil
-    first_entries.instance_variable_get(:@filter).must_equal 'resource.type:"gce_"'
-    first_entries.instance_variable_get(:@order).must_equal "timestamp"
-    first_entries.instance_variable_get(:@max).must_be_nil
+    _(first_entries.instance_variable_get(:@projects)).must_equal ["project1", "project2", "project3"],
+    _(first_entries.instance_variable_get(:@resources)).must_be_nil
+    _(first_entries.instance_variable_get(:@filter)).must_equal 'resource.type:"gce_"'
+    _(first_entries.instance_variable_get(:@order)).must_equal "timestamp"
+    _(first_entries.instance_variable_get(:@max)).must_be_nil
 
-    second_entries.each { |m| m.must_be_kind_of Google::Cloud::Logging::Entry }
-    second_entries.count.must_equal 2
-    second_entries.next?.must_equal false #wont_be :next?
-    second_entries.token.must_be :nil?
+    second_entries.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::Entry }
+    _(second_entries.count).must_equal 2
+    _(second_entries.next?).must_equal false #wont_be :next?
+    _(second_entries.token).must_be :nil?
 
     # ensure the correct values are propogated to the ivars
-    second_entries.instance_variable_get(:@projects).must_equal ["project1", "project2", "project3"],
-    second_entries.instance_variable_get(:@resources).must_be_nil
-    second_entries.instance_variable_get(:@filter).must_equal 'resource.type:"gce_"'
-    second_entries.instance_variable_get(:@order).must_equal "timestamp"
-    second_entries.instance_variable_get(:@max).must_be_nil
+    _(second_entries.instance_variable_get(:@projects)).must_equal ["project1", "project2", "project3"],
+    _(second_entries.instance_variable_get(:@resources)).must_be_nil
+    _(second_entries.instance_variable_get(:@filter)).must_equal 'resource.type:"gce_"'
+    _(second_entries.instance_variable_get(:@order)).must_equal "timestamp"
+    _(second_entries.instance_variable_get(:@max)).must_be_nil
   end
 
   it "paginates entries using all" do
@@ -193,8 +193,8 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
 
     mock.verify
 
-    all_entries.each { |m| m.must_be_kind_of Google::Cloud::Logging::Entry }
-    all_entries.count.must_equal 5
+    all_entries.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::Entry }
+    _(all_entries.count).must_equal 5
   end
 
   it "paginates entries with criteria using all" do
@@ -212,8 +212,8 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
 
     mock.verify
 
-    all_entries.each { |m| m.must_be_kind_of Google::Cloud::Logging::Entry }
-    all_entries.count.must_equal 5
+    all_entries.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::Entry }
+    _(all_entries.count).must_equal 5
   end
 
   it "paginates entries using all using Enumerator" do
@@ -229,8 +229,8 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
 
     mock.verify
 
-    all_entries.each { |m| m.must_be_kind_of Google::Cloud::Logging::Entry }
-    all_entries.count.must_equal 5
+    all_entries.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::Entry }
+    _(all_entries.count).must_equal 5
   end
 
   it "paginates entries using all with request_limit set" do
@@ -246,8 +246,8 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
 
     mock.verify
 
-    all_entries.each { |m| m.must_be_kind_of Google::Cloud::Logging::Entry }
-    all_entries.count.must_equal 6
+    all_entries.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::Entry }
+    _(all_entries.count).must_equal 6
   end
 
   it "paginates entries with one project" do
@@ -261,10 +261,10 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
 
     mock.verify
 
-    entries.each { |m| m.must_be_kind_of Google::Cloud::Logging::Entry }
-    entries.count.must_equal 3
-    entries.token.wont_be :nil?
-    entries.token.must_equal "next_page_token"
+    entries.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::Entry }
+    _(entries.count).must_equal 3
+    _(entries.token).wont_be :nil?
+    _(entries.token).must_equal "next_page_token"
   end
 
   it "paginates entries with multiple projects" do
@@ -278,10 +278,10 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
 
     mock.verify
 
-    entries.each { |m| m.must_be_kind_of Google::Cloud::Logging::Entry }
-    entries.count.must_equal 3
-    entries.token.wont_be :nil?
-    entries.token.must_equal "next_page_token"
+    entries.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::Entry }
+    _(entries.count).must_equal 3
+    _(entries.token).wont_be :nil?
+    _(entries.token).must_equal "next_page_token"
   end
 
   it "paginates entries with multiple resources" do
@@ -295,10 +295,10 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
 
     mock.verify
 
-    entries.each { |m| m.must_be_kind_of Google::Cloud::Logging::Entry }
-    entries.count.must_equal 3
-    entries.token.wont_be :nil?
-    entries.token.must_equal "next_page_token"
+    entries.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::Entry }
+    _(entries.count).must_equal 3
+    _(entries.token).wont_be :nil?
+    _(entries.token).must_equal "next_page_token"
   end
 
   it "paginates entries with a filter" do
@@ -315,10 +315,10 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
 
     mock.verify
 
-    entries.each { |m| m.must_be_kind_of Google::Cloud::Logging::Entry }
-    entries.count.must_equal 3
-    entries.token.wont_be :nil?
-    entries.token.must_equal "next_page_token"
+    entries.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::Entry }
+    _(entries.count).must_equal 3
+    _(entries.token).wont_be :nil?
+    _(entries.token).must_equal "next_page_token"
   end
 
   it "paginates entries with order asc" do
@@ -333,10 +333,10 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
 
     mock.verify
 
-    entries.each { |m| m.must_be_kind_of Google::Cloud::Logging::Entry }
-    entries.count.must_equal 3
-    entries.token.wont_be :nil?
-    entries.token.must_equal "next_page_token"
+    entries.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::Entry }
+    _(entries.count).must_equal 3
+    _(entries.token).wont_be :nil?
+    _(entries.token).must_equal "next_page_token"
   end
 
   it "paginates entries with order desc" do
@@ -351,10 +351,10 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
 
     mock.verify
 
-    entries.each { |m| m.must_be_kind_of Google::Cloud::Logging::Entry }
-    entries.count.must_equal 3
-    entries.token.wont_be :nil?
-    entries.token.must_equal "next_page_token"
+    entries.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::Entry }
+    _(entries.count).must_equal 3
+    _(entries.token).wont_be :nil?
+    _(entries.token).must_equal "next_page_token"
   end
 
   it "paginates entries with max set" do
@@ -369,10 +369,10 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
 
     mock.verify
 
-    entries.each { |m| m.must_be_kind_of Google::Cloud::Logging::Entry }
-    entries.count.must_equal 3
-    entries.token.wont_be :nil?
-    entries.token.must_equal "next_page_token"
+    entries.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::Entry }
+    _(entries.count).must_equal 3
+    _(entries.token).wont_be :nil?
+    _(entries.token).must_equal "next_page_token"
   end
 
   it "paginates entries without max set" do
@@ -387,10 +387,10 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
 
     mock.verify
 
-    entries.each { |m| m.must_be_kind_of Google::Cloud::Logging::Entry }
-    entries.count.must_equal 3
-    entries.token.wont_be :nil?
-    entries.token.must_equal "next_page_token"
+    entries.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::Entry }
+    _(entries.count).must_equal 3
+    _(entries.token).wont_be :nil?
+    _(entries.token).must_equal "next_page_token"
   end
 
   def list_entries_hash count = 2, token = nil

--- a/google-cloud-logging/test/google/cloud/logging/project/list_logs_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/list_logs_test.rb
@@ -28,8 +28,8 @@ describe Google::Cloud::Logging::Project, :list_logs, :mock_logging do
 
     mock.verify
 
-    logs.each { |m| m.must_be_kind_of String }
-    logs.size.must_equal num_logs
+    logs.each { |m| _(m).must_be_kind_of String }
+    _(logs.size).must_equal num_logs
   end
 
   it "lists logs with find_logs alias" do
@@ -45,8 +45,8 @@ describe Google::Cloud::Logging::Project, :list_logs, :mock_logging do
 
     mock.verify
 
-    logs.each { |m| m.must_be_kind_of String }
-    logs.size.must_equal num_logs
+    logs.each { |m| _(m).must_be_kind_of String }
+    _(logs.size).must_equal num_logs
   end
 
   it "paginates logs" do
@@ -63,14 +63,14 @@ describe Google::Cloud::Logging::Project, :list_logs, :mock_logging do
 
     mock.verify
 
-    first_logs.each { |m| m.must_be_kind_of String }
-    first_logs.count.must_equal 3
-    first_logs.token.wont_be :nil?
-    first_logs.token.must_equal "next_page_token"
+    first_logs.each { |m| _(m).must_be_kind_of String }
+    _(first_logs.count).must_equal 3
+    _(first_logs.token).wont_be :nil?
+    _(first_logs.token).must_equal "next_page_token"
 
-    second_logs.each { |m| m.must_be_kind_of String }
-    second_logs.count.must_equal 2
-    second_logs.token.must_be :nil?
+    second_logs.each { |m| _(m).must_be_kind_of String }
+    _(second_logs.count).must_equal 2
+    _(second_logs.token).must_be :nil?
   end
 
   it "paginates logs using next? and next" do
@@ -87,13 +87,13 @@ describe Google::Cloud::Logging::Project, :list_logs, :mock_logging do
 
     mock.verify
 
-    first_logs.each { |m| m.must_be_kind_of String }
-    first_logs.count.must_equal 3
-    first_logs.next?.must_equal true #must_be :next?
+    first_logs.each { |m| _(m).must_be_kind_of String }
+    _(first_logs.count).must_equal 3
+    _(first_logs.next?).must_equal true #must_be :next?
 
-    second_logs.each { |m| m.must_be_kind_of String }
-    second_logs.count.must_equal 2
-    second_logs.next?.must_equal false #wont_be :next?
+    second_logs.each { |m| _(m).must_be_kind_of String }
+    _(second_logs.count).must_equal 2
+    _(second_logs.next?).must_equal false #wont_be :next?
   end
 
   it "paginates logs using all" do
@@ -109,8 +109,8 @@ describe Google::Cloud::Logging::Project, :list_logs, :mock_logging do
 
     mock.verify
 
-    all_logs.each { |m| m.must_be_kind_of String }
-    all_logs.count.must_equal 5
+    all_logs.each { |m| _(m).must_be_kind_of String }
+    _(all_logs.count).must_equal 5
   end
 
   it "paginates logs using all using Enumerator" do
@@ -126,8 +126,8 @@ describe Google::Cloud::Logging::Project, :list_logs, :mock_logging do
 
     mock.verify
 
-    all_logs.each { |m| m.must_be_kind_of String }
-    all_logs.count.must_equal 5
+    all_logs.each { |m| _(m).must_be_kind_of String }
+    _(all_logs.count).must_equal 5
   end
 
   it "paginates logs using all with request_limit set" do
@@ -143,8 +143,8 @@ describe Google::Cloud::Logging::Project, :list_logs, :mock_logging do
 
     mock.verify
 
-    all_logs.each { |m| m.must_be_kind_of String }
-    all_logs.count.must_equal 6
+    all_logs.each { |m| _(m).must_be_kind_of String }
+    _(all_logs.count).must_equal 6
   end
 
   it "paginates logs with a resource" do
@@ -158,10 +158,10 @@ describe Google::Cloud::Logging::Project, :list_logs, :mock_logging do
 
     mock.verify
 
-    logs.each { |m| m.must_be_kind_of String }
-    logs.count.must_equal 3
-    logs.token.wont_be :nil?
-    logs.token.must_equal "next_page_token"
+    logs.each { |m| _(m).must_be_kind_of String }
+    _(logs.count).must_equal 3
+    _(logs.token).wont_be :nil?
+    _(logs.token).must_equal "next_page_token"
   end
 
   it "paginates logs with a resource" do
@@ -178,23 +178,23 @@ describe Google::Cloud::Logging::Project, :list_logs, :mock_logging do
 
     mock.verify
 
-    first_logs.each { |m| m.must_be_kind_of String }
-    first_logs.count.must_equal 3
-    first_logs.next?.must_equal true
-    first_logs.token.must_equal "next_page_token"
+    first_logs.each { |m| _(m).must_be_kind_of String }
+    _(first_logs.count).must_equal 3
+    _(first_logs.next?).must_equal true
+    _(first_logs.token).must_equal "next_page_token"
 
     # ensure the correct values are propogated to the ivars
-    first_logs.instance_variable_get(:@resource).must_equal "projects/project1"
-    first_logs.instance_variable_get(:@max).must_be_nil
+    _(first_logs.instance_variable_get(:@resource)).must_equal "projects/project1"
+    _(first_logs.instance_variable_get(:@max)).must_be_nil
 
-    second_logs.each { |m| m.must_be_kind_of String }
-    second_logs.count.must_equal 2
-    second_logs.next?.must_equal true
-    second_logs.token.must_equal "second_page_token"
+    second_logs.each { |m| _(m).must_be_kind_of String }
+    _(second_logs.count).must_equal 2
+    _(second_logs.next?).must_equal true
+    _(second_logs.token).must_equal "second_page_token"
 
     # ensure the correct values are propogated to the ivars
-    second_logs.instance_variable_get(:@resource).must_equal "projects/project1"
-    second_logs.instance_variable_get(:@max).must_be_nil
+    _(second_logs.instance_variable_get(:@resource)).must_equal "projects/project1"
+    _(second_logs.instance_variable_get(:@max)).must_be_nil
   end
 
   it "paginates logs with a resource" do
@@ -211,23 +211,23 @@ describe Google::Cloud::Logging::Project, :list_logs, :mock_logging do
 
     mock.verify
 
-    first_logs.each { |m| m.must_be_kind_of String }
-    first_logs.count.must_equal 3
-    first_logs.next?.must_equal true
-    first_logs.token.must_equal "next_page_token"
+    first_logs.each { |m| _(m).must_be_kind_of String }
+    _(first_logs.count).must_equal 3
+    _(first_logs.next?).must_equal true
+    _(first_logs.token).must_equal "next_page_token"
 
     # ensure the correct values are propogated to the ivars
-    first_logs.instance_variable_get(:@resource).must_be_nil
-    first_logs.instance_variable_get(:@max).must_equal 3
+    _(first_logs.instance_variable_get(:@resource)).must_be_nil
+    _(first_logs.instance_variable_get(:@max)).must_equal 3
 
-    second_logs.each { |m| m.must_be_kind_of String }
-    second_logs.count.must_equal 2
-    second_logs.next?.must_equal true
-    second_logs.token.must_equal "second_page_token"
+    second_logs.each { |m| _(m).must_be_kind_of String }
+    _(second_logs.count).must_equal 2
+    _(second_logs.next?).must_equal true
+    _(second_logs.token).must_equal "second_page_token"
 
     # ensure the correct values are propogated to the ivars
-    second_logs.instance_variable_get(:@resource).must_be_nil
-    second_logs.instance_variable_get(:@max).must_equal 3
+    _(second_logs.instance_variable_get(:@resource)).must_be_nil
+    _(second_logs.instance_variable_get(:@max)).must_equal 3
   end
 
   def list_logs_hash count = 2, token = nil

--- a/google-cloud-logging/test/google/cloud/logging/project/logger_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/logger_test.rb
@@ -23,11 +23,11 @@ describe Google::Cloud::Logging::Project, :logger, :mock_logging do
     labels = { "env" => "production" }
 
     logger = logging.logger log_name, resource, labels
-    logger.must_be_kind_of Google::Cloud::Logging::Logger
-    logger.log_name.must_equal log_name
-    logger.resource.must_equal resource
-    logger.labels.must_equal labels
-    logger.writer.must_be_kind_of Google::Cloud::Logging::AsyncWriter
+    _(logger).must_be_kind_of Google::Cloud::Logging::Logger
+    _(logger.log_name).must_equal log_name
+    _(logger.resource).must_equal resource
+    _(logger.labels).must_equal labels
+    _(logger.writer).must_be_kind_of Google::Cloud::Logging::AsyncWriter
   end
 
   it "creates a ruby logger object with labels using symbols" do
@@ -38,11 +38,11 @@ describe Google::Cloud::Logging::Project, :logger, :mock_logging do
     labels = { env: "production" }
 
     logger = logging.logger log_name, resource, labels
-    logger.must_be_kind_of Google::Cloud::Logging::Logger
-    logger.log_name.must_equal log_name
-    logger.resource.must_equal resource
-    logger.labels.must_equal labels
-    logger.writer.must_be_kind_of Google::Cloud::Logging::AsyncWriter
+    _(logger).must_be_kind_of Google::Cloud::Logging::Logger
+    _(logger.log_name).must_equal log_name
+    _(logger.resource).must_equal resource
+    _(logger.labels).must_equal labels
+    _(logger.writer).must_be_kind_of Google::Cloud::Logging::AsyncWriter
   end
 
   it "creates a ruby logger object without labels" do
@@ -52,10 +52,10 @@ describe Google::Cloud::Logging::Project, :logger, :mock_logging do
     end
 
     logger = logging.logger log_name, resource
-    logger.must_be_kind_of Google::Cloud::Logging::Logger
-    logger.log_name.must_equal log_name
-    logger.resource.must_equal resource
-    logger.labels.must_be :empty?
-    logger.writer.must_be_kind_of Google::Cloud::Logging::AsyncWriter
+    _(logger).must_be_kind_of Google::Cloud::Logging::Logger
+    _(logger.log_name).must_equal log_name
+    _(logger.resource).must_equal resource
+    _(logger.labels).must_be :empty?
+    _(logger.writer).must_be_kind_of Google::Cloud::Logging::AsyncWriter
   end
 end

--- a/google-cloud-logging/test/google/cloud/logging/project/metrics_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/metrics_test.rb
@@ -27,8 +27,8 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
 
     mock.verify
 
-    metrics.each { |m| m.must_be_kind_of Google::Cloud::Logging::Metric }
-    metrics.size.must_equal num_metrics
+    metrics.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::Metric }
+    _(metrics.size).must_equal num_metrics
   end
 
   it "lists metrics with find_metrics alias" do
@@ -43,8 +43,8 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
 
     mock.verify
 
-    metrics.each { |m| m.must_be_kind_of Google::Cloud::Logging::Metric }
-    metrics.size.must_equal num_metrics
+    metrics.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::Metric }
+    _(metrics.size).must_equal num_metrics
   end
 
   it "paginates metrics" do
@@ -61,14 +61,14 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
 
     mock.verify
 
-    first_metrics.each { |m| m.must_be_kind_of Google::Cloud::Logging::Metric }
-    first_metrics.count.must_equal 3
-    first_metrics.token.wont_be :nil?
-    first_metrics.token.must_equal "next_page_token"
+    first_metrics.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::Metric }
+    _(first_metrics.count).must_equal 3
+    _(first_metrics.token).wont_be :nil?
+    _(first_metrics.token).must_equal "next_page_token"
 
-    second_metrics.each { |m| m.must_be_kind_of Google::Cloud::Logging::Metric }
-    second_metrics.count.must_equal 2
-    second_metrics.token.must_be :nil?
+    second_metrics.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::Metric }
+    _(second_metrics.count).must_equal 2
+    _(second_metrics.token).must_be :nil?
   end
 
   it "paginates metrics with next? and next" do
@@ -85,13 +85,13 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
 
     mock.verify
 
-    first_metrics.each { |m| m.must_be_kind_of Google::Cloud::Logging::Metric }
-    first_metrics.count.must_equal 3
-    first_metrics.next?.must_equal true #must_be :next?
+    first_metrics.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::Metric }
+    _(first_metrics.count).must_equal 3
+    _(first_metrics.next?).must_equal true #must_be :next?
 
-    second_metrics.each { |m| m.must_be_kind_of Google::Cloud::Logging::Metric }
-    second_metrics.count.must_equal 2
-    second_metrics.next?.must_equal false #wont_be :next?
+    second_metrics.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::Metric }
+    _(second_metrics.count).must_equal 2
+    _(second_metrics.next?).must_equal false #wont_be :next?
   end
 
   it "paginates metrics with next? and next and max set" do
@@ -108,21 +108,21 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
 
     mock.verify
 
-    first_metrics.each { |m| m.must_be_kind_of Google::Cloud::Logging::Metric }
-    first_metrics.count.must_equal 3
-    first_metrics.next?.must_equal true
-    first_metrics.token.must_equal "next_page_token"
+    first_metrics.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::Metric }
+    _(first_metrics.count).must_equal 3
+    _(first_metrics.next?).must_equal true
+    _(first_metrics.token).must_equal "next_page_token"
 
     # ensure the correct values are propogated to the ivars
-    first_metrics.instance_variable_get(:@max).must_equal 3
+    _(first_metrics.instance_variable_get(:@max)).must_equal 3
 
-    second_metrics.each { |m| m.must_be_kind_of Google::Cloud::Logging::Metric }
-    second_metrics.count.must_equal 2
-    second_metrics.next?.must_equal true
-    second_metrics.token.must_equal "second_page_token"
+    second_metrics.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::Metric }
+    _(second_metrics.count).must_equal 2
+    _(second_metrics.next?).must_equal true
+    _(second_metrics.token).must_equal "second_page_token"
 
     # ensure the correct values are propogated to the ivars
-    second_metrics.instance_variable_get(:@max).must_equal 3
+    _(second_metrics.instance_variable_get(:@max)).must_equal 3
   end
 
   it "paginates metrics with all" do
@@ -138,8 +138,8 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
 
     mock.verify
 
-    all_metrics.each { |m| m.must_be_kind_of Google::Cloud::Logging::Metric }
-    all_metrics.count.must_equal 5
+    all_metrics.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::Metric }
+    _(all_metrics.count).must_equal 5
   end
 
   it "paginates metrics with all and max set" do
@@ -155,8 +155,8 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
 
     mock.verify
 
-    all_metrics.each { |m| m.must_be_kind_of Google::Cloud::Logging::Metric }
-    all_metrics.count.must_equal 5
+    all_metrics.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::Metric }
+    _(all_metrics.count).must_equal 5
   end
 
   it "iterates metrics with all using Enumerator" do
@@ -172,8 +172,8 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
 
     mock.verify
 
-    all_metrics.each { |m| m.must_be_kind_of Google::Cloud::Logging::Metric }
-    all_metrics.count.must_equal 5
+    all_metrics.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::Metric }
+    _(all_metrics.count).must_equal 5
   end
 
   it "iterates metrics with all request_limit set" do
@@ -189,8 +189,8 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
 
     mock.verify
 
-    all_metrics.each { |m| m.must_be_kind_of Google::Cloud::Logging::Metric }
-    all_metrics.count.must_equal 6
+    all_metrics.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::Metric }
+    _(all_metrics.count).must_equal 6
   end
 
   it "paginates metrics with max set" do
@@ -204,10 +204,10 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
 
     mock.verify
 
-    metrics.each { |m| m.must_be_kind_of Google::Cloud::Logging::Metric }
-    metrics.count.must_equal 3
-    metrics.token.wont_be :nil?
-    metrics.token.must_equal "next_page_token"
+    metrics.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::Metric }
+    _(metrics.count).must_equal 3
+    _(metrics.token).wont_be :nil?
+    _(metrics.token).must_equal "next_page_token"
   end
 
   it "paginates metrics without max set" do
@@ -221,10 +221,10 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
 
     mock.verify
 
-    metrics.each { |m| m.must_be_kind_of Google::Cloud::Logging::Metric }
-    metrics.count.must_equal 3
-    metrics.token.wont_be :nil?
-    metrics.token.must_equal "next_page_token"
+    metrics.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::Metric }
+    _(metrics.count).must_equal 3
+    _(metrics.token).wont_be :nil?
+    _(metrics.token).must_equal "next_page_token"
   end
 
   it "creates a metric" do
@@ -245,10 +245,10 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
 
     mock.verify
 
-    metric.must_be_kind_of Google::Cloud::Logging::Metric
-    metric.name.must_equal new_metric_name
-    metric.filter.must_equal new_metric_filter
-    metric.description.must_be :empty?
+    _(metric).must_be_kind_of Google::Cloud::Logging::Metric
+    _(metric.name).must_equal new_metric_name
+    _(metric.filter).must_equal new_metric_filter
+    _(metric.description).must_be :empty?
 
   end
 
@@ -272,10 +272,10 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
     metric = logging.create_metric new_metric_name, new_metric_filter, description: new_metric_description
     mock.verify
 
-    metric.must_be_kind_of Google::Cloud::Logging::Metric
-    metric.name.must_equal new_metric_name
-    metric.filter.must_equal new_metric_filter
-    metric.description.must_equal new_metric_description
+    _(metric).must_be_kind_of Google::Cloud::Logging::Metric
+    _(metric.name).must_equal new_metric_name
+    _(metric.filter).must_equal new_metric_filter
+    _(metric.description).must_equal new_metric_description
   end
 
   it "gets a metric" do
@@ -290,8 +290,8 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
 
     mock.verify
 
-    metric.must_be_kind_of Google::Cloud::Logging::Metric
-    metric.name.must_equal metric_name
+    _(metric).must_be_kind_of Google::Cloud::Logging::Metric
+    _(metric.name).must_equal metric_name
   end
 
   it "returns nil when getting a metric that is not found" do
@@ -306,7 +306,7 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
     logging.service.mocked_metrics = stub
 
     metric = logging.metric metric_name
-    metric.must_be :nil?
+    _(metric).must_be :nil?
   end
 
   def list_metrics_hash count = 2, token = nil

--- a/google-cloud-logging/test/google/cloud/logging/project/resource_descriptors_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/resource_descriptors_test.rb
@@ -27,8 +27,8 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
 
     mock.verify
 
-    resource_descriptors.each { |m| m.must_be_kind_of Google::Cloud::Logging::ResourceDescriptor }
-    resource_descriptors.size.must_equal num_descriptors
+    resource_descriptors.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::ResourceDescriptor }
+    _(resource_descriptors.size).must_equal num_descriptors
   end
 
   it "lists resource descriptors with find_resource_descriptors alias" do
@@ -43,8 +43,8 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
 
     mock.verify
 
-    resource_descriptors.each { |m| m.must_be_kind_of Google::Cloud::Logging::ResourceDescriptor }
-    resource_descriptors.size.must_equal num_descriptors
+    resource_descriptors.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::ResourceDescriptor }
+    _(resource_descriptors.size).must_equal num_descriptors
   end
 
   it "paginates resource descriptors" do
@@ -61,14 +61,14 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
 
     mock.verify
 
-    first_descriptors.each { |m| m.must_be_kind_of Google::Cloud::Logging::ResourceDescriptor }
-    first_descriptors.count.must_equal 3
-    first_descriptors.token.wont_be :nil?
-    first_descriptors.token.must_equal "next_page_token"
+    first_descriptors.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::ResourceDescriptor }
+    _(first_descriptors.count).must_equal 3
+    _(first_descriptors.token).wont_be :nil?
+    _(first_descriptors.token).must_equal "next_page_token"
 
-    second_descriptors.each { |m| m.must_be_kind_of Google::Cloud::Logging::ResourceDescriptor }
-    second_descriptors.count.must_equal 2
-    second_descriptors.token.must_be :nil?
+    second_descriptors.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::ResourceDescriptor }
+    _(second_descriptors.count).must_equal 2
+    _(second_descriptors.token).must_be :nil?
   end
 
   it "paginates resource descriptors with next? and next" do
@@ -86,13 +86,13 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
 
     mock.verify
 
-    first_descriptors.each { |m| m.must_be_kind_of Google::Cloud::Logging::ResourceDescriptor }
-    first_descriptors.count.must_equal 3
-    first_descriptors.next?.must_equal true #must_be :next?
+    first_descriptors.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::ResourceDescriptor }
+    _(first_descriptors.count).must_equal 3
+    _(first_descriptors.next?).must_equal true #must_be :next?
 
-    second_descriptors.each { |m| m.must_be_kind_of Google::Cloud::Logging::ResourceDescriptor }
-    second_descriptors.count.must_equal 2
-    second_descriptors.next?.must_equal false #wont_be :next?
+    second_descriptors.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::ResourceDescriptor }
+    _(second_descriptors.count).must_equal 2
+    _(second_descriptors.next?).must_equal false #wont_be :next?
   end
 
   it "paginates resource descriptors with next? and next and max set" do
@@ -110,21 +110,21 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
 
     mock.verify
 
-    first_descriptors.each { |m| m.must_be_kind_of Google::Cloud::Logging::ResourceDescriptor }
-    first_descriptors.count.must_equal 3
-    first_descriptors.next?.must_equal true
-    first_descriptors.token.must_equal "next_page_token"
+    first_descriptors.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::ResourceDescriptor }
+    _(first_descriptors.count).must_equal 3
+    _(first_descriptors.next?).must_equal true
+    _(first_descriptors.token).must_equal "next_page_token"
 
     # ensure the correct values are propogated to the ivars
-    first_descriptors.instance_variable_get(:@max).must_equal 3
+    _(first_descriptors.instance_variable_get(:@max)).must_equal 3
 
-    second_descriptors.each { |m| m.must_be_kind_of Google::Cloud::Logging::ResourceDescriptor }
-    second_descriptors.count.must_equal 2
-    second_descriptors.next?.must_equal true
-    second_descriptors.token.must_equal "second_page_token"
+    second_descriptors.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::ResourceDescriptor }
+    _(second_descriptors.count).must_equal 2
+    _(second_descriptors.next?).must_equal true
+    _(second_descriptors.token).must_equal "second_page_token"
 
     # ensure the correct values are propogated to the ivars
-    second_descriptors.instance_variable_get(:@max).must_equal 3
+    _(second_descriptors.instance_variable_get(:@max)).must_equal 3
   end
 
   it "paginates resource descriptors with all" do
@@ -141,8 +141,8 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
 
     mock.verify
 
-    descriptors.each { |m| m.must_be_kind_of Google::Cloud::Logging::ResourceDescriptor }
-    descriptors.count.must_equal 5
+    descriptors.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::ResourceDescriptor }
+    _(descriptors.count).must_equal 5
   end
 
   it "paginates resource descriptors with all and max set" do
@@ -159,8 +159,8 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
 
     mock.verify
 
-    descriptors.each { |m| m.must_be_kind_of Google::Cloud::Logging::ResourceDescriptor }
-    descriptors.count.must_equal 5
+    descriptors.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::ResourceDescriptor }
+    _(descriptors.count).must_equal 5
   end
 
   it "paginates resource descriptors with all using Enumerator" do
@@ -177,8 +177,8 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
 
     mock.verify
 
-    descriptors.each { |m| m.must_be_kind_of Google::Cloud::Logging::ResourceDescriptor }
-    descriptors.count.must_equal 5
+    descriptors.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::ResourceDescriptor }
+    _(descriptors.count).must_equal 5
   end
 
   it "paginates resource descriptors with all and request_limit set" do
@@ -195,8 +195,8 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
 
     mock.verify
 
-    descriptors.each { |m| m.must_be_kind_of Google::Cloud::Logging::ResourceDescriptor }
-    descriptors.count.must_equal 6
+    descriptors.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::ResourceDescriptor }
+    _(descriptors.count).must_equal 6
   end
 
   it "paginates resource descriptors with max set" do
@@ -210,10 +210,10 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
 
     mock.verify
 
-    resource_descriptors.each { |m| m.must_be_kind_of Google::Cloud::Logging::ResourceDescriptor }
-    resource_descriptors.count.must_equal 3
-    resource_descriptors.token.wont_be :nil?
-    resource_descriptors.token.must_equal "next_page_token"
+    resource_descriptors.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::ResourceDescriptor }
+    _(resource_descriptors.count).must_equal 3
+    _(resource_descriptors.token).wont_be :nil?
+    _(resource_descriptors.token).must_equal "next_page_token"
   end
 
   it "paginates resource descriptors without max set" do
@@ -227,10 +227,10 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
 
     mock.verify
 
-    resource_descriptors.each { |m| m.must_be_kind_of Google::Cloud::Logging::ResourceDescriptor }
-    resource_descriptors.count.must_equal 3
-    resource_descriptors.token.wont_be :nil?
-    resource_descriptors.token.must_equal "next_page_token"
+    resource_descriptors.each { |m| _(m).must_be_kind_of Google::Cloud::Logging::ResourceDescriptor }
+    _(resource_descriptors.count).must_equal 3
+    _(resource_descriptors.token).wont_be :nil?
+    _(resource_descriptors.token).must_equal "next_page_token"
   end
 
   def list_resource_descriptors_hash count = 2, token = nil

--- a/google-cloud-logging/test/google/cloud/logging/project/shared_async_writer_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/shared_async_writer_test.rb
@@ -17,13 +17,13 @@ require "helper"
 describe Google::Cloud::Logging::Project, :shared_async_writer, :mock_logging do
   it "returns the same async writer object" do
     async1 = logging.shared_async_writer
-    async1.must_be_kind_of Google::Cloud::Logging::AsyncWriter
-    async1.logging.must_be_same_as logging
-    async1.max_count.must_equal 10000
-    async1.max_bytes.must_equal 10000000
-    async1.interval.must_equal 5
-    async1.threads.must_equal 10
+    _(async1).must_be_kind_of Google::Cloud::Logging::AsyncWriter
+    _(async1.logging).must_be_same_as logging
+    _(async1.max_count).must_equal 10000
+    _(async1.max_bytes).must_equal 10000000
+    _(async1.interval).must_equal 5
+    _(async1.threads).must_equal 10
     async2 = logging.shared_async_writer
-    async2.must_be_same_as async1
+    _(async2).must_be_same_as async1
   end
 end

--- a/google-cloud-logging/test/google/cloud/logging/project/sinks_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/sinks_test.rb
@@ -27,8 +27,8 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
 
     mock.verify
 
-    sinks.each { |s| s.must_be_kind_of Google::Cloud::Logging::Sink }
-    sinks.size.must_equal num_sinks
+    sinks.each { |s| _(s).must_be_kind_of Google::Cloud::Logging::Sink }
+    _(sinks.size).must_equal num_sinks
   end
 
   it "lists sinks with find_sinks alias" do
@@ -43,8 +43,8 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
 
     mock.verify
 
-    sinks.each { |s| s.must_be_kind_of Google::Cloud::Logging::Sink }
-    sinks.size.must_equal num_sinks
+    sinks.each { |s| _(s).must_be_kind_of Google::Cloud::Logging::Sink }
+    _(sinks.size).must_equal num_sinks
   end
 
   it "paginates sinks" do
@@ -61,14 +61,14 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
 
     mock.verify
 
-    first_sinks.each { |s| s.must_be_kind_of Google::Cloud::Logging::Sink }
-    first_sinks.count.must_equal 3
-    first_sinks.token.wont_be :nil?
-    first_sinks.token.must_equal "next_page_token"
+    first_sinks.each { |s| _(s).must_be_kind_of Google::Cloud::Logging::Sink }
+    _(first_sinks.count).must_equal 3
+    _(first_sinks.token).wont_be :nil?
+    _(first_sinks.token).must_equal "next_page_token"
 
-    second_sinks.each { |s| s.must_be_kind_of Google::Cloud::Logging::Sink }
-    second_sinks.count.must_equal 2
-    second_sinks.token.must_be :nil?
+    second_sinks.each { |s| _(s).must_be_kind_of Google::Cloud::Logging::Sink }
+    _(second_sinks.count).must_equal 2
+    _(second_sinks.token).must_be :nil?
   end
 
   it "paginates sinks with next? and next" do
@@ -85,13 +85,13 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
 
     mock.verify
 
-    first_sinks.each { |s| s.must_be_kind_of Google::Cloud::Logging::Sink }
-    first_sinks.count.must_equal 3
-    first_sinks.next?.must_equal true #must_be :next?
+    first_sinks.each { |s| _(s).must_be_kind_of Google::Cloud::Logging::Sink }
+    _(first_sinks.count).must_equal 3
+    _(first_sinks.next?).must_equal true #must_be :next?
 
-    second_sinks.each { |s| s.must_be_kind_of Google::Cloud::Logging::Sink }
-    second_sinks.count.must_equal 2
-    second_sinks.next?.must_equal false #wont_be :next?
+    second_sinks.each { |s| _(s).must_be_kind_of Google::Cloud::Logging::Sink }
+    _(second_sinks.count).must_equal 2
+    _(second_sinks.next?).must_equal false #wont_be :next?
   end
 
   it "paginates sinks with next? and next and max set" do
@@ -108,21 +108,21 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
 
     mock.verify
 
-    first_sinks.each { |s| s.must_be_kind_of Google::Cloud::Logging::Sink }
-    first_sinks.count.must_equal 3
-    first_sinks.next?.must_equal true
-    first_sinks.token.must_equal "next_page_token"
+    first_sinks.each { |s| _(s).must_be_kind_of Google::Cloud::Logging::Sink }
+    _(first_sinks.count).must_equal 3
+    _(first_sinks.next?).must_equal true
+    _(first_sinks.token).must_equal "next_page_token"
 
     # ensure the correct values are propogated to the ivars
-    first_sinks.instance_variable_get(:@max).must_equal 3
+    _(first_sinks.instance_variable_get(:@max)).must_equal 3
 
-    second_sinks.each { |s| s.must_be_kind_of Google::Cloud::Logging::Sink }
-    second_sinks.count.must_equal 2
-    second_sinks.next?.must_equal true
-    second_sinks.token.must_equal "second_page_token"
+    second_sinks.each { |s| _(s).must_be_kind_of Google::Cloud::Logging::Sink }
+    _(second_sinks.count).must_equal 2
+    _(second_sinks.next?).must_equal true
+    _(second_sinks.token).must_equal "second_page_token"
 
     # ensure the correct values are propogated to the ivars
-    second_sinks.instance_variable_get(:@max).must_equal 3
+    _(second_sinks.instance_variable_get(:@max)).must_equal 3
   end
 
   it "paginates sinks with all" do
@@ -138,8 +138,8 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
 
     mock.verify
 
-    all_sinks.each { |s| s.must_be_kind_of Google::Cloud::Logging::Sink }
-    all_sinks.count.must_equal 5
+    all_sinks.each { |s| _(s).must_be_kind_of Google::Cloud::Logging::Sink }
+    _(all_sinks.count).must_equal 5
   end
 
   it "paginates sinks with all and max set" do
@@ -155,8 +155,8 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
 
     mock.verify
 
-    all_sinks.each { |s| s.must_be_kind_of Google::Cloud::Logging::Sink }
-    all_sinks.count.must_equal 5
+    all_sinks.each { |s| _(s).must_be_kind_of Google::Cloud::Logging::Sink }
+    _(all_sinks.count).must_equal 5
   end
 
   it "paginates sinks with all using Enumerator" do
@@ -172,8 +172,8 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
 
     mock.verify
 
-    all_sinks.each { |s| s.must_be_kind_of Google::Cloud::Logging::Sink }
-    all_sinks.count.must_equal 5
+    all_sinks.each { |s| _(s).must_be_kind_of Google::Cloud::Logging::Sink }
+    _(all_sinks.count).must_equal 5
   end
 
   it "paginates sinks with all and request_limit set" do
@@ -189,8 +189,8 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
 
     mock.verify
 
-    all_sinks.each { |s| s.must_be_kind_of Google::Cloud::Logging::Sink }
-    all_sinks.count.must_equal 6
+    all_sinks.each { |s| _(s).must_be_kind_of Google::Cloud::Logging::Sink }
+    _(all_sinks.count).must_equal 6
   end
 
   it "paginates sinks with max set" do
@@ -205,10 +205,10 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
 
     mock.verify
 
-    sinks.each { |s| s.must_be_kind_of Google::Cloud::Logging::Sink }
-    sinks.count.must_equal 3
-    sinks.token.wont_be :nil?
-    sinks.token.must_equal "next_page_token"
+    sinks.each { |s| _(s).must_be_kind_of Google::Cloud::Logging::Sink }
+    _(sinks.count).must_equal 3
+    _(sinks.token).wont_be :nil?
+    _(sinks.token).must_equal "next_page_token"
   end
 
   it "paginates sinks without max set" do
@@ -223,10 +223,10 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
 
     mock.verify
 
-    sinks.each { |s| s.must_be_kind_of Google::Cloud::Logging::Sink }
-    sinks.count.must_equal 3
-    sinks.token.wont_be :nil?
-    sinks.token.must_equal "next_page_token"
+    sinks.each { |s| _(s).must_be_kind_of Google::Cloud::Logging::Sink }
+    _(sinks.count).must_equal 3
+    _(sinks.token).wont_be :nil?
+    _(sinks.token).must_equal "next_page_token"
   end
 
   it "creates a sink" do
@@ -246,11 +246,11 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
 
     mock.verify
 
-    sink.must_be_kind_of Google::Cloud::Logging::Sink
-    sink.name.must_equal new_sink_name
-    sink.destination.must_equal new_sink_destination
-    sink.filter.must_be :empty?
-    sink.writer_identity.must_equal "roles/owner"
+    _(sink).must_be_kind_of Google::Cloud::Logging::Sink
+    _(sink.name).must_equal new_sink_name
+    _(sink.destination).must_equal new_sink_destination
+    _(sink.filter).must_be :empty?
+    _(sink.writer_identity).must_equal "roles/owner"
   end
 
   it "creates a sink with additional attributes" do
@@ -278,11 +278,11 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
 
     mock.verify
 
-    sink.must_be_kind_of Google::Cloud::Logging::Sink
-    sink.name.must_equal new_sink_name
-    sink.destination.must_equal new_sink_destination
-    sink.filter.must_equal new_sink_filter
-    sink.writer_identity.must_equal "roles/owner"
+    _(sink).must_be_kind_of Google::Cloud::Logging::Sink
+    _(sink.name).must_equal new_sink_name
+    _(sink.destination).must_equal new_sink_destination
+    _(sink.filter).must_equal new_sink_filter
+    _(sink.writer_identity).must_equal "roles/owner"
   end
 
   it "creates a sink with unique_writer_identity" do
@@ -302,11 +302,11 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
 
     mock.verify
 
-    sink.must_be_kind_of Google::Cloud::Logging::Sink
-    sink.name.must_equal new_sink_name
-    sink.destination.must_equal new_sink_destination
-    sink.filter.must_be :empty?
-    sink.writer_identity.must_equal "serviceAccount:cloud-logs@system.gserviceaccount.com"
+    _(sink).must_be_kind_of Google::Cloud::Logging::Sink
+    _(sink.name).must_equal new_sink_name
+    _(sink.destination).must_equal new_sink_destination
+    _(sink.filter).must_be :empty?
+    _(sink.writer_identity).must_equal "serviceAccount:cloud-logs@system.gserviceaccount.com"
   end
 
   it "gets a sink" do
@@ -321,9 +321,9 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
 
     mock.verify
 
-    sink.must_be_kind_of Google::Cloud::Logging::Sink
-    sink.name.must_equal sink_name
-    sink.writer_identity.must_equal "roles/owner"
+    _(sink).must_be_kind_of Google::Cloud::Logging::Sink
+    _(sink.name).must_equal sink_name
+    _(sink.writer_identity).must_equal "roles/owner"
   end
 
   def list_sinks_hash count = 2, token = nil

--- a/google-cloud-logging/test/google/cloud/logging/project_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project_test.rb
@@ -16,8 +16,8 @@ require "helper"
 
 describe Google::Cloud::Logging::Project, :mock_logging do
   it "knows the project identifier" do
-    logging.must_be_kind_of Google::Cloud::Logging::Project
-    logging.project.must_equal project
+    _(logging).must_be_kind_of Google::Cloud::Logging::Project
+    _(logging.project).must_equal project
   end
 
   it "creates an empty entry" do
@@ -25,17 +25,17 @@ describe Google::Cloud::Logging::Project, :mock_logging do
     Google::Cloud::Logging::Entry.stub :insert_id, "abc-123" do
       entry = logging.entry
     end
-    entry.must_be_kind_of Google::Cloud::Logging::Entry
-    entry.resource.must_be_kind_of Google::Cloud::Logging::Resource
+    _(entry).must_be_kind_of Google::Cloud::Logging::Entry
+    _(entry.resource).must_be_kind_of Google::Cloud::Logging::Resource
 
-    entry.must_be_kind_of Google::Cloud::Logging::Entry
-    entry.log_name.must_be :nil?
-    entry.resource.must_be :empty?
-    entry.timestamp.must_be :nil?
-    entry.severity.must_equal :DEFAULT
-    entry.insert_id.must_equal "abc-123"
-    entry.labels.must_be :empty?
-    entry.payload.must_be :nil?
+    _(entry).must_be_kind_of Google::Cloud::Logging::Entry
+    _(entry.log_name).must_be :nil?
+    _(entry.resource).must_be :empty?
+    _(entry.timestamp).must_be :nil?
+    _(entry.severity).must_equal :DEFAULT
+    _(entry.insert_id).must_equal "abc-123"
+    _(entry.labels).must_be :empty?
+    _(entry.payload).must_be :nil?
   end
 
   it "creates an entry with all attributes" do
@@ -57,24 +57,24 @@ describe Google::Cloud::Logging::Project, :mock_logging do
                           labels: labels,
                           payload: payload
 
-    entry.must_be_kind_of Google::Cloud::Logging::Entry
-    entry.log_name.must_equal "projects/#{project}/logs/#{log_name}"
-    entry.resource.must_equal resource
-    entry.timestamp.must_equal timestamp
-    entry.severity.must_equal severity
-    entry.insert_id.must_equal insert_id
-    entry.labels.must_equal labels
-    entry.payload.must_equal payload
+    _(entry).must_be_kind_of Google::Cloud::Logging::Entry
+    _(entry.log_name).must_equal "projects/#{project}/logs/#{log_name}"
+    _(entry.resource).must_equal resource
+    _(entry.timestamp).must_equal timestamp
+    _(entry.severity).must_equal severity
+    _(entry.insert_id).must_equal insert_id
+    _(entry.labels).must_equal labels
+    _(entry.payload).must_equal payload
   end
 
   it "creates a resource instance" do
     resource = logging.resource "gae_app",
                                 "module_id" => "1",
                                 "version_id" => "20150925t173233"
-    resource.must_be_kind_of Google::Cloud::Logging::Resource
-    resource.type.must_equal   "gae_app"
-    resource.labels["module_id"].must_equal "1"
-    resource.labels["version_id"].must_equal "20150925t173233"
+    _(resource).must_be_kind_of Google::Cloud::Logging::Resource
+    _(resource.type).must_equal   "gae_app"
+    _(resource.labels["module_id"]).must_equal "1"
+    _(resource.labels["version_id"]).must_equal "20150925t173233"
   end
 
   it "deletes a log" do
@@ -88,7 +88,7 @@ describe Google::Cloud::Logging::Project, :mock_logging do
 
     mock.verify
 
-    success.must_equal true
+    _(success).must_equal true
   end
 
   it "deletes a log with full path name" do
@@ -102,6 +102,6 @@ describe Google::Cloud::Logging::Project, :mock_logging do
 
     mock.verify
 
-    success.must_equal true
+    _(success).must_equal true
   end
 end

--- a/google-cloud-logging/test/google/cloud/logging/rails_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/rails_test.rb
@@ -50,12 +50,12 @@ describe Google::Cloud::Logging::Railtie do
         Google::Cloud::Logging::Railtie.send :consolidate_rails_config, rails_config
 
         Google::Cloud::Logging.configure do |config|
-          config.project_id.must_equal "test-project"
-          config.credentials.must_equal "test/keyfile"
-          config.log_name.must_equal "test-log-name"
-          config.log_name_map.must_equal "test-path" => "log-name"
-          config.monitored_resource.type.must_equal "test-type"
-          config.monitored_resource.labels.must_equal test: "label"
+          _(config.project_id).must_equal "test-project"
+          _(config.credentials).must_equal "test/keyfile"
+          _(config.log_name).must_equal "test-log-name"
+          _(config.log_name_map).must_equal "test-path" => "log-name"
+          _(config.monitored_resource.type).must_equal "test-type"
+          _(config.monitored_resource.labels).must_equal test: "label"
         end
       end
     end
@@ -73,11 +73,11 @@ describe Google::Cloud::Logging::Railtie do
         Google::Cloud::Logging::Railtie.send :consolidate_rails_config, rails_config
 
         Google::Cloud::Logging.configure do |config|
-          config.project_id.must_equal "another-test-project"
-          config.credentials.must_equal "/another/test/keyfile"
-          config.log_name.must_equal  "another-test-log-name"
-          config.log_name_map.must_equal "test-path" => "another-log-name"
-          config.monitored_resource.type.must_equal "another-test-type"
+          _(config.project_id).must_equal "another-test-project"
+          _(config.credentials).must_equal "/another/test/keyfile"
+          _(config.log_name).must_equal  "another-test-log-name"
+          _(config.log_name_map).must_equal "test-path" => "another-log-name"
+          _(config.monitored_resource.type).must_equal "another-test-type"
         end
       end
     end
@@ -87,16 +87,16 @@ describe Google::Cloud::Logging::Railtie do
 
       Google::Cloud::Logging::Railtie.stub :valid_credentials?, false do
         Google::Cloud::Logging::Railtie.send :consolidate_rails_config, rails_config
-        Google::Cloud.configure.use_logging.must_equal false
+        _(Google::Cloud.configure.use_logging).must_equal false
       end
     end
 
     it "Set use_logging to true if Rails is in production" do
       Google::Cloud::Logging::Railtie.stub :valid_credentials?, true do
         Rails.env.stub :production?, true do
-          Google::Cloud.configure.use_logging.must_be_nil
+          _(Google::Cloud.configure.use_logging).must_be_nil
           Google::Cloud::Logging::Railtie.send :consolidate_rails_config, rails_config
-          Google::Cloud.configure.use_logging.must_equal true
+          _(Google::Cloud.configure.use_logging).must_equal true
         end
       end
     end
@@ -107,7 +107,7 @@ describe Google::Cloud::Logging::Railtie do
       Google::Cloud::Logging::Railtie.stub :valid_credentials?, true do
         Rails.env.stub :production?, false do
           Google::Cloud::Logging::Railtie.send :consolidate_rails_config, rails_config
-          Google::Cloud.configure.use_logging.must_equal true
+          _(Google::Cloud.configure.use_logging).must_equal true
         end
       end
     end
@@ -133,12 +133,12 @@ describe Google::Cloud::Logging::Railtie do
         Google::Cloud::Logging::Railtie.send :consolidate_rails_config, rails_config
 
         Google::Cloud::Logging.configure do |config|
-          config.project_id.must_equal "test-project"
-          config.credentials.must_equal "test/keyfile"
-          config.log_name.must_equal "test-log-name"
-          config.log_name_map.must_equal "test-path" => "log-name"
-          config.monitored_resource.type.must_equal "test-type"
-          config.monitored_resource.labels.must_equal test: "label"
+          _(config.project_id).must_equal "test-project"
+          _(config.credentials).must_equal "test/keyfile"
+          _(config.log_name).must_equal "test-log-name"
+          _(config.log_name_map).must_equal "test-path" => "log-name"
+          _(config.monitored_resource.type).must_equal "test-type"
+          _(config.monitored_resource.labels).must_equal test: "label"
         end
       end
     end
@@ -156,11 +156,11 @@ describe Google::Cloud::Logging::Railtie do
         Google::Cloud::Logging::Railtie.send :consolidate_rails_config, rails_config
 
         Google::Cloud::Logging.configure do |config|
-          config.project_id.must_equal "another-test-project"
-          config.credentials.must_equal "/another/test/keyfile"
-          config.log_name.must_equal  "another-test-log-name"
-          config.log_name_map.must_equal "test-path" => "another-log-name"
-          config.monitored_resource.type.must_equal "another-test-type"
+          _(config.project_id).must_equal "another-test-project"
+          _(config.credentials).must_equal "/another/test/keyfile"
+          _(config.log_name).must_equal  "another-test-log-name"
+          _(config.log_name_map).must_equal "test-path" => "another-log-name"
+          _(config.monitored_resource.type).must_equal "another-test-type"
         end
       end
     end
@@ -170,16 +170,16 @@ describe Google::Cloud::Logging::Railtie do
 
       Google::Cloud::Logging::Railtie.stub :valid_credentials?, false do
         Google::Cloud::Logging::Railtie.send :consolidate_rails_config, rails_config
-        Google::Cloud.configure.use_logging.must_equal false
+        _(Google::Cloud.configure.use_logging).must_equal false
       end
     end
 
     it "Set use_logging to true if Rails is in production" do
       Google::Cloud::Logging::Railtie.stub :valid_credentials?, true do
         Rails.env.stub :production?, true do
-          Google::Cloud.configure.use_logging.must_be_nil
+          _(Google::Cloud.configure.use_logging).must_be_nil
           Google::Cloud::Logging::Railtie.send :consolidate_rails_config, rails_config
-          Google::Cloud.configure.use_logging.must_equal true
+          _(Google::Cloud.configure.use_logging).must_equal true
         end
       end
     end
@@ -189,7 +189,7 @@ describe Google::Cloud::Logging::Railtie do
         Rails.env.stub :production?, true do
           Google::Cloud.configure.use_logging = false
           Google::Cloud::Logging::Railtie.send :consolidate_rails_config, rails_config
-          Google::Cloud.configure.use_logging.must_equal false
+          _(Google::Cloud.configure.use_logging).must_equal false
         end
       end
     end
@@ -200,7 +200,7 @@ describe Google::Cloud::Logging::Railtie do
       Google::Cloud::Logging::Railtie.stub :valid_credentials?, true do
         Rails.env.stub :production?, false do
           Google::Cloud::Logging::Railtie.send :consolidate_rails_config, rails_config
-          Google::Cloud.configure.use_logging.must_equal true
+          _(Google::Cloud.configure.use_logging).must_equal true
         end
       end
     end

--- a/google-cloud-logging/test/google/cloud/logging/resource_descriptor_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/resource_descriptor_test.rb
@@ -20,28 +20,28 @@ describe Google::Cloud::Logging::ResourceDescriptor, :mock_logging do
   let(:resource_descriptor) { Google::Cloud::Logging::ResourceDescriptor.from_grpc resource_descriptor_grpc }
 
   it "knows its attributes" do
-    resource_descriptor.type.must_equal        "cloudsql_database"
-    resource_descriptor.name.must_equal        "Cloud SQL Database"
-    resource_descriptor.description.must_equal "This resource is a Cloud SQL Database"
+    _(resource_descriptor.type).must_equal        "cloudsql_database"
+    _(resource_descriptor.name).must_equal        "Cloud SQL Database"
+    _(resource_descriptor.description).must_equal "This resource is a Cloud SQL Database"
   end
 
   it "has label descriptors" do
     labels = resource_descriptor.labels
-    labels.must_be_kind_of Array
-    labels.wont_be :empty?
-    labels.count.must_equal 4
-    labels[0].must_be_kind_of Google::Cloud::Logging::ResourceDescriptor::LabelDescriptor
-    labels[0].key.must_equal "database_id"
-    labels[0].type.must_equal :string # defaults to string...
-    labels[0].description.must_equal "The ID of the database."
-    labels[1].key.must_equal "zone"
-    labels[1].type.must_equal :string
-    labels[1].description.must_equal "The GCP zone in which the database is running."
-    labels[2].key.must_equal "active"
-    labels[2].type.must_equal :boolean
-    labels[2].description.must_equal "Whether the database is active."
-    labels[3].key.must_equal "max_connections"
-    labels[3].type.must_equal :integer
-    labels[3].description.must_equal "The maximum number of connections it supports."
+    _(labels).must_be_kind_of Array
+    _(labels).wont_be :empty?
+    _(labels.count).must_equal 4
+    _(labels[0]).must_be_kind_of Google::Cloud::Logging::ResourceDescriptor::LabelDescriptor
+    _(labels[0].key).must_equal "database_id"
+    _(labels[0].type).must_equal :string # defaults to string...
+    _(labels[0].description).must_equal "The ID of the database."
+    _(labels[1].key).must_equal "zone"
+    _(labels[1].type).must_equal :string
+    _(labels[1].description).must_equal "The GCP zone in which the database is running."
+    _(labels[2].key).must_equal "active"
+    _(labels[2].type).must_equal :boolean
+    _(labels[2].description).must_equal "Whether the database is active."
+    _(labels[3].key).must_equal "max_connections"
+    _(labels[3].type).must_equal :integer
+    _(labels[3].description).must_equal "The maximum number of connections it supports."
   end
 end

--- a/google-cloud-logging/test/google/cloud/logging/resource_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/resource_test.rb
@@ -20,15 +20,15 @@ describe Google::Cloud::Logging::Resource, :mock_logging do
   let(:resource) { Google::Cloud::Logging::Resource.from_grpc resource_grpc }
 
   it "knows its attributes" do
-    resource.type.must_equal resource_hash[:type]
-    resource.labels.keys.sort.must_equal   resource_hash[:labels].keys.sort
-    resource.labels.values.sort.must_equal resource_hash[:labels].values.sort
+    _(resource.type).must_equal resource_hash[:type]
+    _(resource.labels.keys.sort).must_equal   resource_hash[:labels].keys.sort
+    _(resource.labels.values.sort).must_equal resource_hash[:labels].values.sort
   end
 
   it "can export to a grpc object" do
     grpc = resource.to_grpc
-    grpc.type.must_equal resource_hash[:type]
-    grpc.labels.keys.sort.must_equal   resource_hash[:labels].keys.sort
-    grpc.labels.values.sort.must_equal resource_hash[:labels].values.sort
+    _(grpc.type).must_equal resource_hash[:type]
+    _(grpc.labels.keys.sort).must_equal   resource_hash[:labels].keys.sort
+    _(grpc.labels.values.sort).must_equal resource_hash[:labels].values.sort
   end
 end

--- a/google-cloud-logging/test/google/cloud/logging/sink_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/sink_test.rb
@@ -20,50 +20,50 @@ describe Google::Cloud::Logging::Sink, :mock_logging do
   let(:sink_grpc) { Google::Logging::V2::LogSink.new sink_hash }
 
   it "knows its attributes" do
-    sink.name.must_equal        sink_hash[:name]
-    sink.destination.must_equal sink_hash[:destination]
-    sink.filter.must_equal      sink_hash[:filter]
-    sink.writer_identity.must_equal  "roles/owner"
+    _(sink.name).must_equal        sink_hash[:name]
+    _(sink.destination).must_equal sink_hash[:destination]
+    _(sink.filter).must_equal      sink_hash[:filter]
+    _(sink.writer_identity).must_equal  "roles/owner"
   end
 
   it "has deprecated values" do
     assert_output nil, /version is deprecated/ do
-      sink.version.must_equal :V2
+      _(sink.version).must_equal :V2
     end
     assert_output nil, /version= is deprecated and will be ignored/ do
       sink.version = :V1
     end
     assert_output nil, /unspecified\? is deprecated/ do
-      sink.wont_be :unspecified?
+      _(sink).wont_be :unspecified?
     end
     assert_output nil, /v2\? is deprecated/ do
-      sink.must_be :v2?
+      _(sink).must_be :v2?
     end
     assert_output nil, /v1\? is deprecated/ do
-      sink.wont_be :v1?
+      _(sink).wont_be :v1?
     end
 
     assert_output nil, /start_at is deprecated/ do
-      sink.start_at.must_be :nil?
+      _(sink.start_at).must_be :nil?
     end
     assert_output nil, /start_at= is deprecated and will be ignored/ do
       sink.start_at = Time.now
     end
     assert_output nil, /start_at is deprecated/ do
-      sink.start_time.must_be :nil?
+      _(sink.start_time).must_be :nil?
     end
     assert_output nil, /start_at= is deprecated and will be ignored/ do
       sink.start_time = Time.now
     end
 
     assert_output nil, /end_at is deprecated/ do
-      sink.end_at.must_be :nil?
+      _(sink.end_at).must_be :nil?
     end
     assert_output nil, /end_at= is deprecated and will be ignored/ do
       sink.end_at = Time.now
     end
     assert_output nil, /end_at is deprecated/ do
-      sink.end_time.must_be :nil?
+      _(sink.end_time).must_be :nil?
     end
     assert_output nil, /end_at= is deprecated and will be ignored/ do
       sink.end_time = Time.now
@@ -91,10 +91,10 @@ describe Google::Cloud::Logging::Sink, :mock_logging do
 
     mock.verify
 
-    sink.must_be_kind_of Google::Cloud::Logging::Sink
-    sink.destination.must_equal new_sink_destination
-    sink.filter.must_equal new_sink_filter
-    sink.writer_identity.must_equal "roles/owner"
+    _(sink).must_be_kind_of Google::Cloud::Logging::Sink
+    _(sink.destination).must_equal new_sink_destination
+    _(sink.filter).must_equal new_sink_filter
+    _(sink.writer_identity).must_equal "roles/owner"
   end
 
   it "can save itself with unique_writer_identity" do
@@ -121,10 +121,10 @@ describe Google::Cloud::Logging::Sink, :mock_logging do
 
     mock.verify
 
-    sink.must_be_kind_of Google::Cloud::Logging::Sink
-    sink.destination.must_equal new_sink_destination
-    sink.filter.must_equal new_sink_filter
-    sink.writer_identity.must_equal "serviceAccount:cloud-logs@system.gserviceaccount.com"
+    _(sink).must_be_kind_of Google::Cloud::Logging::Sink
+    _(sink.destination).must_equal new_sink_destination
+    _(sink.filter).must_equal new_sink_filter
+    _(sink.writer_identity).must_equal "serviceAccount:cloud-logs@system.gserviceaccount.com"
   end
 
   it "can refresh itself" do

--- a/google-cloud-logging/test/google/cloud/logging_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging_test.rb
@@ -19,51 +19,51 @@ describe Google::Cloud do
     it "calls out to Google::Cloud.logging" do
       gcloud = Google::Cloud.new
       stubbed_logging = ->(project, keyfile, scope: nil, timeout: nil, client_config: nil, host: nil) {
-        project.must_be_nil
-        keyfile.must_be_nil
-        scope.must_be_nil
-        timeout.must_be_nil
-        client_config.must_be_nil
-        host.must_be_nil
+        _(project).must_be_nil
+        _(keyfile).must_be_nil
+        _(scope).must_be_nil
+        _(timeout).must_be_nil
+        _(client_config).must_be_nil
+        _(host).must_be_nil
         "logging-project-object-empty"
       }
       Google::Cloud.stub :logging, stubbed_logging do
         project = gcloud.logging
-        project.must_equal "logging-project-object-empty"
+        _(project).must_equal "logging-project-object-empty"
       end
     end
 
     it "passes project and keyfile to Google::Cloud.logging" do
       gcloud = Google::Cloud.new "project-id", "keyfile-path"
       stubbed_logging = ->(project, keyfile, scope: nil, timeout: nil, client_config: nil, host: nil) {
-        project.must_equal "project-id"
-        keyfile.must_equal "keyfile-path"
-        scope.must_be_nil
-        timeout.must_be_nil
-        client_config.must_be_nil
-        host.must_be_nil
+        _(project).must_equal "project-id"
+        _(keyfile).must_equal "keyfile-path"
+        _(scope).must_be_nil
+        _(timeout).must_be_nil
+        _(client_config).must_be_nil
+        _(host).must_be_nil
         "logging-project-object"
       }
       Google::Cloud.stub :logging, stubbed_logging do
         project = gcloud.logging
-        project.must_equal "logging-project-object"
+        _(project).must_equal "logging-project-object"
       end
     end
 
     it "passes project and keyfile and options to Google::Cloud.logging" do
       gcloud = Google::Cloud.new "project-id", "keyfile-path"
       stubbed_logging = ->(project, keyfile, scope: nil, timeout: nil, client_config: nil, host: nil) {
-        project.must_equal "project-id"
-        keyfile.must_equal "keyfile-path"
-        scope.must_equal "http://example.com/scope"
-        timeout.must_equal 60
-        client_config.must_equal({ "gax" => "options" })
-        host.must_be_nil
+        _(project).must_equal "project-id"
+        _(keyfile).must_equal "keyfile-path"
+        _(scope).must_equal "http://example.com/scope"
+        _(timeout).must_equal 60
+        _(client_config).must_equal({ "gax" => "options" })
+        _(host).must_be_nil
         "logging-project-object-scoped"
       }
       Google::Cloud.stub :logging, stubbed_logging do
         project = gcloud.logging scope: "http://example.com/scope", timeout: 60, client_config: { "gax" => "options" }
-        project.must_equal "logging-project-object-scoped"
+        _(project).must_equal "logging-project-object-scoped"
       end
     end
   end
@@ -85,9 +85,9 @@ describe Google::Cloud do
         Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
           Google::Cloud::Logging::Credentials.stub :default, default_credentials do
             logging = Google::Cloud.logging
-            logging.must_be_kind_of Google::Cloud::Logging::Project
-            logging.project.must_equal "project-id"
-            logging.service.credentials.must_equal default_credentials
+            _(logging).must_be_kind_of Google::Cloud::Logging::Project
+            _(logging.project).must_equal "project-id"
+            _(logging.service.credentials).must_equal default_credentials
           end
         end
       end
@@ -95,16 +95,16 @@ describe Google::Cloud do
 
     it "uses provided project_id and keyfile" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be_nil
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be_nil
         "logging-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, client_config: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "logging-credentials"
-        timeout.must_be_nil
-        client_config.must_be_nil
-        host.must_be_nil
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "logging-credentials"
+        _(timeout).must_be_nil
+        _(client_config).must_be_nil
+        _(host).must_be_nil
         OpenStruct.new project: project
       }
 
@@ -115,9 +115,9 @@ describe Google::Cloud do
             Google::Cloud::Logging::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Logging::Service.stub :new, stubbed_service do
                 logging = Google::Cloud.logging "project-id", "path/to/keyfile.json"
-                logging.must_be_kind_of Google::Cloud::Logging::Project
-                logging.project.must_equal "project-id"
-                logging.service.must_be_kind_of OpenStruct
+                _(logging).must_be_kind_of Google::Cloud::Logging::Project
+                _(logging.project).must_equal "project-id"
+                _(logging.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -143,9 +143,9 @@ describe Google::Cloud do
         Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
           Google::Cloud::Logging::Credentials.stub :default, default_credentials do
             logging = Google::Cloud::Logging.new
-            logging.must_be_kind_of Google::Cloud::Logging::Project
-            logging.project.must_equal "project-id"
-            logging.service.credentials.must_equal default_credentials
+            _(logging).must_be_kind_of Google::Cloud::Logging::Project
+            _(logging.project).must_equal "project-id"
+            _(logging.service.credentials).must_equal default_credentials
           end
         end
       end
@@ -153,16 +153,16 @@ describe Google::Cloud do
 
     it "uses provided project_id and credentials" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be_nil
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be_nil
         "logging-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, client_config: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "logging-credentials"
-        timeout.must_be_nil
-        client_config.must_be_nil
-        host.must_be_nil
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "logging-credentials"
+        _(timeout).must_be_nil
+        _(client_config).must_be_nil
+        _(host).must_be_nil
         OpenStruct.new project: project
       }
 
@@ -173,9 +173,9 @@ describe Google::Cloud do
             Google::Cloud::Logging::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Logging::Service.stub :new, stubbed_service do
                 logging = Google::Cloud::Logging.new project_id: "project-id", credentials: "path/to/keyfile.json"
-                logging.must_be_kind_of Google::Cloud::Logging::Project
-                logging.project.must_equal "project-id"
-                logging.service.must_be_kind_of OpenStruct
+                _(logging).must_be_kind_of Google::Cloud::Logging::Project
+                _(logging.project).must_equal "project-id"
+                _(logging.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -186,11 +186,11 @@ describe Google::Cloud do
     it "uses provided endpoint" do
       endpoint = "logging-endpoint2.example.com"
       stubbed_service = ->(project, credentials, timeout: nil, client_config: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal default_credentials
-        timeout.must_be_nil
-        client_config.must_be_nil
-        host.must_equal endpoint
+        _(project).must_equal "project-id"
+        _(credentials).must_equal default_credentials
+        _(timeout).must_be_nil
+        _(client_config).must_be_nil
+        _(host).must_equal endpoint
         OpenStruct.new project: project
       }
 
@@ -198,25 +198,25 @@ describe Google::Cloud do
       ENV.stub :[], nil do
         Google::Cloud::Logging::Service.stub :new, stubbed_service do
           logging = Google::Cloud::Logging.new project_id: "project-id", credentials: default_credentials, endpoint: endpoint
-          logging.must_be_kind_of Google::Cloud::Logging::Project
-          logging.project.must_equal "project-id"
-          logging.service.must_be_kind_of OpenStruct
+          _(logging).must_be_kind_of Google::Cloud::Logging::Project
+          _(logging.project).must_equal "project-id"
+          _(logging.service).must_be_kind_of OpenStruct
         end
       end
     end
 
     it "uses provided project and keyfile aliases" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be_nil
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be_nil
         "logging-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, client_config: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "logging-credentials"
-        timeout.must_be_nil
-        client_config.must_be_nil
-        host.must_be_nil
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "logging-credentials"
+        _(timeout).must_be_nil
+        _(client_config).must_be_nil
+        _(host).must_be_nil
         OpenStruct.new project: project
       }
 
@@ -227,9 +227,9 @@ describe Google::Cloud do
             Google::Cloud::Logging::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Logging::Service.stub :new, stubbed_service do
                 logging = Google::Cloud::Logging.new project: "project-id", keyfile: "path/to/keyfile.json"
-                logging.must_be_kind_of Google::Cloud::Logging::Project
-                logging.project.must_equal "project-id"
-                logging.service.must_be_kind_of OpenStruct
+                _(logging).must_be_kind_of Google::Cloud::Logging::Project
+                _(logging.project).must_equal "project-id"
+                _(logging.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -239,17 +239,17 @@ describe Google::Cloud do
 
     it "gets project_id from credentials" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be_nil
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be_nil
         OpenStruct.new project_id: "project-id"
       }
       stubbed_service = ->(project, credentials, timeout: nil, client_config: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_be_kind_of OpenStruct
-        credentials.project_id.must_equal "project-id"
-        timeout.must_be_nil
-        client_config.must_be_nil
-        host.must_be_nil
+        _(project).must_equal "project-id"
+        _(credentials).must_be_kind_of OpenStruct
+        _(credentials.project_id).must_equal "project-id"
+        _(timeout).must_be_nil
+        _(client_config).must_be_nil
+        _(host).must_be_nil
         OpenStruct.new project: project
       }
       empty_env = OpenStruct.new
@@ -262,9 +262,9 @@ describe Google::Cloud do
               Google::Cloud::Logging::Credentials.stub :new, stubbed_credentials do
                 Google::Cloud::Logging::Service.stub :new, stubbed_service do
                   logging = Google::Cloud::Logging.new credentials: "path/to/keyfile.json"
-                  logging.must_be_kind_of Google::Cloud::Logging::Project
-                  logging.project.must_equal "project-id"
-                  logging.service.must_be_kind_of OpenStruct
+                  _(logging).must_be_kind_of Google::Cloud::Logging::Project
+                  _(logging.project).must_equal "project-id"
+                  _(logging.service).must_be_kind_of OpenStruct
                 end
               end
             end
@@ -295,16 +295,16 @@ describe Google::Cloud do
 
     it "uses shared config for project and keyfile" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "logging-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, client_config: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "logging-credentials"
-        timeout.must_be :nil?
-        client_config.must_be :nil?
-        host.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "logging-credentials"
+        _(timeout).must_be :nil?
+        _(client_config).must_be :nil?
+        _(host).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -321,9 +321,9 @@ describe Google::Cloud do
             Google::Cloud::Logging::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Logging::Service.stub :new, stubbed_service do
                 logging = Google::Cloud::Logging.new
-                logging.must_be_kind_of Google::Cloud::Logging::Project
-                logging.project.must_equal "project-id"
-                logging.service.must_be_kind_of OpenStruct
+                _(logging).must_be_kind_of Google::Cloud::Logging::Project
+                _(logging.project).must_equal "project-id"
+                _(logging.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -333,16 +333,16 @@ describe Google::Cloud do
 
     it "uses shared config for project_id and credentials" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "logging-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, client_config: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "logging-credentials"
-        timeout.must_be :nil?
-        client_config.must_be :nil?
-        host.must_be :nil?
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "logging-credentials"
+        _(timeout).must_be :nil?
+        _(client_config).must_be :nil?
+        _(host).must_be :nil?
         OpenStruct.new project: project
       }
 
@@ -359,9 +359,9 @@ describe Google::Cloud do
             Google::Cloud::Logging::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Logging::Service.stub :new, stubbed_service do
                 logging = Google::Cloud::Logging.new
-                logging.must_be_kind_of Google::Cloud::Logging::Project
-                logging.project.must_equal "project-id"
-                logging.service.must_be_kind_of OpenStruct
+                _(logging).must_be_kind_of Google::Cloud::Logging::Project
+                _(logging.project).must_equal "project-id"
+                _(logging.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -371,16 +371,16 @@ describe Google::Cloud do
 
     it "uses logging config for project and keyfile" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "logging-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, client_config: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "logging-credentials"
-        timeout.must_equal 42
-        client_config.must_equal logging_client_config
-        host.must_be_nil
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "logging-credentials"
+        _(timeout).must_equal 42
+        _(client_config).must_equal logging_client_config
+        _(host).must_be_nil
         OpenStruct.new project: project
       }
 
@@ -399,9 +399,9 @@ describe Google::Cloud do
             Google::Cloud::Logging::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Logging::Service.stub :new, stubbed_service do
                 logging = Google::Cloud::Logging.new
-                logging.must_be_kind_of Google::Cloud::Logging::Project
-                logging.project.must_equal "project-id"
-                logging.service.must_be_kind_of OpenStruct
+                _(logging).must_be_kind_of Google::Cloud::Logging::Project
+                _(logging.project).must_equal "project-id"
+                _(logging.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -412,11 +412,11 @@ describe Google::Cloud do
     it "uses logging config for endpoint" do
       endpoint = "logging-endpoint2.example.com"
       stubbed_service = ->(project, credentials, timeout: nil, client_config: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal default_credentials
-        timeout.must_be :nil?
-        client_config.must_be :nil?
-        host.must_equal endpoint
+        _(project).must_equal "project-id"
+        _(credentials).must_equal default_credentials
+        _(timeout).must_be :nil?
+        _(client_config).must_be :nil?
+        _(host).must_equal endpoint
         OpenStruct.new project: project
       }
 
@@ -430,25 +430,25 @@ describe Google::Cloud do
 
         Google::Cloud::Logging::Service.stub :new, stubbed_service do
           logging = Google::Cloud::Logging.new project: "project-id", credentials: default_credentials, endpoint: endpoint
-          logging.must_be_kind_of Google::Cloud::Logging::Project
-          logging.project.must_equal "project-id"
-          logging.service.must_be_kind_of OpenStruct
+          _(logging).must_be_kind_of Google::Cloud::Logging::Project
+          _(logging.project).must_equal "project-id"
+          _(logging.service).must_be_kind_of OpenStruct
         end
       end
     end
 
     it "uses logging config for project_id and credentials" do
       stubbed_credentials = ->(keyfile, scope: nil) {
-        keyfile.must_equal "path/to/keyfile.json"
-        scope.must_be :nil?
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(scope).must_be :nil?
         "logging-credentials"
       }
       stubbed_service = ->(project, credentials, timeout: nil, client_config: nil, host: nil) {
-        project.must_equal "project-id"
-        credentials.must_equal "logging-credentials"
-        timeout.must_equal 42
-        client_config.must_equal logging_client_config
-        host.must_be_nil
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "logging-credentials"
+        _(timeout).must_equal 42
+        _(client_config).must_equal logging_client_config
+        _(host).must_be_nil
         OpenStruct.new project: project
       }
 
@@ -467,9 +467,9 @@ describe Google::Cloud do
             Google::Cloud::Logging::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Logging::Service.stub :new, stubbed_service do
                 logging = Google::Cloud::Logging.new
-                logging.must_be_kind_of Google::Cloud::Logging::Project
-                logging.project.must_equal "project-id"
-                logging.service.must_be_kind_of OpenStruct
+                _(logging).must_be_kind_of Google::Cloud::Logging::Project
+                _(logging.project).must_equal "project-id"
+                _(logging.service).must_be_kind_of OpenStruct
               end
             end
           end


### PR DESCRIPTION
Use `rubocop-minitest` gem and `bundle exec rubocop --only Minitest/GlobalExpectations -a` to autocorrect minitest warnings for Ruby 2.7.

refs: #4110
refs: #4116