### PR TITLE
Move ruby quickstart example away from using global resource.

### DIFF
--- a/google-cloud-monitoring/samples/quickstart.rb
+++ b/google-cloud-monitoring/samples/quickstart.rb
@@ -30,8 +30,10 @@ def quickstart project_id:, metric_label:
   series.metric = Google::Api::Metric.new type:   "custom.googleapis.com/my_metric",
                                           labels: { "my_key" => metric_label }
 
-  resource = Google::Api::MonitoredResource.new type: "global"
+  resource = Google::Api::MonitoredResource.new type: "gce_instance"
   resource.labels["project_id"] = project_id
+  resource.labels["instance_id"] = "1234567890123456789"
+  resource.labels["zone"] = "us-central1-f"
   series.resource = resource
 
   point = Google::Cloud::Monitoring::V3::Point.new


### PR DESCRIPTION
Issue: https://github.com/googleapis/google-cloud-ruby/issues/6505

closes: #6505 