### PR TITLE
fix(spanner): update batch and batch, partitioned query, staleness options tests for emulator

### DIFF
--- a/google-cloud-spanner/acceptance/spanner/client/batch_update_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/batch_update_test.rb
@@ -66,8 +66,6 @@ describe "Spanner Client", :batch_update, :spanner do
   end
 
   it "raises InvalidArgumentError when no DML statements are executed in a batch" do
-    skip if emulator_enabled?
-
     prior_results = db.execute_sql "SELECT * FROM accounts"
     _(prior_results.rows.count).must_equal 3
 
@@ -77,7 +75,7 @@ describe "Spanner Client", :batch_update, :spanner do
       err = expect do
         tx.batch_update do |b| end
       end.must_raise Google::Cloud::InvalidArgumentError
-        _(err.message).must_equal "3:No statements in batch DML request."
+        _(err.message).must_match /3:(No statements in batch DML request|Request must contain at least one DML statement)/
     end
     _(timestamp).must_be_kind_of Time
   end

--- a/google-cloud-spanner/acceptance/spanner/client/params/struct_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/params/struct_test.rb
@@ -181,9 +181,7 @@ describe "Spanner Client", :params, :struct, :spanner do
   end
 
   it "queries and returns a struct array" do
-    skip if emulator_enabled?
-
-    struct_sql = "SELECT ARRAY(SELECT AS STRUCT message, repeat FROM (SELECT 'hello' AS message, 1 AS repeat UNION ALL SELECT 'hola' AS message, 2 AS repeat))"
+    struct_sql = "SELECT ARRAY(SELECT AS STRUCT message, repeat FROM (SELECT 'hello' AS message, 1 AS repeat UNION ALL SELECT 'hola' AS message, 2 AS repeat) ORDER BY repeat ASC)"
     results = db.execute_query struct_sql
 
     _(results).must_be_kind_of Google::Cloud::Spanner::Results
@@ -199,5 +197,4 @@ describe "Spanner Client", :params, :struct, :spanner do
     _(results.fields.to_h).must_equal({ 0 => [db.fields(0 => :STRING, 1 => :INT64)] })
     _(results.rows.first.to_h).must_equal({ 0 => [] })
   end
-
 end

--- a/google-cloud-spanner/acceptance/spanner/client/single_use_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/single_use_test.rb
@@ -31,9 +31,7 @@ describe "Spanner Client", :single_use, :spanner do
   end
 
   it "runs a query with strong option" do
-    skip if emulator_enabled?
-
-    results = db.execute_sql "SELECT * FROM accounts", single_use: { strong: true }
+    results = db.execute_sql "SELECT * FROM accounts ORDER BY account_id ASC", single_use: { strong: true }
 
     _(results).must_be_kind_of Google::Cloud::Spanner::Results
     _(results.fields.to_h).must_equal fields_hash
@@ -59,9 +57,7 @@ describe "Spanner Client", :single_use, :spanner do
   end
 
   it "runs a query with timestamp option" do
-    skip if emulator_enabled?
-
-    results = db.execute_sql "SELECT * FROM accounts", single_use: { timestamp: @setup_timestamp }
+    results = db.execute_sql "SELECT * FROM accounts ORDER BY account_id ASC", single_use: { timestamp: @setup_timestamp }
 
     _(results).must_be_kind_of Google::Cloud::Spanner::Results
     _(results.fields.to_h).must_equal fields_hash
@@ -87,9 +83,7 @@ describe "Spanner Client", :single_use, :spanner do
   end
 
   it "runs a query with staleness option" do
-    skip if emulator_enabled?
-
-    results = db.execute_sql "SELECT * FROM accounts", single_use: { staleness: 0.0001 }
+    results = db.execute_sql "SELECT * FROM accounts ORDER BY account_id ASC", single_use: { staleness: 0.0001 }
 
     _(results).must_be_kind_of Google::Cloud::Spanner::Results
     _(results.fields.to_h).must_equal fields_hash
@@ -115,9 +109,7 @@ describe "Spanner Client", :single_use, :spanner do
   end
 
   it "runs a query with bounded_timestamp option" do
-    skip if emulator_enabled?
-
-    results = db.execute_sql "SELECT * FROM accounts", single_use: { bounded_timestamp: @setup_timestamp }
+    results = db.execute_sql "SELECT * FROM accounts ORDER BY account_id ASC", single_use: { bounded_timestamp: @setup_timestamp }
 
     _(results).must_be_kind_of Google::Cloud::Spanner::Results
     _(results.fields.to_h).must_equal fields_hash
@@ -143,9 +135,7 @@ describe "Spanner Client", :single_use, :spanner do
   end
 
   it "runs a query with bounded_staleness option" do
-    skip if emulator_enabled?
-
-    results = db.execute_sql "SELECT * FROM accounts", single_use: { bounded_staleness: 0.0001 }
+    results = db.execute_sql "SELECT * FROM accounts ORDER BY account_id ASC", single_use: { bounded_staleness: 0.0001 }
 
     _(results).must_be_kind_of Google::Cloud::Spanner::Results
     _(results.fields.to_h).must_equal fields_hash

