### PR TITLE
feat(pubsub): Add DeadLetterPolicy with full lifecycle management

### DIFF
--- a/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
+++ b/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
@@ -320,20 +320,37 @@ describe Google::Cloud::PubSub, :pubsub do
 
           # create
           subscription = topic.subscribe "#{$topic_prefix}-sub6", dead_letter_topic: dead_letter_topic, dead_letter_max_delivery_attempts: 6
-          _(subscription.dead_letter_max_delivery_attempts).must_equal 6
-          _(subscription.dead_letter_topic.reload!.name).must_equal dead_letter_topic.name
-
-          # update
-          subscription.dead_letter_max_delivery_attempts = 5
-          _(subscription.dead_letter_max_delivery_attempts).must_equal 5
-          dead_letter_topic_2 = retrieve_topic dead_letter_topic_name_2
-          dead_letter_subscription_2 = dead_letter_topic_2.subscribe "#{$topic_prefix}-dead-letter-sub2"
-          subscription.dead_letter_topic = dead_letter_topic_2
-          _(subscription.dead_letter_topic.reload!.name).must_equal dead_letter_topic_2.name
+          _(subscription.dead_letter_policy.dead_letter_topic.name).must_equal dead_letter_topic.name
+          _(subscription.dead_letter_policy.max_delivery_attempts).must_equal 6
 
           # Publish a new message
           msg = topic.publish "dead-letter-#{rand(1000)}"
           _(msg).wont_be :nil?
+
+          # update using DeadLetterPolicy value object
+          dead_letter_topic_2 = retrieve_topic dead_letter_topic_name_2
+          dead_letter_subscription_2 = dead_letter_topic_2.subscribe "#{$topic_prefix}-dead-letter-sub2"
+          subscription.dead_letter_policy = Google::Cloud::PubSub::DeadLetterPolicy.new(
+            dead_letter_topic:     dead_letter_topic_2,
+            max_delivery_attempts: 5
+          )
+          _(subscription.dead_letter_policy.dead_letter_topic.name).must_equal dead_letter_topic_2.name
+          _(subscription.dead_letter_policy.max_delivery_attempts).must_equal 5
+          subscription.reload!
+          _(subscription.dead_letter_policy.dead_letter_topic.name).must_equal dead_letter_topic_2.name
+          _(subscription.dead_letter_policy.max_delivery_attempts).must_equal 5
+
+          # update using subscription helpers
+          subscription.dead_letter_topic = dead_letter_topic
+          subscription.dead_letter_max_delivery_attempts = 6
+          _(subscription.dead_letter_topic.name).must_equal dead_letter_topic.name
+          _(subscription.dead_letter_max_delivery_attempts).must_equal 6
+          subscription.reload!
+          _(subscription.dead_letter_topic.name).must_equal dead_letter_topic.name
+          _(subscription.dead_letter_max_delivery_attempts).must_equal 6
+
+          # fixture cleanup
+          dead_letter_subscription_2.delete
 
           # Check it pulls the message
           (1..7).each do |i|
@@ -353,6 +370,12 @@ describe Google::Cloud::PubSub, :pubsub do
           _(received_message).wont_be :nil?
           _(received_message.msg.data).must_equal msg.data
           _(received_message.delivery_attempt).must_be :nil?
+
+          # delete the DeadLetterPolicy
+          subscription.dead_letter_policy = nil
+          _(subscription.dead_letter_policy).must_be :nil?
+          subscription.reload!
+          _(subscription.dead_letter_policy).must_be :nil?
         ensure
           # Remove the subscription
           subscription.delete

--- a/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
+++ b/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
@@ -355,7 +355,7 @@ describe Google::Cloud::PubSub, :pubsub do
           dead_letter_subscription_2.delete
 
           # Check the dead letter subscription pulls the message
-          received_messages = dead_letter_subscription.pull
+          received_messages = pull_with_retry dead_letter_subscription
           _(received_messages).wont_be :empty?
           _(received_messages.count).must_equal 1
           received_message = received_messages.first

--- a/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
+++ b/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
@@ -327,16 +327,16 @@ describe Google::Cloud::PubSub, :pubsub do
           msg = topic.publish "dead-letter-#{rand(1000)}"
           _(msg).wont_be :nil?
 
