### PR TITLE
Fix Emulator documentation

### DIFF
--- a/google-cloud-pubsub/EMULATOR.md
+++ b/google-cloud-pubsub/EMULATOR.md
@@ -17,7 +17,7 @@ require "google/cloud/pubsub"
 # Make Pub/Sub use the emulator
 ENV["PUBSUB_EMULATOR_HOST"] = "localhost:8918"
 
-pubsub = Google::Cloud::PubSub.new "emulator-project-id"
+pubsub = Google::Cloud::PubSub.new project_id:"emulator-project-id"
 
 # Get a topic in the current project
 my_topic = pubsub.new_topic "my-topic"


### PR DESCRIPTION
It appears `new` no longer accepts positional arguments.

> ruby-2.4.6/gems/google-cloud-pubsub-1.6.0/lib/google/cloud/pubsub.rb:80:in `new': wrong number of arguments (given 1, expected 0) (ArgumentError)
