### PR TITLE
chore: Temporarily undo new ruby_package proto options for artman-generated libraries

### DIFF
--- a/google-cloud-bigtable/synth.py
+++ b/google-cloud-bigtable/synth.py
@@ -248,3 +248,17 @@ s.replace(
     "https://cloud.google.com/bigtable-admin",
     "https://cloud.google.com/bigtable/docs/reference/admin/rpc"
 )
+
+# We recently added ruby_package proto options, but we want those to apply only
+# when we move to the microgenerator. Undo their effect while the monolith is
+# still in use.
+s.replace(
+    'lib/google/bigtable/v2/*_pb.rb',
+    '\nmodule Google::Cloud::Bigtable::V2\n',
+    '\nmodule Google\n  module Bigtable\n  end\nend\nmodule Google::Bigtable::V2\n',
+)
+s.replace(
+    'lib/google/bigtable/admin/v2/*_pb.rb',
+    '\nmodule Google::Cloud::Bigtable::Admin::V2\n',
+    '\nmodule Google\n  module Bigtable\n    module Admin\n    end\n  end\nend\nmodule Google::Bigtable::Admin::V2\n',
+)

--- a/google-cloud-datastore/synth.py
+++ b/google-cloud-datastore/synth.py
@@ -95,3 +95,17 @@ s.replace(
     "/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString]",
     "/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString)"
 )
+
+# We recently added ruby_package proto options, but we want those to apply only
+# when we move to the microgenerator. Undo their effect while the monolith is
+# still in use.
+s.replace(
+    'lib/google/datastore/v1/*_pb.rb',
+    '\nmodule Google::Cloud::Datastore::V1\n',
+    '\nmodule Google\n  module Datastore\n  end\nend\nmodule Google::Datastore::V1\n',
+)
+s.replace(
+    'lib/google/datastore/admin/v1/*_pb.rb',
+    '\nmodule Google::Cloud::Datastore::Admin::V1\n',
+    '\nmodule Google\n  module Datastore\n    module Admin\n    end\n  end\nend\nmodule Google::Datastore::Admin::V1\n',
+)

--- a/google-cloud-debugger/synth.py
+++ b/google-cloud-debugger/synth.py
@@ -172,3 +172,12 @@ s.replace(
     'https://googleapis.github.io/google-cloud-ruby/#/docs/google-cloud-logging/latest/google/cloud/logging/logger',
     'https://googleapis.dev/ruby/google-cloud-logging/latest'
 )
+
+# We recently added ruby_package proto options, but we want those to apply only
+# when we move to the microgenerator. Undo their effect while the monolith is
+# still in use.
+s.replace(
+    'lib/google/devtools/clouddebugger/v2/*_pb.rb',
+    '\nmodule Google::Cloud::Debugger::V2\n',
+    '\nmodule Google\n  module Devtools\n    module Clouddebugger\n    end\n  end\nend\nmodule Google::Devtools::Clouddebugger::V2\n',
+)

--- a/google-cloud-error_reporting/synth.py
+++ b/google-cloud-error_reporting/synth.py
@@ -96,3 +96,12 @@ s.replace(
     'Gem.loaded_specs\[.*\]\.version\.version',
     'Google::Cloud::ErrorReporting::VERSION'
 )
+
+# We recently added ruby_package proto options, but we want those to apply only
+# when we move to the microgenerator. Undo their effect while the monolith is
+# still in use.
+s.replace(
+    'lib/google/devtools/clouderrorreporting/v1beta1/*_pb.rb',
+    '\nmodule Google::Cloud::ErrorReporting::V1beta1\n',
+    '\nmodule Google\n  module Devtools\n    module Clouderrorreporting\n    end\n  end\nend\nmodule Google::Devtools::Clouderrorreporting::V1beta1\n',
+)

--- a/google-cloud-firestore/synth.py
+++ b/google-cloud-firestore/synth.py
@@ -249,3 +249,22 @@ s.replace(
     "https://cloud.google.com/firestore-admin",
     "https://cloud.google.com/firestore/docs/reference/rpc"
 )
+
+# We recently added ruby_package proto options, but we want those to apply only
+# when we move to the microgenerator. Undo their effect while the monolith is
+# still in use.
+s.replace(
+    'lib/google/firestore/v1/*_pb.rb',
+    '\nmodule Google::Cloud::Firestore::V1\n',
+    '\nmodule Google\n  module Firestore\n  end\nend\nmodule Google::Firestore::V1\n',
+)
+s.replace(
+    'lib/google/firestore/v1beta1/*_pb.rb',
+    '\nmodule Google::Cloud::Firestore::V1beta1\n',
+    '\nmodule Google\n  module Firestore\n  end\nend\nmodule Google::Firestore::V1beta1\n',
+)
+s.replace(
+    'lib/google/firestore/admin/v1/*_pb.rb',
+    '\nmodule Google::Cloud::Firestore::Admin::V1\n',
+    '\nmodule Google\n  module Firestore\n    module Admin\n    end\n  end\nend\nmodule Google::Firestore::Admin::V1\n',
+)

