### PR TITLE
Release google-cloud-error_reporting 0.40.0

### DIFF
--- a/google-cloud-error_reporting/CHANGELOG.md
+++ b/google-cloud-error_reporting/CHANGELOG.md
@@ -7,11 +7,20 @@ instead adds the new `google-cloud-error_reporting-v1beta1` gem as a dependency.
 This is a rewritten low-level client produced by a next-generation client code
 generator, with improved performance and stability.
 
-This change should have no effect on most of the main high-level interface.
-The one exception is that the (mostly undocumented) `client_config` argument
-for creating client objects, has been removed. If you need to adjust low-level
-client parameters such as RPC retry settings, use the configuration interface
-in `google-cloud-error_reporting-v1beta1`.
+This change should have no effect on the high-level interface that most users
+will use. The one exception is that the (mostly undocumented) `client_config`
+argument, for adjusting low-level parameters such as RPC retry settings on
+client objects, has been removed. If you need to adjust these parameters, use
+the configuration interface in `google-cloud-error_reporting-v1beta1`.
+
+Substantial changes have been made in the low-level interfaces, however. If you
+are using the low-level classes under the `Google::Cloud::ErrorReporting::V1beta1`
+module, please review the docs for the new `google-cloud-error_reporting-v1beta1`
+gem. In particular:
+* Some classes have been renamed, notably the client class itself.
+* The client constructor takes a configuration block instead of configuration
+  keyword arguments.
+* All method arguments are now keyword arguments.
 
 ### 0.35.2 / 2020-06-08
 

--- a/google-cloud-error_reporting/CHANGELOG.md
+++ b/google-cloud-error_reporting/CHANGELOG.md
@@ -17,10 +17,11 @@ Substantial changes have been made in the low-level interfaces, however. If you
 are using the low-level classes under the `Google::Cloud::ErrorReporting::V1beta1`
 module, please review the docs for the new `google-cloud-error_reporting-v1beta1`
 gem. In particular:
+
 * Some classes have been renamed, notably the client class itself.
 * The client constructor takes a configuration block instead of configuration
   keyword arguments.
-* All method arguments are now keyword arguments.
+* All RPC method arguments are now keyword arguments.
 
 ### 0.35.2 / 2020-06-08
 

--- a/google-cloud-error_reporting/CHANGELOG.md
+++ b/google-cloud-error_reporting/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Release History
 
+### 0.40.0 / 2020-07-21
+
+This is a major update that removes the "low-level" client interface code, and
+instead adds the new `google-cloud-error_reporting-v1beta1` gem as a dependency.
+This is a rewritten low-level client produced by a next-generation client code
+generator, with improved performance and stability.
+
+This change should have no effect on most of the main high-level interface.
+The one exception is that the (mostly undocumented) `client_config` argument
+for creating client objects, has been removed. If you need to adjust low-level
+client parameters such as RPC retry settings, use the configuration interface
+in `google-cloud-error_reporting-v1beta1`.
+
 ### 0.35.2 / 2020-06-08
 
 #### Documentation

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/version.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module ErrorReporting
-      VERSION = "0.35.2".freeze
+      VERSION = "0.40.0".freeze
     end
   end
 end


### PR DESCRIPTION
This is a major update that removes the "low-level" client interface code, and
instead adds the new `google-cloud-error_reporting-v1beta1` gem as a dependency.
This is a rewritten low-level client produced by a next-generation client code
generator, with improved performance and stability.

This change should have no effect on most of the main high-level interface.
The one exception is that the (mostly undocumented) `client_config` argument
for creating client objects, has been removed. If you need to adjust low-level
client parameters such as RPC retry settings, use the configuration interface
in `google-cloud-error_reporting-v1beta1`.

<details><summary>Commits since previous release</summary><pre><code>commit afae95f9917a37cfee975d32b0764e5ab35f812f
Author: Daniel Azuma <dazuma@google.com>
Date:   Mon Jul 20 17:15:27 2020 -0700

    feat(error_reporting)!: Use new generated client classes

commit 7d35382342311d90650d622879b8deb700e67550
Author: Daniel Azuma <dazuma@google.com>
Date:   Sun Jun 21 18:06:44 2020 -0700

    chore: Unpin protobuf on Ruby 2.4

commit 438ca1d5fde6ec79bfb137d47a08724e6b3a90cf
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Sat Jun 13 13:40:28 2020 -0700

    chore(error_reporting): Retain legacy proto namespaces after ruby_package change

commit 7bbf8ca766f48a31007337259a7801e19d538ca0
Author: Daniel Azuma <dazuma@google.com>
Date:   Thu Jun 11 20:38:39 2020 -0700

    chore: Temporarily undo new ruby_package proto options for artman-generated libraries
</code></pre></details>

This pull request was generated using releasetool.