-          # update using DeadLetterPolicy value object
+          # update using block
           dead_letter_topic_2 = retrieve_topic dead_letter_topic_name_2
           dead_letter_subscription_2 = dead_letter_topic_2.subscribe "#{$topic_prefix}-dead-letter-sub2"
-          updated_dead_letter_policy = Google::Cloud::PubSub::DeadLetterPolicy.new(
-            dead_letter_topic:     dead_letter_topic_2,
-            max_delivery_attempts: nil
-          )
-          subscription.dead_letter_policy = updated_dead_letter_policy
+          updated_dead_letter_policy = subscription.update_dead_letter_policy do |dlp|
+            dlp.dead_letter_topic = dead_letter_topic_2
+            dlp.max_delivery_attempts = nil
+          end
+          _(updated_dead_letter_policy.dead_letter_topic.name).must_equal dead_letter_topic_2.name
+          _(updated_dead_letter_policy.max_delivery_attempts).must_equal 5
           _(subscription.dead_letter_policy.dead_letter_topic.name).must_equal dead_letter_topic_2.name
-          _(updated_dead_letter_policy.max_delivery_attempts).must_be :nil?
           _(subscription.dead_letter_policy.max_delivery_attempts).must_equal 5
           subscription.reload!
           _(subscription.dead_letter_policy.dead_letter_topic.name).must_equal dead_letter_topic_2.name

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/dead_letter_policy.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/dead_letter_policy.rb
@@ -45,23 +45,32 @@ module Google
       #
       #   This field will be honored on a best effort basis.
       #
-      # @example
+      # @example Configure and read a Dead Letter Policy:
       #   require "google/cloud/pubsub"
       #
       #   pubsub = Google::Cloud::PubSub.new
       #
-      #   sub = pubsub.subscription "my-topic-sub"
-      #   dead_letter_topic = pubsub.topic "my-dead-letter-topic", skip_lookup: true
-      #   sub.dead_letter_policy = Google::Cloud::PubSub::DeadLetterPolicy.new(
-      #     dead_letter_topic:     dead_letter_topic,
-      #     max_delivery_attempts: 20
-      #   )
+      #   # Dead Letter Queue (DLQ) testing requires IAM bindings to the Cloud Pub/Sub service account that is
+      #   # automatically created and managed by the service team in a private project.
+      #   my_project_number = "000000000000"
+      #   service_account_email = "serviceAccount:service-#{my_project_number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+      #
+      #   dead_letter_topic = pubsub.topic "my-dead-letter-topic"
+      #   dead_letter_subscription = dead_letter_topic.subscribe "my-dead-letter-sub"
+      #
+      #   dead_letter_topic.policy { |p| p.add "roles/pubsub.publisher", service_account_email }
+      #   dead_letter_subscription.policy { |p| p.add "roles/pubsub.subscriber", service_account_email }
+      #
+      #   topic = pubsub.topic "my-topic"
+      #   sub = topic.subscribe "my-topic-sub",
+      #                         dead_letter_topic: dead_letter_topic,
+      #                         dead_letter_max_delivery_attempts: 10
       #
       #   sub.dead_letter_policy.dead_letter_topic.name #=> "projects/my-project/topics/my-dead-letter-topic"
       #   sub.dead_letter_policy.max_delivery_attempts #=> 10
       #
       class DeadLetterPolicy
-        attr_reader :dead_letter_topic, :max_delivery_attempts
+        attr_accessor :dead_letter_topic, :max_delivery_attempts
 
         ##
         # Creates a new, immutable DeadLetterPolicy value object.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/dead_letter_policy.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/dead_letter_policy.rb
