### PR TITLE
feat(pubsub): Add Subscription#remove_dead_letter_policy

### DIFF
--- a/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
+++ b/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
@@ -321,7 +321,6 @@ describe Google::Cloud::PubSub, :pubsub do
 
           # create
           subscription = topic.subscribe "#{$topic_prefix}-sub6", dead_letter_topic: dead_letter_topic, dead_letter_max_delivery_attempts: 6
-          _(subscription.dead_letter_policy?).must_equal true
           _(subscription.dead_letter_topic.name).must_equal dead_letter_topic.name
           _(subscription.dead_letter_max_delivery_attempts).must_equal 6
 
@@ -352,18 +351,15 @@ describe Google::Cloud::PubSub, :pubsub do
           dead_letter_topic_2 = retrieve_topic dead_letter_topic_name_2
           dead_letter_subscription_2 = dead_letter_topic_2.subscribe "#{$topic_prefix}-dead-letter-sub2"
           subscription.dead_letter_topic = dead_letter_topic_2
-          _(subscription.dead_letter_policy?).must_equal true
           _(subscription.dead_letter_topic.name).must_equal dead_letter_topic_2.name
           _(subscription.dead_letter_max_delivery_attempts).must_equal 6
 
           subscription.dead_letter_max_delivery_attempts = 5
-          _(subscription.dead_letter_policy?).must_equal true
           _(subscription.dead_letter_topic.name).must_equal dead_letter_topic_2.name
           _(subscription.dead_letter_max_delivery_attempts).must_equal 5
 
           # delete
           subscription.remove_dead_letter_policy!
-          _(subscription.dead_letter_policy?).must_equal false
           _(subscription.dead_letter_topic).must_be :nil?
           _(subscription.dead_letter_max_delivery_attempts).must_be :nil?
 

--- a/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
+++ b/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
@@ -359,7 +359,8 @@ describe Google::Cloud::PubSub, :pubsub do
           _(subscription.dead_letter_max_delivery_attempts).must_equal 5
 
           # delete
-          subscription.remove_dead_letter_policy!
+          removed = subscription.remove_dead_letter_policy
+          _(removed).must_equal true
           _(subscription.dead_letter_topic).must_be :nil?
           _(subscription.dead_letter_max_delivery_attempts).must_be :nil?
 

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -450,8 +450,7 @@ module Google
         #
         # Makes an API call to retrieve the value when called on a reference object. See {#reference?}.
         #
-        # @return [Integer, nil] A value between `5` and `100`, or `nil` if no dead letter policy is configured. If this
-        #   value was set to `0` or `nil`, a default value of `5` is used.
+        # @return [Integer, nil] A value between `5` and `100`, or `nil` if no dead letter policy is configured.
         #
         # @example
         #   require "google/cloud/pubsub"
@@ -478,7 +477,7 @@ module Google
         #
         # This field will be honored on a best effort basis. If this parameter is 0, a default value of 5 is used.
         #
-        # The dead letter topic must also be set. See {#dead_letter_topic=}, {#dead_letter_topic},
+        # The dead letter topic must be set first. See {#dead_letter_topic=}, {#dead_letter_topic},
         # {#dead_letter_policy?} and {#remove_dead_letter_policy!}.
         #
         # @param [Integer, nil] new_dead_letter_max_delivery_attempts A value between 5 and 100. If this parameter is
@@ -528,11 +527,11 @@ module Google
         #
         #   sub.dead_letter_topic.name #=> "projects/my-project/topics/my-dead-letter-topic"
         #   sub.dead_letter_max_delivery_attempts #=> 10
-        #
         #   sub.dead_letter_policy? #=> true
-        #   sub.remove_dead_letter_policy!
-        #   sub.dead_letter_policy? #=> false
         #
+        #   sub.remove_dead_letter_policy!
+        #
+        #   sub.dead_letter_policy? #=> false
         #   sub.dead_letter_topic #=> nil
         #   sub.dead_letter_max_delivery_attempts #=> nil
         #
