### PR TITLE
chore: Unpin protobuf on Ruby 2.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,8 +18,6 @@ gem "gems", "~> 0.8"
 gem "actionpack", "~> 5.0"
 gem "railties", "~> 5.0"
 gem "rack", ">= 0.1"
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")
 
 gem "google-cloud-access_approval", path: "google-cloud-access_approval"
 gem "google-cloud-access_approval-v1", path: "google-cloud-access_approval-v1"

--- a/gcloud/Gemfile
+++ b/gcloud/Gemfile
@@ -3,6 +3,3 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-access_approval-v1/Gemfile
+++ b/google-cloud-access_approval-v1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-access_approval/Gemfile
+++ b/google-cloud-access_approval/Gemfile
@@ -3,6 +3,3 @@ source "https://rubygems.org"
 gemspec
 
 gem "google-cloud-access_approval-v1", path: "../google-cloud-access_approval-v1"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-asset-v1/Gemfile
+++ b/google-cloud-asset-v1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-asset-v1beta1/Gemfile
+++ b/google-cloud-asset-v1beta1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-asset/Gemfile
+++ b/google-cloud-asset/Gemfile
@@ -4,6 +4,3 @@ gemspec
 
 gem "google-cloud-asset-v1", path: "../google-cloud-asset-v1"
 gem "google-cloud-asset-v1beta1", path: "../google-cloud-asset-v1beta1"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-automl-v1/Gemfile
+++ b/google-cloud-automl-v1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-automl-v1beta1/Gemfile
+++ b/google-cloud-automl-v1beta1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-automl/Gemfile
+++ b/google-cloud-automl/Gemfile
@@ -4,6 +4,3 @@ gemspec
 
 gem "google-cloud-automl-v1", path: "../google-cloud-automl-v1"
 gem "google-cloud-automl-v1beta1", path: "../google-cloud-automl-v1beta1"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-bigquery-data_transfer-v1/Gemfile
+++ b/google-cloud-bigquery-data_transfer-v1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-bigquery-data_transfer/Gemfile
+++ b/google-cloud-bigquery-data_transfer/Gemfile
@@ -3,6 +3,3 @@ source "https://rubygems.org"
 gemspec
 
 gem "google-cloud-bigquery-data_transfer-v1", path: "../google-cloud-bigquery-data_transfer-v1"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-bigquery-storage-v1/Gemfile
+++ b/google-cloud-bigquery-storage-v1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-bigquery-storage/Gemfile
+++ b/google-cloud-bigquery-storage/Gemfile
@@ -3,6 +3,3 @@ source "https://rubygems.org"
 gemspec
 
 gem "google-cloud-bigquery-storage-v1", path: "../google-cloud-bigquery-storage-v1"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-bigquery/Gemfile
+++ b/google-cloud-bigquery/Gemfile
@@ -9,6 +9,3 @@ gem "google-cloud-storage", path: "../google-cloud-storage"
 
 gem "minitest-reporters", "~> 1.3.5", require: false
 gem "rake"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-bigtable/Gemfile
+++ b/google-cloud-bigtable/Gemfile
@@ -8,6 +8,3 @@ gem "google-cloud-errors", path: "../google-cloud-errors"
 
 gem "minitest-reporters", "~> 1.3.5", require: false
 gem "rake"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-billing-v1/Gemfile
+++ b/google-cloud-billing-v1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-billing/Gemfile
+++ b/google-cloud-billing/Gemfile
@@ -3,6 +3,3 @@ source "https://rubygems.org"
 gemspec
 
 gem "google-cloud-billing-v1", path: "../google-cloud-billing-v1"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-container-v1/Gemfile
+++ b/google-cloud-container-v1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-container-v1beta1/Gemfile
+++ b/google-cloud-container-v1beta1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-container/Gemfile
+++ b/google-cloud-container/Gemfile
@@ -4,6 +4,3 @@ gemspec
 
 gem "google-cloud-container-v1", path: "../google-cloud-container-v1"
 gem "google-cloud-container-v1beta1", path: "../google-cloud-container-v1beta1"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-container_analysis-v1/Gemfile
+++ b/google-cloud-container_analysis-v1/Gemfile
@@ -2,6 +2,3 @@ source "https://rubygems.org"
 
 gemspec
 gem "grafeas-v1", path: "../grafeas-v1"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-container_analysis/Gemfile
+++ b/google-cloud-container_analysis/Gemfile
@@ -4,6 +4,3 @@ gemspec
 
 gem "google-cloud-container_analysis-v1", path: "../google-cloud-container_analysis-v1"
 gem "grafeas-v1", path: "../grafeas-v1"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-core/Gemfile
