### PR TITLE
Update DLP samples to include locations/global in parent field

### DIFF
--- a/google-cloud-dlp/samples/README.md
+++ b/google-cloud-dlp/samples/README.md
@@ -15,8 +15,8 @@ These samples show how to use the [Google Cloud DLP API](https://cloud.google.co
     Follow instructions from the available [quickstarts](https://cloud.google.com/sdk/docs/quickstarts)
 1.  **Clone the repo** and cd into this directory
     ```
-    $ git clone https://github.com/GoogleCloudPlatform/ruby-docs-samples
-    $ cd ruby-docs-samples/dlp
+    $ git clone https://github.com/GoogleCloudPlatform/google-cloud-ruby
+    $ cd google-cloud-ruby/google-cloud-dlp/samples
     ```
 
 1. **Install Dependencies** via [Bundler](https://bundler.io).

--- a/google-cloud-dlp/samples/quickstart.rb
+++ b/google-cloud-dlp/samples/quickstart.rb
@@ -37,7 +37,7 @@ request_configuration = {
 item_to_inspect = { value: "Robert Frost" }
 
 # Run request
-parent = "projects/#{ENV['GOOGLE_CLOUD_PROJECT']}"
+parent = "projects/#{ENV['GOOGLE_CLOUD_PROJECT']}/locations/global"
 response = dlp.inspect_content parent:         parent,
                                inspect_config: request_configuration,
                                item:           item_to_inspect

--- a/google-cloud-dlp/samples/sample.rb
+++ b/google-cloud-dlp/samples/sample.rb
@@ -39,7 +39,7 @@ def inspect_string project_id: nil, content: nil, max_findings: 0
   item_to_inspect = { value: content }
 
   # Run request
-  parent = "projects/#{project_id}"
+  parent = "projects/#{project_id}/locations/global"
   response = dlp.inspect_content parent:         parent,
                                  inspect_config: inspect_config,
                                  item:           item_to_inspect
@@ -85,7 +85,7 @@ def inspect_file project_id: nil, filename: nil, max_findings: 0
   item_to_inspect = { byte_item: { type: :BYTES_TYPE_UNSPECIFIED, data: file.read } }
 
   # Run request
-  parent = "projects/#{project_id}"
+  parent = "projects/#{project_id}/locations/global"
   response = dlp.inspect_content parent:         parent,
                                  inspect_config: inspect_config,
                                  item:           item_to_inspect


### PR DESCRIPTION
This fixes internal bug b/158100365 for Ruby. The Ruby samples actually don't break like some other languages (since there aren't any that use pubsub or depend on the returned job name), but this keeps the usage consistent across languages.

Also a minor fix to the DLP samples README since it seemed to have been copied from a previous repo and not updated.

I couldn't get the tests to run on my machine (various Ruby installation errors), but I was able to run the samples successfully. 