### PR TITLE
chore(video_intelligence): Move samples from the ruby-docs-samples repo

### DIFF
--- a/google-cloud-video_intelligence/samples/Gemfile
+++ b/google-cloud-video_intelligence/samples/Gemfile
@@ -27,4 +27,5 @@ group :test do
   gem "minitest-focus", "~> 1.1"
   gem "minitest-hooks", "~>1.5"
   gem "rake", ">= 12.0"
+  gem "pry"
 end

--- a/google-cloud-video_intelligence/samples/Gemfile
+++ b/google-cloud-video_intelligence/samples/Gemfile
@@ -1,0 +1,30 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source "https://rubygems.org"
+
+master = ENV["GOOGLE_CLOUD_SAMPLES_TEST"] == "master"
+
+gem "google-cloud-video_intelligence", path: master ? "../../google-cloud-video_intelligence" : nil
+gem "google-cloud-video_intelligence-v1", path: master ? "../../google-cloud-video_intelligence-v1" : nil
+gem "google-cloud-video_intelligence-v1p1beta1", path: master ? "../../google-cloud-video_intelligence-v1p1beta1" : nil
+gem "google-cloud-video_intelligence-v1p2beta1", path: master ? "../../google-cloud-video_intelligence-v1p2beta1" : nil
+
+group :test do
+  gem "google-cloud-storage"
+  gem "minitest", "~> 5.14"
+  gem "minitest-focus", "~> 1.1"
+  gem "minitest-hooks", "~>1.5"
+  gem "rake", ">= 12.0"
+end

