### PR TITLE
test(pubsub): Fix acceptance test assertion

### DIFF
--- a/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
+++ b/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
@@ -48,7 +48,7 @@ describe Google::Cloud::PubSub, :pubsub do
 
   it "should raise when endpoint is not the Pub/Sub service" do
     pubsub_invalid_endpoint = Google::Cloud::Pubsub.new endpoint: "example.com"
-    expect { pubsub_invalid_endpoint.topics }.must_raise Google::Cloud::CanceledError
+    expect { pubsub_invalid_endpoint.topics }.must_raise Google::Cloud::UnimplementedError
   end
 
   describe "Topic", :pubsub do


### PR DESCRIPTION
Fixes the following [recurring assertion failure in the acceptance tests](https://source.cloud.google.com/results/invocations/7b61320d-0c20-4409-81bb-0c57ac2bc8fc/log). (To my knowledge, `UnimplementedError` is the correct error code for this scenario.)

```
Finished in 129.852189s, 0.1386 runs/s, 17.4506 assertions/s.

  1) Failure:
Google::Cloud::PubSub::pubsub#test_0001_should raise when endpoint is not the Pub/Sub service [/tmpfs/src/github/google-cloud-ruby/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb:51]:
[Google::Cloud::CanceledError] exception expected, not
Class: <Google::Cloud::UnimplementedError>
Message: <"12:Received http2 header with status: 404. debug_error_string:{\"created\":\"@1594370505.986649786\",\"description\":\"Received http2 :status header with non-200 OK status\",\"file\":\"src/core/ext/filters/http/client/http_client_filter.cc\",\"file_line\":130,\"grpc_message\":\"Received http2 header with status: 404\",\"grpc_status\":12,\"value\":\"404\"}">
---Backtrace---
/tmpfs/src/github/google-cloud-ruby/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb:507:in `rescue in execute'
/tmpfs/src/github/google-cloud-ruby/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb:503:in `execute'
/tmpfs/src/github/google-cloud-ruby/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb:125:in `list_topics'
/tmpfs/src/github/google-cloud-ruby/google-cloud-pubsub/lib/google/cloud/pubsub/project.rb:244:in `topics'
/tmpfs/src/github/google-cloud-ruby/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb:51:in `block (3 levels) in <top (required)>'
---------------

18 runs, 2266 assertions, 1 failures, 0 errors, 0 skips
```