@@ -562,11 +561,11 @@ module Google
         #
         #   sub.dead_letter_topic.name #=> "projects/my-project/topics/my-dead-letter-topic"
         #   sub.dead_letter_max_delivery_attempts #=> 10
-        #
         #   sub.dead_letter_policy? #=> true
-        #   sub.remove_dead_letter_policy!
-        #   sub.dead_letter_policy? #=> false
         #
+        #   sub.remove_dead_letter_policy!
+        #
+        #   sub.dead_letter_policy? #=> false
         #   sub.dead_letter_topic #=> nil
         #   sub.dead_letter_max_delivery_attempts #=> nil
         #

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -504,6 +504,72 @@ module Google
         end
 
         ##
+        # Removes an existing dead letter policy. A dead letter policy specifies the conditions for dead lettering
+        # messages in the subscription. If a dead letter policy is not set, dead lettering is disabled.
+        #
+        # See {#dead_letter_topic}, {#dead_letter_topic=}, {#dead_letter_max_delivery_attempts}, and
+        # {#dead_letter_max_delivery_attempts=}.
+        #
+        # @return [Boolean] `true` if an existing dead letter policy was removed, `false` if no existing dead letter
+        #   policy was present.
+        #
+        # @example
+        #   require "google/cloud/pubsub"
+        #
+        #   pubsub = Google::Cloud::PubSub.new
+        #
+        #   sub = pubsub.subscription "my-topic-sub"
+        #
+        #   sub.dead_letter_topic.name #=> "projects/my-project/topics/my-dead-letter-topic"
+        #   sub.dead_letter_max_delivery_attempts #=> 10
+        #
+        #   sub.dead_letter_policy? #=> true
+        #   sub.remove_dead_letter_policy!
+        #   sub.dead_letter_policy? #=> false
+        #
+        #   sub.dead_letter_topic #=> nil
+        #   sub.dead_letter_max_delivery_attempts #=> nil
+        #
+        def remove_dead_letter_policy!
+          ensure_grpc!
+          return false unless dead_letter_policy?
+          update_grpc = Google::Cloud::PubSub::V1::Subscription.new name: name, dead_letter_policy: nil
+          @grpc = service.update_subscription update_grpc, :dead_letter_policy
+          true
+        end
+
+        ##
+        # Whether the subscription has a dead letter policy. A dead letter policy specifies the conditions for dead
+        # lettering messages in the subscription. If a dead letter policy is not set, dead lettering is disabled.
+        #
+        # See {#dead_letter_topic}, {#dead_letter_topic=}, {#dead_letter_max_delivery_attempts}, and
+        # {#dead_letter_max_delivery_attempts=}.
+        #
+        # @return [Boolean] `true` if the subscription has a dead letter policy, `false` otherwise.
+        #
+        # @example
+        #   require "google/cloud/pubsub"
+        #
+        #   pubsub = Google::Cloud::PubSub.new
+        #
+        #   sub = pubsub.subscription "my-topic-sub"
+        #
+        #   sub.dead_letter_topic.name #=> "projects/my-project/topics/my-dead-letter-topic"
+        #   sub.dead_letter_max_delivery_attempts #=> 10
+        #
+        #   sub.dead_letter_policy? #=> true
+        #   sub.remove_dead_letter_policy!
+        #   sub.dead_letter_policy? #=> false
+        #
+        #   sub.dead_letter_topic #=> nil
+        #   sub.dead_letter_max_delivery_attempts #=> nil
+        #
+        def dead_letter_policy?
+          ensure_grpc!
+          !@grpc.dead_letter_policy.nil?
+        end
+
+        ##
         # A policy that specifies how Cloud Pub/Sub retries message delivery for this subscription. If `nil`, the
         # default retry policy is applied. This generally implies that messages will be retried as soon as possible
         # for healthy subscribers. Retry Policy will be triggered on NACKs or acknowledgement deadline exceeded events

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -377,8 +377,8 @@ module Google
         # otherwise `nil`. Dead lettering is done on a best effort basis. The same message might be dead lettered
         # multiple times.
         #
