### PR TITLE
Release google-cloud-web_risk 1.0.0

### DIFF
--- a/google-cloud-web_risk/CHANGELOG.md
+++ b/google-cloud-web_risk/CHANGELOG.md
@@ -1,2 +1,16 @@
 # Release History
 
+### 1.0.0 / 2020-05-07
+
+This is a major update over the older google-cloud-webrisk gem, with significant new features, improved documentation, and a fair number of breaking changes.
+
+Among the highlights:
+
+* Separate client libraries are now provided for specific service versions.
+* A new configuration mechanism makes it easier to control parameters such as endpoint address, network timeouts, and retry.
+* A consistent method interface using keyword arguments for all fields, and supporting request proto objects.
+* Helper methods for generating resource paths are more accessible.
+* More consistent spelling of module names.
+
+See the MIGRATING file in the documentation for more detailed information, and instructions for migrating from google-cloud-webrisk.
+

--- a/google-cloud-web_risk/CHANGELOG.md
+++ b/google-cloud-web_risk/CHANGELOG.md
@@ -6,6 +6,7 @@ This is a major update over the older google-cloud-webrisk gem, with significant
 
 Among the highlights:
 
+* Support for version V1 of the service.
 * Separate client libraries are now provided for specific service versions.
 * A new configuration mechanism makes it easier to control parameters such as endpoint address, network timeouts, and retry.
 * A consistent method interface using keyword arguments for all fields, and supporting request proto objects.

--- a/google-cloud-web_risk/lib/google/cloud/web_risk/version.rb
+++ b/google-cloud-web_risk/lib/google/cloud/web_risk/version.rb
@@ -20,7 +20,7 @@
 module Google
   module Cloud
     module WebRisk
-      VERSION = "0.0.1"
+      VERSION = "1.0.0"
     end
   end
 end


### PR DESCRIPTION
This is a major update over the older google-cloud-webrisk gem, with significant new features, improved documentation, and a fair number of breaking changes.

Among the highlights:

* Separate client libraries are now provided for specific service versions.
* A new configuration mechanism makes it easier to control parameters such as endpoint address, network timeouts, and retry.
* A consistent method interface using keyword arguments for all fields, and supporting request proto objects.
* Helper methods for generating resource paths are more accessible.
* More consistent spelling of module names.

See the MIGRATING file in the documentation for more detailed information, and instructions for migrating from google-cloud-webrisk.
