### PR TITLE
feat(pubsub): Add Retry Policy support

### DIFF
--- a/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
+++ b/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
@@ -37,6 +37,8 @@ describe Google::Cloud::PubSub, :pubsub do
   let(:dead_letter_topic_name) { $topic_names[8] }
   let(:dead_letter_topic_name_2) { $topic_names[9] }
   let(:labels) { { "foo" => "bar" } }
+  let(:retry_minimum_backoff) { 12.123 }
+  let(:retry_maximum_backoff) { 123.321 }
 
   before do
     # create all topics
@@ -136,23 +138,34 @@ describe Google::Cloud::PubSub, :pubsub do
     end
 
     it "should allow create and update of subscription with options" do
-      begin
-        # create
-        subscription = topic.subscribe "#{$topic_prefix}-sub3", retain_acked: true, retention: 600, labels: labels
-        _(subscription).wont_be :nil?
-        _(subscription).must_be_kind_of Google::Cloud::PubSub::Subscription
-        assert subscription.retain_acked
-        _(subscription.retention).must_equal 600
-        _(subscription.labels).must_equal labels
-        _(subscription.labels).must_be :frozen?
+      # create
+      subscription = topic.subscribe "#{$topic_prefix}-sub3", retain_acked: true,
+                                                              retention: 600,
+                                                              labels: labels,
+                                                              retry_minimum_backoff: retry_minimum_backoff,
+                                                              retry_maximum_backoff: retry_maximum_backoff
+      _(subscription).wont_be :nil?
+      _(subscription).must_be_kind_of Google::Cloud::PubSub::Subscription
+      assert subscription.retain_acked
+      _(subscription.retention).must_equal 600
+      _(subscription.labels).must_equal labels
+      _(subscription.labels).must_be :frozen?
+      _(subscription.retry_minimum_backoff).must_equal retry_minimum_backoff
+      _(subscription.retry_maximum_backoff).must_equal retry_maximum_backoff
 
-        # update
-        subscription.labels = {}
-        _(subscription.labels).must_be :empty?
-      ensure
-        # delete
-        subscription.delete
-      end
+      # update
+      subscription.labels = {}
+      _(subscription.labels).must_be :empty?
+      subscription.retry_minimum_backoff = nil
+      _(subscription.retry_minimum_backoff).must_equal 10 # Default value
+      subscription.retry_maximum_backoff = nil
+      _(subscription.retry_maximum_backoff).must_equal 600 # Default value
+      subscription.retry_minimum_backoff = retry_minimum_backoff
+      _(subscription.retry_minimum_backoff).must_equal retry_minimum_backoff
+      subscription.retry_maximum_backoff = retry_maximum_backoff
+      _(subscription.retry_maximum_backoff).must_equal retry_maximum_backoff
+      # delete
+      subscription.delete
     end
 
     it "should not error when asking for a non-existent subscription" do
@@ -165,6 +178,8 @@ describe Google::Cloud::PubSub, :pubsub do
         subscription = topic.subscribe "#{$topic_prefix}-sub4"
         _(subscription).wont_be :nil?
         _(subscription).must_be_kind_of Google::Cloud::PubSub::Subscription
+        _(subscription.retry_minimum_backoff).must_be :nil?
+        _(subscription.retry_maximum_backoff).must_be :nil?
         # No messages, should be empty
         received_messages = subscription.pull
         _(received_messages).must_be :empty?

--- a/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
+++ b/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
@@ -37,8 +37,6 @@ describe Google::Cloud::PubSub, :pubsub do
   let(:dead_letter_topic_name) { $topic_names[8] }
   let(:dead_letter_topic_name_2) { $topic_names[9] }
   let(:labels) { { "foo" => "bar" } }
-  let(:retry_minimum_backoff) { 12.123 }
-  let(:retry_maximum_backoff) { 123.321 }
 
   before do
     # create all topics
@@ -121,6 +119,14 @@ describe Google::Cloud::PubSub, :pubsub do
                    { name: "#{$topic_prefix}-sub2",
                      options: { deadline: 60 } }
                  ] }
+    let(:retry_minimum_backoff) { 12.123 }
+    let(:retry_maximum_backoff) { 123.321 }
+    let(:retry_policy) do
+      Google::Cloud::PubSub::RetryPolicy.new(
+        minimum_backoff: retry_minimum_backoff,
+        maximum_backoff: retry_maximum_backoff
+      )
+    end
 
     before do
       subs.each do |sub|
@@ -142,28 +148,35 @@ describe Google::Cloud::PubSub, :pubsub do
       subscription = topic.subscribe "#{$topic_prefix}-sub3", retain_acked: true,
                                                               retention: 600,
                                                               labels: labels,
-                                                              retry_minimum_backoff: retry_minimum_backoff,
-                                                              retry_maximum_backoff: retry_maximum_backoff
+                                                              retry_policy: retry_policy
       _(subscription).wont_be :nil?
       _(subscription).must_be_kind_of Google::Cloud::PubSub::Subscription
       assert subscription.retain_acked
       _(subscription.retention).must_equal 600
       _(subscription.labels).must_equal labels
       _(subscription.labels).must_be :frozen?
-      _(subscription.retry_minimum_backoff).must_equal retry_minimum_backoff
-      _(subscription.retry_maximum_backoff).must_equal retry_maximum_backoff
+      _(subscription.retry_policy.minimum_backoff).must_equal retry_minimum_backoff
+      _(subscription.retry_policy.maximum_backoff).must_equal retry_maximum_backoff
 
       # update
       subscription.labels = {}
       _(subscription.labels).must_be :empty?
-      subscription.retry_minimum_backoff = nil
-      _(subscription.retry_minimum_backoff).must_equal 10 # Default value
-      subscription.retry_maximum_backoff = nil
-      _(subscription.retry_maximum_backoff).must_equal 600 # Default value
-      subscription.retry_minimum_backoff = retry_minimum_backoff
-      _(subscription.retry_minimum_backoff).must_equal retry_minimum_backoff
-      subscription.retry_maximum_backoff = retry_maximum_backoff
-      _(subscription.retry_maximum_backoff).must_equal retry_maximum_backoff
+      subscription.retry_policy = nil
+      subscription.reload!
+      _(subscription.retry_policy).must_be :nil?
+      subscription.retry_policy = Google::Cloud::PubSub::RetryPolicy.new
+      _(subscription.retry_policy.minimum_backoff).must_equal 10 # Default value
+      _(subscription.retry_policy.maximum_backoff).must_equal 600 # Default value
+
+      subscription.retry_policy = Google::Cloud::PubSub::RetryPolicy.new minimum_backoff: retry_minimum_backoff
+      _(subscription.retry_policy.minimum_backoff).must_equal retry_minimum_backoff
+      _(subscription.retry_policy.maximum_backoff).must_equal 600 # Default value
+
+
+      subscription.retry_policy = Google::Cloud::PubSub::RetryPolicy.new maximum_backoff: retry_maximum_backoff
+      _(subscription.retry_policy.minimum_backoff).must_equal 10 # Default value
+      _(subscription.retry_policy.maximum_backoff).must_equal retry_maximum_backoff
+
       # delete
       subscription.delete
     end
