### PR TITLE
Release google-cloud-bigquery-data_transfer 1.0.0

### DIFF
--- a/google-cloud-bigquery-data_transfer/CHANGELOG.md
+++ b/google-cloud-bigquery-data_transfer/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Release History
 
+### 1.0.0 / 2020-05-06
+
+This is a major update with significant new features, improved documentation, and a fair number of breaking changes.
+
+Among the highlights:
+
+* Separate client libraries are now provided for specific service versions.
+* A new configuration mechanism makes it easier to control parameters such as endpoint address, network timeouts, and retry.
+* A consistent method interface using keyword arguments for all fields, and supporting request proto objects.
+* Helper methods for generating resource paths are more accessible.
+* More consistent spelling of module names.
+
+See the MIGRATING file in the documentation for more detailed information, and instructions for migrating from earlier versions.
+
 ### 0.9.0 / 2020-04-09
 
 #### Features

--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/version.rb
+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/version.rb
@@ -21,7 +21,7 @@ module Google
   module Cloud
     module Bigquery
       module DataTransfer
-        VERSION = "0.9.0"
+        VERSION = "1.0.0"
       end
     end
   end


### PR DESCRIPTION
This is a major update with significant new features, improved documentation, and a fair number of breaking changes.

Among the highlights:

* Separate client libraries are now provided for specific service versions.
* A new configuration mechanism makes it easier to control parameters such as endpoint address, network timeouts, and retry.
* A consistent method interface using keyword arguments for all fields, and supporting request proto objects.
* Helper methods for generating resource paths are more accessible.
* More consistent spelling of module names.

See the MIGRATING file in the documentation for more detailed information, and instructions for migrating from earlier versions.