+++ b/google-cloud-core/Gemfile
@@ -12,6 +12,3 @@ gem "rake"
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110
 gem "minitest", "~> 5.11.3"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-data_catalog-v1/Gemfile
+++ b/google-cloud-data_catalog-v1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-data_catalog/Gemfile
+++ b/google-cloud-data_catalog/Gemfile
@@ -3,6 +3,3 @@ source "https://rubygems.org"
 gemspec
 
 gem "google-cloud-data_catalog-v1", path: "../google-cloud-data_catalog-v1"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-dataproc-v1/Gemfile
+++ b/google-cloud-dataproc-v1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-dataproc-v1beta2/Gemfile
+++ b/google-cloud-dataproc-v1beta2/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-dataproc/Gemfile
+++ b/google-cloud-dataproc/Gemfile
@@ -4,6 +4,3 @@ gemspec
 
 gem "google-cloud-dataproc-v1", path: "../google-cloud-dataproc-v1"
 gem "google-cloud-dataproc-v1beta2", path: "../google-cloud-dataproc-v1beta2"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-datastore/Gemfile
+++ b/google-cloud-datastore/Gemfile
@@ -7,6 +7,3 @@ gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-errors", path: "../google-cloud-errors"
 
 gem "rake"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-debugger-v2/Gemfile
+++ b/google-cloud-debugger-v2/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-debugger/Gemfile
+++ b/google-cloud-debugger/Gemfile
@@ -9,6 +9,3 @@ gem "google-cloud-logging", path: "../google-cloud-logging"
 gem "stackdriver-core", path: "../stackdriver-core"
 
 gem "rake"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-dialogflow-v2/Gemfile
+++ b/google-cloud-dialogflow-v2/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-dialogflow/Gemfile
+++ b/google-cloud-dialogflow/Gemfile
@@ -3,6 +3,3 @@ source "https://rubygems.org"
 gemspec
 
 gem "google-cloud-dialogflow-v2", path: "../google-cloud-dialogflow-v2"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-dlp-v2/Gemfile
+++ b/google-cloud-dlp-v2/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-dlp/Gemfile
+++ b/google-cloud-dlp/Gemfile
@@ -3,6 +3,3 @@ source "https://rubygems.org"
 gemspec
 
 gem "google-cloud-dlp-v2", path: "../google-cloud-dlp-v2"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-dns/Gemfile
+++ b/google-cloud-dns/Gemfile
@@ -7,6 +7,3 @@ gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-errors", path: "../google-cloud-errors"
 
 gem "rake"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-env/Gemfile
+++ b/google-cloud-env/Gemfile
@@ -7,6 +7,3 @@ gem "rake"
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110
 gem "minitest", "~> 5.11.3"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-error_reporting-v1beta1/Gemfile
+++ b/google-cloud-error_reporting-v1beta1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-error_reporting/Gemfile
+++ b/google-cloud-error_reporting/Gemfile
@@ -8,6 +8,3 @@ gem "google-cloud-errors", path: "../google-cloud-errors"
 gem "stackdriver-core", path: "../stackdriver-core"
 
 gem "rake"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-errors/Gemfile
+++ b/google-cloud-errors/Gemfile
@@ -10,6 +10,3 @@ gem "rake"
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110
 gem "minitest", "~> 5.11.3"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-firestore/Gemfile
+++ b/google-cloud-firestore/Gemfile
@@ -9,6 +9,3 @@ gem "google-cloud-errors", path: "../google-cloud-errors"
 gem "rake"
 
 gem "stackprof" unless Gem.win_platform?
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-iot-v1/Gemfile
+++ b/google-cloud-iot-v1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-iot/Gemfile
+++ b/google-cloud-iot/Gemfile
@@ -3,6 +3,3 @@ source "https://rubygems.org"
 gemspec
 
 gem "google-cloud-iot-v1", path: "../google-cloud-iot-v1"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-kms-v1/Gemfile
+++ b/google-cloud-kms-v1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-kms/Gemfile
+++ b/google-cloud-kms/Gemfile
@@ -3,6 +3,3 @@ source "https://rubygems.org"
 gemspec
 
 gem "google-cloud-kms-v1", path: "../google-cloud-kms-v1"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-language-v1/Gemfile
+++ b/google-cloud-language-v1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-language-v1beta2/Gemfile
+++ b/google-cloud-language-v1beta2/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-language/Gemfile
+++ b/google-cloud-language/Gemfile
@@ -4,6 +4,3 @@ gemspec
 
 gem "google-cloud-language-v1", path: "../google-cloud-language-v1"
 gem "google-cloud-language-v1beta2", path: "../google-cloud-language-v1beta2"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-logging-v2/Gemfile