@@ -178,8 +191,7 @@ describe Google::Cloud::PubSub, :pubsub do
         subscription = topic.subscribe "#{$topic_prefix}-sub4"
         _(subscription).wont_be :nil?
         _(subscription).must_be_kind_of Google::Cloud::PubSub::Subscription
-        _(subscription.retry_minimum_backoff).must_be :nil?
-        _(subscription.retry_maximum_backoff).must_be :nil?
+        _(subscription.retry_policy).must_be :nil?
         # No messages, should be empty
         received_messages = subscription.pull
         _(received_messages).must_be :empty?

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/retry_policy.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/retry_policy.rb
@@ -1,0 +1,92 @@
+# Copyright 2016 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "google/cloud/errors"
+
+module Google
+  module Cloud
+    module PubSub
+      ##
+      # # RetryPolicy
+      #
+      # An immutable Retry Policy value object that specifies how Cloud Pub/Sub retries message delivery.
+      #
+      # Retry delay will be exponential based on provided minimum and maximum backoffs. (See [Exponential
+      # backoff](https://en.wikipedia.org/wiki/Exponential_backoff).)
+      #
+      # Retry Policy will be triggered on NACKs or acknowledgement deadline exceeded events for a given message.
+      #
+      # Retry Policy is implemented on a best effort basis. At times, the delay between consecutive deliveries may not
+      # match the configuration. That is, delay can be more or less than configured backoff.
+      #
+      # **EXPERIMENTAL:** This API might be changed in backward-incompatible ways and is not recommended for production
+      # use. It is not subject to any SLA or deprecation policy.
+      #
+      # @attr [Numeric] minimum_backoff The minimum delay between consecutive deliveries of a given message. Value
+      #   should be between 0 and 600 seconds. The default value is 10 seconds.
+      # @attr [Numeric] maximum_backoff The maximum delay between consecutive deliveries of a given message. Value
+      #   should be between 0 and 600 seconds. The default value is 600 seconds.
+      #
+      # @example
+      #   require "google/cloud/pubsub"
+      #
+      #   pubsub = Google::Cloud::PubSub.new
+      #
+      #   sub = pubsub.subscription "my-topic-sub"
+      #
+      #   sub.retry_policy = Google::Cloud::PubSub::RetryPolicy.new minimum_backoff: 5, maximum_backoff: 300
+      #
+      #   sub.retry_policy.minimum_backoff #=> 5
+      #   sub.retry_policy.maximum_backoff #=> 300
+      #
+      class RetryPolicy
+        attr_reader :minimum_backoff, :maximum_backoff
+
+        ##
+        # Creates a new, immutable RetryPolicy value object.
+        #
+        # @attr [Numeric, nil] minimum_backoff The minimum delay between consecutive deliveries of a given message.
+        #   Value should be between 0 and 600 seconds. If `nil` is provided, the default value is 10 seconds.
+        # @attr [Numeric, nil] maximum_backoff The maximum delay between consecutive deliveries of a given message.
+        #   Value should be between 0 and 600 seconds. If `nil` is provided, the default value is 600 seconds.
+        #
+        def initialize minimum_backoff: nil, maximum_backoff: nil
+          @minimum_backoff = minimum_backoff
+          @maximum_backoff = maximum_backoff
+        end
+
+        ##
+        # @private Convert the RetryPolicy to a Google::Cloud::PubSub::V1::RetryPolicy object.
+        def to_grpc
+          Google::Cloud::PubSub::V1::RetryPolicy.new(
+            minimum_backoff: Convert.number_to_duration(minimum_backoff),
+            maximum_backoff: Convert.number_to_duration(maximum_backoff)
+          )
+        end
+
+        ##
+        # @private New RetryPolicy from a Google::Cloud::PubSub::V1::RetryPolicy object.
+        def self.from_grpc grpc
+          new(
+            minimum_backoff: Convert.duration_to_number(grpc.minimum_backoff),
+            maximum_backoff: Convert.duration_to_number(grpc.maximum_backoff)
+          )
+        end
+      end
+    end
+
+    Pubsub = PubSub unless const_defined? :Pubsub
+  end
+end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/retry_policy.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/retry_policy.rb
@@ -86,7 +86,5 @@ module Google
         end
       end
     end
-
-    Pubsub = PubSub unless const_defined? :Pubsub
   end
 end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
@@ -256,7 +256,7 @@ module Google
               labels:                     labels,
               enable_message_ordering:    message_ordering,
               dead_letter_policy:         dead_letter_policy(options),
-              retry_policy:               retry_policy(options),
+              retry_policy:               options[:retry_policy],
               options:                    default_options
           end
         end
@@ -491,18 +491,6 @@ module Google
           policy = Google::Cloud::PubSub::V1::DeadLetterPolicy.new dead_letter_topic: options[:dead_letter_topic_name]
           if options[:dead_letter_max_delivery_attempts]
             policy.max_delivery_attempts = options[:dead_letter_max_delivery_attempts]
-          end
-          policy
-        end
-
-        def retry_policy options
-          return nil unless options[:retry_minimum_backoff] || options[:retry_maximum_backoff]
-          policy = Google::Cloud::PubSub::V1::RetryPolicy.new
-          if options[:retry_minimum_backoff]
-            policy.minimum_backoff = Convert.number_to_duration options[:retry_minimum_backoff]
-          end
-          if options[:retry_maximum_backoff]
-            policy.maximum_backoff = Convert.number_to_duration options[:retry_maximum_backoff]
           end
           policy
         end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
@@ -256,6 +256,7 @@ module Google
               labels:                     labels,
               enable_message_ordering:    message_ordering,
               dead_letter_policy:         dead_letter_policy(options),
+              retry_policy:               retry_policy(options),
               options:                    default_options
           end
         end
@@ -490,6 +491,18 @@ module Google
           policy = Google::Cloud::PubSub::V1::DeadLetterPolicy.new dead_letter_topic: options[:dead_letter_topic_name]
           if options[:dead_letter_max_delivery_attempts]
             policy.max_delivery_attempts = options[:dead_letter_max_delivery_attempts]
+          end
+          policy
+        end
+
+        def retry_policy options
+          return nil unless options[:retry_minimum_backoff] || options[:retry_maximum_backoff]
+          policy = Google::Cloud::PubSub::V1::RetryPolicy.new
+          if options[:retry_minimum_backoff]
+            policy.minimum_backoff = Convert.number_to_duration options[:retry_minimum_backoff]
+          end
+          if options[:retry_maximum_backoff]
+            policy.maximum_backoff = Convert.number_to_duration options[:retry_maximum_backoff]
           end
           policy
         end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -484,6 +484,110 @@ module Google
         end
 
         ##
