### PR TITLE
fix: Pin protobuf on old rubies

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -25,6 +25,7 @@ versions=($RUBY_VERSIONS)
 # Capture failures
 EXIT_STATUS=0 # everything passed
 function set_failed_status {
+    echo "**** FAILURE DETECTED ****"
     EXIT_STATUS=1
 }
 

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,8 @@ gem "gems", "~> 0.8"
 gem "actionpack", "~> 5.0"
 gem "railties", "~> 5.0"
 gem "rack", ">= 0.1"
+# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
+gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")
 
 gem "google-cloud-access_approval", path: "google-cloud-access_approval"
 gem "google-cloud-access_approval-v1", path: "google-cloud-access_approval-v1"

--- a/gcloud/Gemfile
+++ b/gcloud/Gemfile
@@ -3,3 +3,6 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake"
+
+# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
+gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-bigquery/Gemfile
+++ b/google-cloud-bigquery/Gemfile
@@ -9,3 +9,6 @@ gem "google-cloud-storage", path: "../google-cloud-storage"
 
 gem "minitest-reporters", "~> 1.3.5", require: false
 gem "rake"
+
+# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
+gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-bigquery/support/doctest_helper.rb
+++ b/google-cloud-bigquery/support/doctest_helper.rb
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "minitest/focus"
+
 require "google/cloud/bigquery"
 require "google/cloud/storage"
 

--- a/google-cloud-bigtable/Gemfile
+++ b/google-cloud-bigtable/Gemfile
@@ -8,3 +8,6 @@ gem "google-cloud-errors", path: "../google-cloud-errors"
 
 gem "minitest-reporters", "~> 1.3.5", require: false
 gem "rake"
+
+# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
+gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-bigtable/support/doctest_helper.rb
+++ b/google-cloud-bigtable/support/doctest_helper.rb
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "minitest/focus"
+
 require "google/cloud/bigtable"
 require "grpc/errors"
 

--- a/google-cloud-container_analysis/Gemfile
+++ b/google-cloud-container_analysis/Gemfile
@@ -8,3 +8,6 @@ gem "rake", "~> 12.0"
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110
 gem "minitest", "~> 5.11.3"
+
+# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
+gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-core/Gemfile
+++ b/google-cloud-core/Gemfile
@@ -12,3 +12,6 @@ gem "rake"
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110
 gem "minitest", "~> 5.11.3"
+
+# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
+gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-datastore/Gemfile
+++ b/google-cloud-datastore/Gemfile
@@ -7,3 +7,6 @@ gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-errors", path: "../google-cloud-errors"
 
 gem "rake"
+
+# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
+gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-datastore/support/doctest_helper.rb
+++ b/google-cloud-datastore/support/doctest_helper.rb
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "minitest/focus"
+
 require "grpc"
 require "google/cloud/datastore"
 

--- a/google-cloud-debugger/Gemfile
+++ b/google-cloud-debugger/Gemfile
@@ -9,3 +9,6 @@ gem "google-cloud-logging", path: "../google-cloud-logging"
 gem "stackdriver-core", path: "../stackdriver-core"
 
 gem "rake"
+
+# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
+gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-debugger/support/doctest_helper.rb
+++ b/google-cloud-debugger/support/doctest_helper.rb
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "minitest/focus"
 
 require "google/cloud/debugger"
 require "minitest/rg"

--- a/google-cloud-dns/Gemfile
+++ b/google-cloud-dns/Gemfile
@@ -7,3 +7,6 @@ gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-errors", path: "../google-cloud-errors"
 
 gem "rake"
+
+# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
+gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-dns/support/doctest_helper.rb
+++ b/google-cloud-dns/support/doctest_helper.rb
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "minitest/focus"
+
 require "google/cloud/dns"
 
 class File

--- a/google-cloud-env/Gemfile
+++ b/google-cloud-env/Gemfile
@@ -7,3 +7,6 @@ gem "rake"
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110
 gem "minitest", "~> 5.11.3"
+
+# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
+gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-error_reporting/Gemfile
+++ b/google-cloud-error_reporting/Gemfile
@@ -8,3 +8,6 @@ gem "google-cloud-errors", path: "../google-cloud-errors"
 gem "stackdriver-core", path: "../stackdriver-core"
 
 gem "rake"
+
+# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
+gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-error_reporting/support/doctest_helper.rb
+++ b/google-cloud-error_reporting/support/doctest_helper.rb
@@ -12,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "minitest/focus"
 
 require "google/cloud/error_reporting"
-
-
 
 module Google
   module Cloud

--- a/google-cloud-errors/Gemfile
+++ b/google-cloud-errors/Gemfile
@@ -10,3 +10,6 @@ gem "rake"
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110
 gem "minitest", "~> 5.11.3"
+
+# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
+gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-firestore/Gemfile
+++ b/google-cloud-firestore/Gemfile
@@ -9,3 +9,6 @@ gem "google-cloud-errors", path: "../google-cloud-errors"
 gem "rake"
 
 gem "stackprof" unless Gem.win_platform?
