### PR TITLE
chore: Move translate samples from ruby-docs-samples

### DIFF
--- a/google-cloud-translate-v2/lib/google/cloud/translate/v2/service.rb
+++ b/google-cloud-translate-v2/lib/google/cloud/translate/v2/service.rb
@@ -28,7 +28,7 @@ module Google
         # Represents the Translation API REST service, exposing the API calls.
         class Service #:nodoc:
           API_VERSION = "v2".freeze
-          API_URL = "https://translation.googleapis.com".freeze
+          API_HOST = "translate.googleapis.com".freeze
 
           # @private
           attr_accessor :project_id, :credentials, :retries, :timeout, :key
@@ -41,7 +41,7 @@ module Google
             @retries = retries
             @timeout = timeout
             @key = key
-            @host = host || API_URL
+            @url = "https://#{host || API_HOST}"
           end
 
           ##
@@ -102,7 +102,7 @@ module Google
           # The HTTP object that makes calls to API.
           # This must be a Faraday object.
           def http
-            @http ||= Faraday.new url: @host, request: {
+            @http ||= Faraday.new url: @url, request: {
               open_timeout: @timeout, timeout: @timeout
             }.delete_if { |_k, v| v.nil? }
           end

--- a/google-cloud-translate/acceptance/translate_helper.rb
+++ b/google-cloud-translate/acceptance/translate_helper.rb
@@ -21,7 +21,7 @@ require "minitest/rg"
 require "google/cloud/translate/v2"
 
 # Create shared translate object so we don't create new for each test
-$translate = Google::Cloud::Translate::V2.new retries: 10
+$translate = Google::Cloud::Translate.translation_v2_service retries: 10
 
 module Acceptance
   ##

--- a/google-cloud-translate/lib/google/cloud/translate.rb
+++ b/google-cloud-translate/lib/google/cloud/translate.rb
@@ -39,6 +39,8 @@ require "google/cloud/config"
   config.add_field! :metadata,      nil, match: ::Hash
   config.add_field! :retry_policy,  nil, match: [::Hash, ::Proc]
   config.add_field! :quota_project, nil, match: ::String
+  config.add_field! :key,           nil, match: ::String
+  config.add_field! :retries,       nil, match: ::Integer
 end
 
 module Google

--- a/google-cloud-translate/samples/Gemfile
+++ b/google-cloud-translate/samples/Gemfile
@@ -1,4 +1,4 @@
-# Copyright 2016 Google, Inc
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-translate/samples/Gemfile
+++ b/google-cloud-translate/samples/Gemfile
@@ -1,0 +1,30 @@
+# Copyright 2016 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source "https://rubygems.org"
+
+master = ENV["GOOGLE_CLOUD_SAMPLES_TEST"] == "master"
+
+gem "google-cloud-translate", path: master ? "../../google-cloud-translate" : nil
+gem "google-cloud-translate-v2", path: master ? "../../google-cloud-translate-v2" : nil
+gem "google-cloud-translate-v3", path: master ? "../../google-cloud-translate-v3" : nil
+
+group :test do
+  gem "google-style", "~> 1.24.0"
+  gem "irb"
+  gem "minitest", "~> 5.14"
+  gem "minitest-focus", "~> 1.1"
+  gem "minitest-hooks", "~> 1.5"
+  gem "rake", ">= 12.0"
+end

--- a/google-cloud-translate/samples/README.md
+++ b/google-cloud-translate/samples/README.md
@@ -1,0 +1,103 @@
+<img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
+
+# Google Cloud Translation API Ruby Samples
+
+The [Google Cloud Translation API][translate_docs] can dynamically translate
+text between thousands of language pairs. The Cloud Translation API lets
+websites and programs integrate with the translation service programmatically.
+
+[translate_docs]: https://cloud.google.com/translate/docs/
+
+## Setup
+
+### Authentication
+
+Authentication is typically done through [Application Default Credentials](https://cloud.google.com/docs/authentication#getting_credentials_for_server-centric_flow)
+, which means you do not have to change the code to authenticate as long as your
+environment has credentials. You have a few options for setting up
+authentication:
+
+1. When running locally, use the [Google Cloud SDK](https://cloud.google.com/sdk/)
+
+    `gcloud auth application-default login`
+
+1. When running on App Engine or Compute Engine, credentials are already set-up.
+However, you may need to configure your Compute Engine instance with
+[additional scopes](https://cloud.google.com/compute/docs/authentication#using).
+
+1. You can create a [Service Account key file](https://cloud.google.com/docs/authentication#service_accounts)
+. This file can be used to authenticate to Google Cloud Platform services from
+any environment. To use the file, set the `GOOGLE_APPLICATION_CREDENTIALS`
+environment variable to the path to the key file, for example:
+
+    `export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service_account.json`
+
+### Set Project ID
+
+Next, set the *GOOGLE_CLOUD_PROJECT* environment variable to the project name
+set in the
+[Google Cloud Platform Developer Console](https://console.cloud.google.com):
+
+    `export GOOGLE_CLOUD_PROJECT="YOUR-PROJECT-ID"`
+
+### Set AutoML Translation Model ID
+
+To run the V3 tests that use an AutoML Translation Model, set the
+*AUTOML_TRANSLATION_MODEL_ID* environment variable to the model ID
+you want to use to translate your content. See
+[Using the AutoML API](https://cloud.google.com/translate/automl/docs/predict#using_the).
+
+    `export AUTOML_TRANSLATION_MODEL_ID="YOUR-MODEL-ID"`
+
+### Install Dependencies
+
+1. Install the [Bundler](http://bundler.io/) gem.
+
+1. Install dependencies using:
+
+    `bundle install`
+
+## Run all samples
+
+Run all samples:
+
+    bundle exec rspec
+
+Run only the V3 samples:
+
+    bundle exec rspec spec/translate_v3_samples_spec.rb
+
+Run one specific V3 sample:
+
+    bundle exec rspec -t translate_v3_translate_text
+
+Run a group of V3 samples that share the same example description:
+
+    bundle exec rspec -e "Translating Text"
+
+Some samples require additional environment variables:
+
+    AUTOML_TRANSLATION_MODEL_ID=TRL123 TRANSLATE_BUCKET=trnslt bundle exec rspec
+
+## Run samples (old)
+
+Run the sample:
+
+    bundle exec ruby translate_samples.rb
+
+Usage:
+
+  Usage: ruby translate_samples.rb <command> [arguments]
+
+  Commands:
+    translate       <desired-language-code> <text>
+    detect_language <text>
+    list_names      <language-code-for-display>
+    list_codes
+
+  Examples:
+
+    ruby translate_samples.rb translate fr "Hello World"
+    ruby translate_samples.rb detect_language "Hello World"
+    ruby translate_samples.rb list_codes
+    ruby translate_samples.rb list_names en

--- a/google-cloud-translate/samples/README.md
+++ b/google-cloud-translate/samples/README.md
@@ -17,20 +17,20 @@ Authentication is typically done through [Application Default Credentials](https
 environment has credentials. You have a few options for setting up
 authentication:
 
-1. When running locally, use the [Google Cloud SDK](https://cloud.google.com/sdk/)
+1.  When running locally, use the [Google Cloud SDK](https://cloud.google.com/sdk/)
 
-    `gcloud auth application-default login`
+        gcloud auth application-default login
 
-1. When running on App Engine or Compute Engine, credentials are already set-up.
-However, you may need to configure your Compute Engine instance with
-[additional scopes](https://cloud.google.com/compute/docs/authentication#using).
+1.  When running on App Engine or Compute Engine, credentials are already set-up.
+    However, you may need to configure your Compute Engine instance with
+    [additional scopes](https://cloud.google.com/compute/docs/authentication#using).
 
-1. You can create a [Service Account key file](https://cloud.google.com/docs/authentication#service_accounts)
-. This file can be used to authenticate to Google Cloud Platform services from
-any environment. To use the file, set the `GOOGLE_APPLICATION_CREDENTIALS`
-environment variable to the path to the key file, for example:
+1.  You can create a [Service Account key file](https://cloud.google.com/docs/authentication#service_accounts).
+    This file can be used to authenticate to Google Cloud Platform services from
+    any environment. To use the file, set the `GOOGLE_APPLICATION_CREDENTIALS`
+    environment variable to the path to the key file, for example:
 
-    `export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service_account.json`
+        export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service_account.json
 
 ### Set Project ID
 
@@ -38,66 +38,33 @@ Next, set the *GOOGLE_CLOUD_PROJECT* environment variable to the project name
 set in the
 [Google Cloud Platform Developer Console](https://console.cloud.google.com):
 
-    `export GOOGLE_CLOUD_PROJECT="YOUR-PROJECT-ID"`
-
-### Set AutoML Translation Model ID
-
-To run the V3 tests that use an AutoML Translation Model, set the
-*AUTOML_TRANSLATION_MODEL_ID* environment variable to the model ID
-you want to use to translate your content. See
-[Using the AutoML API](https://cloud.google.com/translate/automl/docs/predict#using_the).
-
-    `export AUTOML_TRANSLATION_MODEL_ID="YOUR-MODEL-ID"`
+    export GOOGLE_CLOUD_PROJECT="YOUR-PROJECT-ID"
 
 ### Install Dependencies
 
-1. Install the [Bundler](http://bundler.io/) gem.
+1.  Install the [Bundler](http://bundler.io/) gem.
 
-1. Install dependencies using:
+2.  Decide whether to run against the current code in git, or the latest gem
+    release. To run against the current git code:
 
-    `bundle install`
+        export GOOGLE_CLOUD_SAMPLES_TEST=master
 
-## Run all samples
+    To run against the latest gem release, unset that variable.
 
-Run all samples:
+3.  Install dependencies using:
 
-    bundle exec rspec
+        bundle install
 
-Run only the V3 samples:
+### Install fixtures
 
-    bundle exec rspec spec/translate_v3_samples_spec.rb
+Some samples require a test fixture to be installed in your project
+(specifically, a glossary that is used for testing get and list commands).
+To install this fixture:
 
-Run one specific V3 sample:
+    bundle exec rake fixtures:create
 
-    bundle exec rspec -t translate_v3_translate_text
+This is a task that needs to be run only once per project.
 
-Run a group of V3 samples that share the same example description:
+## Testing samples
 
-    bundle exec rspec -e "Translating Text"
-
-Some samples require additional environment variables:
-
-    AUTOML_TRANSLATION_MODEL_ID=TRL123 TRANSLATE_BUCKET=trnslt bundle exec rspec
-
-## Run samples (old)
-
-Run the sample:
-
-    bundle exec ruby translate_samples.rb
-
-Usage:
-
-  Usage: ruby translate_samples.rb <command> [arguments]
-
-  Commands:
-    translate       <desired-language-code> <text>
-    detect_language <text>
-    list_names      <language-code-for-display>
-    list_codes
-
-  Examples:
-
-    ruby translate_samples.rb translate fr "Hello World"
-    ruby translate_samples.rb detect_language "Hello World"
-    ruby translate_samples.rb list_codes
-    ruby translate_samples.rb list_names en
+    bundle exec rake test

--- a/google-cloud-translate/samples/Rakefile
+++ b/google-cloud-translate/samples/Rakefile
@@ -1,0 +1,96 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "rake/testtask"
+
+Rake::TestTask.new "test" do |t|
+  t.test_files = FileList["*/acceptance/*_test.rb"]
+  t.warning = false
+end
+
+# rubocop:disable Metrics/BlockLength
+
+namespace :fixtures do
+  desc "Creates the needed fixtures"
+  task :create do
+    require "google/cloud/translate"
+    project_id = ENV["GOOGLE_CLOUD_PROJECT"]
+    location_id = "us-central1"
+    listable_glossary = "glossary-listable"
+    raise "Set the environment variable GOOGLE_CLOUD_PROJECT." if project_id.nil?
+
+    client = Google::Cloud::Translate.translation_service
+    parent = client.location_path project: project_id, location: location_id
+    name = client.glossary_path project: project_id, location: location_id, glossary: listable_glossary
+
+    begin
+      client.get_glossary name: name
+      puts "Fixtures already present."
+    rescue Google::Cloud::NotFoundError
+      input_uri = "gs://cloud-samples-data/translation/glossary_ja.csv"
+      glossary = {
+        name:               name,
+        language_codes_set: { language_codes: ["en", "ja"] },
+        input_config:       { gcs_source: { input_uri: input_uri } }
+      }
+      puts "Creating #{name} ..."
+      operation = client.create_glossary parent: parent, glossary: glossary
+      operation.wait_until_done!
+      if operation.error?
+        puts "Error creating #{name}"
+      elsif operation.response?
+        puts "Finished creating #{name}"
+      else
+        puts "Did not finish creating #{name}"
+      end
+    end
+  end
+
+  desc "Cleans out any extra fixture data that has been left behind by previous tests"
+  task :clean do
+    require "google/cloud/translate"
+    project_id = ENV["GOOGLE_CLOUD_PROJECT"]
+    location_id = "us-central1"
+    listable_glossary = "glossary-listable"
+    raise "Set the environment variable GOOGLE_CLOUD_PROJECT." if project_id.nil?
+
+    client = Google::Cloud::Translate.translation_service
+    parent = client.location_path project: project_id, location: location_id
+    responses = client.list_glossaries parent: parent
+
+    threads = responses.map do |response|
+      name = response.name
+      if name.end_with? listable_glossary
+        puts "Keeping #{name}"
+        nil
+      else
+        puts "Deleting #{name} ..."
+        operation = client.delete_glossary name: name
+        Thread.new do
+          operation.wait_until_done!
+          if operation.error?
+            puts "Error deleting #{name}"
+          elsif operation.response?
+            puts "Finished deleting #{name}"
+          else
+            puts "Did not finish deleting #{name}"
+          end
+        end
+      end
+    end
+    threads.compact.each(&:join)
+  end
+end
+
+# rubocop:enable Metrics/BlockLength

--- a/google-cloud-translate/samples/v2/acceptance/helper.rb
+++ b/google-cloud-translate/samples/v2/acceptance/helper.rb
@@ -1,0 +1,27 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "minitest/autorun"
+require "minitest/focus"
+
+require "google/cloud/translate"
+
+class TranslateSpec < Minitest::Spec
+  register_spec_type self do |_desc, *more_desc|
+    more_desc.include? :translate
+  end
+
+  let(:project_id) { ENV["GOOGLE_CLOUD_PROJECT"] }
+  let(:client) { Google::Cloud::Translate.translation_v2_service }
+end

--- a/google-cloud-translate/samples/v2/acceptance/translate_detect_language_test.rb
+++ b/google-cloud-translate/samples/v2/acceptance/translate_detect_language_test.rb
@@ -1,0 +1,24 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "helper"
+require_relative "../translate_detect_language"
+
+describe "translate_detect_language", :translate do
+  it "detects English" do
+    assert_output(/'Sample text written in English' detected as language: en/) do
+      translate_detect_language project_id: project_id, text: "Sample text written in English"
+    end
+  end
+end

--- a/google-cloud-translate/samples/v2/acceptance/translate_list_codes_test.rb
+++ b/google-cloud-translate/samples/v2/acceptance/translate_list_codes_test.rb
@@ -1,0 +1,30 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "helper"
+require_relative "../translate_list_codes"
+
+describe "translate_list_codes", :translate do
+  it "returns codes" do
+    out, _err, = capture_io do
+      translate_list_codes project_id: project_id
+    end
+    out_lines = out.split "\n"
+    assert_includes out_lines, "af"
+    assert_includes out_lines, "am"
+    assert_includes out_lines, "ar"
+    assert_includes out_lines, "az"
+    assert_includes out_lines, "be"
+  end
+end

--- a/google-cloud-translate/samples/v2/acceptance/translate_list_language_names_test.rb
+++ b/google-cloud-translate/samples/v2/acceptance/translate_list_language_names_test.rb
@@ -1,0 +1,30 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "helper"
+require_relative "../translate_list_language_names"
+
+describe "translate_list_language_names", :translate do
+  it "returns names" do
+    out, _err, = capture_io do
+      translate_list_language_names project_id: project_id
+    end
+    out_lines = out.split "\n"
+    assert_includes out_lines, "af Afrikaans"
+    assert_includes out_lines, "am Amharic"
+    assert_includes out_lines, "ar Arabic"
+    assert_includes out_lines, "az Azerbaijani"
+    assert_includes out_lines, "be Belarusian"
+  end
+end

--- a/google-cloud-translate/samples/v2/acceptance/translate_text_with_model_test.rb
+++ b/google-cloud-translate/samples/v2/acceptance/translate_text_with_model_test.rb
@@ -1,0 +1,28 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "helper"
+require_relative "../translate_text_with_model"
+
+describe "translate_text_with_model", :translate do
+  it "translates English to French" do
+    out, _err = capture_io do
+      translate_text_with_model project_id:    project_id,
+                                language_code: "fr",
+                                text:          "Alice and Bob are kind"
+    end
+    assert_match(/Original language: en translated to: fr/, out)
+    assert_match(/Translated 'Alice and Bob are kind' to '"Alice et Bob sont gentils"'/, out)
+  end
+end

--- a/google-cloud-translate/samples/v2/acceptance/translate_translate_text_test.rb
+++ b/google-cloud-translate/samples/v2/acceptance/translate_translate_text_test.rb
@@ -1,0 +1,28 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "helper"
+require_relative "../translate_translate_text"
+
+describe "translate_translate_text", :translate do
+  it "translates English to French" do
+    out, _err = capture_io do
+      translate_translate_text project_id:    project_id,
+                               language_code: "fr",
+                               text:          "Alice and Bob are kind"
+    end
+    assert_match(/Original language: en translated to: fr/, out)
+    assert_match(/Translated 'Alice and Bob are kind' to '"Alice et Bob sont gentils"'/, out)
+  end
+end

--- a/google-cloud-translate/samples/v2/translate_detect_language.rb
+++ b/google-cloud-translate/samples/v2/translate_detect_language.rb
@@ -1,0 +1,28 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def translate_detect_language project_id:, text:
+  # [START translate_detect_language]
+  # project_id = "Your Google Cloud project ID"
+  # text       = "The text you would like to detect the language of"
+
+  require "google/cloud/translate"
+
+  translate = Google::Cloud::Translate.translation_v2_service project_id: project_id
+  detection = translate.detect text
+
+  puts "'#{text}' detected as language: #{detection.language}"
+  puts "Confidence: #{detection.confidence}"
+  # [END translate_detect_language]
+end

--- a/google-cloud-translate/samples/v2/translate_list_codes.rb
+++ b/google-cloud-translate/samples/v2/translate_list_codes.rb
@@ -1,0 +1,29 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def translate_list_codes project_id:
+  # [START translate_list_codes]
+  # project_id = "Your Google Cloud project ID"
+
+  require "google/cloud/translate"
+
+  translate = Google::Cloud::Translate.translation_v2_service project_id: project_id
+  languages = translate.languages
+
+  puts "Supported language codes:"
+  languages.each do |language|
+    puts language.code
+  end
+  # [END translate_list_codes]
+end

--- a/google-cloud-translate/samples/v2/translate_list_language_names.rb
+++ b/google-cloud-translate/samples/v2/translate_list_language_names.rb
@@ -1,0 +1,33 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def translate_list_language_names project_id:, language_code: "en"
+  # [START translate_list_language_names]
+  # project_id = "Your Google Cloud project ID"
+
+  # To receive the names of the supported languages, provide the code
+  # for the language in which you wish to receive the names
+  # language_code = "en"
+
+  require "google/cloud/translate"
+
+  translate = Google::Cloud::Translate.translation_v2_service project_id: project_id
+  languages = translate.languages language_code
+
+  puts "Supported languages:"
+  languages.each do |language|
+    puts "#{language.code} #{language.name}"
+  end
+  # [END translate_list_language_names]
+end

--- a/google-cloud-translate/samples/v2/translate_text_with_model.rb
+++ b/google-cloud-translate/samples/v2/translate_text_with_model.rb
@@ -1,0 +1,29 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def translate_text_with_model project_id:, text:, language_code:
+  # [START translate_text_with_model]
+  # project_id    = "Your Google Cloud project ID"
+  # text          = "The text you would like to translate"
+  # language_code = "The ISO 639-1 code of language to translate to, eg. 'en'"
+
+  require "google/cloud/translate"
+
+  translate   = Google::Cloud::Translate.translation_v2_service project_id: project_id
+  translation = translate.translate text, to: language_code, model: "nmt"
+
+  puts "Translated '#{text}' to '#{translation.text.inspect}'"
+  puts "Original language: #{translation.from} translated to: #{translation.to}"
+  # [END translate_text_with_model]
+end

--- a/google-cloud-translate/samples/v2/translate_translate_text.rb
+++ b/google-cloud-translate/samples/v2/translate_translate_text.rb
@@ -1,0 +1,29 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def translate_translate_text project_id:, text:, language_code:
+  # [START translate_translate_text]
+  # project_id    = "Your Google Cloud project ID"
+  # text          = "The text you would like to translate"
+  # language_code = "The ISO 639-1 code of language to translate to, eg. 'en'"
+
+  require "google/cloud/translate"
+
+  translate   = Google::Cloud::Translate.translation_v2_service project_id: project_id
+  translation = translate.translate text, to: language_code
+
+  puts "Translated '#{text}' to '#{translation.text.inspect}'"
+  puts "Original language: #{translation.from} translated to: #{translation.to}"
+  # [END translate_translate_text]
+end

--- a/google-cloud-translate/samples/v3/acceptance/batch_translate_text_test.rb
+++ b/google-cloud-translate/samples/v3/acceptance/batch_translate_text_test.rb
@@ -31,8 +31,10 @@ describe "translate_v3_batch_translate_text", :translate do
     @mock_operation.expect :wait_until_done!, nil
     @mock_operation.expect :response, response
     @mock_grpc_stub = Minitest::Mock.new
-    @mock_grpc_stub.expect :call_rpc, @mock_operation do |rpc, _request, _options:|
+    @mock_grpc_stub.expect :call_rpc, @mock_operation do |rpc, request, options:|
       assert_equal :batch_translate_text, rpc
+      assert_instance_of Google::Cloud::Translate::V3::BatchTranslateTextRequest, request
+      refute_nil options
     end
 
     assert_output(/Total Characters: 13/) do

--- a/google-cloud-translate/samples/v3/acceptance/batch_translate_text_test.rb
+++ b/google-cloud-translate/samples/v3/acceptance/batch_translate_text_test.rb
@@ -1,0 +1,50 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "helper"
+require_relative "../batch_translate_text"
+
+require "minitest/mock"
+require "gapic/common"
+require "gapic/grpc"
+require "ostruct"
+
+describe "translate_v3_batch_translate_text", :translate do
+  it "translates English to Japanese" do
+    location_id = "us-central1"
+    input_uri = "gs://cloud-samples-data/text.txt"
+    output_uri = "gs://my-bucket/path_to_store_results/"
+
+    response = OpenStruct.new total_characters: 13, translated_characters: 13
+    @mock_operation = Minitest::Mock.new
+    @mock_operation.expect :wait_until_done!, nil
+    @mock_operation.expect :response, response
+    @mock_grpc_stub = Minitest::Mock.new
+    @mock_grpc_stub.expect :call_rpc, @mock_operation do |rpc, _request, _options:|
+      assert_equal :batch_translate_text, rpc
+    end
+
+    assert_output(/Total Characters: 13/) do
+      Gapic::ServiceStub.stub :new, @mock_grpc_stub do
+        translate_v3_batch_translate_text input_uri:   input_uri,
+                                          output_uri:  output_uri,
+                                          project_id:  project_id,
+                                          location_id: location_id
+      end
+    end
+
+    @mock_grpc_stub.verify
+    @mock_operation.verify
+  end
+end

--- a/google-cloud-translate/samples/v3/acceptance/batch_translate_text_with_glossary_and_model_test.rb
+++ b/google-cloud-translate/samples/v3/acceptance/batch_translate_text_with_glossary_and_model_test.rb
@@ -33,8 +33,10 @@ describe "translate_v3_batch_translate_text_with_glossary_and_model", :translate
     @mock_operation.expect :wait_until_done!, nil
     @mock_operation.expect :response, response
     @mock_grpc_stub = Minitest::Mock.new
-    @mock_grpc_stub.expect :call_rpc, @mock_operation do |rpc, request, _options:|
+    @mock_grpc_stub.expect :call_rpc, @mock_operation do |rpc, request, options:|
       assert_equal :batch_translate_text, rpc
+      assert_instance_of Google::Cloud::Translate::V3::BatchTranslateTextRequest, request
+      refute_nil options
       assert_match(/#{glossary_id}/, request.glossaries["ja"].glossary)
       assert_match(/#{model_id}/, request.models["ja"])
     end

--- a/google-cloud-translate/samples/v3/acceptance/batch_translate_text_with_glossary_and_model_test.rb
+++ b/google-cloud-translate/samples/v3/acceptance/batch_translate_text_with_glossary_and_model_test.rb
@@ -1,0 +1,56 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "helper"
+require_relative "../batch_translate_text_with_glossary_and_model"
+
+require "minitest/mock"
+require "gapic/common"
+require "gapic/grpc"
+require "ostruct"
+
+describe "translate_v3_batch_translate_text_with_glossary_and_model", :translate do
+  it "translates English to Japanese" do
+    location_id = "us-central1"
+    glossary_id = "glossary-listable"
+    model_id = "my-model"
+    input_uri = "gs://cloud-samples-data/text.txt"
+    output_uri = "gs://my-bucket/path_to_store_results/"
+
+    response = OpenStruct.new total_characters: 13, translated_characters: 13
+    @mock_operation = Minitest::Mock.new
+    @mock_operation.expect :wait_until_done!, nil
+    @mock_operation.expect :response, response
+    @mock_grpc_stub = Minitest::Mock.new
+    @mock_grpc_stub.expect :call_rpc, @mock_operation do |rpc, request, _options:|
+      assert_equal :batch_translate_text, rpc
+      assert_match(/#{glossary_id}/, request.glossaries["ja"].glossary)
+      assert_match(/#{model_id}/, request.models["ja"])
+    end
+
+    assert_output(/Total Characters: 13/) do
+      Gapic::ServiceStub.stub :new, @mock_grpc_stub do
+        translate_v3_batch_translate_text_with_glossary_and_model input_uri:   input_uri,
+                                                                  output_uri:  output_uri,
+                                                                  project_id:  project_id,
+                                                                  location_id: location_id,
+                                                                  glossary_id: glossary_id,
+                                                                  model_id:    model_id
+      end
+    end
+
+    @mock_grpc_stub.verify
+    @mock_operation.verify
+  end
+end

--- a/google-cloud-translate/samples/v3/acceptance/batch_translate_text_with_glossary_test.rb
+++ b/google-cloud-translate/samples/v3/acceptance/batch_translate_text_with_glossary_test.rb
@@ -1,0 +1,53 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "helper"
+require_relative "../batch_translate_text_with_glossary"
+
+require "minitest/mock"
+require "gapic/common"
+require "gapic/grpc"
+require "ostruct"
+
+describe "translate_v3_batch_translate_text_with_glossary", :translate do
+  it "translates English to Japanese" do
+    location_id = "us-central1"
+    glossary_id = "glossary-listable"
+    input_uri = "gs://cloud-samples-data/text.txt"
+    output_uri = "gs://my-bucket/path_to_store_results/"
+
+    response = OpenStruct.new total_characters: 13, translated_characters: 13
+    @mock_operation = Minitest::Mock.new
+    @mock_operation.expect :wait_until_done!, nil
+    @mock_operation.expect :response, response
+    @mock_grpc_stub = Minitest::Mock.new
+    @mock_grpc_stub.expect :call_rpc, @mock_operation do |rpc, request, _options:|
+      assert_equal :batch_translate_text, rpc
+      assert_match(/#{glossary_id}/, request.glossaries["ja"].glossary)
+    end
+
+    assert_output(/Total Characters: 13/) do
+      Gapic::ServiceStub.stub :new, @mock_grpc_stub do
+        translate_v3_batch_translate_text_with_glossary input_uri:   input_uri,
+                                                        output_uri:  output_uri,
+                                                        project_id:  project_id,
+                                                        location_id: location_id,
+                                                        glossary_id: glossary_id
+      end
+    end
+
+    @mock_grpc_stub.verify
+    @mock_operation.verify
+  end
+end

--- a/google-cloud-translate/samples/v3/acceptance/batch_translate_text_with_glossary_test.rb
+++ b/google-cloud-translate/samples/v3/acceptance/batch_translate_text_with_glossary_test.rb
@@ -32,8 +32,10 @@ describe "translate_v3_batch_translate_text_with_glossary", :translate do
     @mock_operation.expect :wait_until_done!, nil
     @mock_operation.expect :response, response
     @mock_grpc_stub = Minitest::Mock.new
-    @mock_grpc_stub.expect :call_rpc, @mock_operation do |rpc, request, _options:|
+    @mock_grpc_stub.expect :call_rpc, @mock_operation do |rpc, request, options:|
       assert_equal :batch_translate_text, rpc
+      assert_instance_of Google::Cloud::Translate::V3::BatchTranslateTextRequest, request
+      refute_nil options
       assert_match(/#{glossary_id}/, request.glossaries["ja"].glossary)
     end
 

--- a/google-cloud-translate/samples/v3/acceptance/batch_translate_text_with_model_test.rb
+++ b/google-cloud-translate/samples/v3/acceptance/batch_translate_text_with_model_test.rb
@@ -1,0 +1,53 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "helper"
+require_relative "../batch_translate_text_with_model"
+
+require "minitest/mock"
+require "gapic/common"
+require "gapic/grpc"
+require "ostruct"
+
+describe "translate_v3_batch_translate_text_with_model", :translate do
+  it "translates English to Japanese" do
+    location_id = "us-central1"
+    model_id = "my-model"
+    input_uri = "gs://cloud-samples-data/text.txt"
+    output_uri = "gs://my-bucket/path_to_store_results/"
+
+    response = OpenStruct.new total_characters: 13, translated_characters: 13
+    @mock_operation = Minitest::Mock.new
+    @mock_operation.expect :wait_until_done!, nil
+    @mock_operation.expect :response, response
+    @mock_grpc_stub = Minitest::Mock.new
+    @mock_grpc_stub.expect :call_rpc, @mock_operation do |rpc, request, _options:|
+      assert_equal :batch_translate_text, rpc
+      assert_match(/#{model_id}/, request.models["ja"])
+    end
+
+    assert_output(/Total Characters: 13/) do
+      Gapic::ServiceStub.stub :new, @mock_grpc_stub do
+        translate_v3_batch_translate_text_with_model input_uri:   input_uri,
+                                                     output_uri:  output_uri,
+                                                     project_id:  project_id,
+                                                     location_id: location_id,
+                                                     model_id:    model_id
+      end
+    end
+
+    @mock_grpc_stub.verify
+    @mock_operation.verify
+  end
+end

--- a/google-cloud-translate/samples/v3/acceptance/batch_translate_text_with_model_test.rb
+++ b/google-cloud-translate/samples/v3/acceptance/batch_translate_text_with_model_test.rb
@@ -32,8 +32,10 @@ describe "translate_v3_batch_translate_text_with_model", :translate do
     @mock_operation.expect :wait_until_done!, nil
     @mock_operation.expect :response, response
     @mock_grpc_stub = Minitest::Mock.new
-    @mock_grpc_stub.expect :call_rpc, @mock_operation do |rpc, request, _options:|
+    @mock_grpc_stub.expect :call_rpc, @mock_operation do |rpc, request, options:|
       assert_equal :batch_translate_text, rpc
+      assert_instance_of Google::Cloud::Translate::V3::BatchTranslateTextRequest, request
+      refute_nil options
       assert_match(/#{model_id}/, request.models["ja"])
     end
 

--- a/google-cloud-translate/samples/v3/acceptance/create_glossary_test.rb
+++ b/google-cloud-translate/samples/v3/acceptance/create_glossary_test.rb
@@ -1,0 +1,38 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "helper"
+require_relative "../create_glossary"
+
+require "securerandom"
+
+describe "translate_v3_create_glossary", :translate do
+  let(:glossary_id) { "glossary-#{SecureRandom.uuid}" }
+  let(:location_id) { "us-central1" }
+  let(:glossary_name) { client.glossary_path project: project_id, location: location_id, glossary: glossary_id }
+
+  after do
+    operation = client.delete_glossary name: glossary_name
+    operation.wait_until_done!
+  end
+
+  it "creates a glossary" do
+    out, _err = capture_io do
+      translate_v3_create_glossary project_id: project_id, location_id: location_id, glossary_id: glossary_id
+    end
+    assert_match(/#{glossary_id}/, out)
+
+    client.get_glossary name: glossary_name
+  end
+end

--- a/google-cloud-translate/samples/v3/acceptance/delete_glossary_test.rb
+++ b/google-cloud-translate/samples/v3/acceptance/delete_glossary_test.rb
@@ -1,0 +1,45 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "helper"
+require_relative "../delete_glossary"
+
+require "securerandom"
+
+describe "translate_v3_delete_glossary", :translate do
+  let(:glossary_id) { "glossary-#{SecureRandom.uuid}" }
+  let(:location_id) { "us-central1" }
+  let(:glossary_name) { client.glossary_path project: project_id, location: location_id, glossary: glossary_id }
+
+  it "deletes a glossary" do
+    input_uri = "gs://cloud-samples-data/translation/glossary_ja.csv"
+    glossary = {
+      name:               glossary_name,
+      language_codes_set: { language_codes: ["en", "ja"] },
+      input_config:       { gcs_source: { input_uri: input_uri } }
+    }
+    parent = client.location_path project: project_id, location: location_id
+    operation = client.create_glossary parent: parent, glossary: glossary
+    operation.wait_until_done!
+
+    out, _err = capture_io do
+      translate_v3_delete_glossary project_id: project_id, location_id: location_id, glossary_id: glossary_id
+    end
+    assert_match(/Deleted Glossary/, out)
+
+    assert_raises Google::Cloud::NotFoundError do
+      client.get_glossary name: glossary_name
+    end
+  end
+end

--- a/google-cloud-translate/samples/v3/acceptance/detect_language_test.rb
+++ b/google-cloud-translate/samples/v3/acceptance/detect_language_test.rb
@@ -1,0 +1,24 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "helper"
+require_relative "../detect_language"
+
+describe "translate_v3_detect_language", :translate do
+  it "detects English" do
+    assert_output(/Language Code: en/) do
+      translate_v3_detect_language project_id: project_id, location_id: "us-central1"
+    end
+  end
+end

--- a/google-cloud-translate/samples/v3/acceptance/get_glossary_test.rb
+++ b/google-cloud-translate/samples/v3/acceptance/get_glossary_test.rb
@@ -1,0 +1,28 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "helper"
+require_relative "../get_glossary"
+
+describe "translate_v3_get_glossary", :translate do
+  let(:location_id) { "us-central1" }
+  let(:glossary_id) { "glossary-listable" }
+
+  it "gets the fixture glossary" do
+    out, _err = capture_io do
+      translate_v3_get_glossary project_id: project_id, location_id: location_id, glossary_id: glossary_id
+    end
+    assert_match(/glossary-listable/, out)
+  end
+end

--- a/google-cloud-translate/samples/v3/acceptance/get_supported_languages_for_target_test.rb
+++ b/google-cloud-translate/samples/v3/acceptance/get_supported_languages_for_target_test.rb
@@ -1,0 +1,24 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "helper"
+require_relative "../get_supported_languages_for_target"
+
+describe "translate_v3_get_supported_languages_for_target", :translate do
+  it "reports the name of English" do
+    assert_output(/Display Name: English/) do
+      translate_v3_get_supported_languages_for_target project_id: project_id, location_id: "us-central1"
+    end
+  end
+end

--- a/google-cloud-translate/samples/v3/acceptance/get_supported_languages_test.rb
+++ b/google-cloud-translate/samples/v3/acceptance/get_supported_languages_test.rb
@@ -1,0 +1,24 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "helper"
+require_relative "../get_supported_languages"
+
+describe "translate_v3_get_supported_languages", :translate do
+  it "reports some languages" do
+    assert_output(/Language Code: ar/) do
+      translate_v3_get_supported_languages project_id: project_id, location_id: "us-central1"
+    end
+  end
+end

--- a/google-cloud-translate/samples/v3/acceptance/helper.rb
+++ b/google-cloud-translate/samples/v3/acceptance/helper.rb
@@ -1,0 +1,27 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "minitest/autorun"
+require "minitest/focus"
+
+require "google/cloud/translate"
+
+class TranslateSpec < Minitest::Spec
+  register_spec_type self do |_desc, *more_desc|
+    more_desc.include? :translate
+  end
+
+  let(:project_id) { ENV["GOOGLE_CLOUD_PROJECT"] }
+  let(:client) { Google::Cloud::Translate.translation_service }
+end

--- a/google-cloud-translate/samples/v3/acceptance/list_glossary_test.rb
+++ b/google-cloud-translate/samples/v3/acceptance/list_glossary_test.rb
@@ -1,0 +1,27 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "helper"
+require_relative "../list_glossary"
+
+describe "translate_v3_list_glossary", :translate do
+  let(:location_id) { "us-central1" }
+
+  it "lists glossaries" do
+    out, _err = capture_io do
+      translate_v3_list_glossary project_id: project_id, location_id: location_id
+    end
+    assert_match(/glossary-listable/, out)
+  end
+end

--- a/google-cloud-translate/samples/v3/acceptance/translate_text_test.rb
+++ b/google-cloud-translate/samples/v3/acceptance/translate_text_test.rb
@@ -1,0 +1,24 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "helper"
+require_relative "../translate_text"
+
+describe "translate_v3_translate_text", :translate do
+  it "translates English to French" do
+    assert_output "Translated text: Bonjour le monde!\n" do
+      translate_v3_translate_text project_id: project_id, location_id: "global"
+    end
+  end
+end

--- a/google-cloud-translate/samples/v3/acceptance/translate_text_with_glossary_and_model_test.rb
+++ b/google-cloud-translate/samples/v3/acceptance/translate_text_with_glossary_and_model_test.rb
@@ -28,7 +28,7 @@ describe "translate_v3_translate_text_with_glossary_and_model", :translate do
 
     @mock_grpc_stub = Minitest::Mock.new
     translation = OpenStruct.new translated_text: "Bonjour le monde!"
-    response = OpenStruct.new translations: [translation]
+    response = OpenStruct.new glossary_translations: [translation]
     @mock_grpc_stub.expect :call_rpc, response do |rpc, request, options:|
       assert_equal :translate_text, rpc
       assert_instance_of Google::Cloud::Translate::V3::TranslateTextRequest, request

--- a/google-cloud-translate/samples/v3/acceptance/translate_text_with_glossary_and_model_test.rb
+++ b/google-cloud-translate/samples/v3/acceptance/translate_text_with_glossary_and_model_test.rb
@@ -1,0 +1,49 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "helper"
+require_relative "../translate_text_with_glossary_and_model"
+
+require "minitest/mock"
+require "gapic/common"
+require "gapic/grpc"
+require "ostruct"
+
+describe "translate_v3_translate_text_with_glossary_and_model", :translate do
+  it "translates English to French" do
+    location_id = "us-central1"
+    glossary_id = "glossary-listable"
+    model_id = "my-model"
+
+    @mock_grpc_stub = Minitest::Mock.new
+    translation = OpenStruct.new translated_text: "Bonjour le monde!"
+    response = OpenStruct.new translations: [translation]
+    @mock_grpc_stub.expect :call_rpc, response do |rpc, request, _options:|
+      assert_equal :translate_text, rpc
+      assert_match(/#{glossary_id}/, request.glossary_config.glossary)
+      assert_match(/#{model_id}/, request.model)
+    end
+
+    assert_output "Translated text: Bonjour le monde!\n" do
+      Gapic::ServiceStub.stub :new, @mock_grpc_stub do
+        translate_v3_translate_text_with_glossary_and_model project_id:  project_id,
+                                                            location_id: location_id,
+                                                            glossary_id: glossary_id,
+                                                            model_id:    model_id
+      end
+    end
+
+    @mock_grpc_stub.verify
+  end
+end

--- a/google-cloud-translate/samples/v3/acceptance/translate_text_with_glossary_and_model_test.rb
+++ b/google-cloud-translate/samples/v3/acceptance/translate_text_with_glossary_and_model_test.rb
@@ -29,8 +29,10 @@ describe "translate_v3_translate_text_with_glossary_and_model", :translate do
     @mock_grpc_stub = Minitest::Mock.new
     translation = OpenStruct.new translated_text: "Bonjour le monde!"
     response = OpenStruct.new translations: [translation]
-    @mock_grpc_stub.expect :call_rpc, response do |rpc, request, _options:|
+    @mock_grpc_stub.expect :call_rpc, response do |rpc, request, options:|
       assert_equal :translate_text, rpc
+      assert_instance_of Google::Cloud::Translate::V3::TranslateTextRequest, request
+      refute_nil options
       assert_match(/#{glossary_id}/, request.glossary_config.glossary)
       assert_match(/#{model_id}/, request.model)
     end

--- a/google-cloud-translate/samples/v3/acceptance/translate_text_with_glossary_test.rb
+++ b/google-cloud-translate/samples/v3/acceptance/translate_text_with_glossary_test.rb
@@ -28,8 +28,10 @@ describe "translate_v3_translate_text_with_glossary", :translate do
     @mock_grpc_stub = Minitest::Mock.new
     translation = OpenStruct.new translated_text: "Bonjour le monde!"
     response = OpenStruct.new translations: [translation]
-    @mock_grpc_stub.expect :call_rpc, response do |rpc, request, _options:|
+    @mock_grpc_stub.expect :call_rpc, response do |rpc, request, options:|
       assert_equal :translate_text, rpc
+      assert_instance_of Google::Cloud::Translate::V3::TranslateTextRequest, request
+      refute_nil options
       assert_match(/#{glossary_id}/, request.glossary_config.glossary)
     end
 

--- a/google-cloud-translate/samples/v3/acceptance/translate_text_with_glossary_test.rb
+++ b/google-cloud-translate/samples/v3/acceptance/translate_text_with_glossary_test.rb
@@ -27,7 +27,7 @@ describe "translate_v3_translate_text_with_glossary", :translate do
 
     @mock_grpc_stub = Minitest::Mock.new
     translation = OpenStruct.new translated_text: "Bonjour le monde!"
-    response = OpenStruct.new translations: [translation]
+    response = OpenStruct.new glossary_translations: [translation]
     @mock_grpc_stub.expect :call_rpc, response do |rpc, request, options:|
       assert_equal :translate_text, rpc
       assert_instance_of Google::Cloud::Translate::V3::TranslateTextRequest, request

--- a/google-cloud-translate/samples/v3/acceptance/translate_text_with_glossary_test.rb
+++ b/google-cloud-translate/samples/v3/acceptance/translate_text_with_glossary_test.rb
@@ -1,0 +1,46 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "helper"
+require_relative "../translate_text_with_glossary"
+
+require "minitest/mock"
+require "gapic/common"
+require "gapic/grpc"
+require "ostruct"
+
+describe "translate_v3_translate_text_with_glossary", :translate do
+  it "translates English to French" do
+    location_id = "us-central1"
+    glossary_id = "glossary-listable"
+
+    @mock_grpc_stub = Minitest::Mock.new
+    translation = OpenStruct.new translated_text: "Bonjour le monde!"
+    response = OpenStruct.new translations: [translation]
+    @mock_grpc_stub.expect :call_rpc, response do |rpc, request, _options:|
+      assert_equal :translate_text, rpc
+      assert_match(/#{glossary_id}/, request.glossary_config.glossary)
+    end
+
+    assert_output "Translated text: Bonjour le monde!\n" do
+      Gapic::ServiceStub.stub :new, @mock_grpc_stub do
+        translate_v3_translate_text_with_glossary project_id:  project_id,
+                                                  location_id: location_id,
+                                                  glossary_id: glossary_id
+      end
+    end
+
+    @mock_grpc_stub.verify
+  end
+end

--- a/google-cloud-translate/samples/v3/acceptance/translate_text_with_model_test.rb
+++ b/google-cloud-translate/samples/v3/acceptance/translate_text_with_model_test.rb
@@ -1,0 +1,46 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "helper"
+require_relative "../translate_text_with_model"
+
+require "minitest/mock"
+require "gapic/common"
+require "gapic/grpc"
+require "ostruct"
+
+describe "translate_v3_translate_text_with_model", :translate do
+  it "translates English to French" do
+    location_id = "us-central1"
+    model_id = "my-model"
+
+    @mock_grpc_stub = Minitest::Mock.new
+    translation = OpenStruct.new translated_text: "Bonjour le monde!"
+    response = OpenStruct.new translations: [translation]
+    @mock_grpc_stub.expect :call_rpc, response do |rpc, request, _options:|
+      assert_equal :translate_text, rpc
+      assert_match(/#{model_id}/, request.model)
+    end
+
+    assert_output "Translated text: Bonjour le monde!\n" do
+      Gapic::ServiceStub.stub :new, @mock_grpc_stub do
+        translate_v3_translate_text_with_model project_id:  project_id,
+                                               location_id: location_id,
+                                               model_id:    model_id
+      end
+    end
+
+    @mock_grpc_stub.verify
+  end
+end

--- a/google-cloud-translate/samples/v3/acceptance/translate_text_with_model_test.rb
+++ b/google-cloud-translate/samples/v3/acceptance/translate_text_with_model_test.rb
@@ -28,8 +28,10 @@ describe "translate_v3_translate_text_with_model", :translate do
     @mock_grpc_stub = Minitest::Mock.new
     translation = OpenStruct.new translated_text: "Bonjour le monde!"
     response = OpenStruct.new translations: [translation]
-    @mock_grpc_stub.expect :call_rpc, response do |rpc, request, _options:|
+    @mock_grpc_stub.expect :call_rpc, response do |rpc, request, options:|
       assert_equal :translate_text, rpc
+      assert_instance_of Google::Cloud::Translate::V3::TranslateTextRequest, request
+      refute_nil options
       assert_match(/#{model_id}/, request.model)
     end
 

--- a/google-cloud-translate/samples/v3/batch_translate_text.rb
+++ b/google-cloud-translate/samples/v3/batch_translate_text.rb
@@ -1,0 +1,56 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def translate_v3_batch_translate_text input_uri:, output_uri:, project_id:, location_id:
+  # [START translate_v3_batch_translate_text]
+  require "google/cloud/translate"
+
+  # input_uri = "gs://cloud-samples-data/text.txt"
+  # output_uri = "gs://YOUR_BUCKET_ID/path_to_store_results/"
+  # project_id = "[Google Cloud Project ID]"
+  # location_id = "[LOCATION ID]"
+
+  source_lang = "en"
+  target_lang = "ja"
+  # Optional. Can be "text/plain" or "text/html".
+  mime_type = "text/plain"
+
+  client = Google::Cloud::Translate.translation_service
+
+  parent = client.location_path project: project_id, location: location_id
+  input_config = {
+    mime_type:  mime_type,
+    gcs_source: { input_uri: input_uri }
+  }
+  output_config = {
+    gcs_destination: { output_uri_prefix: output_uri }
+  }
+
+  operation = client.batch_translate_text(
+    parent:                parent,
+    source_language_code:  source_lang,
+    target_language_codes: [target_lang],
+    input_configs:         [input_config],
+    output_config:         output_config
+  )
+
+  # Wait until the long running operation is done
+  operation.wait_until_done!
+
+  response = operation.response
+
+  puts "Total Characters: #{response.total_characters}"
+  puts "Translated Characters: #{response.translated_characters}"
+  # [END translate_v3_batch_translate_text]
+end

--- a/google-cloud-translate/samples/v3/batch_translate_text_with_glossary.rb
+++ b/google-cloud-translate/samples/v3/batch_translate_text_with_glossary.rb
@@ -1,0 +1,70 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# rubocop:disable Metrics/MethodLength
+
+def translate_v3_batch_translate_text_with_glossary \
+  input_uri:, output_uri:, project_id:, location_id:, glossary_id:
+
+  # [START translate_v3_batch_translate_text_with_glossary]
+  require "google/cloud/translate"
+
+  # input_uri = "gs://cloud-samples-data/text.txt"
+  # output_uri = "gs://YOUR_BUCKET_ID/path_to_store_results/"
+  # project_id = "[Google Cloud Project ID]"
+  # location_id = "[LOCATION ID]"
+  # glossary_id = "[YOUR_GLOSSARY_ID]"
+
+  source_lang = "en"
+  target_lang = "ja"
+  # Optional. Can be "text/plain" or "text/html".
+  mime_type = "text/plain"
+
+  client = Google::Cloud::Translate.translation_service
+
+  parent = client.location_path project: project_id, location: location_id
+  glossary_path = client.glossary_path project:  project_id,
+                                       location: location_id,
+                                       glossary: glossary_id
+  glossaries = {
+    target_lang => { glossary: glossary_path }
+  }
+  input_config = {
+    mime_type:  mime_type,
+    gcs_source: { input_uri: input_uri }
+  }
+  output_config = {
+    gcs_destination: { output_uri_prefix: output_uri }
+  }
+
+  operation = client.batch_translate_text(
+    parent:                parent,
+    source_language_code:  source_lang,
+    target_language_codes: [target_lang],
+    input_configs:         [input_config],
+    output_config:         output_config,
+    glossaries:            glossaries
+  )
+
+  # Wait until the long running operation is done
+  operation.wait_until_done!
+
+  response = operation.response
+
+  puts "Total Characters: #{response.total_characters}"
+  puts "Translated Characters: #{response.translated_characters}"
+  # [END translate_v3_batch_translate_text_with_glossary]
+end
+
+# rubocop:enable Metrics/MethodLength

--- a/google-cloud-translate/samples/v3/batch_translate_text_with_glossary_and_model.rb
+++ b/google-cloud-translate/samples/v3/batch_translate_text_with_glossary_and_model.rb
@@ -1,0 +1,74 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# rubocop:disable Metrics/MethodLength
+
+def translate_v3_batch_translate_text_with_glossary_and_model \
+  input_uri:, output_uri:, project_id:, location_id:, model_id:, glossary_id:
+
+  # [START translate_v3_batch_translate_text_with_glossary_and_model]
+  require "google/cloud/translate"
+
+  # input_uri = "gs://cloud-samples-data/text.txt"
+  # output_uri = "gs://YOUR_BUCKET_ID/path_to_store_results/"
+  # project_id = "[Google Cloud Project ID]"
+  # location_id = "[LOCATION ID]"
+  # model_id = "[MODEL ID]"
+  # glossary_id = "[YOUR_GLOSSARY_ID]"
+
+  source_lang = "en"
+  target_lang = "ja"
+  # Optional. Can be "text/plain" or "text/html".
+  mime_type = "text/plain"
+
+  client = Google::Cloud::Translate.translation_service
+
+  parent = client.location_path project: project_id, location: location_id
+  glossary_path = client.glossary_path project:  project_id,
+                                       location: location_id,
+                                       glossary: glossary_id
+  model = "projects/#{project_id}/locations/#{location_id}/models/#{model_id}"
+  models = { target_lang => model }
+  glossaries = {
+    target_lang => { glossary: glossary_path }
+  }
+  input_config = {
+    mime_type:  mime_type,
+    gcs_source: { input_uri: input_uri }
+  }
+  output_config = {
+    gcs_destination: { output_uri_prefix: output_uri }
+  }
+
+  operation = client.batch_translate_text(
+    parent:                parent,
+    source_language_code:  source_lang,
+    target_language_codes: [target_lang],
+    input_configs:         [input_config],
+    output_config:         output_config,
+    models:                models,
+    glossaries:            glossaries
+  )
+
+  # Wait until the long running operation is done
+  operation.wait_until_done!
+
+  response = operation.response
+
+  puts "Total Characters: #{response.total_characters}"
+  puts "Translated Characters: #{response.translated_characters}"
+  # [END translate_v3_batch_translate_text_with_glossary_and_model]
+end
+
+# rubocop:enable Metrics/MethodLength

--- a/google-cloud-translate/samples/v3/batch_translate_text_with_model.rb
+++ b/google-cloud-translate/samples/v3/batch_translate_text_with_model.rb
@@ -1,0 +1,66 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# rubocop:disable Metrics/MethodLength
+
+def translate_v3_batch_translate_text_with_model \
+  input_uri:, output_uri:, project_id:, location_id:, model_id:
+
+  # [START translate_v3_batch_translate_text_with_model]
+  require "google/cloud/translate"
+
+  # input_uri = "gs://cloud-samples-data/text.txt"
+  # output_uri = "gs://YOUR_BUCKET_ID/path_to_store_results/"
+  # project_id = "[Google Cloud Project ID]"
+  # location_id = "[LOCATION ID]"
+  # model_id = "[MODEL ID]"
+
+  source_lang = "en"
+  target_lang = "ja"
+  # Optional. Can be "text/plain" or "text/html".
+  mime_type = "text/plain"
+
+  client = Google::Cloud::Translate.translation_service
+
+  parent = client.location_path project: project_id, location: location_id
+  model = "projects/#{project_id}/locations/#{location_id}/models/#{model_id}"
+  models = { target_lang => model }
+  input_config = {
+    mime_type:  mime_type,
+    gcs_source: { input_uri: input_uri }
+  }
+  output_config = {
+    gcs_destination: { output_uri_prefix: output_uri }
+  }
+
+  operation = client.batch_translate_text(
+    parent:                parent,
+    source_language_code:  source_lang,
+    target_language_codes: [target_lang],
+    input_configs:         [input_config],
+    output_config:         output_config,
+    models:                models
+  )
+
+  # Wait until the long running operation is done
+  operation.wait_until_done!
+
+  response = operation.response
+
+  puts "Total Characters: #{response.total_characters}"
+  puts "Translated Characters: #{response.translated_characters}"
+  # [END translate_v3_batch_translate_text_with_model]
+end
+
+# rubocop:enable Metrics/MethodLength

--- a/google-cloud-translate/samples/v3/create_glossary.rb
+++ b/google-cloud-translate/samples/v3/create_glossary.rb
@@ -1,0 +1,49 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def translate_v3_create_glossary project_id:, location_id:, glossary_id:
+  # [START translate_v3_create_glossary]
+  require "google/cloud/translate"
+
+  # project_id = "[Google Cloud Project ID]"
+  # location_id = "[LOCATION ID]"
+  # glossary_id = "your-glossary-display-name"
+
+  client = Google::Cloud::Translate.translation_service
+
+  input_uri = "gs://cloud-samples-data/translation/glossary_ja.csv"
+
+  parent = client.location_path project: project_id, location: location_id
+  glossary_name = client.glossary_path project:  project_id,
+                                       location: location_id,
+                                       glossary: glossary_id
+  language_codes_set = { language_codes: ["en", "ja"] }
+  input_config = { gcs_source: { input_uri: input_uri } }
+  glossary = {
+    name:               glossary_name,
+    language_codes_set: language_codes_set,
+    input_config:       input_config
+  }
+
+  operation = client.create_glossary parent: parent, glossary: glossary
+  # Wait until the long running operation is done
+  operation.wait_until_done!
+  response = operation.response
+
+  puts "Created Glossary."
+  puts "Glossary name: #{response.name}"
+  puts "Entry count: #{response.entry_count}"
+  puts "Input URI: #{response.input_config.gcs_source.input_uri}"
+  # [END translate_v3_create_glossary]
+end

--- a/google-cloud-translate/samples/v3/delete_glossary.rb
+++ b/google-cloud-translate/samples/v3/delete_glossary.rb
@@ -1,0 +1,36 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def translate_v3_delete_glossary project_id:, location_id:, glossary_id:
+  # [START translate_v3_delete_glossary]
+  require "google/cloud/translate"
+
+  # project_id = "[Google Cloud Project ID]"
+  # location_id = "[LOCATION ID]"
+  # glossary_id = "[YOUR_GLOSSARY_ID]"
+
+  client = Google::Cloud::Translate.translation_service
+
+  name = client.glossary_path project:  project_id,
+                              location: location_id,
+                              glossary: glossary_id
+
+  operation = client.delete_glossary name: name
+
+  # Wait until the long running operation is done
+  operation.wait_until_done!
+
+  puts "Deleted Glossary."
+  # [END translate_v3_delete_glossary]
+end

--- a/google-cloud-translate/samples/v3/detect_language.rb
+++ b/google-cloud-translate/samples/v3/detect_language.rb
@@ -1,0 +1,44 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def translate_v3_detect_language project_id:, location_id:
+  # [START translate_v3_detect_language]
+  require "google/cloud/translate"
+
+  # project_id = "[Google Cloud Project ID]"
+  # location_id = "[LOCATION ID]"
+
+  client = Google::Cloud::Translate.translation_service
+
+  # The text string for performing language detection
+  content = "Hello, world!"
+  # Optional. Can be "text/plain" or "text/html".
+  mime_type = "text/plain"
+
+  parent = client.location_path project: project_id, location: location_id
+
+  response = client.detect_language parent:    parent,
+                                    content:   content,
+                                    mime_type: mime_type
+
+  # Display list of detected languages sorted by detection confidence.
+  # The most probable language is first.
+  response.languages.each do |language|
+    # The language detected
+    puts "Language Code: #{language.language_code}"
+    # Confidence of detection result for this language
+    puts "Confidence: #{language.confidence}"
+  end
+  # [END translate_v3_detect_language]
+end

--- a/google-cloud-translate/samples/v3/get_glossary.rb
+++ b/google-cloud-translate/samples/v3/get_glossary.rb
@@ -1,0 +1,35 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def translate_v3_get_glossary project_id:, location_id:, glossary_id:
+  # [START translate_v3_get_glossary]
+  require "google/cloud/translate"
+
+  # project_id = "[Google Cloud Project ID]"
+  # location_id = "[LOCATION ID]"
+  # glossary_id = "[YOUR_GLOSSARY_ID]"
+
+  client = Google::Cloud::Translate.translation_service
+
+  name = client.glossary_path project:  project_id,
+                              location: location_id,
+                              glossary: glossary_id
+
+  response = client.get_glossary name: name
+
+  puts "Glossary name: #{response.name}"
+  puts "Entry count: #{response.entry_count}"
+  puts "Input URI: #{response.input_config.gcs_source.input_uri}"
+  # [END translate_v3_get_glossary]
+end

--- a/google-cloud-translate/samples/v3/get_supported_languages.rb
+++ b/google-cloud-translate/samples/v3/get_supported_languages.rb
@@ -1,0 +1,33 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def translate_v3_get_supported_languages project_id:, location_id:
+  # [START translate_v3_get_supported_languages]
+  require "google/cloud/translate"
+
+  # project_id = "[Google Cloud Project ID]"
+  # location_id = "[LOCATION ID]"
+
+  client = Google::Cloud::Translate.translation_service
+
+  parent = client.location_path project: project_id, location: location_id
+
+  response = client.get_supported_languages parent: parent
+
+  # List language codes of supported languages
+  response.languages.each do |language|
+    puts "Language Code: #{language.language_code}"
+  end
+  # [END translate_v3_get_supported_languages]
+end

--- a/google-cloud-translate/samples/v3/get_supported_languages_for_target.rb
+++ b/google-cloud-translate/samples/v3/get_supported_languages_for_target.rb
@@ -1,0 +1,36 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def translate_v3_get_supported_languages_for_target project_id:, location_id:
+  # [START translate_v3_get_supported_languages_for_target]
+  require "google/cloud/translate"
+
+  # project_id = "[Google Cloud Project ID]"
+  # location_id = "[LOCATION ID]"
+
+  client = Google::Cloud::Translate.translation_service
+
+  language_code = "en"
+  parent = client.location_path project: project_id, location: location_id
+
+  response = client.get_supported_languages parent:                parent,
+                                            display_language_code: language_code
+
+  # List language codes of supported languages
+  response.languages.each do |language|
+    puts "Language Code: #{language.language_code}"
+    puts "Display Name: #{language.display_name}"
+  end
+  # [END translate_v3_get_supported_languages_for_target]
+end

--- a/google-cloud-translate/samples/v3/list_glossary.rb
+++ b/google-cloud-translate/samples/v3/list_glossary.rb
@@ -1,0 +1,34 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def translate_v3_list_glossary project_id:, location_id:
+  # [START translate_v3_list_glossary]
+  require "google/cloud/translate"
+
+  # project_id = "[Google Cloud Project ID]"
+  # location_id = "[LOCATION ID]"
+
+  client = Google::Cloud::Translate.translation_service
+
+  parent = client.location_path project: project_id, location: location_id
+
+  responses = client.list_glossaries parent: parent
+
+  responses.each do |response|
+    puts "Glossary name: #{response.name}"
+    puts "Entry count: #{response.entry_count}"
+    puts "Input URI: #{response.input_config.gcs_source.input_uri}"
+  end
+  # [END translate_v3_list_glossary]
+end

--- a/google-cloud-translate/samples/v3/translate_text.rb
+++ b/google-cloud-translate/samples/v3/translate_text.rb
@@ -1,0 +1,40 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def translate_v3_translate_text project_id:, location_id:
+  # [START translate_v3_translate_text]
+  require "google/cloud/translate"
+
+  # project_id = "[Google Cloud Project ID]"
+  # location_id = "[LOCATION ID]"
+
+  # The content to translate in string format
+  contents = ["Hello, world!"]
+  # Required. The BCP-47 language code to use for translation.
+  target_language = "fr"
+
+  client = Google::Cloud::Translate.translation_service
+
+  parent = client.location_path project: project_id, location: location_id
+
+  response = client.translate_text parent:               parent,
+                                   contents:             contents,
+                                   target_language_code: target_language
+
+  # Display the translation for each input text provided
+  response.translations.each do |translation|
+    puts "Translated text: #{translation.translated_text}"
+  end
+  # [END translate_v3_translate_text]
+end

--- a/google-cloud-translate/samples/v3/translate_text_with_glossary.rb
+++ b/google-cloud-translate/samples/v3/translate_text_with_glossary.rb
@@ -45,7 +45,7 @@ def translate_v3_translate_text_with_glossary project_id:, location_id:, glossar
                                    mime_type:            mime_type
 
   # Display the translation for each input text provided
-  response.translations.each do |translation|
+  response.glossary_translations.each do |translation|
     puts "Translated text: #{translation.translated_text}"
   end
   # [END translate_v3_translate_text_with_glossary]

--- a/google-cloud-translate/samples/v3/translate_text_with_glossary.rb
+++ b/google-cloud-translate/samples/v3/translate_text_with_glossary.rb
@@ -1,0 +1,52 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def translate_v3_translate_text_with_glossary project_id:, location_id:, glossary_id:
+  # [START translate_v3_translate_text_with_glossary]
+  require "google/cloud/translate"
+
+  # project_id = "[Google Cloud Project ID]"
+  # location_id = "[LOCATION ID]"
+  # glossary_id = "[YOUR_GLOSSARY_ID]"
+
+  # The content to translate in string format
+  contents = ["Hello, world!"]
+  # Required. The BCP-47 language code to use for translation.
+  target_language = "fr"
+  # Optional. The BCP-47 language code of the input text.
+  source_language = "en"
+  # Optional. Can be "text/plain" or "text/html".
+  mime_type = "text/plain"
+
+  client = Google::Cloud::Translate.translation_service
+
+  parent = client.location_path project: project_id, location: location_id
+  glossary_path = client.glossary_path project:  project_id,
+                                       location: location_id,
+                                       glossary: glossary_id
+  glossary_config = { glossary: glossary_path }
+
+  response = client.translate_text parent:               parent,
+                                   contents:             contents,
+                                   target_language_code: target_language,
+                                   source_language_code: source_language,
+                                   glossary_config:      glossary_config,
+                                   mime_type:            mime_type
+
+  # Display the translation for each input text provided
+  response.translations.each do |translation|
+    puts "Translated text: #{translation.translated_text}"
+  end
+  # [END translate_v3_translate_text_with_glossary]
+end

--- a/google-cloud-translate/samples/v3/translate_text_with_glossary_and_model.rb
+++ b/google-cloud-translate/samples/v3/translate_text_with_glossary_and_model.rb
@@ -49,7 +49,7 @@ def translate_v3_translate_text_with_glossary_and_model project_id:, location_id
                                    mime_type:            mime_type
 
   # Display the translation for each input text provided
-  response.translations.each do |translation|
+  response.glossary_translations.each do |translation|
     puts "Translated text: #{translation.translated_text}"
   end
   # [END translate_v3_translate_text_with_glossary_and_model]

--- a/google-cloud-translate/samples/v3/translate_text_with_glossary_and_model.rb
+++ b/google-cloud-translate/samples/v3/translate_text_with_glossary_and_model.rb
@@ -1,0 +1,56 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def translate_v3_translate_text_with_glossary_and_model project_id:, location_id:, glossary_id:, model_id:
+  # [START translate_v3_translate_text_with_glossary_and_model]
+  require "google/cloud/translate"
+
+  # project_id = "[Google Cloud Project ID]"
+  # location_id = "[LOCATION ID]"
+  # model_id = "[MODEL ID]"
+  # glossary_id = "[YOUR_GLOSSARY_ID]"
+
+  # The `model` type requested for this translation.
+  model = "projects/#{project_id}/locations/#{location_id}/models/#{model_id}"
+  # The content to translate in string format
+  contents = ["Hello, world!"]
+  # Required. The BCP-47 language code to use for translation.
+  target_language = "fr"
+  # Optional. The BCP-47 language code of the input text.
+  source_language = "en"
+  # Optional. Can be "text/plain" or "text/html".
+  mime_type = "text/plain"
+
+  client = Google::Cloud::Translate.translation_service
+
+  parent = client.location_path project: project_id, location: location_id
+  glossary_path = client.glossary_path project:  project_id,
+                                       location: location_id,
+                                       glossary: glossary_id
+  glossary_config = { glossary: glossary_path }
+
+  response = client.translate_text parent:               parent,
+                                   contents:             contents,
+                                   target_language_code: target_language,
+                                   source_language_code: source_language,
+                                   model:                model,
+                                   glossary_config:      glossary_config,
+                                   mime_type:            mime_type
+
+  # Display the translation for each input text provided
+  response.translations.each do |translation|
+    puts "Translated text: #{translation.translated_text}"
+  end
+  # [END translate_v3_translate_text_with_glossary_and_model]
+end

--- a/google-cloud-translate/samples/v3/translate_text_with_model.rb
+++ b/google-cloud-translate/samples/v3/translate_text_with_model.rb
@@ -1,0 +1,50 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def translate_v3_translate_text_with_model project_id:, location_id:, model_id:
+  # [START translate_v3_translate_text_with_model]
+  require "google/cloud/translate"
+
+  # project_id = "[Google Cloud Project ID]"
+  # location_id = "[LOCATION ID]"
+  # model_id = "[MODEL ID]"
+
+  # The `model` type requested for this translation.
+  model = "projects/#{project_id}/locations/#{location_id}/models/#{model_id}"
+  # The content to translate in string format
+  contents = ["Hello, world!"]
+  # Required. The BCP-47 language code to use for translation.
+  target_language = "fr"
+  # Optional. The BCP-47 language code of the input text.
+  source_language = "en"
+  # Optional. Can be "text/plain" or "text/html".
+  mime_type = "text/plain"
+
+  client = Google::Cloud::Translate.translation_service
+
+  parent = client.location_path project: project_id, location: location_id
+
+  response = client.translate_text parent:               parent,
+                                   contents:             contents,
+                                   target_language_code: target_language,
+                                   source_language_code: source_language,
+                                   model:                model,
+                                   mime_type:            mime_type
+
+  # Display the translation for each input text provided
+  response.translations.each do |translation|
+    puts "Translated text: #{translation.translated_text}"
+  end
+  # [END translate_v3_translate_text_with_model]
+end


### PR DESCRIPTION
Moves all the translate samples over from ruby-docs-samples, along with tests.

There are a few tests in the v3 group that aren't end-to-end. I didn't feel like standing up all the automl model fixtures or the storage buckets for batch translation results, so the backend is mocked out for those tests.

Also fixed two issues that were uncovered:
* If the V2 client is created in the presence of the wrapper gem, the wrapper's config's endpoint host is used, but the V2 client wasn't interpreting it correctly (i.e. it assumed a full URL would be passed in). Fixed.
* If the V2 client is created in the presence of the wrapper gem, it tries to load the `key` and `retries` fields from the config, but those keys don't exist, resulting in a warning. Added those keys to the wrapper's config.
