### PR TITLE
chore: Kick linkinator can till after the fixit 2 weeks

### DIFF
--- a/rakelib/kokoro/kokoro.rb
+++ b/rakelib/kokoro/kokoro.rb
@@ -43,7 +43,7 @@ class Kokoro < Command
         run "bundle exec rake ci", 1800
         # TODO: Remove date requirement
         require "date"
-        next unless Date.today > Date.new(2020, 6, 1)
+        next unless Date.today > Date.new(2020, 6, 15)
         local_docs_test if should_link_check? gem || (
           autorelease_pending? && @should_release
         )


### PR DESCRIPTION
Disable presubmit link checking until after the fixit period (June 1-12). Maybe we'll get lucky and be able to fix the remaining link issues by then.