### PR TITLE
Release google-cloud-data_catalog 1.0.0

### DIFF
--- a/google-cloud-data_catalog/CHANGELOG.md
+++ b/google-cloud-data_catalog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 1.0.0 / 2020-06-24
+
+Promote to version 1.0.0
+
 ### 0.3.0 / 2020-05-20
 
 #### Features

--- a/google-cloud-data_catalog/lib/google/cloud/data_catalog/version.rb
+++ b/google-cloud-data_catalog/lib/google/cloud/data_catalog/version.rb
@@ -20,7 +20,7 @@
 module Google
   module Cloud
     module DataCatalog
-      VERSION = "0.3.0"
+      VERSION = "1.0.0"
     end
   end
 end


### PR DESCRIPTION
Promote to version 1.0.0

<details><summary>Commits since previous release</summary><pre><code>commit 7d35382342311d90650d622879b8deb700e67550
Author: Daniel Azuma <dazuma@google.com>
Date:   Sun Jun 21 18:06:44 2020 -0700

    chore: Unpin protobuf on Ruby 2.4

commit dd2a5d0ecd05c03cf93e9c2fde43ae9edb97ae8d
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Wed Jun 17 08:48:39 2020 -0700

    chore: Filled out additional repo-metadata fields

commit 22be4c2663fe386237a030b7913034a3c9dcc6d9
Author: Daniel Azuma <dazuma@google.com>
Date:   Tue Jun 16 23:18:57 2020 -0700

    chore: Update synth scripts with additional repo metadata fields

commit 012d62a99251d295379db60cdb59e32e7b58564f
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Wed Jun 3 08:39:01 2020 -0700

    chore: Update Gemfile and rubocop config
</code></pre></details>

This pull request was generated using releasetool.