+        # The minimum delay between consecutive deliveries of a given message.
+        #
+        # If set, the subscription will have a retry policy that specifies how Cloud Pub/Sub retries message delivery.
+        # Retry delay will be exponential based on provided minimum and maximum backoffs. Retry Policy will be
+        # triggered on NACKs or acknowledgement deadline exceeded events for a given message. Retry Policy is
+        # implemented on a best effort basis. At times, the delay between consecutive deliveries may not match the
+        # configuration. That is, delay can be more or less than configured backoff.
+        #
+        # If the subscription does not have a retry policy, the default retry policy is applied. This generally
+        # implies that messages will be retried as soon as possible for healthy subscribers. Retry Policy will be
+        # triggered on NACKs or acknowledgement deadline exceeded events for a given message.
+        #
+        # **EXPERIMENTAL:** This API might be changed in backward-incompatible ways and is not recommended for
+        # production use. It is not subject to any SLA or deprecation policy.
+        #
+        # @return [Numeric, nil] A value between 0 and 600 seconds, or `nil` if no retry policy is configured. If the
+        #   subscription has a retry policy, the default value is 10 seconds.
+        #
+        def retry_minimum_backoff
+          ensure_grpc!
+          Convert.duration_to_number @grpc.retry_policy&.minimum_backoff
+        end
+
+        ##
+        # The minimum delay between consecutive deliveries of a given message.
+        #
+        # If set, the subscription will have a retry policy that specifies how Cloud Pub/Sub retries message delivery.
+        # Retry delay will be exponential based on provided minimum and maximum backoffs. Retry Policy will be
+        # triggered on NACKs or acknowledgement deadline exceeded events for a given message. Retry Policy is
+        # implemented on a best effort basis. At times, the delay between consecutive deliveries may not match the
+        # configuration. That is, delay can be more or less than configured backoff.
+        #
+        # If the subscription does not have a retry policy, the default retry policy is applied. This generally
+        # implies that messages will be retried as soon as possible for healthy subscribers. Retry Policy will be
+        # triggered on NACKs or acknowledgement deadline exceeded events for a given message.
+        #
+        # **EXPERIMENTAL:** This API might be changed in backward-incompatible ways and is not recommended for
+        # production use. It is not subject to any SLA or deprecation policy.
+        #
+        # @param [Numeric] new_minimum_backoff Value should be between 0 and 600 seconds. The default value is 10
+        #   seconds.
+        #
+        def retry_minimum_backoff= new_minimum_backoff
+          ensure_grpc!
+          retry_policy = @grpc.retry_policy || Google::Cloud::PubSub::V1::RetryPolicy.new
+          retry_policy.minimum_backoff = Convert.number_to_duration new_minimum_backoff
+          update_grpc = Google::Cloud::PubSub::V1::Subscription.new name: name, retry_policy: retry_policy
+          @grpc = service.update_subscription update_grpc, :retry_policy
+          @resource_name = nil
+        end
+
+        ##
+        # The maximum delay between consecutive deliveries of a given message.
+        #
+        # If set, the subscription will have a retry policy that specifies how Cloud Pub/Sub retries message delivery.
+        # Retry delay will be exponential based on provided minimum and maximum backoffs. Retry Policy will be
+        # triggered on NACKs or acknowledgement deadline exceeded events for a given message. Retry Policy is
+        # implemented on a best effort basis. At times, the delay between consecutive deliveries may not match the
+        # configuration. That is, delay can be more or less than configured backoff.
+        #
+        # If the subscription does not have a retry policy, the default retry policy is applied. This generally
+        # implies that messages will be retried as soon as possible for healthy subscribers. Retry Policy will be
+        # triggered on NACKs or acknowledgement deadline exceeded events for a given message.
+        #
+        # **EXPERIMENTAL:** This API might be changed in backward-incompatible ways and is not recommended for
+        # production use. It is not subject to any SLA or deprecation policy.
+        #
+        # @return [Numeric, nil] A value between 0 and 600 seconds, or `nil` if no retry policy is configured. If the
+        #   subscription has a retry policy, the default value is 600 seconds.
+        #
+        def retry_maximum_backoff
+          ensure_grpc!
+          Convert.duration_to_number @grpc.retry_policy&.maximum_backoff
+        end
+
+        #
+        # The maximum delay between consecutive deliveries of a given message.
+        #
+        # If set, the subscription will have a retry policy that specifies how Cloud Pub/Sub retries message delivery.
+        # Retry delay will be exponential based on provided minimum and maximum backoffs. Retry Policy will be
+        # triggered on NACKs or acknowledgement deadline exceeded events for a given message. Retry Policy is
+        # implemented on a best effort basis. At times, the delay between consecutive deliveries may not match the
+        # configuration. That is, delay can be more or less than configured backoff.
+        #
+        # If the subscription does not have a retry policy, the default retry policy is applied. This generally
+        # implies that messages will be retried as soon as possible for healthy subscribers. Retry Policy will be
+        # triggered on NACKs or acknowledgement deadline exceeded events for a given message.
+        #
+        # **EXPERIMENTAL:** This API might be changed in backward-incompatible ways and is not recommended for
+        # production use. It is not subject to any SLA or deprecation policy.
+        #
+        # @param [Numeric] new_maximum_backoff Value should be between 0 and 600 seconds. The default value is 600
+        #   seconds.
+        #
+        def retry_maximum_backoff= new_maximum_backoff
+          ensure_grpc!
+          retry_policy = @grpc.retry_policy || Google::Cloud::PubSub::V1::RetryPolicy.new
+          retry_policy.maximum_backoff = Convert.number_to_duration new_maximum_backoff
+          update_grpc = Google::Cloud::PubSub::V1::Subscription.new name: name, retry_policy: retry_policy
+          @grpc = service.update_subscription update_grpc, :retry_policy
+          @resource_name = nil
+        end
+
+        ##
         # Whether message ordering has been enabled. When enabled, messages
         # published with the same `ordering_key` will be delivered in the order
         # they were published. When disabled, messages may be delivered in any

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
@@ -297,6 +297,36 @@ module Google
         #   the subscription's dead letter policy. Dead lettering is done on a best effort basis. The same message might
         #   be dead lettered multiple times. The value must be between 5 and 100. If this parameter is 0, a default
         #   value of 5 is used. The `dead_letter_topic` must also be set.