-        # See also {#dead_letter_topic=}, {#dead_letter_max_delivery_attempts=}, {#dead_letter_max_delivery_attempts},
-        # {#dead_letter_policy?} and {#remove_dead_letter_policy!}.
+        # See also {#dead_letter_topic=}, {#dead_letter_max_delivery_attempts=}, {#dead_letter_max_delivery_attempts}
+        # and {#remove_dead_letter_policy!}.
         #
         # Makes an API call to retrieve the topic name when called on a reference object. See {#reference?}.
         #
@@ -409,8 +409,8 @@ module Google
         # The operation will fail if the topic does not exist. Users should ensure that there is a subscription attached
         # to this topic since messages published to a topic with no subscriptions are lost.
         #
-        # See also {#dead_letter_topic}, {#dead_letter_max_delivery_attempts=}, {#dead_letter_max_delivery_attempts},
-        # {#dead_letter_policy?} and {#remove_dead_letter_policy!}.
+        # See also {#dead_letter_topic}, {#dead_letter_max_delivery_attempts=}, {#dead_letter_max_delivery_attempts}
+        # and {#remove_dead_letter_policy!}.
         #
         # @param [Topic] new_dead_letter_topic The topic to which dead letter messages for the subscription should be
         #   published.
@@ -445,8 +445,8 @@ module Google
         # This field will be honored on a best effort basis. If this parameter is `nil` or `0`, a default value of `5`
         # is used.
         #
-        # See also {#dead_letter_max_delivery_attempts=}, {#dead_letter_topic=}, {#dead_letter_topic},
-        # {#dead_letter_policy?} and {#remove_dead_letter_policy!}.
+        # See also {#dead_letter_max_delivery_attempts=}, {#dead_letter_topic=}, {#dead_letter_topic}
+        # and {#remove_dead_letter_policy!}.
         #
         # Makes an API call to retrieve the value when called on a reference object. See {#reference?}.
         #
@@ -477,8 +477,8 @@ module Google
         #
         # This field will be honored on a best effort basis. If this parameter is 0, a default value of 5 is used.
         #
-        # The dead letter topic must be set first. See {#dead_letter_topic=}, {#dead_letter_topic},
-        # {#dead_letter_policy?} and {#remove_dead_letter_policy!}.
+        # The dead letter topic must be set first. See {#dead_letter_topic=}, {#dead_letter_topic} and
+        # {#remove_dead_letter_policy!}.
         #
         # @param [Integer, nil] new_dead_letter_max_delivery_attempts A value between 5 and 100. If this parameter is
         #   `nil` or `0`, a default value of 5 is used.
@@ -512,8 +512,8 @@ module Google
         # Removes an existing dead letter policy. A dead letter policy specifies the conditions for dead lettering
         # messages in the subscription. If a dead letter policy is not set, dead lettering is disabled.
         #
-        # See {#dead_letter_topic}, {#dead_letter_topic=}, {#dead_letter_max_delivery_attempts},
-        # {#dead_letter_max_delivery_attempts=} and {#dead_letter_policy?}.
+        # See {#dead_letter_topic}, {#dead_letter_topic=}, {#dead_letter_max_delivery_attempts} and
+        # {#dead_letter_max_delivery_attempts=}.
         #
         # @return [Boolean] `true` if an existing dead letter policy was removed, `false` if no existing dead letter
         #   policy was present.
@@ -527,51 +527,18 @@ module Google
         #
         #   sub.dead_letter_topic.name #=> "projects/my-project/topics/my-dead-letter-topic"
         #   sub.dead_letter_max_delivery_attempts #=> 10
-        #   sub.dead_letter_policy? #=> true
         #
         #   sub.remove_dead_letter_policy!
         #
-        #   sub.dead_letter_policy? #=> false
         #   sub.dead_letter_topic #=> nil
         #   sub.dead_letter_max_delivery_attempts #=> nil
         #
         def remove_dead_letter_policy!
           ensure_grpc!
-          return false unless dead_letter_policy?
+          return false if @grpc.dead_letter_policy.nil?
           update_grpc = Google::Cloud::PubSub::V1::Subscription.new name: name, dead_letter_policy: nil
           @grpc = service.update_subscription update_grpc, :dead_letter_policy
           true
