### PR TITLE
Release google-cloud-spanner-admin-instance-v1 0.1.0

### DIFF
--- a/google-cloud-spanner-admin-instance-v1/CHANGELOG.md
+++ b/google-cloud-spanner-admin-instance-v1/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-### 0.1.0 / 2020-07-01
+### 0.1.0 / 2020-07-06
 
 Initial release.
 

--- a/google-cloud-spanner-admin-instance-v1/CHANGELOG.md
+++ b/google-cloud-spanner-admin-instance-v1/CHANGELOG.md
@@ -1,2 +1,6 @@
 # Release History
 
+### 0.1.0 / 2020-07-01
+
+Initial release.
+

--- a/google-cloud-spanner-admin-instance-v1/lib/google/cloud/spanner/admin/instance/v1/version.rb
+++ b/google-cloud-spanner-admin-instance-v1/lib/google/cloud/spanner/admin/instance/v1/version.rb
@@ -23,7 +23,7 @@ module Google
       module Admin
         module Instance
           module V1
-            VERSION = "0.0.1"
+            VERSION = "0.1.0"
           end
         end
       end


### PR DESCRIPTION
Initial release.

<details><summary>Commits since previous release</summary><pre><code></code></pre></details>

This pull request was generated using releasetool.