### PR TITLE
Release google-cloud-memcache 0.1.0

### DIFF
--- a/google-cloud-memcache/CHANGELOG.md
+++ b/google-cloud-memcache/CHANGELOG.md
@@ -1,2 +1,6 @@
 # Release History
 
+### 0.1.0 / 2020-06-18
+
+Initial release.
+

--- a/google-cloud-memcache/lib/google/cloud/memcache/version.rb
+++ b/google-cloud-memcache/lib/google/cloud/memcache/version.rb
@@ -20,7 +20,7 @@
 module Google
   module Cloud
     module Memcache
-      VERSION = "0.0.1"
+      VERSION = "0.1.0"
     end
   end
 end


### PR DESCRIPTION
Initial release.

<details><summary>Commits since previous release</summary><pre><code></code></pre></details>

This pull request was generated using releasetool.