### PR TITLE
fix(dlp): Update dependency on dlp-v2 to 0.2

### DIFF
--- a/google-cloud-dlp/google-cloud-dlp.gemspec
+++ b/google-cloud-dlp/google-cloud-dlp.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "google-cloud-core", "~> 1.5"
-  gem.add_dependency "google-cloud-dlp-v2", "~> 0.0"
+  gem.add_dependency "google-cloud-dlp-v2", "~> 0.2"
 
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "google-style", "~> 1.24.0"

--- a/google-cloud-dlp/synth.py
+++ b/google-cloud-dlp/synth.py
@@ -30,7 +30,7 @@ library = gapic.ruby_library(
         "ruby-cloud-title": "Cloud Data Loss Prevention (DLP)",
         "ruby-cloud-description": "Provides methods for detection of privacy-sensitive fragments in text, images, and Google Cloud Platform storage repositories.",
         "ruby-cloud-env-prefix": "DLP",
-        "ruby-cloud-wrapper-of": "v2:0.0",
+        "ruby-cloud-wrapper-of": "v2:0.2",
         "ruby-cloud-product-url": "https://cloud.google.com/dlp",
         "ruby-cloud-api-id": "dlp",
         "ruby-cloud-migration-version": "1.0",


### PR DESCRIPTION
Version 0.2 includes some upstream breaking changes, we want to make sure the migrated wrapper pulls those in before we release it.