### PR TITLE
tests(monitoring): Deflake monitoring sample tests

### DIFF
--- a/google-cloud-monitoring/samples/Rakefile
+++ b/google-cloud-monitoring/samples/Rakefile
@@ -19,15 +19,18 @@ Rake::TestTask.new "test" do |t|
   t.warning = false
 end
 
-task "clean_fixtures" do
-  require "google/cloud/monitoring"
-  project_id = ENV["GOOGLE_CLOUD_PROJECT"]
-  raise "Set the environment variable GOOGLE_CLOUD_PROJECT." if project_id.nil?
-  client = Google::Cloud::Monitoring.uptime_check_service
-  project_name = client.project_path project: project_id
-  configs = client.list_uptime_check_configs parent: project_name
-  configs.each do |config|
-    puts "Cleaning #{config.name}..."
-    client.delete_uptime_check_config name: config.name
+namespace :fixtures do
+  desc "Cleans out any fixture data that has been left behind by previous tests"
+  task :clean do
+    require "google/cloud/monitoring"
+    project_id = ENV["GOOGLE_CLOUD_PROJECT"]
+    raise "Set the environment variable GOOGLE_CLOUD_PROJECT." if project_id.nil?
+    client = Google::Cloud::Monitoring.uptime_check_service
+    project_name = client.project_path project: project_id
+    configs = client.list_uptime_check_configs parent: project_name
+    configs.each do |config|
+      puts "Cleaning #{config.name}..."
+      client.delete_uptime_check_config name: config.name
+    end
   end
 end

--- a/google-cloud-monitoring/samples/Rakefile
+++ b/google-cloud-monitoring/samples/Rakefile
@@ -18,3 +18,16 @@ Rake::TestTask.new "test" do |t|
   t.test_files = FileList["acceptance/*_test.rb"]
   t.warning = false
 end
+
+task "clean_fixtures" do
+  require "google/cloud/monitoring"
+  project_id = ENV["GOOGLE_CLOUD_PROJECT"]
+  raise "Set the environment variable GOOGLE_CLOUD_PROJECT." if project_id.nil?
+  client = Google::Cloud::Monitoring.uptime_check_service
+  project_name = client.project_path project: project_id
+  configs = client.list_uptime_check_configs parent: project_name
+  configs.each do |config|
+    puts "Cleaning #{config.name}..."
+    client.delete_uptime_check_config name: config.name
+  end
+end

--- a/google-cloud-monitoring/samples/acceptance/helper.rb
+++ b/google-cloud-monitoring/samples/acceptance/helper.rb
@@ -15,6 +15,7 @@
 require "minitest/autorun"
 require "minitest/spec"
 require "minitest/focus"
+require "minitest/hooks/default"
 
 require "google/cloud/monitoring"
 require "google/cloud/monitoring/v3"

--- a/google-cloud-monitoring/samples/acceptance/uptime_check_test.rb
+++ b/google-cloud-monitoring/samples/acceptance/uptime_check_test.rb
@@ -20,16 +20,6 @@ describe "Monitoring uptime check" do
     @project_id = ENV["GOOGLE_CLOUD_PROJECT"]
     raise "Set the environment variable GOOGLE_CLOUD_PROJECT." if @project_id.nil?
 
-    # Delete all uptime checks before running tests.
-    client = Google::Cloud::Monitoring.uptime_check_service
-    project_name = client.project_path project: @project_id
-    configs = client.list_uptime_check_configs parent: project_name
-    configs.each do |config|
-      capture_io do
-        delete_uptime_check_config config.name
-      end
-    end
-
     capture_io do
       @configs = [create_uptime_check_config(project_id: @project_id),
                   create_uptime_check_config(project_id: @project_id)]


### PR DESCRIPTION
Monitoring sample tests would flake if multiple tests were run simultaneously, because the uptime check test would attempt to delete checks at the beginning, and that could stomp on checks being used by other concurrently running tests. Instead, we assume that tests clean up after themselves, and do not attempt to clean up at the beginning. We also provide a manual rake task that cleans the fixtures in a project if we should need it.

Also: added the proper "require" for minitest/hooks. Forgot to require it before, so the `before :all` and `after :all` were not behaving correctly.