@@ -1,0 +1,112 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Cloud
+    module PubSub
+      ##
+      # # DeadLetterPolicy
+      #
+      # An immutable Dead Letter Policy value object that specifies the conditions for dead lettering messages in a
+      # subscription.
+      #
+      # Dead lettering is done on a best effort basis. The same message might be dead lettered multiple times.
+      #
+      # If validation on any of the fields fails at subscription creation/updation, the create/update subscription
+      # request will fail.
+      #
+      # @attr [Numeric] dead_letter_topic The topic to which dead letter messages for the subscription should be
+      #   published. Dead lettering is done on a best effort basis. The same message might be dead lettered multiple
+      #   times. The Cloud Pub/Sub service account associated with the enclosing subscription's parent project (i.e.,
+      #   `service-\\{project_number}@gcp-sa-pubsub.iam.gserviceaccount.com`) must have permission to Publish() to this
+      #   topic.
+      #
+      #   The operation will fail if the topic does not exist. Users should ensure that there is a subscription attached
+      #   to this topic since messages published to a topic with no subscriptions are lost.
+      # @attr [Numeric] max_delivery_attempts The maximum number of delivery attempts for any message in the
+      #   subscription's dead letter policy. Dead lettering is done on a best effort basis. The same message might be
+      #   dead lettered multiple times. The value must be between 5 and 100.
+      #
+      #   The number of delivery attempts is defined as 1 + (the sum of number of NACKs and number of times the
+      #   acknowledgement deadline has been exceeded for the message). A NACK is any call to ModifyAckDeadline with a 0
+      #   deadline. Note that client libraries may automatically extend ack_deadlines.
+      #
+      #   This field will be honored on a best effort basis.
+      #
+      # @example
+      #   require "google/cloud/pubsub"
+      #
+      #   pubsub = Google::Cloud::PubSub.new
+      #
+      #   sub = pubsub.subscription "my-topic-sub"
+      #   dead_letter_topic = pubsub.topic "my-dead-letter-topic", skip_lookup: true
+      #   sub.dead_letter_policy = Google::Cloud::PubSub::DeadLetterPolicy.new(
+      #     dead_letter_topic:     dead_letter_topic,
+      #     max_delivery_attempts: 20
+      #   )
+      #
+      #   sub.dead_letter_policy.dead_letter_topic.name #=> "projects/my-project/topics/my-dead-letter-topic"
+      #   sub.dead_letter_policy.max_delivery_attempts #=> 10
+      #
+      class DeadLetterPolicy
+        attr_reader :dead_letter_topic, :max_delivery_attempts
+
+        ##
+        # Creates a new, immutable DeadLetterPolicy value object.
+        #
+        # @attr [Topic, nil] dead_letter_topic The topic to which dead letter messages for the subscription should be
+        #   published. Dead lettering is done on a best effort basis. The same message might be dead lettered multiple
+        #   times. The Cloud Pub/Sub service account associated with the enclosing subscription's parent project (i.e.,
+        #   `service-\\{project_number}@gcp-sa-pubsub.iam.gserviceaccount.com`) must have permission to Publish() to
+        #   this topic.
+        #
+        #   The operation will fail if the topic does not exist. Users should ensure that there is a subscription
+        #   attached to this topic since messages published to a topic with no subscriptions are lost.
+        # @attr [Integer, nil] max_delivery_attempts The maximum number of delivery attempts for any message in the
+        #   subscription's dead letter policy. Dead lettering is done on a best effort basis. The same message might be
+        #   dead lettered multiple times. The value must be between 5 and 100.
+        #
+        #   The number of delivery attempts is defined as 1 + (the sum of number of NACKs and number of times the
+        #   acknowledgement deadline has been exceeded for the message). A NACK is any call to ModifyAckDeadline with a
+        #   0 deadline. Note that client libraries may automatically extend ack_deadlines.
+        #
+        #   This field will be honored on a best effort basis. If this parameter is 0, a default value of 5 is used.
+        #
+        def initialize dead_letter_topic: nil, max_delivery_attempts: nil
+          @dead_letter_topic = dead_letter_topic
+          @max_delivery_attempts = max_delivery_attempts
+        end
+
+        ##
+        # @private Convert the DeadLetterPolicy to a Google::Cloud::PubSub::V1::DeadLetterPolicy object.
+        def to_grpc
+          Google::Cloud::PubSub::V1::DeadLetterPolicy.new(
+            dead_letter_topic:     dead_letter_topic.name,
+            max_delivery_attempts: max_delivery_attempts
+          )
+        end
+
+        ##
+        # @private New DeadLetterPolicy from a Google::Cloud::PubSub::V1::DeadLetterPolicy object.
+        def self.from_grpc grpc, service
+          new(
+            dead_letter_topic:     Topic.from_name(grpc.dead_letter_topic, service),
+            max_delivery_attempts: grpc.max_delivery_attempts
+          )
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/dead_letter_policy.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/dead_letter_policy.rb
@@ -27,7 +27,7 @@ module Google
       # If validation on any of the fields fails at subscription creation/updation, the create/update subscription
       # request will fail.
       #
