### PR TITLE
Release google-cloud-bigquery-storage 1.0.0

### DIFF
--- a/google-cloud-bigquery-storage/CHANGELOG.md
+++ b/google-cloud-bigquery-storage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 1.0.0 / 2020-06-24
+
+Promote to version 1.0.0.
+
 ### 0.3.0 / 2020-05-20
 
 #### Features

--- a/google-cloud-bigquery-storage/lib/google/cloud/bigquery/storage/version.rb
+++ b/google-cloud-bigquery-storage/lib/google/cloud/bigquery/storage/version.rb
@@ -21,7 +21,7 @@ module Google
   module Cloud
     module Bigquery
       module Storage
-        VERSION = "0.3.0"
+        VERSION = "1.0.0"
       end
     end
   end


### PR DESCRIPTION
Promote to version 1.0.0.

<details><summary>Commits since previous release</summary><pre><code>commit 7d35382342311d90650d622879b8deb700e67550
Author: Daniel Azuma <dazuma@google.com>
Date:   Sun Jun 21 18:06:44 2020 -0700

    chore: Unpin protobuf on Ruby 2.4

commit 497b3775dd392a353ca85198ce31ac3713c476aa
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Wed Jun 17 09:00:16 2020 -0700

    chore: Filled out additional repo-metadata fields

commit 22be4c2663fe386237a030b7913034a3c9dcc6d9
Author: Daniel Azuma <dazuma@google.com>
Date:   Tue Jun 16 23:18:57 2020 -0700

    chore: Update synth scripts with additional repo metadata fields

commit 1ff5062c50be1e8a92672331df3e5daf6f499edf
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Wed Jun 3 08:42:52 2020 -0700

    chore: Update Gemfile and rubocop config
</code></pre></details>

This pull request was generated using releasetool.