+        # @param [Numeric] retry_minimum_backoff The minimum delay between consecutive deliveries of a given message.
+        #   If set, the subscription will have a retry policy that specifies how Cloud Pub/Sub retries message delivery.
+        #   Retry delay will be exponential based on provided minimum and maximum backoffs. Retry Policy will be
+        #   triggered on NACKs or acknowledgement deadline exceeded events for a given message. Retry Policy is
+        #   implemented on a best effort basis. At times, the delay between consecutive deliveries may not match the
+        #   configuration. That is, delay can be more or less than configured backoff.
+        #
+        #   If the subscription does not have a retry policy, the default retry policy is applied. This generally
+        #   implies that messages will be retried as soon as possible for healthy subscribers. Retry Policy will be
+        #   triggered on NACKs or acknowledgement deadline exceeded events for a given message.
+        #
+        #   Value should be between 0 and 600 seconds. The default value is 10 seconds.
+        #
+        #   **EXPERIMENTAL:** This API might be changed in backward-incompatible ways and is not recommended for
+        #   production use. It is not subject to any SLA or deprecation policy.
+        # @param [Numeric] retry_maximum_backoff The maximum delay between consecutive deliveries of a given message.
+        #   If set, the subscription will have a retry policy that specifies how Cloud Pub/Sub retries message delivery.
+        #   Retry delay will be exponential based on provided minimum and maximum backoffs. Retry Policy will be
+        #   triggered on NACKs or acknowledgement deadline exceeded events for a given message. Retry Policy is
+        #   implemented on a best effort basis. At times, the delay between consecutive deliveries may not match the
+        #   configuration. That is, delay can be more or less than configured backoff.
+        #
+        #   If the subscription does not have a retry policy, the default retry policy is applied. This generally
+        #   implies that messages will be retried as soon as possible for healthy subscribers. Retry Policy will be
+        #   triggered on NACKs or acknowledgement deadline exceeded events for a given message.
+        #
+        #   Value should be between 0 and 600 seconds. The default value is 600 seconds.
+        #
+        #   **EXPERIMENTAL:** This API might be changed in backward-incompatible ways and is not recommended for
+        #   production use. It is not subject to any SLA or deprecation policy.
         #
         # @return [Google::Cloud::PubSub::Subscription]
         #
@@ -341,11 +371,13 @@ module Google
         #                         dead_letter_max_delivery_attempts: 10
         #
         def subscribe subscription_name, deadline: nil, retain_acked: false, retention: nil, endpoint: nil, labels: nil,
-                      message_ordering: nil, dead_letter_topic: nil, dead_letter_max_delivery_attempts: nil
+                      message_ordering: nil, dead_letter_topic: nil, dead_letter_max_delivery_attempts: nil,
+                      retry_minimum_backoff: nil, retry_maximum_backoff: nil
           ensure_service!
           options = { deadline: deadline, retain_acked: retain_acked, retention: retention, endpoint: endpoint,
                       labels: labels, message_ordering: message_ordering,
-                      dead_letter_max_delivery_attempts: dead_letter_max_delivery_attempts }
+                      dead_letter_max_delivery_attempts: dead_letter_max_delivery_attempts,
+                      retry_minimum_backoff: retry_minimum_backoff, retry_maximum_backoff: retry_maximum_backoff }
           options[:dead_letter_topic_name] = dead_letter_topic.name if dead_letter_topic
           if options[:dead_letter_max_delivery_attempts] && !options[:dead_letter_topic_name]
             # Service error message "3:Invalid resource name given (name=)." does not identify param.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
@@ -19,6 +19,7 @@ require "google/cloud/pubsub/async_publisher"
 require "google/cloud/pubsub/batch_publisher"
 require "google/cloud/pubsub/subscription"
 require "google/cloud/pubsub/policy"
+require "google/cloud/pubsub/retry_policy"
 
 module Google
   module Cloud
@@ -297,33 +298,10 @@ module Google
         #   the subscription's dead letter policy. Dead lettering is done on a best effort basis. The same message might
         #   be dead lettered multiple times. The value must be between 5 and 100. If this parameter is 0, a default
         #   value of 5 is used. The `dead_letter_topic` must also be set.
-        # @param [Numeric] retry_minimum_backoff The minimum delay between consecutive deliveries of a given message.
-        #   If set, the subscription will have a retry policy that specifies how Cloud Pub/Sub retries message delivery.
-        #   Retry delay will be exponential based on provided minimum and maximum backoffs. Retry Policy will be
-        #   triggered on NACKs or acknowledgement deadline exceeded events for a given message. Retry Policy is
-        #   implemented on a best effort basis. At times, the delay between consecutive deliveries may not match the
-        #   configuration. That is, delay can be more or less than configured backoff.
-        #
-        #   If the subscription does not have a retry policy, the default retry policy is applied. This generally
-        #   implies that messages will be retried as soon as possible for healthy subscribers. Retry Policy will be
-        #   triggered on NACKs or acknowledgement deadline exceeded events for a given message.
-        #
-        #   Value should be between 0 and 600 seconds. The default value is 10 seconds.
-        #
-        #   **EXPERIMENTAL:** This API might be changed in backward-incompatible ways and is not recommended for
-        #   production use. It is not subject to any SLA or deprecation policy.
-        # @param [Numeric] retry_maximum_backoff The maximum delay between consecutive deliveries of a given message.
-        #   If set, the subscription will have a retry policy that specifies how Cloud Pub/Sub retries message delivery.
-        #   Retry delay will be exponential based on provided minimum and maximum backoffs. Retry Policy will be
-        #   triggered on NACKs or acknowledgement deadline exceeded events for a given message. Retry Policy is
-        #   implemented on a best effort basis. At times, the delay between consecutive deliveries may not match the
-        #   configuration. That is, delay can be more or less than configured backoff.
-        #
-        #   If the subscription does not have a retry policy, the default retry policy is applied. This generally
-        #   implies that messages will be retried as soon as possible for healthy subscribers. Retry Policy will be
-        #   triggered on NACKs or acknowledgement deadline exceeded events for a given message.
-        #
-        #   Value should be between 0 and 600 seconds. The default value is 600 seconds.
+        # @param [RetryPolicy] retry_policy A policy that specifies how Cloud Pub/Sub retries message delivery for
+        #   this subscription. If not set, the default retry policy is applied. This generally implies that messages
+        #   will be retried as soon as possible for healthy subscribers. Retry Policy will be triggered on NACKs or
+        #   acknowledgement deadline exceeded events for a given message.
         #
         #   **EXPERIMENTAL:** This API might be changed in backward-incompatible ways and is not recommended for
         #   production use. It is not subject to any SLA or deprecation policy.
@@ -370,19 +348,29 @@ module Google
         #                         dead_letter_topic: dead_letter_topic,
         #                         dead_letter_max_delivery_attempts: 10
         #
+        # @example Configure a Retry Policy:
+        #   require "google/cloud/pubsub"
+        #
+        #   pubsub = Google::Cloud::PubSub.new
+        #
+        #   topic = pubsub.topic "my-topic"
+        #
+        #   retry_policy = Google::Cloud::PubSub::RetryPolicy.new minimum_backoff: 5, maximum_backoff: 300
+        #   sub = topic.subscribe "my-topic-sub", retry_policy: retry_policy
+        #
         def subscribe subscription_name, deadline: nil, retain_acked: false, retention: nil, endpoint: nil, labels: nil,
                       message_ordering: nil, dead_letter_topic: nil, dead_letter_max_delivery_attempts: nil,
