### PR TITLE
Release google-cloud-build-v1 0.1.0

### DIFF
--- a/google-cloud-build-v1/CHANGELOG.md
+++ b/google-cloud-build-v1/CHANGELOG.md
@@ -1,2 +1,6 @@
 # Release History
 
+### 0.1.0 / 2020-06-25
+
+Initial release.
+

--- a/google-cloud-build-v1/lib/google/cloud/build/v1/version.rb
+++ b/google-cloud-build-v1/lib/google/cloud/build/v1/version.rb
@@ -21,7 +21,7 @@ module Google
   module Cloud
     module Build
       module V1
-        VERSION = "0.0.1"
+        VERSION = "0.1.0"
       end
     end
   end


### PR DESCRIPTION
Initial release.

<details><summary>Commits since previous release</summary><pre><code></code></pre></details>

This pull request was generated using releasetool.