+
+# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
+gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-firestore/support/doctest_helper.rb
+++ b/google-cloud-firestore/support/doctest_helper.rb
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "minitest/focus"
+
 require "google/cloud/firestore"
 
 ##

--- a/google-cloud-logging/Gemfile
+++ b/google-cloud-logging/Gemfile
@@ -11,3 +11,6 @@ gem "stackdriver-core", path: "../stackdriver-core"
 
 gem "minitest-reporters", "~> 1.3.5", require: false
 gem "rake"
+
+# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
+gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-logging/support/doctest_helper.rb
+++ b/google-cloud-logging/support/doctest_helper.rb
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "minitest/focus"
+
 require "google/cloud/storage"
 require "google/cloud/logging"
 

--- a/google-cloud-phishing_protection/Gemfile
+++ b/google-cloud-phishing_protection/Gemfile
@@ -7,3 +7,6 @@ gem "rake", "~> 12.0"
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110
 gem "minitest", "~> 5.11.3"
+
+# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
+gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-pubsub/Gemfile
+++ b/google-cloud-pubsub/Gemfile
@@ -8,3 +8,6 @@ gem "google-cloud-errors", path: "../google-cloud-errors"
 
 gem "minitest-reporters", "~> 1.3.5", require: false
 gem "rake"
+
+# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
+gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-pubsub/support/doctest_helper.rb
+++ b/google-cloud-pubsub/support/doctest_helper.rb
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "minitest/focus"
+
 require "google/cloud/pubsub"
 
 class File

--- a/google-cloud-resource_manager/Gemfile
+++ b/google-cloud-resource_manager/Gemfile
@@ -11,3 +11,6 @@ gem "rake"
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110
 gem "minitest", "~> 5.11.3"
+
+# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
+gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-resource_manager/support/doctest_helper.rb
+++ b/google-cloud-resource_manager/support/doctest_helper.rb
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "minitest/focus"
+
 require "google/cloud/resource_manager"
 
 module Google

--- a/google-cloud-spanner/Gemfile
+++ b/google-cloud-spanner/Gemfile
@@ -7,3 +7,6 @@ gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-errors", path: "../google-cloud-errors"
 
 gem "rake"
+
+# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
+gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-spanner/support/doctest_helper.rb
+++ b/google-cloud-spanner/support/doctest_helper.rb
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "minitest/focus"
+
 require "google/cloud/spanner"
 require "grpc/errors"
 

--- a/google-cloud-storage/Gemfile
+++ b/google-cloud-storage/Gemfile
@@ -11,3 +11,6 @@ gem "minitest-reporters", "~> 1.3.5", require: false
 gem "rake"
 
 gem "minitest"
+
+# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
+gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-storage/support/doctest_helper.rb
+++ b/google-cloud-storage/support/doctest_helper.rb
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "minitest/focus"
+
 require "google/cloud/storage"
 require "google/cloud/pubsub"
 

--- a/google-cloud-trace/Gemfile
+++ b/google-cloud-trace/Gemfile
@@ -12,3 +12,6 @@ gem "rake"
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110
 gem "minitest", "~> 5.11.3"
+
+# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
+gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-trace/support/doctest_helper.rb
+++ b/google-cloud-trace/support/doctest_helper.rb
@@ -15,6 +15,7 @@
 
 require "google/cloud/trace"
 require "minitest/rg"
+require "minitest/focus"
 require "active_record"
 
 module Google

--- a/google-cloud/Gemfile
+++ b/google-cloud/Gemfile
@@ -3,3 +3,6 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake"
+
+# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
+gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/grafeas-client/Gemfile
+++ b/grafeas-client/Gemfile
@@ -5,3 +5,6 @@ gemspec
 gem "grafeas", path: "../grafeas"
 
 gem "rake", "~> 12.0"
+
+# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
+gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/grafeas/Gemfile
+++ b/grafeas/Gemfile
@@ -7,3 +7,6 @@ gem "rake", "~> 12.0"
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110
 gem "minitest", "~> 5.11.3"
+
+# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
+gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/stackdriver-core/Gemfile
+++ b/stackdriver-core/Gemfile
@@ -11,3 +11,6 @@ gem "rake"
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110
 gem "minitest", "~> 5.11.3"
+
+# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
+gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/stackdriver/Gemfile
+++ b/stackdriver/Gemfile
@@ -16,3 +16,6 @@ gem "rake"
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110
 gem "minitest", "~> 5.11.3"
+
+# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
+gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")


### PR DESCRIPTION
Works around two CI issues that appeared over the weekend:

* The `google-protobuf` gem 3.12.0 won't install on Ruby 2.4. I'm working to get this resolved upstream, but until then, this adjusts the Gemfiles to pin the gem to 3.11 on Ruby 2.4.
* The `minitest-focus` gem 1.2.0 crashes if the gem is present (in the bundle) but `require "minitest/focus"` is never invoked. I also have a PR to resolve this upstream, but until then, I added the necessary require statement.

This PR applies the fixes only to libraries that are not automated. I have microgenerator PRs in flight to apply these changes to generated libraries.