+++ b/google-cloud-logging-v2/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-logging/Gemfile
+++ b/google-cloud-logging/Gemfile
@@ -11,6 +11,3 @@ gem "stackdriver-core", path: "../stackdriver-core"
 
 gem "minitest-reporters", "~> 1.3.5", require: false
 gem "rake"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-memcache-v1beta2/Gemfile
+++ b/google-cloud-memcache-v1beta2/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-memcache/Gemfile
+++ b/google-cloud-memcache/Gemfile
@@ -3,6 +3,3 @@ source "https://rubygems.org"
 gemspec
 
 gem "google-cloud-memcache-v1beta2", path: "../google-cloud-memcache-v1beta2"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-monitoring-dashboard-v1/Gemfile
+++ b/google-cloud-monitoring-dashboard-v1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-monitoring-v3/Gemfile
+++ b/google-cloud-monitoring-v3/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-monitoring/Gemfile
+++ b/google-cloud-monitoring/Gemfile
@@ -4,6 +4,3 @@ gemspec
 
 gem "google-cloud-monitoring-v3", path: "../google-cloud-monitoring-v3"
 gem "google-cloud-monitoring-dashboard-v1", path: "../google-cloud-monitoring-dashboard-v1"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-os_config-v1/Gemfile
+++ b/google-cloud-os_config-v1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-os_config/Gemfile
+++ b/google-cloud-os_config/Gemfile
@@ -3,6 +3,3 @@ source "https://rubygems.org"
 gemspec
 
 gem "google-cloud-os_config-v1", path: "../google-cloud-os_config-v1"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-os_login-v1/Gemfile
+++ b/google-cloud-os_login-v1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-os_login-v1beta/Gemfile
+++ b/google-cloud-os_login-v1beta/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-os_login/Gemfile
+++ b/google-cloud-os_login/Gemfile
@@ -4,6 +4,3 @@ gemspec
 
 gem "google-cloud-os_login-v1", path: "../google-cloud-os_login-v1"
 gem "google-cloud-os_login-v1beta", path: "../google-cloud-os_login-v1beta"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-phishing_protection-v1beta1/Gemfile
+++ b/google-cloud-phishing_protection-v1beta1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-phishing_protection/Gemfile
+++ b/google-cloud-phishing_protection/Gemfile
@@ -3,6 +3,3 @@ source "https://rubygems.org"
 gemspec
 
 gem "google-cloud-phishing_protection-v1beta1", path: "../google-cloud-phishing_protection-v1beta1"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-pubsub/Gemfile
+++ b/google-cloud-pubsub/Gemfile
@@ -8,6 +8,3 @@ gem "google-cloud-errors", path: "../google-cloud-errors"
 
 gem "minitest-reporters", "~> 1.3.5", require: false
 gem "rake"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-recaptcha_enterprise-v1/Gemfile
+++ b/google-cloud-recaptcha_enterprise-v1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-recaptcha_enterprise-v1beta1/Gemfile
+++ b/google-cloud-recaptcha_enterprise-v1beta1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-recaptcha_enterprise/Gemfile
+++ b/google-cloud-recaptcha_enterprise/Gemfile
@@ -4,6 +4,3 @@ gemspec
 
 gem "google-cloud-recaptcha_enterprise-v1", path: "../google-cloud-recaptcha_enterprise-v1"
 gem "google-cloud-recaptcha_enterprise-v1beta1", path: "../google-cloud-recaptcha_enterprise-v1beta1"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-recommender-v1/Gemfile
+++ b/google-cloud-recommender-v1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-recommender/Gemfile
+++ b/google-cloud-recommender/Gemfile
@@ -3,6 +3,3 @@ source "https://rubygems.org"
 gemspec
 
 gem "google-cloud-recommender-v1", path: "../google-cloud-recommender-v1"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-redis-v1/Gemfile
+++ b/google-cloud-redis-v1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-redis-v1beta1/Gemfile
+++ b/google-cloud-redis-v1beta1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-redis/Gemfile
+++ b/google-cloud-redis/Gemfile
@@ -4,6 +4,3 @@ gemspec
 
 gem "google-cloud-redis-v1", path: "../google-cloud-redis-v1"
 gem "google-cloud-redis-v1beta1", path: "../google-cloud-redis-v1beta1"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-resource_manager/Gemfile
