### PR TITLE
Release google-cloud-build 0.1.0

### DIFF
--- a/google-cloud-build/CHANGELOG.md
+++ b/google-cloud-build/CHANGELOG.md
@@ -1,2 +1,6 @@
 # Release History
 
+### 0.1.0 / 2020-07-13
+
+Initial release.
+

--- a/google-cloud-build/lib/google/cloud/build/version.rb
+++ b/google-cloud-build/lib/google/cloud/build/version.rb
@@ -20,7 +20,7 @@
 module Google
   module Cloud
     module Build
-      VERSION = "0.0.1"
+      VERSION = "0.1.0"
     end
   end
 end


### PR DESCRIPTION
Initial release.

<details><summary>Commits since previous release</summary><pre><code></code></pre></details>

This pull request was generated using releasetool.