### PR TITLE
chore: Workaround for grpc/grpc#23490 in OSLogin synth files

### DIFF
--- a/google-cloud-os_login-v1/synth.py
+++ b/google-cloud-os_login-v1/synth.py
@@ -42,3 +42,10 @@ library = gapic.ruby_library(
 )
 
 s.copy(library, merge=ruby.global_merge)
+
+# Workaround for https://github.com/grpc/grpc/issues/23490
+s.replace(
+    "lib/**/*_pb.rb",
+    'Google::Cloud::OsLogin::Common::Google::Cloud::Oslogin::Common::',
+    'Google::Cloud::OsLogin::Common::'
+)

--- a/google-cloud-os_login-v1beta/synth.py
+++ b/google-cloud-os_login-v1beta/synth.py
@@ -42,3 +42,10 @@ library = gapic.ruby_library(
 )
 
 s.copy(library, merge=ruby.global_merge)
+
+# Workaround for https://github.com/grpc/grpc/issues/23490
+s.replace(
+    "lib/**/*_pb.rb",
+    'Google::Cloud::OsLogin::Common::Google::Cloud::Oslogin::Common::',
+    'Google::Cloud::OsLogin::Common::'
+)


### PR DESCRIPTION
Workaround for https://github.com/grpc/grpc/issues/23490 for synthing OsLogin. Should prevent the breaking changes exhibited by #7035 and #7036.
