### PR TITLE
bigquery(docs): Update documentation for udfs param

### DIFF
--- a/google-cloud-bigquery/Rakefile
+++ b/google-cloud-bigquery/Rakefile
@@ -106,7 +106,7 @@ namespace :acceptance do
     Google::Cloud.bigquery.datasets.all do |ds|
       begin
         ds.tables.all(&:delete)
-        ds.delete
+        ds.delete force: true
       rescue Google::Cloud::Error => e
         puts e.message
       end

--- a/google-cloud-bigquery/acceptance/bigquery/bigquery_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/bigquery_test.rb
@@ -176,24 +176,25 @@ describe Google::Cloud::Bigquery, :bigquery do
 
   it "should run a query job with job labels" do
     job = bigquery.query_job publicdata_query, labels: labels
-    _(job).must_be_kind_of Google::Cloud::Bigquery::Job
+    job.wait_until_done!
+    _(job).wont_be :failed?
     _(job.labels).must_equal labels
   end
 
-  it "should run a query job with user defined function resources" do
+  it "receives error when a standard SQL query job is passed a udfs param" do
     job = bigquery.query_job publicdata_query, udfs: udfs
-    _(job).must_be_kind_of Google::Cloud::Bigquery::Job
-    _(job.udfs).must_equal udfs
+    job.wait_until_done!
+    _(job).must_be :failed?
+    _(job.error["message"]).must_match /Legacy SQL UDFs cannot be used in Standard SQL queries/
   end
 
-  it "should run a query job with job labels and user defined function resources in a block updater" do
+  it "should run a query job with job labels in a block updater" do
     job = bigquery.query_job publicdata_query do |j|
       j.labels = labels
-      j.udfs = udfs
     end
-    _(job).must_be_kind_of Google::Cloud::Bigquery::Job
+    job.wait_until_done!
+    _(job).wont_be :failed?
     _(job.labels).must_equal labels
-    _(job.udfs).must_equal udfs
   end
 
   it "should get a list of jobs" do

--- a/google-cloud-bigquery/acceptance/bigquery_helper.rb
+++ b/google-cloud-bigquery/acceptance/bigquery_helper.rb
@@ -159,7 +159,7 @@ def clean_up_bigquery_datasets
   $bigquery.datasets.all do |dataset|
     if dataset.dataset_id.start_with? $prefix
       dataset.tables.all(&:delete)
-      dataset.delete
+      dataset.delete force: true
     end
   end
 rescue => e

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -636,12 +636,20 @@ module Google
         #   SQL](https://cloud.google.com/bigquery/docs/reference/legacy-sql)
         #   dialect. Optional. The default value is false.
         # @param [Array<String>, String] udfs User-defined function resources
-        #   used in the query. May be either a code resource to load from a
-        #   Google Cloud Storage URI (`gs://bucket/path`), or an inline resource
+        #   used in a legacy SQL query. May be either a code resource to load from
+        #   a Google Cloud Storage URI (`gs://bucket/path`), or an inline resource
         #   that contains code for a user-defined function (UDF). Providing an
         #   inline code resource is equivalent to providing a URI for a file
-        #   containing the same code. See [User-Defined
-        #   Functions](https://cloud.google.com/bigquery/docs/reference/standard-sql/user-defined-functions).
+        #   containing the same code.
+        #
+        #   This parameter is used for defining User Defined Function (UDF)
+        #   resources only when using legacy SQL. Users of standard SQL should
+        #   leverage either DDL (e.g. `CREATE [TEMPORARY] FUNCTION ...`) or the
+        #   Routines API to define UDF resources.
+        #
+        #   For additional information on migrating, see: [Migrating to
+        #   standard SQL - Differences in user-defined JavaScript
+        #   functions](https://cloud.google.com/bigquery/docs/reference/standard-sql/migrating-from-legacy-sql#differences_in_user-defined_javascript_functions)
         #
         # @return [Google::Cloud::Bigquery::Table] A new table object.
         #
@@ -1171,12 +1179,20 @@ module Google
         #   list must have a different key. See [Requirements for
         #   labels](https://cloud.google.com/bigquery/docs/creating-managing-labels#requirements).
         # @param [Array<String>, String] udfs User-defined function resources
