### PR TITLE
Release google-cloud-debugger 0.40.0

### DIFF
--- a/google-cloud-debugger/CHANGELOG.md
+++ b/google-cloud-debugger/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Release History
 
+### 0.40.0 / 2020-07-21
+
+This is a major update that removes the "low-level" client interface code, and
+instead adds the new `google-cloud-debugger-v2` gem as a dependency.
+The new dependency is a rewritten low-level client, produced by a next-
+generation client code generator, with improved performance and stability.
+
+This change should have no effect on the high-level interface that most users
+will use. The one exception is that the (mostly undocumented) `client_config`
+argument, for adjusting low-level parameters such as RPC retry settings on
+client objects, has been removed. If you need to adjust these parameters, use
+the configuration interface in `google-cloud-debugger-v2`.
+
+Substantial changes have been made in the low-level interfaces, however. If you
+are using the low-level classes under the `Google::Cloud::Debugger::V2` module,
+please review the docs for the new `google-cloud-debugger-v2` gem. In
+particular:
+
+* Some classes have been renamed, notably the client class itself.
+* The client constructor takes a configuration block instead of configuration
+  keyword arguments.
+* All RPC method arguments are now keyword arguments.
+
 ### 0.36.3 / 2020-07-06
 
 #### Bug Fixes

--- a/google-cloud-debugger/lib/google/cloud/debugger/version.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Debugger
-      VERSION = "0.36.3".freeze
+      VERSION = "0.40.0".freeze
     end
   end
 end


### PR DESCRIPTION
This is a major update that removes the "low-level" client interface code, and
instead adds the new `google-cloud-debugger-v2` gem as a dependency.
The new dependency is a rewritten low-level client, produced by a next-
generation client code generator, with improved performance and stability.

This change should have no effect on the high-level interface that most users
will use. The one exception is that the (mostly undocumented) `client_config`
argument, for adjusting low-level parameters such as RPC retry settings on
client objects, has been removed. If you need to adjust these parameters, use
the configuration interface in `google-cloud-debugger-v2`.

Substantial changes have been made in the low-level interfaces, however. If you
are using the low-level classes under the `Google::Cloud::Debugger::V2` module,
please review the docs for the new `google-cloud-debugger-v2` gem. In
particular:

* Some classes have been renamed, notably the client class itself.
* The client constructor takes a configuration block instead of configuration
  keyword arguments.
* All RPC method arguments are now keyword arguments.

<details><summary>Commits since previous release</summary><pre><code>commit de2197e3d69439d3b8bc73476789a1622473f54e
Author: Daniel Azuma <dazuma@google.com>
Date:   Tue Jul 21 15:29:18 2020 -0700

    feat(debugger): Update logging dependency to 2.0

commit efc526e1046083279415bb1a15ee3f59cd0669df
Author: Daniel Azuma <dazuma@google.com>
Date:   Mon Jul 20 17:15:04 2020 -0700

    feat(debugger)!: Use new generated client classes
</code></pre></details>

This pull request was generated using releasetool.