### PR TITLE
chore: Pin ubuntu to bionic in docker images

### DIFF
--- a/.kokoro/docker/autosynth/Dockerfile
+++ b/.kokoro/docker/autosynth/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:latest
+FROM ubuntu:bionic
 
 ENTRYPOINT /bin/bash
 

--- a/.kokoro/docker/release/Dockerfile
+++ b/.kokoro/docker/release/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:bionic
 
 ENTRYPOINT /bin/bash
 

--- a/.kokoro/osx.sh
+++ b/.kokoro/osx.sh
@@ -32,7 +32,7 @@ if [[ $JOB_TYPE = "presubmit" ]]; then
     if [[ $COMMIT_MESSAGE = *"[ci skip]"* || $COMMIT_MESSAGE = *"[skip ci]"* ]]; then
         echo "[ci skip] found. Exiting"
     else
-        version=${versions[2]}
+        version=${versions[3]}
         if [[ $rvm_versions != *$version* ]]; then
             rvm install $version
         fi

--- a/.kokoro/templates/autosynth.Dockerfile.erb
+++ b/.kokoro/templates/autosynth.Dockerfile.erb
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:latest
+FROM ubuntu:bionic
 
 ENTRYPOINT /bin/bash
 

--- a/.kokoro/templates/release.Dockerfile.erb
+++ b/.kokoro/templates/release.Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:bionic
 
 ENTRYPOINT /bin/bash
 


### PR DESCRIPTION
The docker images want to install libssl-1.0 which is not present in the latest ubuntu (Focal). Pin the docker base images to Bionic to ensure they build.