### PR TITLE
fix(env): Project ID should honor GOOGLE_CLOUD_PROJECT

### DIFF
--- a/google-cloud-env/lib/google/cloud/env.rb
+++ b/google-cloud-env/lib/google/cloud/env.rb
@@ -210,7 +210,10 @@ module Google
       # @return [String,nil]
       #
       def project_id
-        env["GCLOUD_PROJECT"] || env["DEVSHELL_PROJECT_ID"] || lookup_metadata("project", "project-id")
+        env["GOOGLE_CLOUD_PROJECT"] ||
+          env["GCLOUD_PROJECT"] ||
+          env["DEVSHELL_PROJECT_ID"] ||
+          lookup_metadata("project", "project-id")
       end
 
       ##


### PR DESCRIPTION
This went unnoticed for so long because all the veneers currently use `Google::Cloud.configure.project_id` (which does honor the `GOOGLE_CLOUD_PROJECT` environment variable) before defaulting to this logic in google-cloud-env. So in practice this code would never get executed if `GOOGLE_CLOUD_PROJECT` is being used to declare the project. However, using a microgenerator-produced library by itself (without a wrapper) does not provide access to `Google::Cloud.configure` and therefore falls back to this logic.