### PR TITLE
fix(logging): Prevent error when calling stop! on unused AsyncWriter

### DIFF
--- a/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
@@ -155,7 +155,7 @@ module Google
               max_threads: @threads, max_queue: @max_queue
             @thread ||= Thread.new { run_background }
 
-            publish_batch! if @batch && @batch.ready?
+            publish_batch! if @batch&.ready?
 
             @cond.broadcast
           end

--- a/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/async_writer.rb
@@ -223,7 +223,8 @@ module Google
         # to block until the writer is stopped.
         #
         # @param [Number, nil] timeout The maximum number of seconds to wait for
-        #   shutdown to complete. The default value is `nil`.
+        #   shutdown to complete. Will wait forever when the value is `nil`. The
+        #   default value is `nil`.
         #
         # @return [AsyncWriter] returns self so calls can be chained.
         def wait! timeout = nil
@@ -241,7 +242,8 @@ module Google
         # Stop this asynchronous writer and block until it has been stopped.
         #
         # @param [Number, nil] timeout The maximum number of seconds to wait for
-        #   shutdown to complete. The default value is `nil`.
+        #   shutdown to complete. Will wait forever when the value is `nil`. The
+        #   default value is `nil`.
         # @param [Boolean] force If set to true, and the writer hasn't stopped
         #   within the given timeout, kill it forcibly by terminating the
         #   thread. This should be used with extreme caution, as it can

--- a/google-cloud-logging/test/google/cloud/logging/async_writer_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/async_writer_test.rb
@@ -57,6 +57,27 @@ describe Google::Cloud::Logging::AsyncWriter, :mock_logging do
     [entries, log_name: nil, resource: nil, labels: nil, partial_success: true, options: default_options]
   end
 
+  it "does not raise error on empty entries" do
+    mock = Minitest::Mock.new
+    logging.service.mocked_logging = mock
+
+    async_writer.write_entries []
+    status = async_writer.stop! 1
+    _(status).must_equal :waited
+
+    mock.verify
+  end
+
+  it "does not raise error if stop! called before write_entries" do
+    mock = Minitest::Mock.new
+    logging.service.mocked_logging = mock
+
+    status = async_writer.stop! 1
+    _(status).must_equal :new
+
+    mock.verify
+  end
+
   it "writes a single entry" do
     mock = Minitest::Mock.new
     logging.service.mocked_logging = mock
@@ -69,7 +90,8 @@ describe Google::Cloud::Logging::AsyncWriter, :mock_logging do
       resource: resource,
       labels: labels1
     )
-    async_writer.stop! 1
+    status = async_writer.stop! 1
+    _(status).must_equal :waited
 
     mock.verify
   end
@@ -92,7 +114,8 @@ describe Google::Cloud::Logging::AsyncWriter, :mock_logging do
       resource: resource,
       labels: labels1
     )
-    async_writer.stop! 1
+    status = async_writer.stop! 1
+    _(status).must_equal :waited
 
     mock.verify
   end


### PR DESCRIPTION
* Prevent similar uninitialized variable error in `#write_entries` when `entries` is empty.
* Update `timeout` param documentation.

fixes: #5210 
