### PR TITLE
docs(automl-v1): Fix additional broken/misformatted links

### DIFF
--- a/google-cloud-automl-v1/proto_docs/google/cloud/automl/v1/io.rb
+++ b/google-cloud-automl-v1/proto_docs/google/cloud/automl/v1/io.rb
@@ -884,7 +884,7 @@ module Google
         # The column names must contain the model's
         #
         # [input_feature_column_specs'][google.cloud.automl.v1.TablesModelMetadata.input_feature_column_specs]
-        # [display_name-s][google.cloud.automl.v1.ColumnSpec.display_name]
+        # display_name-s
         # (order doesn't matter). The columns corresponding to the model's
         # input feature column specs must contain values compatible with the
         # column spec's data types. Prediction on all the rows, i.e. the CSV
@@ -907,7 +907,7 @@ module Google
         # The column names must contain the model's
         #
         # [input_feature_column_specs'][google.cloud.automl.v1.TablesModelMetadata.input_feature_column_specs]
-        # [display_name-s][google.cloud.automl.v1.ColumnSpec.display_name]
+        # display_name-s
         # (order doesn't matter). The columns corresponding to the model's
         # input feature column specs must contain values compatible with the
         # column spec's data types. Prediction on all the rows of the table

--- a/google-cloud-automl-v1/synth.metadata
+++ b/google-cloud-automl-v1/synth.metadata
@@ -3,16 +3,16 @@
     {
       "git": {
         "name": ".",
-        "remote": "https://github.com/googleapis/google-cloud-ruby.git",
-        "sha": "af8706c1ea7d63d8660f08f171cbc392bd27a954"
+        "remote": "git@github.com:googleapis/google-cloud-ruby.git",
+        "sha": "62cf4e3689ab467c8847902995ff99e5c41cca71"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "973c671823c076165b2371cda0174586d4078b0d",
-        "internalRef": "313004561"
+        "sha": "dd244bb3a5023a4a9290b21dae6b99020c026123",
+        "internalRef": "315023125"
       }
     }
   ],

--- a/google-cloud-automl-v1/synth.py
+++ b/google-cloud-automl-v1/synth.py
@@ -46,3 +46,9 @@ s.replace(
     "proto_docs/google/cloud/automl/v1/io.rb",
     "https:\n\\s+# //",
     "https://")
+
+# See internal issue b/158466893
+s.replace(
+    "proto_docs/google/cloud/automl/v1/io.rb",
+    "\\[display_name-s\\]\\[google\\.cloud\\.automl\\.v1\\.ColumnSpec\\.display_name\\]",
+    "display_name-s")


### PR DESCRIPTION
This is another temporary patch in the automl docs to fix a broken link. The actual fix is upstream and somewhat larger in scope, and we'll be tracking it internally.