-        end
-
-        ##
-        # Whether the subscription has a dead letter policy. A dead letter policy specifies the conditions for dead
-        # lettering messages in the subscription. If a dead letter policy is not set, dead lettering is disabled.
-        #
-        # See {#dead_letter_topic}, {#dead_letter_topic=}, {#dead_letter_max_delivery_attempts},
-        # {#dead_letter_max_delivery_attempts=} and {#remove_dead_letter_policy!}.
-        #
-        # @return [Boolean] `true` if the subscription has a dead letter policy, `false` otherwise.
-        #
-        # @example
-        #   require "google/cloud/pubsub"
-        #
-        #   pubsub = Google::Cloud::PubSub.new
-        #
-        #   sub = pubsub.subscription "my-topic-sub"
-        #
-        #   sub.dead_letter_topic.name #=> "projects/my-project/topics/my-dead-letter-topic"
-        #   sub.dead_letter_max_delivery_attempts #=> 10
-        #   sub.dead_letter_policy? #=> true
-        #
-        #   sub.remove_dead_letter_policy!
-        #
-        #   sub.dead_letter_policy? #=> false
-        #   sub.dead_letter_topic #=> nil
-        #   sub.dead_letter_max_delivery_attempts #=> nil
-        #
-        def dead_letter_policy?
-          ensure_grpc!
-          !@grpc.dead_letter_policy.nil?
         end
 
         ##

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -378,7 +378,7 @@ module Google
         # multiple times.
         #
         # See also {#dead_letter_topic=}, {#dead_letter_max_delivery_attempts=}, {#dead_letter_max_delivery_attempts}
-        # and {#remove_dead_letter_policy!}.
+        # and {#remove_dead_letter_policy}.
         #
         # Makes an API call to retrieve the topic name when called on a reference object. See {#reference?}.
         #
@@ -410,7 +410,7 @@ module Google
         # to this topic since messages published to a topic with no subscriptions are lost.
         #
         # See also {#dead_letter_topic}, {#dead_letter_max_delivery_attempts=}, {#dead_letter_max_delivery_attempts}
-        # and {#remove_dead_letter_policy!}.
+        # and {#remove_dead_letter_policy}.
         #
         # @param [Topic] new_dead_letter_topic The topic to which dead letter messages for the subscription should be
         #   published.
@@ -446,7 +446,7 @@ module Google
         # is used.
         #
         # See also {#dead_letter_max_delivery_attempts=}, {#dead_letter_topic=}, {#dead_letter_topic}
-        # and {#remove_dead_letter_policy!}.
+        # and {#remove_dead_letter_policy}.
         #
         # Makes an API call to retrieve the value when called on a reference object. See {#reference?}.
         #
@@ -478,7 +478,7 @@ module Google
         # This field will be honored on a best effort basis. If this parameter is 0, a default value of 5 is used.
         #
         # The dead letter topic must be set first. See {#dead_letter_topic=}, {#dead_letter_topic} and
-        # {#remove_dead_letter_policy!}.
+        # {#remove_dead_letter_policy}.
         #
         # @param [Integer, nil] new_dead_letter_max_delivery_attempts A value between 5 and 100. If this parameter is
         #   `nil` or `0`, a default value of 5 is used.
@@ -528,12 +528,12 @@ module Google
         #   sub.dead_letter_topic.name #=> "projects/my-project/topics/my-dead-letter-topic"
         #   sub.dead_letter_max_delivery_attempts #=> 10
         #
-        #   sub.remove_dead_letter_policy!
+        #   sub.remove_dead_letter_policy
         #
         #   sub.dead_letter_topic #=> nil
         #   sub.dead_letter_max_delivery_attempts #=> nil
         #
-        def remove_dead_letter_policy!
+        def remove_dead_letter_policy
           ensure_grpc!
           return false if @grpc.dead_letter_policy.nil?
           update_grpc = Google::Cloud::PubSub::V1::Subscription.new name: name, dead_letter_policy: nil

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -377,8 +377,8 @@ module Google
         # otherwise `nil`. Dead lettering is done on a best effort basis. The same message might be dead lettered
         # multiple times.
         #
