### PR TITLE
Release google-cloud-phishing_protection 0.10.0

### DIFF
--- a/google-cloud-phishing_protection/CHANGELOG.md
+++ b/google-cloud-phishing_protection/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Release History
 
+### 0.10.0 / 2020-06-01
+
+This is a major update with significant new features, improved documentation, and a fair number of breaking changes.
+
+Among the highlights:
+
+* Separate client libraries are now provided for specific service versions.
+* A new configuration mechanism makes it easier to control parameters such as endpoint address, network timeouts, and retry.
+* A consistent method interface using keyword arguments for all fields, and supporting request proto objects.
+* Helper methods for generating resource paths are more accessible.
+
+See the MIGRATING file in the documentation for more detailed information, and instructions for migrating from earlier versions.
+
 ### 0.5.0 / 2020-04-08
 
 #### Features

--- a/google-cloud-phishing_protection/lib/google/cloud/phishing_protection/version.rb
+++ b/google-cloud-phishing_protection/lib/google/cloud/phishing_protection/version.rb
@@ -20,7 +20,7 @@
 module Google
   module Cloud
     module PhishingProtection
-      VERSION = "0.9.99"
+      VERSION = "0.10.0"
     end
   end
 end


### PR DESCRIPTION
This is a major update with significant new features, improved documentation, and a fair number of breaking changes.

Among the highlights:

* Separate client libraries are now provided for specific service versions.
* A new configuration mechanism makes it easier to control parameters such as endpoint address, network timeouts, and retry.
* A consistent method interface using keyword arguments for all fields, and supporting request proto objects.
* Helper methods for generating resource paths are more accessible.

See the MIGRATING file in the documentation for more detailed information, and instructions for migrating from earlier versions.
