### PR TITLE
Release grafeas 1.0.0

### DIFF
--- a/grafeas-client/grafeas-client.gemspec
+++ b/grafeas-client/grafeas-client.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.4"
 
-  gem.add_dependency "grafeas", "~> 0.1"
+  gem.add_dependency "grafeas", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "redcarpet", "~> 3.0"

--- a/grafeas/CHANGELOG.md
+++ b/grafeas/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Release History
 
+### 1.0.0 / 2020-06-15
+
+This is a major update with significant new features, improved documentation, and a fair number of breaking changes.
+
+Among the highlights:
+
+* Generic defaults do not default to Google's implementation. (Use the google-cloud-container_analysis gem for a Google-specific client.)
+* Separate client libraries are now provided for specific service versions.
+* A new configuration mechanism makes it easier to control parameters such as endpoint address, network timeouts, and retry.
+* A consistent method interface using keyword arguments for all fields, and supporting request proto objects.
+* Helper methods for generating resource paths are more accessible.
+
+See the MIGRATING file in the documentation for more detailed information, and instructions for migrating from earlier versions.
+
 ### 0.3.1 / 2020-04-01
 
 #### Documentation

--- a/grafeas/lib/grafeas/version.rb
+++ b/grafeas/lib/grafeas/version.rb
@@ -18,5 +18,5 @@
 
 
 module Grafeas
-  VERSION = "0.3.1"
+  VERSION = "1.0.0"
 end


### PR DESCRIPTION
This is a major update with significant new features, improved documentation, and a fair number of breaking changes.

Among the highlights:

* Generic defaults do not default to Google's implementation. (Use the google-cloud-container_analysis gem for a Google-specific client.)
* Separate client libraries are now provided for specific service versions.
* A new configuration mechanism makes it easier to control parameters such as endpoint address, network timeouts, and retry.
* A consistent method interface using keyword arguments for all fields, and supporting request proto objects.
* Helper methods for generating resource paths are more accessible.

See the MIGRATING file in the documentation for more detailed information, and instructions for migrating from earlier versions.

<details><summary>Commits since previous release</summary><pre><code>commit e3071bebfaf2acfec3a747920d097cacaee49e37
Author: Daniel Azuma <dazuma@google.com>
Date:   Mon Jun 8 10:37:29 2020 -0700

    feat(grafeas)!: Convert grafeas to a wrapper gem

commit 703b3425a905bdb2de1a7653229d5fb4af28f65a
Author: Daniel Azuma <dazuma@google.com>
Date:   Tue May 19 09:14:38 2020 -0700

    chore: Pin protobuf for old rubies and always require minitest/focus

commit c4b951980c636dc65842dd09fbd85ebdbbb46592
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Sun Apr 12 08:52:12 2020 -0700

    chore(grafeas): Regenerate with Artman 2.0.0

commit c79a0200e1e920cee6cf2c4ea813be4cc119ad6c
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Wed Apr 8 14:06:56 2020 -0700

    refactor(grafeas): A couple of methods reordered because gapic V2.
</code></pre></details>

This pull request was generated using releasetool.