-      # @attr [Numeric] dead_letter_topic The topic to which dead letter messages for the subscription should be
+      # @attr [Topic] dead_letter_topic The topic to which dead letter messages for the subscription should be
       #   published. Dead lettering is done on a best effort basis. The same message might be dead lettered multiple
       #   times. The Cloud Pub/Sub service account associated with the enclosing subscription's parent project (i.e.,
       #   `service-\\{project_number}@gcp-sa-pubsub.iam.gserviceaccount.com`) must have permission to Publish() to this
@@ -66,15 +66,14 @@ module Google
         ##
         # Creates a new, immutable DeadLetterPolicy value object.
         #
-        # @attr [Topic, nil] dead_letter_topic The topic to which dead letter messages for the subscription should be
+        # @param [Topic] dead_letter_topic The topic to which dead letter messages for the subscription should be
         #   published. Dead lettering is done on a best effort basis. The same message might be dead lettered multiple
         #   times. The Cloud Pub/Sub service account associated with the enclosing subscription's parent project (i.e.,
         #   `service-\\{project_number}@gcp-sa-pubsub.iam.gserviceaccount.com`) must have permission to Publish() to
-        #   this topic.
-        #
-        #   The operation will fail if the topic does not exist. Users should ensure that there is a subscription
-        #   attached to this topic since messages published to a topic with no subscriptions are lost.
-        # @attr [Integer, nil] max_delivery_attempts The maximum number of delivery attempts for any message in the
+        #   this topic. The operation will fail if the topic does not exist. Users should ensure that there is a
+        #   subscription attached to this topic since messages published to a topic with no subscriptions are lost.
+        #   Required.
+        # @param [Integer, nil] max_delivery_attempts The maximum number of delivery attempts for any message in the
         #   subscription's dead letter policy. Dead lettering is done on a best effort basis. The same message might be
         #   dead lettered multiple times. The value must be between 5 and 100.
         #

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -512,7 +512,8 @@ module Google
         # If validation on any of the fields fails at subscription creation/updation, the create/update subscription
         # request will fail.
         #
-        # @return [DeadLetterPolicy, nil] The dead letter policy for the subscription, or `nil`.
+        # @return [DeadLetterPolicy, nil] The dead letter policy for the subscription, or `nil` for no policy,
+        #   indicating that dead lettering is disabled.
         #
         # @example
         #   require "google/cloud/pubsub"
@@ -543,7 +544,8 @@ module Google
         # If validation on any of the fields fails at subscription creation/updation, the create/update subscription
         # request will fail.
         #
-        # @param [DeadLetterPolicy, nil] new_dead_letter_policy A new dead_letter policy for the subscription, or `nil`.
+        # @param [DeadLetterPolicy, nil] new_dead_letter_policy A new dead_letter policy for the subscription, or `nil`
+        #   for no policy, indicating that dead lettering is disabled.
         #
         # @example
         #   require "google/cloud/pubsub"
@@ -559,6 +561,15 @@ module Google
         #
         #   sub.dead_letter_policy.dead_letter_topic.name #=> "projects/my-project/topics/my-dead-letter-topic"
         #   sub.dead_letter_policy.max_delivery_attempts #=> 10
+        #
+        # @example Remove an existing policy to disable dead lettering:
+        #   require "google/cloud/pubsub"
+        #
+        #   pubsub = Google::Cloud::PubSub.new
+        #
+        #   sub = pubsub.subscription "my-topic-sub"
+        #   dead_letter_topic = pubsub.topic "my-dead-letter-topic", skip_lookup: true
+        #   sub.dead_letter_policy = nil
         #
         def dead_letter_policy= new_dead_letter_policy
           ensure_grpc!

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -505,7 +505,8 @@ module Google
         end
 
         ##
-        # A policy that specifies the conditions for dead lettering messages in a subscription.
+        # A policy that specifies the conditions for dead lettering messages in a subscription. See also
+        # {#update_dead_letter_policy} and {#remove_dead_letter_policy}.
         #
         # Dead lettering is done on a best effort basis. The same message might be dead lettered multiple times.
         #
@@ -534,36 +535,7 @@ module Google
 
         ##
         # Sets a policy that specifies the conditions for dead lettering messages in a subscription.
