### PR TITLE
Release google-cloud-logging 2.0.0

### DIFF
--- a/google-cloud-logging/CHANGELOG.md
+++ b/google-cloud-logging/CHANGELOG.md
@@ -4,6 +4,29 @@
 
 This is a major update that removes the "low-level" client interface code, and
 instead adds the new `google-cloud-logging-v2` gem as a dependency.
+The new dependency is a rewritten low-level client, produced by a next-
+generation client code generator, with improved performance and stability.
+
+This change should have no effect on the high-level interface that most users
+will use. The one exception is that the (mostly undocumented) `client_config`
+argument, for adjusting low-level parameters such as RPC retry settings on
+client objects, has been removed. If you need to adjust these parameters, use
+the configuration interface in `google-cloud-logging-v2`.
+
+Substantial changes have been made in the low-level interfaces, however. If you
+are using the low-level classes under the `Google::Cloud::Logging::V2` module,
+please review the docs for the new `google-cloud-logging-v2` gem. In
+particular:
+
+* Some classes have been renamed, notably the client class itself.
+* The client constructor takes a configuration block instead of configuration
+  keyword arguments.
+* All RPC method arguments are now keyword arguments.
+
+### 2.0.0 / 2020-07-21
+
+This is a major update that removes the "low-level" client interface code, and
+instead adds the new `google-cloud-logging-v2` gem as a dependency.
 This is a rewritten low-level client produced by a next-generation client code
 generator, with improved performance and stability.
 

--- a/google-cloud-logging/CHANGELOG.md
+++ b/google-cloud-logging/CHANGELOG.md
@@ -23,29 +23,6 @@ particular:
   keyword arguments.
 * All RPC method arguments are now keyword arguments.
 
-### 2.0.0 / 2020-07-21
-
-This is a major update that removes the "low-level" client interface code, and
-instead adds the new `google-cloud-logging-v2` gem as a dependency.
-This is a rewritten low-level client produced by a next-generation client code
-generator, with improved performance and stability.
-
-This change should have no effect on the high-level interface that most users
-will use. The one exception is that the (mostly undocumented) `client_config`
-argument, for adjusting low-level parameters such as RPC retry settings on
-client objects, has been removed. If you need to adjust these parameters, use
-the configuration interface in `google-cloud-logging-v2`.
-
-Substantial changes have been made in the low-level interfaces, however. If you
-are using the low-level classes under the `Google::Cloud::Logging::V2` module,
-please review the docs for the new `google-cloud-logging-v2` gem. In
-particular:
-
-* Some classes have been renamed, notably the client class itself.
-* The client constructor takes a configuration block instead of configuration
-  keyword arguments.
-* All RPC method arguments are now keyword arguments.
-
 ### 1.10.9 / 2020-06-17
 
 #### Documentation

--- a/stackdriver/stackdriver.gemspec
+++ b/stackdriver/stackdriver.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency "google-cloud-debugger", "~> 0.32"
   gem.add_runtime_dependency "google-cloud-error_reporting", "~> 0.30"
-  gem.add_runtime_dependency "google-cloud-logging", "~> 1.5"
+  gem.add_runtime_dependency "google-cloud-logging", "~> 2.0"
   gem.add_runtime_dependency "google-cloud-trace", "~> 0.33"
 
   gem.add_development_dependency "autotest-suffix", "~> 1.1"


### PR DESCRIPTION
This is a major update that removes the "low-level" client interface code, and
instead adds the new `google-cloud-logging-v2` gem as a dependency.
The new dependency is a rewritten low-level client, produced by a next-
generation client code generator, with improved performance and stability.

This change should have no effect on the high-level interface that most users
will use. The one exception is that the (mostly undocumented) `client_config`
argument, for adjusting low-level parameters such as RPC retry settings on
client objects, has been removed. If you need to adjust these parameters, use
the configuration interface in `google-cloud-logging-v2`.

Substantial changes have been made in the low-level interfaces, however. If you
are using the low-level classes under the `Google::Cloud::Logging::V2` module,
please review the docs for the new `google-cloud-logging-v2` gem. In
particular:

* Some classes have been renamed, notably the client class itself.
* The client constructor takes a configuration block instead of configuration
  keyword arguments.
* All RPC method arguments are now keyword arguments.

<details><summary>Commits since previous release</summary><pre><code>commit d7d7f599e2ae50af0aec226118b69f0eee633f88
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Tue Jul 21 15:28:09 2020 -0700

    Release google-cloud-logging 2.0.0 (#7058)
    
    * Update to use the microgenerator-generated low-level client

commit b8ac0dfc9d37433763439c62d2f07f2f7cdef936
Author: Daniel Azuma <dazuma@google.com>
Date:   Mon Jul 20 17:14:45 2020 -0700

    feat(logging)!: Use new generated client classes

commit 7d35382342311d90650d622879b8deb700e67550
Author: Daniel Azuma <dazuma@google.com>
Date:   Sun Jun 21 18:06:44 2020 -0700

    chore: Unpin protobuf on Ruby 2.4
</code></pre></details>

This pull request was generated using releasetool.