### PR TITLE
chore(monitoring-v3): Hack synth file to remove dead links in docs for an obsolete proto

### DIFF
--- a/google-cloud-monitoring-v3/synth.py
+++ b/google-cloud-monitoring-v3/synth.py
@@ -37,3 +37,16 @@ library = gapic.ruby_library(
 )
 
 s.copy(library, merge=ruby.global_merge)
+
+# Temporary: Remove docs for the obsolete ServiceTier module which contain
+# broken links.
+s.replace(
+    'proto_docs/google/monitoring/v3/common.rb',
+    '(\n        #[^\n]*)+\n        module ServiceTier\n',
+    '\n        # Obsolete.\n        module ServiceTier\n'
+)
+s.replace(
+    'proto_docs/google/monitoring/v3/common.rb',
+    '(\n          #[^\n]*)+\n          SERVICE_TIER_',
+    '\n          # Obsolete.\n          SERVICE_TIER_'
+)


### PR DESCRIPTION
Needed for now to get 404 checking to pass. (This is currently also present in the monitoring synth script: https://github.com/googleapis/google-cloud-ruby/blob/master/google-cloud-monitoring/synth.py#L289-L300)