### PR TITLE
docs(automl-v1): Fix a few broken links

### DIFF
--- a/google-cloud-automl-v1/proto_docs/google/cloud/automl/v1/io.rb
+++ b/google-cloud-automl-v1/proto_docs/google/cloud/automl/v1/io.rb
@@ -1041,8 +1041,7 @@ module Google
         #         that wraps the same "ID" : "<id_value>" but here followed by
         #         exactly one
         #
-        # [`google.rpc.Status`](https:
-        # //github.com/googleapis/googleapis/blob/master/google/rpc/status.proto)
+        # [`google.rpc.Status`](https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto)
         #         containing only `code` and `message`fields.
         #
         #  *  For Image Object Detection:
@@ -1063,8 +1062,7 @@ module Google
         #         that wraps the same "ID" : "<id_value>" but here followed by
         #         exactly one
         #
-        # [`google.rpc.Status`](https:
-        # //github.com/googleapis/googleapis/blob/master/google/rpc/status.proto)
+        # [`google.rpc.Status`](https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto)
         #         containing only `code` and `message`fields.
         #  *  For Video Classification:
         #         In the created directory a video_classification.csv file, and a .JSON
@@ -1138,8 +1136,7 @@ module Google
         #         failed predictions). These files will have a JSON representation of a
         #         proto that wraps input file followed by exactly one
         #
-        # [`google.rpc.Status`](https:
-        # //github.com/googleapis/googleapis/blob/master/google/rpc/status.proto)
+        # [`google.rpc.Status`](https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto)
         #         containing only `code` and `message`.
         #
         #  *  For Text Sentiment:
@@ -1162,8 +1159,7 @@ module Google
         #         failed predictions). These files will have a JSON representation of a
         #         proto that wraps input file followed by exactly one
         #
-        # [`google.rpc.Status`](https:
-        # //github.com/googleapis/googleapis/blob/master/google/rpc/status.proto)
+        # [`google.rpc.Status`](https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto)
         #         containing only `code` and `message`.
         #
         #   *  For Text Extraction:
@@ -1198,8 +1194,7 @@ module Google
         #         or the document proto (in case of document) but here followed by
         #         exactly one
         #
-        # [`google.rpc.Status`](https:
-        # //github.com/googleapis/googleapis/blob/master/google/rpc/status.proto)
+        # [`google.rpc.Status`](https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto)
         #         containing only `code` and `message`.
         #
         #  *  For Tables:
@@ -1251,8 +1246,7 @@ module Google
         #             will have analogous format as `tables_*.csv`, but always with a
         #             single target column having
         #
-        # [`google.rpc.Status`](https:
-        # //github.com/googleapis/googleapis/blob/master/google/rpc/status.proto)
+        # [`google.rpc.Status`](https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto)
         #             represented as a JSON string, and containing only `code` and
         #             `message`.
         #         BigQuery case:
@@ -1290,8 +1284,7 @@ module Google
         # [display_name][google.cloud.automl.v1p1beta.ColumnSpec.display_name]>",
         #           and as a value has
         #
-        # [`google.rpc.Status`](https:
-        # //github.com/googleapis/googleapis/blob/master/google/rpc/status.proto)
+        # [`google.rpc.Status`](https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto)
         #           represented as a STRUCT, and containing only `code` and `message`.
         # @!attribute [rw] gcs_destination
         #   @return [::Google::Cloud::AutoML::V1::GcsDestination]

--- a/google-cloud-automl-v1/synth.metadata
+++ b/google-cloud-automl-v1/synth.metadata
@@ -3,16 +3,16 @@
     {
       "git": {
         "name": ".",
-        "remote": "https://github.com/googleapis/google-cloud-ruby.git",
-        "sha": "aaeed1e55688fa3948aef7998683c1e0cd6f70c1"
+        "remote": "git@github.com:googleapis/google-cloud-ruby.git",
+        "sha": "02b3b0e10a3ceccd0da64825154cff274054c880"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "3f5f8a2258c6a41f9fbf7b80acbca631dda0a952",
-        "internalRef": "308922843"
+        "sha": "973c671823c076165b2371cda0174586d4078b0d",
+        "internalRef": "313004561"
       }
     }
   ],

--- a/google-cloud-automl-v1/synth.py
+++ b/google-cloud-automl-v1/synth.py
@@ -39,3 +39,10 @@ library = gapic.ruby_library(
 )
 
 s.copy(library, merge=ruby.global_merge)
+
+# Fixes for some misformatted markdown links.
+# See internal issue b/153077040.
+s.replace(
+    "proto_docs/google/cloud/automl/v1/io.rb",
+    "https:\n\\s+# //",
+    "https://")


### PR DESCRIPTION
Fixes the automl-v1 issues in #6254. The misformatting is coming from upstream due to an issue with an internal tool. It's not immediately clear to me how to address it upstream, so I'm fixing it in synth for now.