-        #
-        # Dead lettering is done on a best effort basis. The same message might be dead lettered multiple times.
-        #
-        # If validation on any of the fields fails at subscription creation/updation, the create/update subscription
-        # request will fail.
-        #
-        # @param [DeadLetterPolicy, nil] new_dead_letter_policy A new dead_letter policy for the subscription, or `nil`
-        #   for no policy, indicating that dead lettering is disabled.
-        #
-        # @example Remove an existing policy to disable dead lettering:
-        #   require "google/cloud/pubsub"
-        #
-        #   pubsub = Google::Cloud::PubSub.new
-        #
-        #   sub = pubsub.subscription "my-topic-sub"
-        #   dead_letter_topic = pubsub.topic "my-dead-letter-topic", skip_lookup: true
-        #   sub.dead_letter_policy = nil
-        #
-        def dead_letter_policy= new_dead_letter_policy
-          ensure_grpc!
-          new_dead_letter_policy = new_dead_letter_policy.to_grpc if new_dead_letter_policy
-          update_grpc = Google::Cloud::PubSub::V1::Subscription.new(
-            name:               name,
-            dead_letter_policy: new_dead_letter_policy
-          )
-          @grpc = service.update_subscription update_grpc, :dead_letter_policy
-        end
-
-        ##
-        # Sets a policy that specifies the conditions for dead lettering messages in a subscription.
+        # See also {#dead_letter_policy} and {#remove_dead_letter_policy}.
         #
         # Dead lettering is done on a best effort basis. The same message might be dead lettered multiple times.
         #
@@ -604,6 +576,27 @@ module Google
           )
           @grpc = service.update_subscription update_grpc, :dead_letter_policy
           DeadLetterPolicy.from_grpc(@grpc.dead_letter_policy, service).freeze
+        end
+
+        ##
+        # Deletes the policy that specifies the conditions for dead lettering messages in the subscription, if one
+        # exists. See also {#dead_letter_policy} and {#update_dead_letter_policy}.
+        #
+        # @example Remove an existing policy to disable dead lettering:
+        #   require "google/cloud/pubsub"
+        #
+        #   pubsub = Google::Cloud::PubSub.new
+        #
+        #   sub = pubsub.subscription "my-topic-sub"
+        #   sub.remove_dead_letter_policy
+        #
+        def remove_dead_letter_policy
+          ensure_service!
+          update_grpc = Google::Cloud::PubSub::V1::Subscription.new(
+            name:               name,
+            dead_letter_policy: nil
+          )
+          @grpc = service.update_subscription update_grpc, :dead_letter_policy
         end
 
         ##

--- a/google-cloud-pubsub/support/doctest_helper.rb
+++ b/google-cloud-pubsub/support/doctest_helper.rb
@@ -142,9 +142,15 @@ YARD::Doctest.configure do |doctest|
   # DeadLetterPolicy
 
   doctest.before "Google::Cloud::PubSub::DeadLetterPolicy" do
-    mock_pubsub do |mock_publisher, mock_subscriber|
-      mock_subscriber.expect :get_subscription, subscription_resp("my-topic-sub", dead_letter_topic: "my-dead-letter-topic", max_delivery_attempts: 10), [Hash]
-      mock_subscriber.expect :update_subscription, subscription_resp("my-topic-sub", dead_letter_topic: "my-dead-letter-topic", max_delivery_attempts: 10), [Hash]
+    mock_pubsub do |mock_publisher, mock_subscriber, mock_iam|
+      mock_publisher.expect :get_topic, topic_resp("my-dead-letter-topic"), [Hash]
+      mock_subscriber.expect :create_subscription, OpenStruct.new(name: "my-dead-letter-sub"), [Hash]
+      mock_iam.expect :get_iam_policy, policy_resp, [Hash]
+      mock_iam.expect :get_iam_policy, policy_resp, [Hash]
+      mock_iam.expect :set_iam_policy, policy_resp, [Hash]
+      mock_iam.expect :set_iam_policy, policy_resp, [Hash]
+      mock_publisher.expect :get_topic, topic_resp, [Hash]
+      mock_subscriber.expect :create_subscription, subscription_resp("my-topic-sub", dead_letter_topic: "my-dead-letter-topic", max_delivery_attempts: 10), [Hash]
     end
   end
 