-                      retry_minimum_backoff: nil, retry_maximum_backoff: nil
+                      retry_policy: nil
           ensure_service!
           options = { deadline: deadline, retain_acked: retain_acked, retention: retention, endpoint: endpoint,
                       labels: labels, message_ordering: message_ordering,
-                      dead_letter_max_delivery_attempts: dead_letter_max_delivery_attempts,
-                      retry_minimum_backoff: retry_minimum_backoff, retry_maximum_backoff: retry_maximum_backoff }
+                      dead_letter_max_delivery_attempts: dead_letter_max_delivery_attempts }
           options[:dead_letter_topic_name] = dead_letter_topic.name if dead_letter_topic
           if options[:dead_letter_max_delivery_attempts] && !options[:dead_letter_topic_name]
             # Service error message "3:Invalid resource name given (name=)." does not identify param.
             raise ArgumentError, "dead_letter_topic is required with dead_letter_max_delivery_attempts"
           end
+          options[:retry_policy] = retry_policy.to_grpc if retry_policy
           grpc = service.create_subscription name, subscription_name, options
           Subscription.from_grpc grpc, service
         end

--- a/google-cloud-pubsub/support/doctest_helper.rb
+++ b/google-cloud-pubsub/support/doctest_helper.rb
@@ -286,7 +286,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::PubSub::RetryPolicy" do
     mock_pubsub do |mock_publisher, mock_subscriber|
-      mock_subscriber.expect :get_subscription, subscription_resp("my-topic-sub", dead_letter_topic: "my-dead-letter-topic", max_delivery_attempts: 10), ["projects/my-project/subscriptions/my-topic-sub", Hash]
+      mock_subscriber.expect :get_subscription, subscription_resp("my-topic-sub"), ["projects/my-project/subscriptions/my-topic-sub", Hash]
       mock_subscriber.expect :update_subscription, subscription_resp, [Google::Cloud::PubSub::V1::Subscription, Google::Protobuf::FieldMask, Hash]
     end
   end
@@ -445,7 +445,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::PubSub::Subscription#retry_policy" do
     mock_pubsub do |mock_publisher, mock_subscriber|
-      mock_subscriber.expect :get_subscription, subscription_resp("my-topic-sub", dead_letter_topic: "my-dead-letter-topic", max_delivery_attempts: 10), ["projects/my-project/subscriptions/my-topic-sub", Hash]
+      mock_subscriber.expect :get_subscription, subscription_resp("my-topic-sub"), ["projects/my-project/subscriptions/my-topic-sub", Hash]
       mock_subscriber.expect :update_subscription, subscription_resp, [Google::Cloud::PubSub::V1::Subscription, Google::Protobuf::FieldMask, Hash]
     end
   end

--- a/google-cloud-pubsub/support/doctest_helper.rb
+++ b/google-cloud-pubsub/support/doctest_helper.rb
@@ -282,6 +282,16 @@ YARD::Doctest.configure do |doctest|
   end
 
   ##
+  # RetryPolicy
+
+  doctest.before "Google::Cloud::PubSub::RetryPolicy" do
+    mock_pubsub do |mock_publisher, mock_subscriber|
+      mock_subscriber.expect :get_subscription, subscription_resp("my-topic-sub", dead_letter_topic: "my-dead-letter-topic", max_delivery_attempts: 10), ["projects/my-project/subscriptions/my-topic-sub", Hash]
+      mock_subscriber.expect :update_subscription, subscription_resp, [Google::Cloud::PubSub::V1::Subscription, Google::Protobuf::FieldMask, Hash]
+    end
+  end
+
+  ##
   # Snapshot
 
   doctest.before "Google::Cloud::PubSub::Snapshot" do
@@ -432,6 +442,13 @@ YARD::Doctest.configure do |doctest|
     end
   end
   doctest.skip "Google::Cloud::PubSub::Subscription#refresh!"
+
+  doctest.before "Google::Cloud::PubSub::Subscription#retry_policy" do
+    mock_pubsub do |mock_publisher, mock_subscriber|
+      mock_subscriber.expect :get_subscription, subscription_resp("my-topic-sub", dead_letter_topic: "my-dead-letter-topic", max_delivery_attempts: 10), ["projects/my-project/subscriptions/my-topic-sub", Hash]
+      mock_subscriber.expect :update_subscription, subscription_resp, [Google::Cloud::PubSub::V1::Subscription, Google::Protobuf::FieldMask, Hash]
+    end
+  end
 
   doctest.before "Google::Cloud::PubSub::Subscription#push_config" do
     mock_pubsub do |mock_publisher, mock_subscriber|
@@ -743,7 +760,8 @@ def subscription_hash topic_name, sub_name,
     ack_deadline_seconds: deadline,
     retain_acked_messages: true,
     message_retention_duration: { seconds: 600, nanos: 900000000 }, # 600.9 seconds
