### PR TITLE
Release google-cloud-speech 1.0.0

### DIFF
--- a/google-cloud-speech/CHANGELOG.md
+++ b/google-cloud-speech/CHANGELOG.md
@@ -12,7 +12,7 @@ Among the highlights:
 * Helper methods for generating resource paths are more accessible.
 * An expanded, standardized streaming interface.
 
-See the MIGRATING file in the documentation for more detailed information, and instructions for migrating from earlier versions.
+See the [MIGRATING](https://googleapis.dev/ruby/google-cloud-speech/latest/file.MIGRATING.html) file in the documentation for more detailed information, and instructions for migrating from earlier versions.
 
 ### 0.41.0 / 2020-03-11
 

--- a/google-cloud-speech/CHANGELOG.md
+++ b/google-cloud-speech/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Release History
 
+### 1.0.0 / 2020-05-05
+
+This is a major update with significant new features, improved documentation, and a fair number of breaking changes.
+
+Among the highlights:
+
+* Separate client libraries are now provided for specific service versions.
+* A new configuration mechanism makes it easier to control parameters such as endpoint address, network timeouts, and retry.
+* A consistent method interface using keyword arguments for all fields, and supporting request proto objects.
+* Helper methods for generating resource paths are more accessible.
+* An expanded, standardized streaming interface.
+
+See the MIGRATING file in the documentation for more detailed information, and instructions for migrating from earlier versions.
+
 ### 0.41.0 / 2020-03-11
 
 #### Features

--- a/google-cloud-speech/lib/google/cloud/speech/version.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Speech
-      VERSION = "0.41.0".freeze
+      VERSION = "1.0.0".freeze
     end
   end
 end


### PR DESCRIPTION
This is a major update with significant new features, improved documentation, and a fair number of breaking changes.

Among the highlights:

* Separate client libraries are now provided for specific service versions.
* A new configuration mechanism makes it easier to control parameters such as endpoint address, network timeouts, and retry.
* A consistent method interface using keyword arguments for all fields, and supporting request proto objects.
* Helper methods for generating resource paths are more accessible.
* An expanded, standardized streaming interface.

See the MIGRATING file in the documentation for more detailed information, and instructions for migrating from earlier versions.