### PR TITLE
test(bigtable): Fix several issues with the tests

### DIFF
--- a/google-cloud-bigtable/Rakefile
+++ b/google-cloud-bigtable/Rakefile
@@ -149,23 +149,11 @@ end
 
 namespace :samples do
   task :latest do
-    Dir.chdir "samples" do
-      Bundler.with_clean_env do
-        ENV["GOOGLE_CLOUD_SAMPLES_TEST"] = "not_master"
-        sh "bundle update"
-        sh "bundle exec rake test"
-      end
-    end
+    puts "The google-cloud-bigtable gem has no sample tests."
   end
 
   task :master do
-    Dir.chdir "samples" do
-      Bundler.with_clean_env do
-        ENV["GOOGLE_CLOUD_SAMPLES_TEST"] = "master"
-        sh "bundle update"
-        sh "bundle exec rake test"
-      end
-    end
+    puts "The google-cloud-bigtable gem has no sample tests."
   end
 end
 

--- a/google-cloud-bigtable/Rakefile
+++ b/google-cloud-bigtable/Rakefile
@@ -143,6 +143,32 @@ namespace :acceptance do
   end
 end
 
+task :samples do
+  Rake::Task["samples:latest"].invoke
+end
+
+namespace :samples do
+  task :latest do
+    Dir.chdir "samples" do
+      Bundler.with_clean_env do
+        ENV["GOOGLE_CLOUD_SAMPLES_TEST"] = "not_master"
+        sh "bundle update"
+        sh "bundle exec rake test"
+      end
+    end
+  end
+
+  task :master do
+    Dir.chdir "samples" do
+      Bundler.with_clean_env do
+        ENV["GOOGLE_CLOUD_SAMPLES_TEST"] = "master"
+        sh "bundle update"
+        sh "bundle exec rake test"
+      end
+    end
+  end
+end
+
 require "yard"
 require "yard/rake/yardoc_task"
 YARD::Rake::YardocTask.new do |y|

--- a/google-cloud-bigtable/test/google/cloud/bigtable/column_family_map_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/column_family_map_test.rb
@@ -77,7 +77,7 @@ describe Google::Cloud::Bigtable::ColumnFamilyMap, :mock_bigtable do
     cfm.freeze
 
     error = expect { cfm.add cf_name }.must_raise frozen_error_class
-    _(error.message).must_equal "can't modify frozen Hash"
+    _(error.message).must_match(/can't modify frozen Hash/)
   end
 
   it "updates a column family" do
@@ -119,7 +119,7 @@ describe Google::Cloud::Bigtable::ColumnFamilyMap, :mock_bigtable do
     cfm.freeze
 
     error = expect { cfm.update cf_name }.must_raise frozen_error_class
-    _(error.message).must_equal "can't modify frozen Hash"
+    _(error.message).must_match(/can't modify frozen Hash/)
   end
 
   it "deletes a column family" do
@@ -146,6 +146,6 @@ describe Google::Cloud::Bigtable::ColumnFamilyMap, :mock_bigtable do
     cfm.freeze
 
     error = expect { cfm.delete cf_name }.must_raise frozen_error_class
-    _(error.message).must_equal "can't modify frozen Hash"
+    _(error.message).must_match(/can't modify frozen Hash/)
   end
 end


### PR DESCRIPTION
* These tests were failing on Ruby 2.7 because Ruby added to the error message text. Fixed by relaxing the check.
* Sample tests launched from CI would fail because the rake tasks are not present. (There are no actual sample tests, but the rake tasks need to be there nonetheless.)