@@ -347,7 +353,14 @@ YARD::Doctest.configure do |doctest|
   doctest.before "Google::Cloud::PubSub::Subscription#dead_letter" do
     mock_pubsub do |mock_publisher, mock_subscriber|
       mock_subscriber.expect :get_subscription, subscription_resp("my-topic-sub", dead_letter_topic: "my-dead-letter-topic", max_delivery_attempts: 10), [Hash]
-      mock_subscriber.expect :update_subscription, subscription_resp("my-topic-sub", dead_letter_topic: "my-dead-letter-topic", max_delivery_attempts: 10), [Hash]
+      mock_subscriber.expect :update_subscription, subscription_resp("my-topic-sub", dead_letter_topic: "my-dead-letter-topic", max_delivery_attempts: 20), [Hash]
+    end
+  end
+
+  doctest.before "Google::Cloud::PubSub::Subscription#update_dead_letter_policy" do
+    mock_pubsub do |mock_publisher, mock_subscriber|
+      mock_subscriber.expect :get_subscription, subscription_resp("my-topic-sub", dead_letter_topic: "my-dead-letter-topic", max_delivery_attempts: 10), [Hash]
+      mock_subscriber.expect :update_subscription, subscription_resp("my-topic-sub", dead_letter_topic: "my-dead-letter-topic", max_delivery_attempts: 20), [Hash]
     end
   end
 

--- a/google-cloud-pubsub/support/doctest_helper.rb
+++ b/google-cloud-pubsub/support/doctest_helper.rb
@@ -139,6 +139,15 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  # DeadLetterPolicy
+
+  doctest.before "Google::Cloud::PubSub::DeadLetterPolicy" do
+    mock_pubsub do |mock_publisher, mock_subscriber|
+      mock_subscriber.expect :get_subscription, subscription_resp("my-topic-sub", dead_letter_topic: "my-dead-letter-topic", max_delivery_attempts: 10), ["projects/my-project/subscriptions/my-topic-sub", Hash]
+      mock_subscriber.expect :update_subscription, subscription_resp("my-topic-sub", dead_letter_topic: "my-dead-letter-topic", max_delivery_attempts: 10), [Google::Cloud::PubSub::V1::Subscription, Google::Protobuf::FieldMask, Hash]
+    end
+  end
+
   # Policy
 
   doctest.before "Google::Cloud::PubSub::Policy" do
@@ -338,7 +347,7 @@ YARD::Doctest.configure do |doctest|
   doctest.before "Google::Cloud::PubSub::Subscription#dead_letter" do
     mock_pubsub do |mock_publisher, mock_subscriber|
       mock_subscriber.expect :get_subscription, subscription_resp("my-topic-sub", dead_letter_topic: "my-dead-letter-topic", max_delivery_attempts: 10), [Hash]
-      mock_subscriber.expect :update_subscription, subscription_resp, [Hash]
+      mock_subscriber.expect :update_subscription, subscription_resp("my-topic-sub", dead_letter_topic: "my-dead-letter-topic", max_delivery_attempts: 10), [Hash]
     end
   end
 

--- a/google-cloud-pubsub/support/doctest_helper.rb
+++ b/google-cloud-pubsub/support/doctest_helper.rb
@@ -364,6 +364,13 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::PubSub::Subscription#remove_dead_letter_policy" do
+    mock_pubsub do |mock_publisher, mock_subscriber|
+      mock_subscriber.expect :get_subscription, subscription_resp("my-topic-sub", dead_letter_topic: "my-dead-letter-topic", max_delivery_attempts: 10), [Hash]
+      mock_subscriber.expect :update_subscription, subscription_resp("my-topic-sub", dead_letter_topic: "my-dead-letter-topic", max_delivery_attempts: 20), [Hash]
+    end
+  end
+
   doctest.before "Google::Cloud::PubSub::Subscription#modify_ack_deadline" do
     mock_pubsub do |mock_publisher, mock_subscriber|
       mock_subscriber.expect :get_subscription, subscription_resp("my-topic-sub"), [Hash]

--- a/google-cloud-pubsub/support/doctest_helper.rb
+++ b/google-cloud-pubsub/support/doctest_helper.rb
@@ -143,8 +143,8 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::PubSub::DeadLetterPolicy" do
     mock_pubsub do |mock_publisher, mock_subscriber|