-    labels: labels
+    labels: labels,
+    retry_policy: { minimum_backoff: 5, maximum_backoff: 300 }
   }
   hsh[:dead_letter_policy] = {
     dead_letter_topic: topic_path(dead_letter_topic),

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/attrs_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/attrs_test.rb
@@ -91,11 +91,11 @@ describe Google::Cloud::PubSub::Subscription, :attributes, :mock_pubsub do
   end
 
   it "gets retry_minimum_backoff from the Google API object" do
-    _(subscription.retry_minimum_backoff).must_equal retry_minimum_backoff
+    _(subscription.retry_policy.minimum_backoff).must_equal retry_minimum_backoff
   end
 
   it "gets retry_maximum_backoff from the Google API object" do
-    _(subscription.retry_maximum_backoff).must_equal retry_maximum_backoff
+    _(subscription.retry_policy.maximum_backoff).must_equal retry_maximum_backoff
   end
 
   describe "reference subscription object of a subscription that does exist" do
@@ -194,7 +194,7 @@ describe Google::Cloud::PubSub::Subscription, :attributes, :mock_pubsub do
       mock.expect :get_subscription, get_res, [subscription_path(sub_name), options: default_options]
       subscription.service.mocked_subscriber = mock
 
-      _(subscription.retry_minimum_backoff).must_equal retry_minimum_backoff
+      _(subscription.retry_policy.minimum_backoff).must_equal retry_minimum_backoff
 
       mock.verify
     end
@@ -205,7 +205,7 @@ describe Google::Cloud::PubSub::Subscription, :attributes, :mock_pubsub do
       mock.expect :get_subscription, get_res, [subscription_path(sub_name), options: default_options]
       subscription.service.mocked_subscriber = mock
 
-      _(subscription.retry_maximum_backoff).must_equal retry_maximum_backoff
+      _(subscription.retry_policy.maximum_backoff).must_equal retry_maximum_backoff
 
       mock.verify
     end
@@ -327,7 +327,7 @@ describe Google::Cloud::PubSub::Subscription, :attributes, :mock_pubsub do
       end.must_raise Google::Cloud::NotFoundError
     end
 
-    it "raises NotFoundError when retrieving retry_minimum_backoff" do
+    it "raises NotFoundError when retrieving retry_policy" do
       stub = Object.new
       def stub.get_subscription *args
         gax_error = Google::Gax::GaxError.new "not found"
@@ -337,21 +337,7 @@ describe Google::Cloud::PubSub::Subscription, :attributes, :mock_pubsub do
       subscription.service.mocked_subscriber = stub
 
       expect do
-        subscription.retry_minimum_backoff
-      end.must_raise Google::Cloud::NotFoundError
-    end
-
-    it "raises NotFoundError when retrieving retry_maximum_backoff" do
-      stub = Object.new
-      def stub.get_subscription *args
-        gax_error = Google::Gax::GaxError.new "not found"
-        gax_error.instance_variable_set :@cause, GRPC::BadStatus.new(5, "not found")
-        raise gax_error
-      end
-      subscription.service.mocked_subscriber = stub
-
-      expect do
-        subscription.retry_maximum_backoff
+        subscription.retry_policy
       end.must_raise Google::Cloud::NotFoundError
     end
   end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/attrs_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/attrs_test.rb
@@ -18,8 +18,10 @@ describe Google::Cloud::PubSub::Subscription, :attributes, :mock_pubsub do
   let(:labels) { { "foo" => "bar" } }
   let(:topic_name) { "topic-name-goes-here" }
   let(:dead_letter_topic_path) { topic_path("topic-name-dead-letter") }
+  let(:retry_minimum_backoff) { 12.123 }
+  let(:retry_maximum_backoff) { 123.321 }
   let(:sub_name) { "subscription-name-goes-here" }
-  let(:sub_hash) { subscription_hash topic_name, sub_name, labels: labels, dead_letter_topic: dead_letter_topic_path, max_delivery_attempts: 6 }
+  let(:sub_hash) { subscription_hash topic_name, sub_name, labels: labels, dead_letter_topic: dead_letter_topic_path, max_delivery_attempts: 6, retry_minimum_backoff: retry_minimum_backoff, retry_maximum_backoff: retry_maximum_backoff }
   let(:sub_deadline) { sub_hash[:ack_deadline_seconds] }
   let(:sub_endpoint) { sub_hash[:push_config][:push_endpoint] }
   let(:sub_grpc) { Google::Cloud::PubSub::V1::Subscription.new(sub_hash) }
@@ -86,6 +88,14 @@ describe Google::Cloud::PubSub::Subscription, :attributes, :mock_pubsub do
 
   it "gets dead_letter_max_delivery_attempts from the Google API object" do
     _(subscription.dead_letter_max_delivery_attempts).must_equal 6
+  end
+
+  it "gets retry_minimum_backoff from the Google API object" do
+    _(subscription.retry_minimum_backoff).must_equal retry_minimum_backoff
+  end
+
+  it "gets retry_maximum_backoff from the Google API object" do
+    _(subscription.retry_maximum_backoff).must_equal retry_maximum_backoff
   end
 
   describe "reference subscription object of a subscription that does exist" do
@@ -178,13 +188,24 @@ describe Google::Cloud::PubSub::Subscription, :attributes, :mock_pubsub do
       mock.verify
     end
 
-    it "makes an HTTP API call to retrieve labels" do
-      get_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, sub_name, labels: labels)
+    it "makes an HTTP API call to retrieve retry_minimum_backoff" do
+      get_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, sub_name, retry_minimum_backoff: retry_minimum_backoff)
       mock = Minitest::Mock.new
       mock.expect :get_subscription, get_res, [subscription_path(sub_name), options: default_options]
       subscription.service.mocked_subscriber = mock
 
-      _(subscription.labels).must_equal labels
+      _(subscription.retry_minimum_backoff).must_equal retry_minimum_backoff
+
+      mock.verify
+    end
+
+    it "makes an HTTP API call to retrieve retry_maximum_backoff" do
+      get_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, sub_name, retry_maximum_backoff: retry_maximum_backoff)
+      mock = Minitest::Mock.new
+      mock.expect :get_subscription, get_res, [subscription_path(sub_name), options: default_options]
+      subscription.service.mocked_subscriber = mock
+
+      _(subscription.retry_maximum_backoff).must_equal retry_maximum_backoff
 
       mock.verify
     end
@@ -303,6 +324,34 @@ describe Google::Cloud::PubSub::Subscription, :attributes, :mock_pubsub do
 
       expect do
         subscription.dead_letter_max_delivery_attempts
+      end.must_raise Google::Cloud::NotFoundError
+    end
+
+    it "raises NotFoundError when retrieving retry_minimum_backoff" do
+      stub = Object.new
+      def stub.get_subscription *args
+        gax_error = Google::Gax::GaxError.new "not found"
+        gax_error.instance_variable_set :@cause, GRPC::BadStatus.new(5, "not found")
+        raise gax_error
+      end
+      subscription.service.mocked_subscriber = stub
+
+      expect do
+        subscription.retry_minimum_backoff
+      end.must_raise Google::Cloud::NotFoundError
+    end
+
+    it "raises NotFoundError when retrieving retry_maximum_backoff" do
+      stub = Object.new
+      def stub.get_subscription *args
+        gax_error = Google::Gax::GaxError.new "not found"
+        gax_error.instance_variable_set :@cause, GRPC::BadStatus.new(5, "not found")
+        raise gax_error
+      end
+      subscription.service.mocked_subscriber = stub
+
+      expect do
+        subscription.retry_maximum_backoff
       end.must_raise Google::Cloud::NotFoundError
     end
   end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/update_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/update_test.rb
@@ -29,7 +29,11 @@ describe Google::Cloud::PubSub::Subscription, :update, :mock_pubsub do
   let(:dead_letter_topic_path) { topic_path(dead_letter_topic_name) }
   let(:new_dead_letter_topic_name) { "topic-name-dead-letter-2" }
   let(:new_dead_letter_topic) { Google::Cloud::PubSub::Topic.from_grpc Google::Cloud::PubSub::V1::Topic.new(topic_hash(new_dead_letter_topic_name)), pubsub.service }
-  let(:sub_hash) { subscription_hash topic_name, sub_name, labels: labels, dead_letter_topic: dead_letter_topic_path, max_delivery_attempts: 6 }
+  let(:retry_minimum_backoff) { 12.123 }
+  let(:new_retry_minimum_backoff) { 13 }
+  let(:retry_maximum_backoff) { 123.321 }
+  let(:new_retry_maximum_backoff) { 130 }
+  let(:sub_hash) { subscription_hash topic_name, sub_name, labels: labels, dead_letter_topic: dead_letter_topic_path, max_delivery_attempts: 6, retry_minimum_backoff: retry_minimum_backoff, retry_maximum_backoff: retry_maximum_backoff }
   let(:sub_deadline) { sub_hash["ack_deadline_seconds"] }
   let(:sub_endpoint) { sub_hash["push_config"]["push_endpoint"] }
   let(:sub_grpc) { Google::Cloud::PubSub::V1::Subscription.new(sub_hash) }
@@ -255,6 +259,38 @@ describe Google::Cloud::PubSub::Subscription, :update, :mock_pubsub do
     assert_raises ArgumentError do
       subscription_without_dead_letter.dead_letter_max_delivery_attempts = 7
     end
