### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,4 +9,6 @@
 # explicitly taken by someone else.
 *                               @googleapis/yoshi-ruby
 
-/google-cloud-storage/        @GoogleCloudPlatform/storage-dpe @googleapis/yoshi-ruby
+/google-cloud-storage/          @GoogleCloudPlatform/storage-dpe @googleapis/yoshi-ruby
+/google-cloud-bigtable/         @GoogleCloudPlatform/bigtable-dpe @googleapis/yoshi-ruby
+/google-cloud-firestore/        @GoogleCloudPlatform/firestore-dpe @googleapis/yoshi-ruby

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# Code owners file.
+# This file controls who is tagged for review for any given pull request.
+#
+# For syntax help see:
+# https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
+
+
+# The yoshi-ruby team is the default owner for anything not
+# explicitly taken by someone else.
+*                               @googleapis/yoshi-ruby
+
+/google-cloud-storage/        @GoogleCloudPlatform/storage-dpe @googleapis/yoshi-ruby

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,3 +12,4 @@
 /google-cloud-storage/          @GoogleCloudPlatform/storage-dpe @googleapis/yoshi-ruby
 /google-cloud-bigtable/         @GoogleCloudPlatform/bigtable-dpe @googleapis/yoshi-ruby
 /google-cloud-firestore/        @GoogleCloudPlatform/firestore-dpe @googleapis/yoshi-ruby
+/google-cloud-datastore/        @GoogleCloudPlatform/firestore-dpe @googleapis/yoshi-ruby


### PR DESCRIPTION
@crwilcox requested teams for repo access across the board for SoDa teams. Adding a CODEOWNERS file with yoshi-ruby as default and with the storage team.