-        # See also {#dead_letter_topic=}, {#dead_letter_max_delivery_attempts=} and
-        # {#dead_letter_max_delivery_attempts}.
+        # See also {#dead_letter_topic=}, {#dead_letter_max_delivery_attempts=}, {#dead_letter_max_delivery_attempts},
+        # {#dead_letter_policy?} and {#remove_dead_letter_policy!}.
         #
         # Makes an API call to retrieve the topic name when called on a reference object. See {#reference?}.
         #
@@ -409,7 +409,8 @@ module Google
         # The operation will fail if the topic does not exist. Users should ensure that there is a subscription attached
         # to this topic since messages published to a topic with no subscriptions are lost.
         #
-        # See also {#dead_letter_topic}, {#dead_letter_max_delivery_attempts=} and {#dead_letter_max_delivery_attempts}.
+        # See also {#dead_letter_topic}, {#dead_letter_max_delivery_attempts=}, {#dead_letter_max_delivery_attempts},
+        # {#dead_letter_policy?} and {#remove_dead_letter_policy!}.
         #
         # @param [Topic] new_dead_letter_topic The topic to which dead letter messages for the subscription should be
         #   published.
@@ -441,14 +442,16 @@ module Google
         # acknowledgement deadline has been exceeded for the message). A NACK is any call to ModifyAckDeadline with a 0
         # deadline. Note that client libraries may automatically extend ack_deadlines.
         #
-        # This field will be honored on a best effort basis. If this parameter is 0, a default value of 5 is used.
+        # This field will be honored on a best effort basis. If this parameter is `nil` or `0`, a default value of `5`
+        # is used.
         #
-        # See also {#dead_letter_max_delivery_attempts=}, {#dead_letter_topic=} and {#dead_letter_topic}.
+        # See also {#dead_letter_max_delivery_attempts=}, {#dead_letter_topic=}, {#dead_letter_topic},
+        # {#dead_letter_policy?} and {#remove_dead_letter_policy!}.
         #
         # Makes an API call to retrieve the value when called on a reference object. See {#reference?}.
         #
-        # @return [Integer, nil] A value between 5 and 100, or `nil` if no dead letter policy is configured. If this
-        #   value is 0, a default value of 5 is used.
+        # @return [Integer, nil] A value between `5` and `100`, or `nil` if no dead letter policy is configured. If this
+        #   value was set to `0` or `nil`, a default value of `5` is used.
         #
         # @example
         #   require "google/cloud/pubsub"
@@ -475,10 +478,13 @@ module Google
         #
         # This field will be honored on a best effort basis. If this parameter is 0, a default value of 5 is used.
         #
-        # The dead letter topic must also be set. See {#dead_letter_topic=} and {#dead_letter_topic}.
+        # The dead letter topic must also be set. See {#dead_letter_topic=}, {#dead_letter_topic},
+        # {#dead_letter_policy?} and {#remove_dead_letter_policy!}.
         #
-        # @param [Integer] new_dead_letter_max_delivery_attempts A value between 5 and 100. If this parameter is 0, a
-        #   default value of 5 is used.
+        # @param [Integer, nil] new_dead_letter_max_delivery_attempts A value between 5 and 100. If this parameter is
+        #   `nil` or `0`, a default value of 5 is used.
+        #
+        # @raise [ArgumentError] if the dead letter topic has not been set. See {#dead_letter_topic=}.
         #
         # @example
         #   require "google/cloud/pubsub"
@@ -507,8 +513,8 @@ module Google
         # Removes an existing dead letter policy. A dead letter policy specifies the conditions for dead lettering
         # messages in the subscription. If a dead letter policy is not set, dead lettering is disabled.
         #