--- a/google-cloud-spanner/acceptance/spanner/client/snapshot_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/snapshot_test.rb
@@ -31,14 +31,12 @@ describe "Spanner Client", :snapshot, :spanner do
   end
 
   it "runs a query" do
-    skip if emulator_enabled?
-
     results = nil
     db.snapshot do |snp|
       _(snp.transaction_id).wont_be :nil?
       _(snp.timestamp).wont_be :nil?
 
-      results = snp.execute_sql "SELECT * FROM accounts"
+      results = snp.execute_sql "SELECT * FROM accounts ORDER BY account_id ASC"
     end
 
     _(results).must_be_kind_of Google::Cloud::Spanner::Results
@@ -49,15 +47,13 @@ describe "Spanner Client", :snapshot, :spanner do
   end
 
   it "runs a query with query options" do
-    skip if emulator_enabled?
-
     query_options = { optimizer_version: "latest" }
     results = nil
     db.snapshot do |snp|
       _(snp.transaction_id).wont_be :nil?
       _(snp.timestamp).wont_be :nil?
 
-      results = snp.execute_sql "SELECT * FROM accounts", query_options: query_options
+      results = snp.execute_sql "SELECT * FROM accounts ORDER BY account_id ASC", query_options: query_options
     end
 
     _(results).must_be_kind_of Google::Cloud::Spanner::Results
@@ -84,14 +80,12 @@ describe "Spanner Client", :snapshot, :spanner do
   end
 
   it "runs a query with strong option" do
-    skip if emulator_enabled?
-
     results = nil
     db.snapshot strong: true do |snp|
       _(snp.transaction_id).wont_be :nil?
       _(snp.timestamp).wont_be :nil?
 
-      results = snp.execute_sql "SELECT * FROM accounts"
+      results = snp.execute_sql "SELECT * FROM accounts ORDER BY account_id ASC"
     end
 
     _(results).must_be_kind_of Google::Cloud::Spanner::Results
@@ -118,14 +112,12 @@ describe "Spanner Client", :snapshot, :spanner do
   end
 
   it "runs a query with timestamp option" do
-    skip if emulator_enabled?
-
     results = nil
     db.snapshot timestamp: @setup_timestamp do |snp|
       _(snp.transaction_id).wont_be :nil?
       _(snp.timestamp).wont_be :nil?
 
-      results = snp.execute_sql "SELECT * FROM accounts"
+      results = snp.execute_sql "SELECT * FROM accounts ORDER BY account_id ASC"
     end
 
     _(results).must_be_kind_of Google::Cloud::Spanner::Results
@@ -152,14 +144,12 @@ describe "Spanner Client", :snapshot, :spanner do
   end
 
   it "runs a query with staleness option" do
-    skip if emulator_enabled?
-
     results = nil
     db.snapshot staleness: 0.0001 do |snp|
       _(snp.transaction_id).wont_be :nil?
       _(snp.timestamp).wont_be :nil?
 
-      results = snp.execute_sql "SELECT * FROM accounts"
+      results = snp.execute_sql "SELECT * FROM accounts ORDER BY account_id ASC"
     end
 
     _(results).must_be_kind_of Google::Cloud::Spanner::Results
@@ -275,13 +265,11 @@ describe "Spanner Client", :snapshot, :spanner do
   end
 
   it "staleness reads are consistent even when updates happen" do
-    skip if emulator_enabled?
-
     first_row = default_account_rows.first
     sample_row = { account_id: first_row[:account_id], username: first_row[:username] }
     modified_row = { account_id: first_row[:account_id], username: first_row[:username].reverse }
 
-    db.snapshot staleness: 0.01 do |snp|
+    db.snapshot staleness: 0.0001 do |snp|
       _(snp.transaction_id).wont_be :nil?
       _(snp.timestamp).wont_be :nil?
 
@@ -299,13 +287,11 @@ describe "Spanner Client", :snapshot, :spanner do
   end
 
   it "staleness queries are consistent even when updates happen" do
-    skip if emulator_enabled?
-
     first_row = default_account_rows.first
     sample_row = { account_id: first_row[:account_id], username: first_row[:username] }
     modified_row = { account_id: first_row[:account_id], username: first_row[:username].reverse }
 
-    db.snapshot staleness: 0.01 do |snp|
+    db.snapshot staleness: 0.0001 do |snp|
       _(snp.transaction_id).wont_be :nil?
       _(snp.timestamp).wont_be :nil?
 

--- a/google-cloud-spanner/acceptance/spanner/client/transaction_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/transaction_test.rb
@@ -128,7 +128,7 @@ describe "Spanner Client", :transaction, :spanner do
   end
 
   it "supports tx isolation with read and update" do
-    skip if emulator_enabled?
+    skip "The emulator only supports one transaction at a time" if emulator_enabled?
 
     results = db.read "accounts", [:reputation], keys: 1, limit: 1
     original_val = results.rows.first[:reputation]


### PR DESCRIPTION
Removed skip for acceptance test cases for 
- batch client partition execution
- reads with staleness options 

Added read order to select queries due to emulator returning data in `desc` order not in the order of insert.

closes: #6898 