--- a/google-cloud-logging/synth.py
+++ b/google-cloud-logging/synth.py
@@ -158,3 +158,12 @@ s.replace(
     '\{Google::Logging::V2::ConfigServiceV2::GetCmekSettings GetCmekSettings\}',
     '{Google::Cloud::Logging::V2::ConfigServiceV2Client#get_cmek_settings}'
 )
+
+# We recently added ruby_package proto options, but we want those to apply only
+# when we move to the microgenerator. Undo their effect while the monolith is
+# still in use.
+s.replace(
+    'lib/google/logging/v2/*_pb.rb',
+    '\nmodule Google::Cloud::Logging::V2\n',
+    '\nmodule Google\n  module Logging\n  end\nend\nmodule Google::Logging::V2\n',
+)

--- a/google-cloud-spanner/synth.py
+++ b/google-cloud-spanner/synth.py
@@ -262,3 +262,22 @@ s.replace(
     'https://googleapis.github.io/google-cloud-ruby/#/docs/.*/authentication',
     'https://googleapis.dev/ruby/google-cloud-spanner/latest/file.AUTHENTICATION.html'
 )
+
+# We recently added ruby_package proto options, but we want those to apply only
+# when we move to the microgenerator. Undo their effect while the monolith is
+# still in use.
+s.replace(
+    'lib/google/spanner/v1/*_pb.rb',
+    '\nmodule Google::Cloud::Spanner::V1\n',
+    '\nmodule Google\n  module Spanner\n  end\nend\nmodule Google::Spanner::V1\n',
+)
+s.replace(
+    'lib/google/spanner/admin/database/v1/*_pb.rb',
+    '\nmodule Google::Cloud::Spanner::Admin::Database::V1\n',
+    '\nmodule Google\n  module Spanner\n    module Admin\n      module Database\n      end\n    end\n  end\nend\nmodule Google::Spanner::Admin::Database::V1\n',
+)
+s.replace(
+    'lib/google/spanner/admin/instance/v1/*_pb.rb',
+    '\nmodule Google::Cloud::Spanner::Admin::Instance::V1\n',
+    '\nmodule Google\n  module Spanner\n    module Admin\n      module Instance\n      end\n    end\n  end\nend\nmodule Google::Spanner::Admin::Instance::V1\n',
+)

--- a/google-cloud-trace/synth.py
+++ b/google-cloud-trace/synth.py
@@ -151,3 +151,17 @@ for version in ['v1', 'v2']:
         'Gem.loaded_specs\[.*\]\.version\.version',
         'Google::Cloud::Trace::VERSION'
     )
+
+# We recently added ruby_package proto options, but we want those to apply only
+# when we move to the microgenerator. Undo their effect while the monolith is
+# still in use.
+s.replace(
+    'lib/google/devtools/cloudtrace/v1/*_pb.rb',
+    '\nmodule Google::Cloud::Trace::V1\n',
+    '\nmodule Google\n  module Devtools\n    module Cloudtrace\n    end\n  end\nend\nmodule Google::Devtools::Cloudtrace::V1\n',
+)
+s.replace(
+    'lib/google/devtools/cloudtrace/v2/*_pb.rb',
+    '\nmodule Google::Cloud::Trace::V2\n',
+    '\nmodule Google\n  module Devtools\n    module Cloudtrace\n    end\n  end\nend\nmodule Google::Devtools::Cloudtrace::V2\n',
+)


### PR DESCRIPTION
The gapics underlying pretty much all our veneers are being generated into namespaces that do not match the proto namespaces. This is currently being controlled by gapic configs, but those are going away with the move to microgenerators. Thus, we are updating the source protos with the appropriate `ruby_package` options to set the desired namespaces.

Unfortunately, doing this has an adverse effect on the monolith, which does not know how to deal with `ruby_package` correctly (https://github.com/googleapis/gapic-generator/issues/2525). Therefore, we are updating the synth scripts for the veneers to _undo_ the effect of `ruby_package` so the monolith-generated code doesn't get confused. So this change will result in a small syntax change but no functional difference while we are running the gapic monolith. When we move to the microgenerator, we can drop this synth hack (along with all the others). (Note: we added a similar hack in other libraries earlier, e.g. https://github.com/googleapis/google-cloud-ruby/pull/5407)