-        # See {#dead_letter_topic}, {#dead_letter_topic=}, {#dead_letter_max_delivery_attempts}, and
-        # {#dead_letter_max_delivery_attempts=}.
+        # See {#dead_letter_topic}, {#dead_letter_topic=}, {#dead_letter_max_delivery_attempts},
+        # {#dead_letter_max_delivery_attempts=} and {#dead_letter_policy?}.
         #
         # @return [Boolean] `true` if an existing dead letter policy was removed, `false` if no existing dead letter
         #   policy was present.
@@ -542,8 +548,8 @@ module Google
         # Whether the subscription has a dead letter policy. A dead letter policy specifies the conditions for dead
         # lettering messages in the subscription. If a dead letter policy is not set, dead lettering is disabled.
         #
-        # See {#dead_letter_topic}, {#dead_letter_topic=}, {#dead_letter_max_delivery_attempts}, and
-        # {#dead_letter_max_delivery_attempts=}.
+        # See {#dead_letter_topic}, {#dead_letter_topic=}, {#dead_letter_max_delivery_attempts},
+        # {#dead_letter_max_delivery_attempts=} and {#remove_dead_letter_policy!}.
         #
         # @return [Boolean] `true` if the subscription has a dead letter policy, `false` otherwise.
         #

--- a/google-cloud-pubsub/support/doctest_helper.rb
+++ b/google-cloud-pubsub/support/doctest_helper.rb
@@ -342,6 +342,13 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::PubSub::Subscription#remove_dead_letter_policy!" do
+    mock_pubsub do |mock_publisher, mock_subscriber|
+      mock_subscriber.expect :get_subscription, subscription_resp("my-topic-sub", dead_letter_topic: "my-dead-letter-topic", max_delivery_attempts: 10), ["projects/my-project/subscriptions/my-topic-sub", Hash]
+      mock_subscriber.expect :update_subscription, subscription_resp, [Google::Cloud::PubSub::V1::Subscription, Google::Protobuf::FieldMask, Hash]
+    end
+  end
+
   doctest.before "Google::Cloud::PubSub::Subscription#modify_ack_deadline" do
     mock_pubsub do |mock_publisher, mock_subscriber|
       mock_subscriber.expect :get_subscription, subscription_resp("my-topic-sub"), [Hash]

--- a/google-cloud-pubsub/support/doctest_helper.rb
+++ b/google-cloud-pubsub/support/doctest_helper.rb
@@ -344,8 +344,8 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::PubSub::Subscription#remove_dead_letter_policy!" do
     mock_pubsub do |mock_publisher, mock_subscriber|
-      mock_subscriber.expect :get_subscription, subscription_resp("my-topic-sub", dead_letter_topic: "my-dead-letter-topic", max_delivery_attempts: 10), ["projects/my-project/subscriptions/my-topic-sub", Hash]
-      mock_subscriber.expect :update_subscription, subscription_resp, [Google::Cloud::PubSub::V1::Subscription, Google::Protobuf::FieldMask, Hash]
+      mock_subscriber.expect :get_subscription, subscription_resp("my-topic-sub", dead_letter_topic: "my-dead-letter-topic", max_delivery_attempts: 10), [Hash]
+      mock_subscriber.expect :update_subscription, subscription_resp, [Hash]
     end
   end
 

--- a/google-cloud-pubsub/support/doctest_helper.rb
+++ b/google-cloud-pubsub/support/doctest_helper.rb
@@ -342,7 +342,7 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.before "Google::Cloud::PubSub::Subscription#remove_dead_letter_policy!" do
+  doctest.before "Google::Cloud::PubSub::Subscription#remove_dead_letter_policy" do
     mock_pubsub do |mock_publisher, mock_subscriber|
       mock_subscriber.expect :get_subscription, subscription_resp("my-topic-sub", dead_letter_topic: "my-dead-letter-topic", max_delivery_attempts: 10), [Hash]
       mock_subscriber.expect :update_subscription, subscription_resp, [Hash]

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/update_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/update_test.rb
@@ -262,11 +262,11 @@ describe Google::Cloud::PubSub::Subscription, :update, :mock_pubsub do
     subscription.service.mocked_subscriber = mock
 
     _(subscription.dead_letter_topic).wont_be :nil?
