### PR TITLE
chore(dlp): Move samples from the ruby-docs-samples repo

### DIFF
--- a/google-cloud-dlp/samples/Gemfile
+++ b/google-cloud-dlp/samples/Gemfile
@@ -1,0 +1,24 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source "https://rubygems.org"
+master = ENV["GOOGLE_CLOUD_SAMPLES_TEST"] == "master"
+
+gem "google-cloud-dlp", path: master ? "../../google-cloud-dlp" : nil
+gem "google-cloud-dlp-v2", path: master ? "../../google-cloud-dlp-v2" : nil
+
+group :test do
+  gem "minitest", "~> 5.14"
+  gem "rake", ">= 12.0"
+end

--- a/google-cloud-dlp/samples/README.md
+++ b/google-cloud-dlp/samples/README.md
@@ -1,0 +1,53 @@
+<img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google
+Cloud Platform logo" title="Google Cloud Platform" align="right" height="96"
+width="96"/>
+
+# Google Cloud DLP API Samples
+
+## Description
+
+These samples show how to use the [Google Cloud DLP API](https://cloud.google.com/dlp/).
+
+## Build and Run
+1.  **Enable APIs** - [Enable the DLP API](https://console.cloud.google.com/flows/enableapi?apiid=dlp.googleapis.com)
+    and create a new project or select an existing project.
+1.  **Install and Initialize Cloud SDK**
+    Follow instructions from the available [quickstarts](https://cloud.google.com/sdk/docs/quickstarts)
+1.  **Clone the repo** and cd into this directory
+    ```
+    $ git clone https://github.com/GoogleCloudPlatform/ruby-docs-samples
+    $ cd ruby-docs-samples/dlp
+    ```
+
+1. **Install Dependencies** via [Bundler](https://bundler.io).
+
+    `bundle install`
+
+1. **Create a [Service Account key file](https://cloud.google.com/docs/authentication#service_accounts)** - This file can be used to authenticate to Google Cloud Platform services from any environment. To use the file, set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to the path to the key file, for example:
+
+    `export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service_account.json`
+
+1. **Set your Project Environment Variables**
+
+    `export GOOGLE_CLOUD_PROJECT="YOUR_PROJECT_ID"`
+
+1. **Run samples**
+    ```
+    Usage: ruby sample.rb <command> [arguments]
+
+    Commands:
+      inspect_string <content> <max_findings> Inspect a string.
+      inspect_file <filename> <max_findings> Inspect a local file.
+
+    Environment variables:
+      GOOGLE_CLOUD_PROJECT must be set to your Google Cloud project ID
+      GOOGLE_APPLICATION_CREDENTIALS set to the path to your JSON credentials
+    ```
+
+## Contributing changes
+
+* See [CONTRIBUTING.md](../CONTRIBUTING.md)
+
+## Licensing
+
+* See [LICENSE](../LICENSE)

--- a/google-cloud-dlp/samples/Rakefile
+++ b/google-cloud-dlp/samples/Rakefile
@@ -1,0 +1,20 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "rake/testtask"
+
+Rake::TestTask.new "test" do |t|
+  t.test_files = FileList["**/*_test.rb"]
+  t.warning = false
+end

--- a/google-cloud-dlp/samples/acceptance/data/test.txt
+++ b/google-cloud-dlp/samples/acceptance/data/test.txt
@@ -1,0 +1,1 @@
+Robert Frost was an American poet.

--- a/google-cloud-dlp/samples/acceptance/quickstart_test.rb
+++ b/google-cloud-dlp/samples/acceptance/quickstart_test.rb
@@ -1,0 +1,30 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "minitest/autorun"
+
+describe "DLP Quickstart" do
+  it "prints results found in sample text" do
+    out, err = capture_io do
+      load File.expand_path("../quickstart.rb", __dir__)
+    end
+
+    assert_empty err
+    assert_match(
+      "Quote:      Robert Frost\n" \
+      "Info type:  PERSON_NAME\n" \
+      "Likelihood: LIKELY\n", out
+    )
+  end
+end

--- a/google-cloud-dlp/samples/acceptance/sample_test.rb
+++ b/google-cloud-dlp/samples/acceptance/sample_test.rb
@@ -1,0 +1,63 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "minitest/autorun"
+require_relative "../sample"
+
+describe "DLP sample" do
+  before do
+    @project = ENV["GOOGLE_CLOUD_PROJECT"]
+  end
+
+  it "can inspect name in string" do
+    out, err = capture_io do
+      inspect_string project_id: @project, content: "Robert Frost"
+    end
+
+    assert_empty err
+    assert_match(
+      "Quote:      Robert Frost\n" \
+      "Info type:  PERSON_NAME\n" \
+      "Likelihood: LIKELY\n", out
+    )
+  end
+
+  it "can limit max findings of inspect string results" do
+    out, err = capture_io do
+      inspect_string(
+        project_id:   @project,
+        content:      "Robert Frost is the name of poet Robert Frost",
+        max_findings: 1
+      )
+    end
+    assert_empty err
+    assert_match(
+      "Quote:      Robert Frost\n" \
+      "Info type:  PERSON_NAME\n" \
+      "Likelihood: LIKELY\n", out
+    )
+  end
+
+  it "can inspect name in file" do
+    out, err = capture_io do
+      inspect_file project_id: @project, filename: "acceptance/data/test.txt"
+    end
+    assert_empty err
+    assert_match(
+      "Quote:      Robert Frost\n" \
+      "Info type:  PERSON_NAME\n" \
+      "Likelihood: LIKELY\n", out
+    )
+  end
+end

--- a/google-cloud-dlp/samples/quickstart.rb
+++ b/google-cloud-dlp/samples/quickstart.rb
@@ -1,0 +1,51 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START dlp_quickstart]
+# Imports the Google Cloud client library
+require "google/cloud/dlp"
+
+# Instantiates a client
+dlp = Google::Cloud::Dlp.dlp_service
+
+request_configuration = {
+  # The types of information to match
+  info_types:     [{ name: "PERSON_NAME" }, { name: "US_STATE" }],
+
+  # Only return results above a likelihood threshold (0 for all)
+  min_likelihood: :LIKELIHOOD_UNSPECIFIED,
+
+  # Limit the number of findings (0 for no limit)
+  limits:         { max_findings_per_request: 0 },
+
+  # Whether to include the matching string in the response
+  include_quote:  true
+}
+
+# The items to inspect
+item_to_inspect = { value: "Robert Frost" }
+
+# Run request
+parent = "projects/#{ENV['GOOGLE_CLOUD_PROJECT']}"
+response = dlp.inspect_content parent:         parent,
+                               inspect_config: request_configuration,
+                               item:           item_to_inspect
+
+# Print the results
+response.result.findings.each do |finding|
+  puts "Quote:      #{finding.quote}"
+  puts "Info type:  #{finding.info_type.name}"
+  puts "Likelihood: #{finding.likelihood}"
+end
+# [END dlp_quickstart]

--- a/google-cloud-dlp/samples/sample.rb
+++ b/google-cloud-dlp/samples/sample.rb
@@ -1,0 +1,136 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def inspect_string project_id: nil, content: nil, max_findings: 0
+  # [START dlp_inspect_string]
+  # project_id   = "Your Google Cloud project ID"
+  # content      = "The text to inspect"
+  # max_findings = "Maximum number of findings to report per request (0 = server maximum)"
+
+  require "google/cloud/dlp"
+
+  dlp = Google::Cloud::Dlp.dlp_service
+  inspect_config = {
+    # The types of information to match
+    info_types:     [{ name: "PERSON_NAME" }, { name: "US_STATE" }],
+
+    # Only return results above a likelihood threshold (0 for all)
+    min_likelihood: :POSSIBLE,
+
+    # Limit the number of findings (0 for no limit)
+    limits:         { max_findings_per_request: max_findings },
+
+    # Whether to include the matching string in the response
+    include_quote:  true
+  }
+
+  # The item to inspect
+  item_to_inspect = { value: content }
+
+  # Run request
+  parent = "projects/#{project_id}"
+  response = dlp.inspect_content parent:         parent,
+                                 inspect_config: inspect_config,
+                                 item:           item_to_inspect
+
+  # Print the results
+  if response.result.findings.empty?
+    puts "No findings"
+  else
+    response.result.findings.each do |finding|
+      puts "Quote:      #{finding.quote}"
+      puts "Info type:  #{finding.info_type.name}"
+      puts "Likelihood: #{finding.likelihood}"
+    end
+  end
+  # [END dlp_inspect_string]
+end
+
+def inspect_file project_id: nil, filename: nil, max_findings: 0
+  # [START dlp_inspect_file]
+  # project_id   = "Your Google Cloud project ID"
+  # filename     = "The file path to the file to inspect"
+  # max_findings = "Maximum number of findings to report per request (0 = server maximum)"
+
+  require "google/cloud/dlp"
+
+  dlp = Google::Cloud::Dlp.dlp_service
+  inspect_config = {
+    # The types of information to match
+    info_types:     [{ name: "PERSON_NAME" }, { name: "PHONE_NUMBER" }],
+
+    # Only return results above a likelihood threshold (0 for all)
+    min_likelihood: :POSSIBLE,
+
+    # Limit the number of findings (0 for no limit)
+    limits:         { max_findings_per_request: max_findings },
+
+    # Whether to include the matching string in the response
+    include_quote:  true
+  }
+
+  # The item to inspect
+  file = File.open filename, "rb"
+  item_to_inspect = { byte_item: { type: :BYTES_TYPE_UNSPECIFIED, data: file.read } }
+
+  # Run request
+  parent = "projects/#{project_id}"
+  response = dlp.inspect_content parent:         parent,
+                                 inspect_config: inspect_config,
+                                 item:           item_to_inspect
+
+  # Print the results
+  if response.result.findings.empty?
+    puts "No findings"
+  else
+    response.result.findings.each do |finding|
+      puts "Quote:      #{finding.quote}"
+      puts "Info type:  #{finding.info_type.name}"
+      puts "Likelihood: #{finding.likelihood}"
+    end
+  end
+  # [END dlp_inspect_file]
+end
+
+if $PROGRAM_NAME == __FILE__
+  project_id = ENV["GOOGLE_CLOUD_PROJECT"]
+  command    = ARGV.shift
+
+  case command
+  when "inspect_string"
+    inspect_string(
+      project_id:   project_id,
+      content:      ARGV.shift.to_s,
+      max_findings: ARGV.shift.to_i
+    )
+  when "inspect_file"
+    inspect_file(
+      project_id:   project_id,
+      filename:     ARGV.shift.to_s,
+      max_findings: ARGV.shift.to_i
+    )
+  else
+    puts <<~USAGE
+      Usage: ruby sample.rb <command> [arguments]
+
+      Commands:
+        inspect_string <content> <max_findings> Inspect a string.
+        inspect_file <filename> <max_findings> Inspect a local file.
+
+      Environment variables:
+        GOOGLE_CLOUD_PROJECT must be set to your Google Cloud project ID
+        GOOGLE_APPLICATION_CREDENTIALS set to the path to your JSON credentials
+    USAGE
+  end
+end


### PR DESCRIPTION
see GoogleCloudPlatform/ruby-docs-samples#567 for the in-place migration of samples to the minitest

move samples for dlp from ruby-docs-samples
update the samples to use the microgenerated library