+++ b/google-cloud-resource_manager/Gemfile
@@ -11,6 +11,3 @@ gem "rake"
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110
 gem "minitest", "~> 5.11.3"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-scheduler-v1/Gemfile
+++ b/google-cloud-scheduler-v1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-scheduler-v1beta1/Gemfile
+++ b/google-cloud-scheduler-v1beta1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-scheduler/Gemfile
+++ b/google-cloud-scheduler/Gemfile
@@ -4,6 +4,3 @@ gemspec
 
 gem "google-cloud-scheduler-v1", path: "../google-cloud-scheduler-v1"
 gem "google-cloud-scheduler-v1beta1", path: "../google-cloud-scheduler-v1beta1"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-secret_manager-v1/Gemfile
+++ b/google-cloud-secret_manager-v1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-secret_manager-v1beta1/Gemfile
+++ b/google-cloud-secret_manager-v1beta1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-secret_manager/Gemfile
+++ b/google-cloud-secret_manager/Gemfile
@@ -4,6 +4,3 @@ gemspec
 
 gem "google-cloud-secret_manager-v1", path: "../google-cloud-secret_manager-v1"
 gem "google-cloud-secret_manager-v1beta1", path: "../google-cloud-secret_manager-v1beta1"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-security_center-v1/Gemfile
+++ b/google-cloud-security_center-v1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-security_center-v1p1beta1/Gemfile
+++ b/google-cloud-security_center-v1p1beta1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-security_center/Gemfile
+++ b/google-cloud-security_center/Gemfile
@@ -4,6 +4,3 @@ gemspec
 
 gem "google-cloud-security_center-v1", path: "../google-cloud-security_center-v1"
 gem "google-cloud-security_center-v1p1beta1", path: "../google-cloud-security_center-v1p1beta1"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-service_directory-v1beta1/Gemfile
+++ b/google-cloud-service_directory-v1beta1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-service_directory/Gemfile
+++ b/google-cloud-service_directory/Gemfile
@@ -3,6 +3,3 @@ source "https://rubygems.org"
 gemspec
 
 gem "google-cloud-service_directory-v1beta1", path: "../google-cloud-service_directory-v1beta1"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-spanner/Gemfile
+++ b/google-cloud-spanner/Gemfile
@@ -7,6 +7,3 @@ gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-errors", path: "../google-cloud-errors"
 
 gem "rake"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-speech-v1/Gemfile
+++ b/google-cloud-speech-v1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-speech-v1p1beta1/Gemfile
+++ b/google-cloud-speech-v1p1beta1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-speech/Gemfile
+++ b/google-cloud-speech/Gemfile
@@ -4,6 +4,3 @@ gemspec
 
 gem "google-cloud-speech-v1", path: "../google-cloud-speech-v1"
 gem "google-cloud-speech-v1p1beta1", path: "../google-cloud-speech-v1p1beta1"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-storage/Gemfile
+++ b/google-cloud-storage/Gemfile
@@ -11,6 +11,3 @@ gem "minitest-reporters", "~> 1.3.5", require: false
 gem "rake"
 
 gem "minitest"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-talent-v4beta1/Gemfile
+++ b/google-cloud-talent-v4beta1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-talent/Gemfile
+++ b/google-cloud-talent/Gemfile
@@ -3,6 +3,3 @@ source "https://rubygems.org"
 gemspec
 
 gem "google-cloud-talent-v4beta1", path: "../google-cloud-talent-v4beta1"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-tasks-v2/Gemfile
+++ b/google-cloud-tasks-v2/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-tasks-v2beta2/Gemfile
+++ b/google-cloud-tasks-v2beta2/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-tasks-v2beta3/Gemfile
+++ b/google-cloud-tasks-v2beta3/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-tasks/Gemfile
+++ b/google-cloud-tasks/Gemfile
@@ -5,6 +5,3 @@ gemspec
 gem "google-cloud-tasks-v2", path: "../google-cloud-tasks-v2"
 gem "google-cloud-tasks-v2beta2", path: "../google-cloud-tasks-v2beta2"
 gem "google-cloud-tasks-v2beta3", path: "../google-cloud-tasks-v2beta3"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-text_to_speech-v1/Gemfile
+++ b/google-cloud-text_to_speech-v1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-text_to_speech-v1beta1/Gemfile
+++ b/google-cloud-text_to_speech-v1beta1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-text_to_speech/Gemfile
+++ b/google-cloud-text_to_speech/Gemfile
@@ -4,6 +4,3 @@ gemspec
 
 gem "google-cloud-text_to_speech-v1", path: "../google-cloud-text_to_speech-v1"
 gem "google-cloud-text_to_speech-v1beta1", path: "../google-cloud-text_to_speech-v1beta1"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-trace-v1/Gemfile