+  end
+
+  it "updates retry_minimum_backoff" do
+    retry_policy = Google::Cloud::PubSub::V1::RetryPolicy.new minimum_backoff: new_retry_minimum_backoff, maximum_backoff: retry_maximum_backoff
+    update_sub = Google::Cloud::PubSub::V1::Subscription.new name: sub_path, retry_policy: retry_policy
+    update_mask = Google::Protobuf::FieldMask.new paths: ["retry_policy"]
+    mock = Minitest::Mock.new
+    mock.expect :update_subscription, update_sub, [update_sub, update_mask, options: default_options]
+    subscription.service.mocked_subscriber = mock
+
+    subscription.retry_minimum_backoff = new_retry_minimum_backoff
+
+    mock.verify
+
+    _(subscription.retry_minimum_backoff).must_equal new_retry_minimum_backoff
+    _(subscription.retry_maximum_backoff).must_equal retry_maximum_backoff
+  end
+
+  it "updates retry_maximum_backoff" do
+    retry_policy = Google::Cloud::PubSub::V1::RetryPolicy.new minimum_backoff: retry_minimum_backoff, maximum_backoff: new_retry_maximum_backoff
+    update_sub = Google::Cloud::PubSub::V1::Subscription.new name: sub_path, retry_policy: retry_policy
+    update_mask = Google::Protobuf::FieldMask.new paths: ["retry_policy"]
+    mock = Minitest::Mock.new
+    mock.expect :update_subscription, update_sub, [update_sub, update_mask, options: default_options]
+    subscription.service.mocked_subscriber = mock
+
+    subscription.retry_maximum_backoff = new_retry_maximum_backoff
+
+    mock.verify
+
+    _(subscription.retry_minimum_backoff).must_equal retry_minimum_backoff
+    _(subscription.retry_maximum_backoff).must_equal new_retry_maximum_backoff
   end
 
   describe :reference do

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/update_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/update_test.rb
@@ -269,12 +269,12 @@ describe Google::Cloud::PubSub::Subscription, :update, :mock_pubsub do
     mock.expect :update_subscription, update_sub, [update_sub, update_mask, options: default_options]
     subscription.service.mocked_subscriber = mock
 
-    subscription.retry_minimum_backoff = new_retry_minimum_backoff
+    subscription.retry_policy = Google::Cloud::PubSub::RetryPolicy.new minimum_backoff: new_retry_minimum_backoff, maximum_backoff: retry_maximum_backoff
 
     mock.verify
 
-    _(subscription.retry_minimum_backoff).must_equal new_retry_minimum_backoff
-    _(subscription.retry_maximum_backoff).must_equal retry_maximum_backoff
+    _(subscription.retry_policy.minimum_backoff).must_equal new_retry_minimum_backoff
+    _(subscription.retry_policy.maximum_backoff).must_equal retry_maximum_backoff
   end
 
   it "updates retry_maximum_backoff" do
@@ -285,12 +285,12 @@ describe Google::Cloud::PubSub::Subscription, :update, :mock_pubsub do
     mock.expect :update_subscription, update_sub, [update_sub, update_mask, options: default_options]
     subscription.service.mocked_subscriber = mock
 
-    subscription.retry_maximum_backoff = new_retry_maximum_backoff
+    subscription.retry_policy = Google::Cloud::PubSub::RetryPolicy.new minimum_backoff: retry_minimum_backoff, maximum_backoff: new_retry_maximum_backoff
 
     mock.verify
 
-    _(subscription.retry_minimum_backoff).must_equal retry_minimum_backoff
-    _(subscription.retry_maximum_backoff).must_equal new_retry_maximum_backoff
+    _(subscription.retry_policy.minimum_backoff).must_equal retry_minimum_backoff
+    _(subscription.retry_policy.maximum_backoff).must_equal new_retry_maximum_backoff
   end
 
   describe :reference do

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscribe_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/subscribe_test.rb
@@ -23,7 +23,7 @@ describe Google::Cloud::PubSub::Topic, :subscribe, :mock_pubsub do
   it "creates a subscription when calling subscribe" do
     create_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, new_sub_name)
     mock = Minitest::Mock.new
-    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: nil, enable_message_ordering: nil, dead_letter_policy: nil, options: default_options]
+    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: nil, enable_message_ordering: nil, dead_letter_policy: nil, retry_policy: nil, options: default_options]
     topic.service.mocked_subscriber = mock
 
     sub = topic.subscribe new_sub_name
@@ -37,7 +37,7 @@ describe Google::Cloud::PubSub::Topic, :subscribe, :mock_pubsub do
   it "creates a subscription with labels" do
     create_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, new_sub_name, labels: labels)
     mock = Minitest::Mock.new
-    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: labels, enable_message_ordering: nil, dead_letter_policy: nil, options: default_options]
+    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: labels, enable_message_ordering: nil, dead_letter_policy: nil, retry_policy: nil, options: default_options]
     topic.service.mocked_subscriber = mock
 
     sub = topic.subscribe new_sub_name, labels: labels
@@ -56,7 +56,7 @@ describe Google::Cloud::PubSub::Topic, :subscribe, :mock_pubsub do
     it "creates a subscription when calling subscribe" do
       create_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, new_sub_name)
       mock = Minitest::Mock.new
-      mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: nil, enable_message_ordering: nil, dead_letter_policy: nil, options: default_options]
+      mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: nil, enable_message_ordering: nil, dead_letter_policy: nil, retry_policy: nil, options: default_options]
       topic.service.mocked_subscriber = mock
 
       sub = topic.subscribe new_sub_name

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic_test.rb
@@ -32,6 +32,8 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
   end
   let(:dead_letter_topic_name) { "topic-name-dead-letter" }
   let(:dead_letter_topic) { Google::Cloud::PubSub::Topic.from_grpc Google::Cloud::PubSub::V1::Topic.new(topic_hash(dead_letter_topic_name)), pubsub.service }
+  let(:retry_minimum_backoff) { 12.123 }
+  let(:retry_maximum_backoff) { 123.321 }
 
   it "knows its name" do
     _(topic.name).must_equal topic_path(topic_name)
@@ -57,7 +59,7 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
     new_sub_name = "new-sub-#{Time.now.to_i}"
     create_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, new_sub_name)
     mock = Minitest::Mock.new
-    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: nil, enable_message_ordering: nil, dead_letter_policy: nil, options: default_options]
+    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: nil, enable_message_ordering: nil, dead_letter_policy: nil, retry_policy: nil, options: default_options]
     topic.service.mocked_subscriber = mock
 
     sub = topic.subscribe new_sub_name
@@ -72,7 +74,7 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
     new_sub_name = "new-sub-#{Time.now.to_i}"
     create_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, new_sub_name)
     mock = Minitest::Mock.new
-    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: nil, enable_message_ordering: nil, dead_letter_policy: nil, options: default_options]
+    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: nil, enable_message_ordering: nil, dead_letter_policy: nil, retry_policy: nil, options: default_options]
     topic.service.mocked_subscriber = mock
 
     sub = topic.create_subscription new_sub_name