-        #   used in the query. May be either a code resource to load from a
-        #   Google Cloud Storage URI (`gs://bucket/path`), or an inline resource
+        #   used in a legacy SQL query. May be either a code resource to load from
+        #   a Google Cloud Storage URI (`gs://bucket/path`), or an inline resource
         #   that contains code for a user-defined function (UDF). Providing an
         #   inline code resource is equivalent to providing a URI for a file
-        #   containing the same code. See [User-Defined
-        #   Functions](https://cloud.google.com/bigquery/docs/reference/standard-sql/user-defined-functions).
+        #   containing the same code.
+        #
+        #   This parameter is used for defining User Defined Function (UDF)
+        #   resources only when using legacy SQL. Users of standard SQL should
+        #   leverage either DDL (e.g. `CREATE [TEMPORARY] FUNCTION ...`) or the
+        #   Routines API to define UDF resources.
+        #
+        #   For additional information on migrating, see: [Migrating to
+        #   standard SQL - Differences in user-defined JavaScript
+        #   functions](https://cloud.google.com/bigquery/docs/reference/standard-sql/migrating-from-legacy-sql#differences_in_user-defined_javascript_functions)
         # @param [Integer] maximum_billing_tier Deprecated: Change the billing
         #   tier to allow high-compute queries.
         # @yield [job] a job configuration object

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -419,12 +419,20 @@ module Google
         #   list must have a different key. See [Requirements for
         #   labels](https://cloud.google.com/bigquery/docs/creating-managing-labels#requirements).
         # @param [Array<String>, String] udfs User-defined function resources
-        #   used in the query. May be either a code resource to load from a
-        #   Google Cloud Storage URI (`gs://bucket/path`), or an inline resource
+        #   used in a legacy SQL query. May be either a code resource to load from
+        #   a Google Cloud Storage URI (`gs://bucket/path`), or an inline resource
         #   that contains code for a user-defined function (UDF). Providing an
         #   inline code resource is equivalent to providing a URI for a file
-        #   containing the same code. See [User-Defined
-        #   Functions](https://cloud.google.com/bigquery/docs/reference/standard-sql/user-defined-functions).
+        #   containing the same code.
+        #
+        #   This parameter is used for defining User Defined Function (UDF)
+        #   resources only when using legacy SQL. Users of standard SQL should
+        #   leverage either DDL (e.g. `CREATE [TEMPORARY] FUNCTION ...`) or the
+        #   Routines API to define UDF resources.
+        #
+        #   For additional information on migrating, see: [Migrating to
+        #   standard SQL - Differences in user-defined JavaScript
+        #   functions](https://cloud.google.com/bigquery/docs/reference/standard-sql/migrating-from-legacy-sql#differences_in_user-defined_javascript_functions)
         # @param [Integer] maximum_billing_tier Deprecated: Change the billing
         #   tier to allow high-compute queries.
         # @yield [job] a job configuration object

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -1181,12 +1181,20 @@ module Google
         #   SQL](https://cloud.google.com/bigquery/docs/reference/legacy-sql)
         #   dialect. Optional. The default value is false.
         # @param [Array<String>, String] udfs User-defined function resources
-        #   used in the query. May be either a code resource to load from a
-        #   Google Cloud Storage URI (`gs://bucket/path`), or an inline resource
+        #   used in a legacy SQL query. May be either a code resource to load from
+        #   a Google Cloud Storage URI (`gs://bucket/path`), or an inline resource
         #   that contains code for a user-defined function (UDF). Providing an
         #   inline code resource is equivalent to providing a URI for a file
-        #   containing the same code. See [User-Defined
-        #   Functions](https://cloud.google.com/bigquery/docs/reference/standard-sql/user-defined-functions).
+        #   containing the same code.
+        #
+        #   This parameter is used for defining User Defined Function (UDF)
+        #   resources only when using legacy SQL. Users of standard SQL should
+        #   leverage either DDL (e.g. `CREATE [TEMPORARY] FUNCTION ...`) or the
+        #   Routines API to define UDF resources.
+        #
+        #   For additional information on migrating, see: [Migrating to
+        #   standard SQL - Differences in user-defined JavaScript
+        #   functions](https://cloud.google.com/bigquery/docs/reference/standard-sql/migrating-from-legacy-sql#differences_in_user-defined_javascript_functions)
         #
         # @example
         #   require "google/cloud/bigquery"


### PR DESCRIPTION
closes: #5915 

This PR also fixes the acceptance cleanup by adding `force: true` to dataset deletes. 