### PR TITLE
fix(translate): Declare the project_id configuration key (used by the V2 client)

### DIFF
--- a/google-cloud-translate/lib/google/cloud/translate.rb
+++ b/google-cloud-translate/lib/google/cloud/translate.rb
@@ -39,8 +39,6 @@ require "google/cloud/config"
   config.add_field! :metadata,      nil, match: ::Hash
   config.add_field! :retry_policy,  nil, match: [::Hash, ::Proc]
   config.add_field! :quota_project, nil, match: ::String
-  config.add_field! :key,           nil, match: ::String
-  config.add_field! :retries,       nil, match: ::Integer
 end
 
 module Google

--- a/google-cloud-translate/lib/google/cloud/translate/helpers.rb
+++ b/google-cloud-translate/lib/google/cloud/translate/helpers.rb
@@ -95,6 +95,13 @@ module Google
                                          timeout:     timeout,
                                          endpoint:    endpoint
       end
+
+      # Additional config keys used by V2
+      configure do |config|
+        config.add_field! :project_id, nil, match: ::String
+        config.add_field! :key,        nil, match: ::String
+        config.add_field! :retries,    nil, match: ::Integer
+      end
     end
   end
 end


### PR DESCRIPTION
The translation configuration was missing the `project_id` key (used by the V2 client), which resulted in warnings. Added the key declaration. Also, moved the V2-specific keys out of the generated file (where autosynth would remove them, see #6808) and into the partial gapic helper.