### PR TITLE
Release google-cloud-memcache-v1beta2 0.1.0

### DIFF
--- a/google-cloud-memcache-v1beta2/CHANGELOG.md
+++ b/google-cloud-memcache-v1beta2/CHANGELOG.md
@@ -1,2 +1,6 @@
 # Release History
 
+### 0.1.0 / 2020-06-15
+
+Initial release.
+

--- a/google-cloud-memcache-v1beta2/lib/google/cloud/memcache/v1beta2/version.rb
+++ b/google-cloud-memcache-v1beta2/lib/google/cloud/memcache/v1beta2/version.rb
@@ -21,7 +21,7 @@ module Google
   module Cloud
     module Memcache
       module V1beta2
-        VERSION = "0.0.1"
+        VERSION = "0.1.0"
       end
     end
   end


### PR DESCRIPTION
Initial release.

<details><summary>Commits since previous release</summary><pre><code></code></pre></details>

This pull request was generated using releasetool.