-      mock_subscriber.expect :get_subscription, subscription_resp("my-topic-sub", dead_letter_topic: "my-dead-letter-topic", max_delivery_attempts: 10), ["projects/my-project/subscriptions/my-topic-sub", Hash]
-      mock_subscriber.expect :update_subscription, subscription_resp("my-topic-sub", dead_letter_topic: "my-dead-letter-topic", max_delivery_attempts: 10), [Google::Cloud::PubSub::V1::Subscription, Google::Protobuf::FieldMask, Hash]
+      mock_subscriber.expect :get_subscription, subscription_resp("my-topic-sub", dead_letter_topic: "my-dead-letter-topic", max_delivery_attempts: 10), [Hash]
+      mock_subscriber.expect :update_subscription, subscription_resp("my-topic-sub", dead_letter_topic: "my-dead-letter-topic", max_delivery_attempts: 10), [Hash]
     end
   end
 

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/attrs_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/attrs_test.rb
@@ -91,6 +91,12 @@ describe Google::Cloud::PubSub::Subscription, :attributes, :mock_pubsub do
     _(subscription.filter).must_equal filter
   end
 
+  it "gets dead_letter_policy from the Google API object" do
+    dead_letter_policy = subscription.dead_letter_policy
+    _(dead_letter_policy.dead_letter_topic.name).must_equal dead_letter_topic_path
+    _(dead_letter_policy.max_delivery_attempts).must_equal 6
+  end
+
   it "gets dead_letter_topic from the Google API object" do
     _(subscription.dead_letter_topic.name).must_equal dead_letter_topic_path
   end
@@ -206,6 +212,12 @@ describe Google::Cloud::PubSub::Subscription, :attributes, :mock_pubsub do
       mock.expect :get_subscription, get_res, [subscription: subscription_path(sub_name)]
       subscription.service.mocked_subscriber = mock
 
+      # read using DeadLetterPolicy value object
+      dead_letter_policy = subscription.dead_letter_policy
+      _(dead_letter_policy).must_be_kind_of Google::Cloud::PubSub::DeadLetterPolicy
+      _(dead_letter_policy.dead_letter_topic.name).must_equal dead_letter_topic_path
+      _(dead_letter_policy.max_delivery_attempts).must_equal 7
+      # read using subscription helpers
       _(subscription.dead_letter_topic.name).must_equal dead_letter_topic_path
       _(subscription.dead_letter_max_delivery_attempts).must_equal 7
 

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/update_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/update_test.rb
@@ -230,10 +230,10 @@ describe Google::Cloud::PubSub::Subscription, :update, :mock_pubsub do
     mock.expect :update_subscription, update_sub, [subscription: update_sub, update_mask: update_mask]
     subscription.service.mocked_subscriber = mock
 
-    subscription.dead_letter_policy = Google::Cloud::PubSub::DeadLetterPolicy.new(
-      dead_letter_topic:     new_dead_letter_topic,
-      max_delivery_attempts: 6
-    )
+    subscription.update_dead_letter_policy do |dlp|
+      dlp.dead_letter_topic = new_dead_letter_topic
+      dlp.max_delivery_attempts = 6
+    end
     mock.verify
 
     # read using DeadLetterPolicy value object
@@ -255,10 +255,10 @@ describe Google::Cloud::PubSub::Subscription, :update, :mock_pubsub do
     mock.expect :update_subscription, update_sub, [subscription: update_sub, update_mask: update_mask]
     subscription.service.mocked_subscriber = mock
 
-    subscription.dead_letter_policy = Google::Cloud::PubSub::DeadLetterPolicy.new(
-      dead_letter_topic:     dead_letter_topic,
-      max_delivery_attempts: 7
-    )
+    subscription.update_dead_letter_policy do |dlp|
+      dlp.dead_letter_topic = dead_letter_topic
+      dlp.max_delivery_attempts = 7
+    end
 
     mock.verify
 

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/update_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/update_test.rb
@@ -279,7 +279,7 @@ describe Google::Cloud::PubSub::Subscription, :update, :mock_pubsub do
     mock.expect :update_subscription, update_sub, [subscription: update_sub, update_mask: update_mask]
     subscription.service.mocked_subscriber = mock
 
-    subscription.dead_letter_policy = nil
+    subscription.remove_dead_letter_policy
 
     mock.verify
 

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/update_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/update_test.rb
@@ -227,7 +227,7 @@ describe Google::Cloud::PubSub::Subscription, :update, :mock_pubsub do
       name: sub_path, dead_letter_policy: dead_letter_policy_gapi
     update_mask = Google::Protobuf::FieldMask.new paths: ["dead_letter_policy"]
     mock = Minitest::Mock.new