-    removed = subscription.remove_dead_letter_policy!
+    removed = subscription.remove_dead_letter_policy
     _(removed).must_equal true
     _(subscription.dead_letter_topic).must_be :nil?
     _(subscription.dead_letter_max_delivery_attempts).must_be :nil?
-    removed = subscription.remove_dead_letter_policy!
+    removed = subscription.remove_dead_letter_policy
     _(removed).must_equal false
 
     mock.verify

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/update_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/update_test.rb
@@ -253,6 +253,27 @@ describe Google::Cloud::PubSub::Subscription, :update, :mock_pubsub do
     _(subscription.dead_letter_max_delivery_attempts).must_equal 7
   end
 
+  it "removes the dead letter policy if present" do
+    dead_letter_policy = Google::Cloud::PubSub::V1::DeadLetterPolicy.new(dead_letter_topic: new_dead_letter_topic.name, max_delivery_attempts: 6)
+    update_sub = Google::Cloud::PubSub::V1::Subscription.new name: sub_path, dead_letter_policy: nil
+    update_mask = Google::Protobuf::FieldMask.new paths: ["dead_letter_policy"]
+    mock = Minitest::Mock.new
+    mock.expect :update_subscription, update_sub, [update_sub, update_mask, options: default_options]
+    subscription.service.mocked_subscriber = mock
+
+    _(subscription.dead_letter_policy?).must_equal true
+    removed = subscription.remove_dead_letter_policy!
+    _(removed).must_equal true
+    _(subscription.dead_letter_policy?).must_equal false
+    removed = subscription.remove_dead_letter_policy!
+    _(removed).must_equal false
+
+    _(subscription.dead_letter_topic).must_be :nil?
+    _(subscription.dead_letter_max_delivery_attempts).must_be :nil?
+
+    mock.verify
+  end
+
   it "raises when updating dead_letter_max_delivery_attempts if dead_letter_topic is not set" do
     grpc = Google::Cloud::PubSub::V1::Subscription.new(subscription_hash(topic_name, sub_name))
     subscription_without_dead_letter = Google::Cloud::PubSub::Subscription.from_grpc grpc, pubsub.service

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/update_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/update_test.rb
@@ -261,15 +261,13 @@ describe Google::Cloud::PubSub::Subscription, :update, :mock_pubsub do
     mock.expect :update_subscription, update_sub, [subscription: update_sub, update_mask: update_mask]
     subscription.service.mocked_subscriber = mock
 
-    _(subscription.dead_letter_policy?).must_equal true
+    _(subscription.dead_letter_topic).wont_be :nil?
     removed = subscription.remove_dead_letter_policy!
     _(removed).must_equal true
-    _(subscription.dead_letter_policy?).must_equal false
-    removed = subscription.remove_dead_letter_policy!
-    _(removed).must_equal false
-
     _(subscription.dead_letter_topic).must_be :nil?
     _(subscription.dead_letter_max_delivery_attempts).must_be :nil?
+    removed = subscription.remove_dead_letter_policy!
+    _(removed).must_equal false
 
     mock.verify
   end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/update_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/update_test.rb
@@ -258,7 +258,7 @@ describe Google::Cloud::PubSub::Subscription, :update, :mock_pubsub do
     update_sub = Google::Cloud::PubSub::V1::Subscription.new name: sub_path, dead_letter_policy: nil
     update_mask = Google::Protobuf::FieldMask.new paths: ["dead_letter_policy"]
     mock = Minitest::Mock.new
-    mock.expect :update_subscription, update_sub, [update_sub, update_mask, options: default_options]
+    mock.expect :update_subscription, update_sub, [subscription: update_sub, update_mask: update_mask]
     subscription.service.mocked_subscriber = mock
 
     _(subscription.dead_letter_policy?).must_equal true


### PR DESCRIPTION
This is an alternative solution to #6314 that has the advantage of not exposing a value object. The value object in #6314 may be in a state that is inconsistent with the service, due to the replacement of the special values `nil` and `0` with a default value.

closes: #6159