### PR TITLE
Fix Ruby 2.7 warn

### DIFF
--- a/google-cloud-firestore/lib/google/cloud/firestore/service.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/service.rb
@@ -195,7 +195,7 @@ module Google
         end
 
         def call_options parent: nil, token: nil
-          Google::Gax::CallOptions.new({
+          Google::Gax::CallOptions.new(**{
             metadata:   default_headers(parent),
             page_token: token
           }.delete_if { |_, v| v.nil? })


### PR DESCRIPTION
```
/app/vendor/bundle/ruby/2.7.0/gems/google-cloud-firestore-1.4.1/lib/google/cloud/firestore/service.rb:198: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/app/vendor/bundle/ruby/2.7.0/gems/google-gax-1.8.1/lib/google/gax/settings.rb:171: warning: The called method `initialize' is defined here
```

- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-ruby/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea.
- [x] Follow the instructions in [CONTRIBUTING](CONTRIBUTING.md). Most importantly, ensure the tests and linter pass by running `bundle exec rake ci` in the gem subdirectory.
- [x] Update code documentation if necessary.

closes: https://github.com/googleapis/google-cloud-ruby/issues/5950