-    mock.expect :update_subscription, update_sub, [update_sub, update_mask, options: default_options]
+    mock.expect :update_subscription, update_sub, [subscription: update_sub, update_mask: update_mask]
     subscription.service.mocked_subscriber = mock
 
     subscription.dead_letter_policy = Google::Cloud::PubSub::DeadLetterPolicy.new(
@@ -252,7 +252,7 @@ describe Google::Cloud::PubSub::Subscription, :update, :mock_pubsub do
       name: sub_path, dead_letter_policy: dead_letter_policy_gapi
     update_mask = Google::Protobuf::FieldMask.new paths: ["dead_letter_policy"]
     mock = Minitest::Mock.new
-    mock.expect :update_subscription, update_sub, [update_sub, update_mask, options: default_options]
+    mock.expect :update_subscription, update_sub, [subscription: update_sub, update_mask: update_mask]
     subscription.service.mocked_subscriber = mock
 
     subscription.dead_letter_policy = Google::Cloud::PubSub::DeadLetterPolicy.new(
@@ -276,7 +276,7 @@ describe Google::Cloud::PubSub::Subscription, :update, :mock_pubsub do
     update_sub = Google::Cloud::PubSub::V1::Subscription.new name: sub_path, dead_letter_policy: nil
     update_mask = Google::Protobuf::FieldMask.new paths: ["dead_letter_policy"]
     mock = Minitest::Mock.new
-    mock.expect :update_subscription, update_sub, [update_sub, update_mask, options: default_options]
+    mock.expect :update_subscription, update_sub, [subscription: update_sub, update_mask: update_mask]
     subscription.service.mocked_subscriber = mock
 
     subscription.dead_letter_policy = nil

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic_test.rb
@@ -239,6 +239,12 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
     mock.verify
 
     _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
+    # read using DeadLetterPolicy value object
+    dead_letter_policy = sub.dead_letter_policy
+    _(dead_letter_policy).must_be_kind_of Google::Cloud::PubSub::DeadLetterPolicy
+    _(dead_letter_policy.dead_letter_topic.name).must_equal topic_path(dead_letter_topic_name)
+    _(dead_letter_policy.max_delivery_attempts).must_equal 7
+    # read using subscription helpers
     _(sub.dead_letter_topic.name).must_equal topic_path(dead_letter_topic_name)
     _(sub.dead_letter_max_delivery_attempts).must_equal 7
   end


### PR DESCRIPTION
Add a `DeadLetterPolicy` immutable value object, similar to `RetryPolicy`, so that an existing policy may be set to `nil`.

closes: #6159

- [x] `DeadLetterPolicy`
- [x] `Subscription#dead_letter_policy`
- [ ] `Subscription#set_dead_letter_policy`
- [x] `Subscription#update_dead_letter_policy`
- [x] `Subscription#remove_dead_letter_policy`

### Example code

```rb
      # get before create
      dlp = subscription.dead_letter_policy # NO RPC
      rt.nil? #=> true

      # update before create
      subscription.update_dead_letter_policy do |dlp|
       dlp.max_delivery_attempts = 20
      end # raise runtime error

      # create or replace
      dlp = subscription.set_dead_letter_policy # Use service default settings # RPC update_subscription
      dlp = subscription.set_dead_letter_policy other_subscription.dead_letter_policy # RPC update_subscription
      dlp = subscription.set_dead_letter_policy do |dlp| 
        dlp.max_delivery_attempts = 30 # updater subclass with setters
      end 
      dlp = subscription.set_dead_letter_policy other_subscription.dead_letter_policy do |dlp| 
        dlp.max_delivery_attempts = 40 # updater subclass with setters
      end 
      dlp.max_delivery_attempts = 40 # no method error, immutable object

      # get
      subscription.reload! # RPC
      dlp = subscription.dead_letter_policy # NO RPC
      dlp.max_delivery_attempts #=> 5

      # update partial
      subscription.update_dead_letter_policy do |dlp|
        dlp.max_delivery_attempts = 30 # updater subclass with setters
      end # RPC update_subscription

      # delete
      subscription.dead_letter_policy.nil? # NO RPC
      subscription.remove_dead_letter_policy # RPC update_subscription # return nil
```