--- a/google-cloud-video_intelligence/samples/README.md
+++ b/google-cloud-video_intelligence/samples/README.md
@@ -1,0 +1,58 @@
+<img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
+
+# Google Cloud Video Intelligence Ruby Samples
+
+The [Google Cloud Video Intelligence API](https://cloud.google.com/video-intelligence/)
+enables easy integration of Google speech recognition technologies into
+developer applications.
+
+## Setup
+
+### Authentication
+
+Authentication is typically done through [Application Default Credentials](https://cloud.google.com/docs/authentication#getting_credentials_for_server-centric_flow)
+, which means you do not have to change the code to authenticate as long as your
+environment has credentials. You have a few options for setting up
+authentication:
+
+1. When running locally, use the [Google Cloud SDK](https://cloud.google.com/sdk/)
+
+    `gcloud auth application-default login`
+
+1. When running on App Engine or Compute Engine, credentials are already set-up.
+However, you may need to configure your Compute Engine instance with
+[additional scopes](https://cloud.google.com/compute/docs/authentication#using).
+
+1. You can create a [Service Account key file](https://cloud.google.com/docs/authentication#service_accounts)
+. This file can be used to authenticate to Google Cloud Platform services from
+any environment. To use the file, set the `GOOGLE_APPLICATION_CREDENTIALS`
+environment variable to the path to the key file, for example:
+
+    `export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service_account.json`
+
+### Install Dependencies
+
+1. Install the [Bundler](http://bundler.io/) gem.
+
+1. Install dependencies using:
+
+    `bundle install`
+
+## Run Quickstart
+
+    bundle exec ruby quickstart.rb
+
+## Run Samples
+
+    Usage: bundle exec ruby video_samples.rb [command] [arguments]
+
+    Commands:
+      analyze_labels           <gcs_path>   Detects labels given a GCS path.
+      analyze_labels_local     <local_path> Detects labels given file path.
+      analyze_shots            <gcs_path>   Detects camera shot changes given a GCS path.
+      analyze_explicit_content <gcs_path>   Detects explicit content given a GCS path.
+      speech_transcription     <gcs_path>   Transcribes speech given a GCS path.
+      detect_text_gcs          <gcs_path>   Detects text given a GCS path.
+      detect_text_local        <local_path> Detects text given file path.
+      track_objects_gcs        <gcs_path>   Track objects given a GCS path.
+      track_objects_local      <local_path> Track objects given file path.

--- a/google-cloud-video_intelligence/samples/Rakefile
+++ b/google-cloud-video_intelligence/samples/Rakefile
@@ -1,0 +1,20 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "rake/testtask"
+
+Rake::TestTask.new "test" do |t|
+  t.test_files = FileList["**/*_test.rb"]
+  t.warning = false
+end

--- a/google-cloud-video_intelligence/samples/acceptance/quickstart_test.rb
+++ b/google-cloud-video_intelligence/samples/acceptance/quickstart_test.rb
@@ -1,0 +1,23 @@
+# Copyright 2020 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "minitest/autorun"
+
+describe "Video Intelligence API Quickstart" do
+  it "can find labels for a cat video" do
+    assert_output(/Label description: animal/) do
+      load File.expand_path("../quickstart.rb", __dir__)
+    end
+  end
+end

--- a/google-cloud-video_intelligence/samples/acceptance/video_samples_test.rb
+++ b/google-cloud-video_intelligence/samples/acceptance/video_samples_test.rb
@@ -1,0 +1,117 @@
+# Copyright 2020 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "../video_samples"
+require "minitest/autorun"
+require "minitest/focus"
+require "minitest/hooks/default"
+require "net/http"
+require "tempfile"
+require "uri"
+
+describe "Google Cloud Video API sample" do
+  before :all do
+    @labels_file        = "cloud-samples-data/video/cat.mp4"
+    @shots_file         = "cloud-samples-data/video/gbikes_dinosaur.mp4"
+    @safe_search_file   = "cloud-samples-data/video/pizza.mp4"
+    @transcription_file = "cloud-samples-data/video/googlework_short.mp4"
+  end
+
+  it "can analyze labels from a gcs file" do
+    assert_output(/Label description: animal/) do
+      analyze_labels_gcs path: "gs://#{@labels_file}"
+    end
+  end
+
+  it "can analyze labels from a local file" do
+    begin
+      local_tempfile = Tempfile.new "temp_video"
+      File.open local_tempfile.path, "w" do |file|
+        file_contents = Net::HTTP.get URI("http://storage.googleapis.com/#{@transcription_file}")
+        file.write file_contents
+        file.flush
+      end
+      assert_output(/Finished Processing./) do
+        analyze_labels_local path: local_tempfile.path
+      end
+    ensure
+      local_tempfile.close
+      local_tempfile.unlink
+    end
+  end
+
+  it "can analyze explicit content from a gcs file" do
+    assert_output(/pornography: VERY_UNLIKELY/) do
+      analyze_explicit_content path: "gs://#{@safe_search_file}"
+    end
+  end
+
+  it "can analyze shots from a gcs file" do
+    assert_output(/0.0 to 5/) do
+      analyze_shots path: "gs://#{@shots_file}"
+    end
+  end
+
+  it "can transcribe speech from a gcs file" do
+    assert_output(/cultural/) do
+      transcribe_speech_gcs path: "gs://#{@transcription_file}"
+    end
+  end
+
+  it "can detect texts from a gcs file" do
+    assert_output(/GOOGLE/) do
+      detect_text_gcs path: "gs://#{@transcription_file}"
+    end
+  end
+
+  it "can detect texts from a local file" do
+    begin
+      local_tempfile = Tempfile.new "temp_video"
+      File.open local_tempfile.path, "w" do |file|
+        file_contents = Net::HTTP.get URI("http://storage.googleapis.com/#{@transcription_file}")
+        file.write file_contents
+        file.flush
+      end
+      assert_output(/GOOGLE/) do
+        detect_text_local path: local_tempfile.path
+      end
+    ensure
+      local_tempfile.close
+      local_tempfile.unlink
+    end
+  end
+
+  it "can track objects from a gcs file" do
+    assert_output(/cat/) do
+      track_objects_gcs path: "gs://#{@labels_file}"
+    end
+  end
+
+  it "can track objects from a local file" do
+    begin
+      local_tempfile = Tempfile.new "temp_video"
+      File.open local_tempfile.path, "w" do |file|
+        file_contents = Net::HTTP.get URI("http://storage.googleapis.com/#{@transcription_file}")
+        file.write file_contents
+        file.flush
+      end
+      assert_output(/Finished Processing./) do
+        track_objects_local path: local_tempfile.path
+      end
+    ensure
+      local_tempfile.close
+      local_tempfile.unlink
+    end
+  end
+end

--- a/google-cloud-video_intelligence/samples/quickstart.rb
+++ b/google-cloud-video_intelligence/samples/quickstart.rb
@@ -15,36 +15,36 @@
 # [START video_quickstart]
 require "google/cloud/video_intelligence"
 
-video_client = Google::Cloud::VideoIntelligence.new
+video_client = Google::Cloud::VideoIntelligence.video_intelligence_service
 features     = [:LABEL_DETECTION]
 path         = "gs://cloud-samples-data/video/cat.mp4"
 
 # Register a callback during the method call
-operation = video_client.annotate_video features, input_uri: path do |ops|
-  raise ops.results.message? if ops.error?
-  puts "Finished Processing."
-
-  labels = ops.results.annotation_results.first.segment_label_annotations
-
-  labels.each do |label|
-    puts "Label description: #{label.entity.description}"
-
-    label.category_entities.each do |category_entity|
-      puts "Label category description: #{category_entity.description}"
-    end
-
-    label.segments.each do |segment|
-      start_time = (segment.segment.start_time_offset.seconds +
-                     segment.segment.start_time_offset.nanos / 1e9)
-      end_time =   (segment.segment.end_time_offset.seconds +
-                     segment.segment.end_time_offset.nanos / 1e9)
-
-      puts "Segment: #{start_time} to #{end_time}"
-      puts "Confidence: #{segment.confidence}"
-    end
-  end
-end
+operation = video_client.annotate_video features: features, input_uri: path
 
 puts "Processing video for label annotations:"
 operation.wait_until_done!
+
+raise operation.results.message? if operation.error?
+puts "Finished Processing."
+
+labels = operation.results.annotation_results.first.segment_label_annotations
+
+labels.each do |label|
+  puts "Label description: #{label.entity.description}"
+
+  label.category_entities.each do |category_entity|
+    puts "Label category description: #{category_entity.description}"
+  end
+
+  label.segments.each do |segment|
+    start_time = (segment.segment.start_time_offset.seconds +
+                   segment.segment.start_time_offset.nanos / 1e9)
+    end_time =   (segment.segment.end_time_offset.seconds +
+                   segment.segment.end_time_offset.nanos / 1e9)
+
+    puts "Segment: #{start_time} to #{end_time}"
+    puts "Confidence: #{segment.confidence}"
+  end
+end
 # [END video_quickstart]

--- a/google-cloud-video_intelligence/samples/quickstart.rb
+++ b/google-cloud-video_intelligence/samples/quickstart.rb
@@ -1,0 +1,50 @@
+# Copyright 2017 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START video_quickstart]
+require "google/cloud/video_intelligence"
+
+video_client = Google::Cloud::VideoIntelligence.new
+features     = [:LABEL_DETECTION]
+path         = "gs://cloud-samples-data/video/cat.mp4"
+
+# Register a callback during the method call
+operation = video_client.annotate_video features, input_uri: path do |ops|
+  raise ops.results.message? if ops.error?
+  puts "Finished Processing."
+
+  labels = ops.results.annotation_results.first.segment_label_annotations
+
+  labels.each do |label|
+    puts "Label description: #{label.entity.description}"
+
+    label.category_entities.each do |category_entity|
+      puts "Label category description: #{category_entity.description}"
+    end
+
+    label.segments.each do |segment|
+      start_time = (segment.segment.start_time_offset.seconds +
+                     segment.segment.start_time_offset.nanos / 1e9)
+      end_time =   (segment.segment.end_time_offset.seconds +
+                     segment.segment.end_time_offset.nanos / 1e9)
+
+      puts "Segment: #{start_time} to #{end_time}"
+      puts "Confidence: #{segment.confidence}"
+    end
+  end
+end
+
+puts "Processing video for label annotations:"
+operation.wait_until_done!
+# [END video_quickstart]

--- a/google-cloud-video_intelligence/samples/video_samples.rb
+++ b/google-cloud-video_intelligence/samples/video_samples.rb
@@ -20,19 +20,18 @@ def analyze_labels_gcs path:
 
   require "google/cloud/video_intelligence"
 
-  video = Google::Cloud::VideoIntelligence.new
+  video = Google::Cloud::VideoIntelligence.video_intelligence_service
 
   # Register a callback during the method call
-  op_promise = video.annotate_video [:LABEL_DETECTION], input_uri: path do |operation|
-    raise operation.results.message? if operation.error?
-    puts "Finished Processing."
-
-    labels = operation.results.annotation_results.first.segment_label_annotations
-    print_labels labels
-  end
-
+  operation = video.annotate_video features: [:LABEL_DETECTION], input_uri: path
   puts "Processing video for label annotations:"
-  op_promise.wait_until_done!
+  operation.wait_until_done!
+
+  raise operation.results.message? if operation.error?
+  puts "Finished Processing."
+
+  labels = operation.results.annotation_results.first.segment_label_annotations
+  print_labels labels
   # [END video_analyze_labels_gcs]
 end
 
@@ -42,21 +41,21 @@ def analyze_labels_local path:
 
   require "google/cloud/video_intelligence"
 
-  video = Google::Cloud::VideoIntelligence.new
+  video = Google::Cloud::VideoIntelligence.video_intelligence_service
 
   video_contents = File.binread path
 
   # Register a callback during the method call
-  op_promise = video.annotate_video [:LABEL_DETECTION], input_content: video_contents do |operation|
-    raise operation.results.message? if operation.error?
-    puts "Finished Processing."
-
-    labels = operation.results.annotation_results.first.segment_label_annotations
-    print_labels labels
-  end
+  operation = video.annotate_video features: [:LABEL_DETECTION], input_content: video_contents
 
   puts "Processing video for label annotations:"
-  op_promise.wait_until_done!
+  operation.wait_until_done!
+
+  raise operation.results.message? if operation.error?
+  puts "Finished Processing."
+
+  labels = operation.results.annotation_results.first.segment_label_annotations
+  print_labels labels
   # [END video_analyze_labels]
 end
 
@@ -66,20 +65,20 @@ def analyze_shots path:
 
   require "google/cloud/video_intelligence"
 
-  video = Google::Cloud::VideoIntelligence.new
+  video = Google::Cloud::VideoIntelligence.video_intelligence_service
 
   # Register a callback during the method call
-  op_promise = video.annotate_video [:SHOT_CHANGE_DETECTION], input_uri: path do |operation|
-    raise operation.results.message? if operation.error?
-    puts "Finished processing."
-
-    # first result is retrieved because a single video was processed
-    annotation_result = operation.results.annotation_results.first
-    print_annotations annotation_result
-  end
+  operation = video.annotate_video features: [:SHOT_CHANGE_DETECTION], input_uri: path
 
   puts "Processing video for shot change annotations:"
-  op_promise.wait_until_done!
+  operation.wait_until_done!
+
+  raise operation.results.message? if operation.error?
+  puts "Finished processing."
+
+  # first result is retrieved because a single video was processed
+  annotation_result = operation.results.annotation_results.first
+  print_annotations annotation_result
   # [END video_analyze_shots]
 end
 
@@ -89,19 +88,19 @@ def analyze_explicit_content path:
 
   require "google/cloud/video_intelligence"
 
-  video = Google::Cloud::VideoIntelligence.new
+  video = Google::Cloud::VideoIntelligence.video_intelligence_service
 
   # Register a callback during the method call
-  op_promise = video.annotate_video [:EXPLICIT_CONTENT_DETECTION], input_uri: path do |operation|
-    raise operation.results.message? if operation.error?
-    puts "Finished Processing."
-
-    explicit_annotation = operation.results.annotation_results.first.explicit_annotation
-    print_explicit_annotation_frames explicit_annotation
-  end
+  operation = video.annotate_video features: [:EXPLICIT_CONTENT_DETECTION], input_uri: path
 
   puts "Processing video for label annotations:"
-  op_promise.wait_until_done!
+  operation.wait_until_done!
+
+  raise operation.results.message? if operation.error?
+  puts "Finished Processing."
+
+  explicit_annotation = operation.results.annotation_results.first.explicit_annotation
+  print_explicit_annotation_frames explicit_annotation
   # [END video_analyze_explicit_content]
 end
 
@@ -111,7 +110,7 @@ def transcribe_speech_gcs path:
 
   require "google/cloud/video_intelligence"
 
-  video = Google::Cloud::VideoIntelligence.new
+  video = Google::Cloud::VideoIntelligence.video_intelligence_service
 
   context = {
     speech_transcription_config: {
@@ -121,16 +120,16 @@ def transcribe_speech_gcs path:
   }
 
   # Register a callback during the method call
-  op_promise = video.annotate_video [:SPEECH_TRANSCRIPTION], input_uri: path, video_context: context do |operation|
-    raise operation.results.message? if operation.error?
-    puts "Finished Processing."
-
-    transcriptions = operation.results.annotation_results.first.speech_transcriptions
-    print_transcriptions transcriptions
-  end
+  operation = video.annotate_video features: [:SPEECH_TRANSCRIPTION], input_uri: path, video_context: context
 
   puts "Processing video for speech transcriptions:"
-  op_promise.wait_until_done!
+  operation.wait_until_done!
+
+  raise operation.results.message? if operation.error?
+  puts "Finished Processing."
+
+  transcriptions = operation.results.annotation_results.first.speech_transcriptions
+  print_transcriptions transcriptions
   # [END video_speech_transcription_gcs]
 end
 
@@ -140,19 +139,19 @@ def detect_text_gcs path:
 
   require "google/cloud/video_intelligence"
 
-  video = Google::Cloud::VideoIntelligence.new
+  video = Google::Cloud::VideoIntelligence.video_intelligence_service
 
   # Register a callback during the method call
-  op_promise = video.annotate_video [:TEXT_DETECTION], input_uri: path do |operation|
-    raise operation.results.message? if operation.error?
-    puts "Finished Processing."
-
-    text_annotations = operation.results.annotation_results.first.text_annotations
-    print_text_annotations text_annotations
-  end
+  operation = video.annotate_video features: [:TEXT_DETECTION], input_uri: path
 
   puts "Processing video for text detection:"
-  op_promise.wait_until_done!
+  operation.wait_until_done!
+
+  raise operation.results.message? if operation.error?
+  puts "Finished Processing."
+
+  text_annotations = operation.results.annotation_results.first.text_annotations
+  print_text_annotations text_annotations
   # [END video_detect_text_gcs]
 end
 
@@ -162,21 +161,22 @@ def detect_text_local path:
 
   require "google/cloud/video_intelligence"
 
-  video = Google::Cloud::VideoIntelligence.new
+  video = Google::Cloud::VideoIntelligence.video_intelligence_service
 
   video_contents = File.binread path
 
   # Register a callback during the method call
-  op_promise = video.annotate_video [:TEXT_DETECTION], input_content: video_contents do |operation|
-    raise operation.results.message? if operation.error?
-    puts "Finished Processing."
-
-    text_annotations = operation.results.annotation_results.first.text_annotations
-    print_text_annotations text_annotations
-  end
+  operation = video.annotate_video features: [:TEXT_DETECTION], input_content: video_contents
 
   puts "Processing video for text detection:"
-  op_promise.wait_until_done!
+  operation.wait_until_done!
+
+  raise operation.results.message? if operation.error?
+  puts "Finished Processing."
+
+  text_annotations = operation.results.annotation_results.first.text_annotations
+  print_text_annotations text_annotations
+
   # [END video_detect_text]
 end
 
@@ -186,19 +186,19 @@ def track_objects_gcs path:
 
   require "google/cloud/video_intelligence"
 
-  video = Google::Cloud::VideoIntelligence.new
+  video = Google::Cloud::VideoIntelligence.video_intelligence_service
 
   # Register a callback during the method call
-  op_promise = video.annotate_video [:OBJECT_TRACKING], input_uri: path do |operation|
-    raise operation.results.message? if operation.error?
-    puts "Finished Processing."
-
-    object_annotations = operation.results.annotation_results.first.object_annotations
-    print_object_annotations object_annotations
-  end
+  operation = video.annotate_video features: [:OBJECT_TRACKING], input_uri: path
 
   puts "Processing video for object tracking:"
-  op_promise.wait_until_done!
+  operation.wait_until_done!
+
+  raise operation.results.message? if operation.error?
+  puts "Finished Processing."
+
+  object_annotations = operation.results.annotation_results.first.object_annotations
+  print_object_annotations object_annotations
   # [END video_object_tracking_gcs]
 end
 
@@ -208,21 +208,21 @@ def track_objects_local path:
 
   require "google/cloud/video_intelligence"
 
-  video = Google::Cloud::VideoIntelligence.new
+  video = Google::Cloud::VideoIntelligence.video_intelligence_service
 
   video_contents = File.binread path
 
   # Register a callback during the method call
-  op_promise = video.annotate_video [:OBJECT_TRACKING], input_content: video_contents do |operation|
-    raise operation.results.message? if operation.error?
-    puts "Finished Processing."
-
-    object_annotations = operation.results.annotation_results.first.object_annotations
-    print_object_annotations object_annotations
-  end
+  operation = video.annotate_video features: [:OBJECT_TRACKING], input_content: video_contents
 
   puts "Processing video for object tracking:"
-  op_promise.wait_until_done!
+  operation.wait_until_done!
+
+  raise operation.results.message? if operation.error?
+  puts "Finished Processing."
+
+  object_annotations = operation.results.annotation_results.first.object_annotations
+  print_object_annotations object_annotations
   # [END video_object_tracking]
 end
 

--- a/google-cloud-video_intelligence/samples/video_samples.rb
+++ b/google-cloud-video_intelligence/samples/video_samples.rb
@@ -1,0 +1,256 @@
+# Copyright 2017 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "video_samples_helper"
+
+def analyze_labels_gcs path:
+  # [START video_analyze_labels_gcs]
+  # path = "Path to a video file on Google Cloud Storage: gs://bucket/video.mp4"
+
+  require "google/cloud/video_intelligence"
+
+  video = Google::Cloud::VideoIntelligence.new
+
+  # Register a callback during the method call
+  op_promise = video.annotate_video [:LABEL_DETECTION], input_uri: path do |operation|
+    raise operation.results.message? if operation.error?
+    puts "Finished Processing."
+
+    labels = operation.results.annotation_results.first.segment_label_annotations
+    print_labels labels
+  end
+
+  puts "Processing video for label annotations:"
+  op_promise.wait_until_done!
+  # [END video_analyze_labels_gcs]
+end
+
+def analyze_labels_local path:
+  # [START video_analyze_labels]
+  # path = "Path to a local video file: path/to/file.mp4"
+
+  require "google/cloud/video_intelligence"
+
+  video = Google::Cloud::VideoIntelligence.new
+
+  video_contents = File.binread path
+
+  # Register a callback during the method call
+  op_promise = video.annotate_video [:LABEL_DETECTION], input_content: video_contents do |operation|
+    raise operation.results.message? if operation.error?
+    puts "Finished Processing."
+
+    labels = operation.results.annotation_results.first.segment_label_annotations
+    print_labels labels
+  end
+
+  puts "Processing video for label annotations:"
+  op_promise.wait_until_done!
+  # [END video_analyze_labels]
+end
+
+def analyze_shots path:
+  # [START video_analyze_shots]
+  # path = "Path to a video file on Google Cloud Storage: gs://bucket/video.mp4"
+
+  require "google/cloud/video_intelligence"
+
+  video = Google::Cloud::VideoIntelligence.new
+
+  # Register a callback during the method call
+  op_promise = video.annotate_video [:SHOT_CHANGE_DETECTION], input_uri: path do |operation|
+    raise operation.results.message? if operation.error?
+    puts "Finished processing."
+
+    # first result is retrieved because a single video was processed
+    annotation_result = operation.results.annotation_results.first
+    print_annotations annotation_result
+  end
+
+  puts "Processing video for shot change annotations:"
+  op_promise.wait_until_done!
+  # [END video_analyze_shots]
+end
+
+def analyze_explicit_content path:
+  # [START video_analyze_explicit_content]
+  # path = "Path to a video file on Google Cloud Storage: gs://bucket/video.mp4"
+
+  require "google/cloud/video_intelligence"
+
+  video = Google::Cloud::VideoIntelligence.new
+
+  # Register a callback during the method call
+  op_promise = video.annotate_video [:EXPLICIT_CONTENT_DETECTION], input_uri: path do |operation|
+    raise operation.results.message? if operation.error?
+    puts "Finished Processing."
+
+    explicit_annotation = operation.results.annotation_results.first.explicit_annotation
+    print_explicit_annotation_frames explicit_annotation
+  end
+
+  puts "Processing video for label annotations:"
+  op_promise.wait_until_done!
+  # [END video_analyze_explicit_content]
+end
+
+def transcribe_speech_gcs path:
+  # [START video_speech_transcription_gcs]
+  # path = "Path to a video file on Google Cloud Storage: gs://bucket/video.mp4"
+
+  require "google/cloud/video_intelligence"
+
+  video = Google::Cloud::VideoIntelligence.new
+
+  context = {
+    speech_transcription_config: {
+      language_code:                "en-US",
+      enable_automatic_punctuation: true
+    }
+  }
+
+  # Register a callback during the method call
+  op_promise = video.annotate_video [:SPEECH_TRANSCRIPTION], input_uri: path, video_context: context do |operation|
+    raise operation.results.message? if operation.error?
+    puts "Finished Processing."
+
+    transcriptions = operation.results.annotation_results.first.speech_transcriptions
+    print_transcriptions transcriptions
+  end
+
+  puts "Processing video for speech transcriptions:"
+  op_promise.wait_until_done!
+  # [END video_speech_transcription_gcs]
+end
+
+def detect_text_gcs path:
+  # [START video_detect_text_gcs]
+  # path = "Path to a video file on Google Cloud Storage: gs://bucket/video.mp4"
+
+  require "google/cloud/video_intelligence"
+
+  video = Google::Cloud::VideoIntelligence.new
+
+  # Register a callback during the method call
+  op_promise = video.annotate_video [:TEXT_DETECTION], input_uri: path do |operation|
+    raise operation.results.message? if operation.error?
+    puts "Finished Processing."
+
+    text_annotations = operation.results.annotation_results.first.text_annotations
+    print_text_annotations text_annotations
+  end
+
+  puts "Processing video for text detection:"
+  op_promise.wait_until_done!
+  # [END video_detect_text_gcs]
+end
+
+def detect_text_local path:
+  # [START video_detect_text]
+  # "Path to a local video file: path/to/file.mp4"
+
+  require "google/cloud/video_intelligence"
+
+  video = Google::Cloud::VideoIntelligence.new
+
+  video_contents = File.binread path
+
+  # Register a callback during the method call
+  op_promise = video.annotate_video [:TEXT_DETECTION], input_content: video_contents do |operation|
+    raise operation.results.message? if operation.error?
+    puts "Finished Processing."
+
+    text_annotations = operation.results.annotation_results.first.text_annotations
+    print_text_annotations text_annotations
+  end
+
+  puts "Processing video for text detection:"
+  op_promise.wait_until_done!
+  # [END video_detect_text]
+end
+
+def track_objects_gcs path:
+  # [START video_object_tracking_gcs]
+  # path = "Path to a video file on Google Cloud Storage: gs://bucket/video.mp4"
+
+  require "google/cloud/video_intelligence"
+
+  video = Google::Cloud::VideoIntelligence.new
+
+  # Register a callback during the method call
+  op_promise = video.annotate_video [:OBJECT_TRACKING], input_uri: path do |operation|
+    raise operation.results.message? if operation.error?
+    puts "Finished Processing."
+
+    object_annotations = operation.results.annotation_results.first.object_annotations
+    print_object_annotations object_annotations
+  end
+
+  puts "Processing video for object tracking:"
+  op_promise.wait_until_done!
+  # [END video_object_tracking_gcs]
+end
+
+def track_objects_local path:
+  # [START video_object_tracking]
+  # "Path to a local video file: path/to/file.mp4"
+
+  require "google/cloud/video_intelligence"
+
+  video = Google::Cloud::VideoIntelligence.new
+
+  video_contents = File.binread path
+
+  # Register a callback during the method call
+  op_promise = video.annotate_video [:OBJECT_TRACKING], input_content: video_contents do |operation|
+    raise operation.results.message? if operation.error?
+    puts "Finished Processing."
+
+    object_annotations = operation.results.annotation_results.first.object_annotations
+    print_object_annotations object_annotations
+  end
+
+  puts "Processing video for object tracking:"
+  op_promise.wait_until_done!
+  # [END video_object_tracking]
+end
+
+def run_sample arguments
+  command = arguments.shift
+
+  case command
+  when "analyze_labels"
+    analyze_labels_gcs path: arguments.shift
+  when "analyze_labels_local"
+    analyze_labels_local path: arguments.shift
+  when "analyze_shots"
+    analyze_shots path: arguments.shift
+  when "analyze_explicit_content"
+    analyze_explicit_content path: arguments.shift
+  when "transcribe_speech"
+    transcribe_speech_gcs path: arguments.shift
+  when "detect_text_gcs"
+    detect_text_gcs path: arguments.shift
+  when "detect_text_local"
+    detect_text_local path: arguments.shift
+  when "track_objects_gcs"
+    track_objects_gcs path: arguments.shift
+  when "track_objects_local"
+    track_objects_local path: arguments.shift
+  else
+    print_usage
+  end
+end
+
+run_sample ARGV if $PROGRAM_NAME == __FILE__

--- a/google-cloud-video_intelligence/samples/video_samples_helper.rb
+++ b/google-cloud-video_intelligence/samples/video_samples_helper.rb
@@ -1,0 +1,156 @@
+# Copyright 2020 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def print_labels labels
+  labels.each do |label|
+    puts "Label description: #{label.entity.description}"
+
+    label.category_entities.each do |category_entity|
+      puts "Label category description: #{category_entity.description}"
+    end
+
+    label.segments.each do |segment|
+      start_time = (segment.segment.start_time_offset.seconds +
+                     segment.segment.start_time_offset.nanos / 1e9)
+      end_time =   (segment.segment.end_time_offset.seconds +
+                     segment.segment.end_time_offset.nanos / 1e9)
+
+      puts "Segment: #{start_time} to #{end_time}"
+      puts "Confidence: #{segment.confidence}"
+    end
+  end
+end
+
+def print_annotations annotation_result
+  puts "Scenes:"
+
+  annotation_result.shot_annotations.each do |shot_annotation|
+    start_time = (shot_annotation.start_time_offset.seconds +
+                  shot_annotation.start_time_offset.nanos / 1e9)
+    end_time =   (shot_annotation.end_time_offset.seconds +
+                  shot_annotation.end_time_offset.nanos / 1e9)
+
+    puts "#{start_time} to #{end_time}"
+  end
+end
+
+def print_explicit_annotation_frames explicit_annotation
+  explicit_annotation.frames.each do |frame|
+    frame_time = frame.time_offset.seconds + frame.time_offset.nanos / 1e9
+
+    puts "Time: #{frame_time}"
+    puts "pornography: #{frame.pornography_likelihood}"
+  end
+end
+
+def print_transcriptions transcriptions
+  transcriptions.each do |transcription|
+    transcription.alternatives.each do |alternative|
+      puts "Alternative level information:"
+
+      puts "Transcript: #{alternative.transcript}"
+      puts "Confidence: #{alternative.confidence}"
+
+      puts "Word level information:"
+      alternative.words.each do |word_info|
+        start_time = (word_info.start_time.seconds +
+                       word_info.start_time.nanos / 1e9)
+        end_time =   (word_info.end_time.seconds +
+                       word_info.end_time.nanos / 1e9)
+
+        puts "#{word_info.word}: #{start_time} to #{end_time}"
+      end
+    end
+  end
+end
+
+def print_text_annotations text_annotations
+  text_annotations.each do |text_annotation|
+    puts "Text: #{text_annotation.text}"
+
+    # Print information about the first segment of the text.
+    text_segment = text_annotation.segments.first
+    print_segment_times text_segment
+
+    puts "Confidence: #{text_segment.confidence}"
+
+    # Print information about the first frame of the segment.
+    frame = text_segment.frames.first
+    time_offset = (frame.time_offset.seconds +
+                    frame.time_offset.nanos / 1e9)
+    puts "Time offset for the first frame: #{time_offset}"
+
+    puts "Rotated bounding box vertices:"
+    frame.rotated_bounding_box.vertices.each do |vertex|
+      puts "\tVertex.x: #{vertex.x}, Vertex.y: #{vertex.y}"
+    end
+  end
+end
+
+def print_object_annotations object_annotations
+  object_annotations.each do |object_annotation|
+    puts "Entity description: #{object_annotation.entity.description}"
+    puts "Entity id: #{object_annotation.entity.entity_id}" if object_annotation.entity.entity_id
+
+    object_segment = object_annotation.segment
+    print_segment_times object_segment
+
+    puts "Confidence: #{object_annotation.confidence}"
+
+    # Print information about the first frame of the segment.
+    frame = object_annotation.frames.first
+
+    time_offset = (frame.time_offset.seconds +
+                    frame.time_offset.nanos / 1e9)
+    puts "Time offset for the first frame: #{time_offset}s"
+
+    box = frame.normalized_bounding_box
+    print_bounding_box_position box
+  end
+end
+
+def print_segment_times segment
+  start_time_offset = segment.segment.start_time_offset
+  end_time_offset = segment.segment.end_time_offset
+  start_time = (start_time_offset.seconds +
+                start_time_offset.nanos / 1e9)
+  end_time =   (end_time_offset.seconds +
+                end_time_offset.nanos / 1e9)
+  puts "Segment start_time: #{start_time}, end_time: #{end_time}"
+end
+
+def print_bounding_box_position box
+  puts "Bounding box position:"
+  puts "\tleft  : #{box.left}"
+  puts "\ttop   : #{box.top}"
+  puts "\tright : #{box.right}"
+  puts "\tbottom: #{box.bottom}\n"
+end
+
+def print_usage
+  puts <<~USAGE
+    Usage: bundle exec ruby video_samples.rb [command] [arguments]
+
+    Commands:
+      analyze_labels           <gcs_path>   Detects labels given a GCS path.
+      analyze_labels_local     <local_path> Detects labels given file path.
+      analyze_shots            <gcs_path>   Detects camera shot changes given a GCS path.
+      analyze_explicit_content <gcs_path>   Detects explicit content given a GCS path.
+      transcribe_speech        <gcs_path>   Transcribes speech given a GCS path.
+      detect_text_gcs          <gcs_path>   Detects text given a GCS path.
+      detect_text_local        <local_path> Detects text given file path.
+      track_objects_gcs        <gcs_path>   Track objects given a GCS path.
+      track_objects_local      <local_path> Track objects given file path.
+  USAGE
+end

--- a/google-cloud-video_intelligence/samples/video_samples_helper.rb
+++ b/google-cloud-video_intelligence/samples/video_samples_helper.rb
@@ -81,7 +81,7 @@ def print_text_annotations text_annotations
 
     # Print information about the first segment of the text.
     text_segment = text_annotation.segments.first
-    print_segment_times text_segment
+    print_segment_times text_segment.segment
 
     puts "Confidence: #{text_segment.confidence}"
 
@@ -121,8 +121,8 @@ def print_object_annotations object_annotations
 end
 
 def print_segment_times segment
-  start_time_offset = segment.segment.start_time_offset
-  end_time_offset = segment.segment.end_time_offset
+  start_time_offset = segment.start_time_offset
+  end_time_offset = segment.end_time_offset
   start_time = (start_time_offset.seconds +
                 start_time_offset.nanos / 1e9)
   end_time =   (end_time_offset.seconds +


### PR DESCRIPTION
see https://github.com/GoogleCloudPlatform/ruby-docs-samples/pull/612 for the in-place migration of samples to the minitest

move samples for video_intelligence from ruby-docs-samples
update the samples to use the microgenerated library