### PR TITLE
docs(automl-v1beta1): Fix a few broken links

### DIFF
--- a/google-cloud-automl-v1beta1/proto_docs/google/cloud/automl/v1beta1/io.rb
+++ b/google-cloud-automl-v1beta1/proto_docs/google/cloud/automl/v1beta1/io.rb
@@ -723,8 +723,7 @@ module Google
         #         that wraps the same "ID" : "<id_value>" but here followed by
         #         exactly one
         #
-        # [`google.rpc.Status`](https:
-        # //github.com/googleapis/googleapis/blob/master/google/rpc/status.proto)
+        # [`google.rpc.Status`](https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto)
         #         containing only `code` and `message`fields.
         #
         #  *  For Image Object Detection:
@@ -745,8 +744,7 @@ module Google
         #         that wraps the same "ID" : "<id_value>" but here followed by
         #         exactly one
         #
-        # [`google.rpc.Status`](https:
-        # //github.com/googleapis/googleapis/blob/master/google/rpc/status.proto)
+        # [`google.rpc.Status`](https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto)
         #         containing only `code` and `message`fields.
         #  *  For Video Classification:
         #         In the created directory a video_classification.csv file, and a .JSON
@@ -820,8 +818,7 @@ module Google
         #         proto that wraps input text snippet or input text file followed by
         #         exactly one
         #
-        # [`google.rpc.Status`](https:
-        # //github.com/googleapis/googleapis/blob/master/google/rpc/status.proto)
+        # [`google.rpc.Status`](https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto)
         #         containing only `code` and `message`.
         #
         #  *  For Text Sentiment:
@@ -844,8 +841,7 @@ module Google
         #         proto that wraps input text snippet or input text file followed by
         #         exactly one
         #
-        # [`google.rpc.Status`](https:
-        # //github.com/googleapis/googleapis/blob/master/google/rpc/status.proto)
+        # [`google.rpc.Status`](https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto)
         #         containing only `code` and `message`.
         #
         #   *  For Text Extraction:
@@ -880,8 +876,7 @@ module Google
         #         or the document proto (in case of document) but here followed by
         #         exactly one
         #
-        # [`google.rpc.Status`](https:
-        # //github.com/googleapis/googleapis/blob/master/google/rpc/status.proto)
+        # [`google.rpc.Status`](https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto)
         #         containing only `code` and `message`.
         #
         #  *  For Tables:
@@ -933,8 +928,7 @@ module Google
         #             will have analogous format as `tables_*.csv`, but always with a
         #             single target column having
         #
-        # [`google.rpc.Status`](https:
-        # //github.com/googleapis/googleapis/blob/master/google/rpc/status.proto)
+        # [`google.rpc.Status`](https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto)
         #             represented as a JSON string, and containing only `code` and
         #             `message`.
         #         BigQuery case:
@@ -972,8 +966,7 @@ module Google
         # {::Google::Cloud::AutoML::V1beta1::ColumnSpec#display_name display_name}>",
         #           and as a value has
         #
-        # [`google.rpc.Status`](https:
-        # //github.com/googleapis/googleapis/blob/master/google/rpc/status.proto)
+        # [`google.rpc.Status`](https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto)
         #           represented as a STRUCT, and containing only `code` and `message`.
         # @!attribute [rw] gcs_destination
         #   @return [::Google::Cloud::AutoML::V1beta1::GcsDestination]

--- a/google-cloud-automl-v1beta1/synth.metadata
+++ b/google-cloud-automl-v1beta1/synth.metadata
@@ -3,16 +3,16 @@
     {
       "git": {
         "name": ".",
-        "remote": "https://github.com/googleapis/google-cloud-ruby.git",
-        "sha": "aaeed1e55688fa3948aef7998683c1e0cd6f70c1"
+        "remote": "git@github.com:googleapis/google-cloud-ruby.git",
+        "sha": "02b3b0e10a3ceccd0da64825154cff274054c880"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "3f5f8a2258c6a41f9fbf7b80acbca631dda0a952",
-        "internalRef": "308922843"
+        "sha": "973c671823c076165b2371cda0174586d4078b0d",
+        "internalRef": "313004561"
       }
     }
   ],

--- a/google-cloud-automl-v1beta1/synth.py
+++ b/google-cloud-automl-v1beta1/synth.py
@@ -38,3 +38,10 @@ library = gapic.ruby_library(
 )
 
 s.copy(library, merge=ruby.global_merge)
+
+# Fixes for some misformatted markdown links.
+# See internal issue b/153077040.
+s.replace(
+    "proto_docs/google/cloud/automl/v1beta1/io.rb",
+    "https:\n\\s+# //",
+    "https://")


### PR DESCRIPTION
Fixes the automl-v1beta1 issues in #6254. The misformatting is coming from upstream due to an issue with an internal tool. It's not immediately clear to me how to address it upstream, so I'm fixing it in synth for now.