+++ b/google-cloud-trace-v1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-trace-v2/Gemfile
+++ b/google-cloud-trace-v2/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-trace/Gemfile
+++ b/google-cloud-trace/Gemfile
@@ -12,6 +12,3 @@ gem "rake"
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110
 gem "minitest", "~> 5.11.3"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-translate-v3/Gemfile
+++ b/google-cloud-translate-v3/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-translate/Gemfile
+++ b/google-cloud-translate/Gemfile
@@ -4,6 +4,3 @@ gemspec
 
 gem "google-cloud-translate-v2", path: "../google-cloud-translate-v2"
 gem "google-cloud-translate-v3", path: "../google-cloud-translate-v3"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-video_intelligence-v1/Gemfile
+++ b/google-cloud-video_intelligence-v1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-video_intelligence-v1beta2/Gemfile
+++ b/google-cloud-video_intelligence-v1beta2/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-video_intelligence-v1p1beta1/Gemfile
+++ b/google-cloud-video_intelligence-v1p1beta1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-video_intelligence-v1p2beta1/Gemfile
+++ b/google-cloud-video_intelligence-v1p2beta1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-video_intelligence/Gemfile
+++ b/google-cloud-video_intelligence/Gemfile
@@ -6,6 +6,3 @@ gem "google-cloud-video_intelligence-v1", path: "../google-cloud-video_intellige
 gem "google-cloud-video_intelligence-v1beta2", path: "../google-cloud-video_intelligence-v1beta2"
 gem "google-cloud-video_intelligence-v1p1beta1", path: "../google-cloud-video_intelligence-v1p1beta1"
 gem "google-cloud-video_intelligence-v1p2beta1", path: "../google-cloud-video_intelligence-v1p2beta1"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-vision-v1/Gemfile
+++ b/google-cloud-vision-v1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-vision-v1p3beta1/Gemfile
+++ b/google-cloud-vision-v1p3beta1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-vision/Gemfile
+++ b/google-cloud-vision/Gemfile
@@ -4,6 +4,3 @@ gemspec
 
 gem "google-cloud-vision-v1", path: "../google-cloud-vision-v1"
 gem "google-cloud-vision-v1p3beta1", path: "../google-cloud-vision-v1p3beta1"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-web_risk-v1/Gemfile
+++ b/google-cloud-web_risk-v1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-web_risk-v1beta1/Gemfile
+++ b/google-cloud-web_risk-v1beta1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud-web_risk/Gemfile
+++ b/google-cloud-web_risk/Gemfile
@@ -4,6 +4,3 @@ gemspec
 
 gem "google-cloud-web_risk-v1", path: "../google-cloud-web_risk-v1"
 gem "google-cloud-web_risk-v1beta1", path: "../google-cloud-web_risk-v1beta1"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/google-cloud/Gemfile
+++ b/google-cloud/Gemfile
@@ -3,6 +3,3 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/grafeas-client/Gemfile
+++ b/grafeas-client/Gemfile
@@ -5,6 +5,3 @@ gemspec
 gem "grafeas", path: "../grafeas"
 
 gem "rake", "~> 12.0"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/grafeas-v1/Gemfile
+++ b/grafeas-v1/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/grafeas/Gemfile
+++ b/grafeas/Gemfile
@@ -3,6 +3,3 @@ source "https://rubygems.org"
 gemspec
 
 gem "grafeas-v1", path: "../grafeas-v1"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/stackdriver-core/Gemfile
+++ b/stackdriver-core/Gemfile
@@ -11,6 +11,3 @@ gem "rake"
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110
 gem "minitest", "~> 5.11.3"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")

--- a/stackdriver/Gemfile
+++ b/stackdriver/Gemfile
@@ -16,6 +16,3 @@ gem "rake"
 # Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
 # See https://github.com/googleapis/google-cloud-ruby/issues/4110
 gem "minitest", "~> 5.11.3"
-
-# google-protobuf 3.12.0 requires Ruby 2.5 or later, so pin to 3.11 on older Rubies
-gem "google-protobuf", (RUBY_VERSION < "2.5" ? "~> 3.11.4" : "~> 3.12")


### PR DESCRIPTION
This just does a global search-and-remove of the protobuf pinning we did to deal with google-protobuf 3.12.0 not installing on Ruby 2.4 (which was fixed in google-protobuf 3.12.1). This will allow us to close a bunch of the autosynth PRs en masse instead of merging them one by one.