@@ -87,7 +89,7 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
     new_sub_name = "new-sub-#{Time.now.to_i}"
     create_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, new_sub_name)
     mock = Minitest::Mock.new
-    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: nil, enable_message_ordering: nil, dead_letter_policy: nil, options: default_options]
+    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: nil, enable_message_ordering: nil, dead_letter_policy: nil, retry_policy: nil, options: default_options]
     topic.service.mocked_subscriber = mock
 
     sub = topic.new_subscription new_sub_name
@@ -103,7 +105,7 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
     deadline = 42
     create_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, new_sub_name)
     mock = Minitest::Mock.new
-    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: 42, retain_acked_messages: false, message_retention_duration: nil, labels: nil, enable_message_ordering: nil, dead_letter_policy: nil, options: default_options]
+    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: 42, retain_acked_messages: false, message_retention_duration: nil, labels: nil, enable_message_ordering: nil, dead_letter_policy: nil, retry_policy: nil, options: default_options]
     topic.service.mocked_subscriber = mock
 
     sub = topic.subscribe new_sub_name, deadline: deadline
@@ -120,7 +122,7 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
 
     duration = Google::Protobuf::Duration.new seconds: 600, nanos: 0
     mock = Minitest::Mock.new
-    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: true, message_retention_duration: duration, labels: nil, enable_message_ordering: nil, dead_letter_policy: nil, options: default_options]
+    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: true, message_retention_duration: duration, labels: nil, enable_message_ordering: nil, dead_letter_policy: nil, retry_policy: nil, options: default_options]
     topic.service.mocked_subscriber = mock
 
     sub = topic.subscribe new_sub_name, retain_acked: true, retention: 600
@@ -137,7 +139,7 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
     push_config = Google::Cloud::PubSub::V1::PushConfig.new(push_endpoint: endpoint)
     create_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, new_sub_name)
     mock = Minitest::Mock.new
-    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: push_config, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: nil, enable_message_ordering: nil, dead_letter_policy: nil, options: default_options]
+    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: push_config, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: nil, enable_message_ordering: nil, dead_letter_policy: nil, retry_policy: nil, options: default_options]
     topic.service.mocked_subscriber = mock
 
     sub = topic.subscribe new_sub_name, endpoint: endpoint
@@ -152,7 +154,7 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
     new_sub_name = "new-sub-#{Time.now.to_i}"
     create_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, new_sub_name, labels: labels)
     mock = Minitest::Mock.new
-    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: labels, enable_message_ordering: nil, dead_letter_policy: nil, options: default_options]
+    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: labels, enable_message_ordering: nil, dead_letter_policy: nil, retry_policy: nil, options: default_options]
     topic.service.mocked_subscriber = mock
 
     sub = topic.subscribe new_sub_name, labels: labels
@@ -170,14 +172,13 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
     create_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, new_sub_name, dead_letter_topic: dead_letter_topic_name, max_delivery_attempts: 7)
     dead_letter_policy = Google::Cloud::PubSub::V1::DeadLetterPolicy.new dead_letter_topic: topic_path(dead_letter_topic_name), max_delivery_attempts: 7
     mock = Minitest::Mock.new
-    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: nil, enable_message_ordering: nil, dead_letter_policy: dead_letter_policy, options: default_options]
+    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: nil, enable_message_ordering: nil, dead_letter_policy: dead_letter_policy, retry_policy: nil, options: default_options]
     topic.service.mocked_subscriber = mock
 
     sub = topic.subscribe new_sub_name, dead_letter_topic: dead_letter_topic, dead_letter_max_delivery_attempts: 7
 
     mock.verify
 
-    _(sub).wont_be :nil?
     _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
     _(sub.dead_letter_topic.name).must_equal topic_path(dead_letter_topic_name)
     _(sub.dead_letter_max_delivery_attempts).must_equal 7
@@ -187,6 +188,23 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
     assert_raises ArgumentError do
       topic.subscribe "my-new-sub", dead_letter_max_delivery_attempts: 7
     end
+  end
+
+  it "creates a subscription with retry_minimum_backoff and retry_maximum_backoff" do
+    new_sub_name = "new-sub-#{Time.now.to_i}"
+    create_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, new_sub_name, retry_minimum_backoff: retry_minimum_backoff, retry_maximum_backoff: retry_maximum_backoff)
+    retry_policy = Google::Cloud::PubSub::V1::RetryPolicy.new minimum_backoff: retry_minimum_backoff, maximum_backoff: retry_maximum_backoff
+    mock = Minitest::Mock.new
+    mock.expect :create_subscription, create_res, [subscription_path(new_sub_name), topic_path(topic_name), push_config: nil, ack_deadline_seconds: nil, retain_acked_messages: false, message_retention_duration: nil, labels: nil, enable_message_ordering: nil, dead_letter_policy: nil, retry_policy: retry_policy, options: default_options]
+    topic.service.mocked_subscriber = mock
+
+    sub = topic.subscribe new_sub_name, retry_minimum_backoff: retry_minimum_backoff, retry_maximum_backoff: retry_maximum_backoff
+
+    mock.verify
+
+    _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+    _(sub.retry_minimum_backoff).must_equal retry_minimum_backoff
+    _(sub.retry_maximum_backoff).must_equal retry_maximum_backoff
   end
 
   it "raises when creating a subscription that already exists" do

--- a/google-cloud-pubsub/test/helper.rb
+++ b/google-cloud-pubsub/test/helper.rb
@@ -174,7 +174,9 @@ class MockPubsub < Minitest::Spec
                         endpoint = "http://example.com/callback",
                         labels: nil,
                         dead_letter_topic: nil,
-                        max_delivery_attempts: nil
+                        max_delivery_attempts: nil,
+                        retry_minimum_backoff: nil,
+                        retry_maximum_backoff: nil
     raise "dead_letter_topic is required" if max_delivery_attempts && !dead_letter_topic
     hsh = { name: subscription_path(sub_name),
       topic: topic_path(topic_name),
@@ -195,6 +197,10 @@ class MockPubsub < Minitest::Spec
       dead_letter_topic: dead_letter_topic,
       max_delivery_attempts: max_delivery_attempts
     } if dead_letter_topic
+    hsh[:retry_policy] = {
+      minimum_backoff: retry_minimum_backoff,
+      maximum_backoff: retry_maximum_backoff
+    } if retry_minimum_backoff || retry_maximum_backoff
     hsh
   end
 


### PR DESCRIPTION
closes: #5584 

Note: Because it follows the existing "flattened" design used to expose attributes on nested value objects, this implementation does not support updating an existing `RetryPolicy` to a `nil` value. [It seems possible](https://github.com/googleapis/google-cloud-ruby/issues/5584#issuecomment-625935361) that this may prevent users from returning a Subscription to the default behavior of not having a retry policy. Please let me know if more work is needed to support that use case.