### PR TITLE
Release google-cloud-trace 0.40.0

### DIFF
--- a/google-cloud-trace/CHANGELOG.md
+++ b/google-cloud-trace/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Release History
 
+### 0.40.0 / 2020-07-23
+
+This is a major update that removes the "low-level" client interface code, and
+instead adds the new gems `google-cloud-trace-v1` and `google-cloud-trace-v2`,
+as dependencies.
+The new dependencies are rewritten low-level clients, produced by a next-
+generation client code generator, with improved performance and stability.
+
+This change should have no effect on the high-level interface that most users
+will use. The one exception is that the (mostly undocumented) `client_config`
+argument, for adjusting low-level parameters such as RPC retry settings on
+client objects, has been removed. If you need to adjust these parameters, use
+the configuration interface in low-level clients.
+
+Substantial changes have been made in the low-level interfaces, however. If you
+are using the low-level classes under the old `Google::Devtools::Cloudtrace`,
+`Google::Cloud::Trace::V1`, or `Google::Cloud::Trace::V2` modules, please
+review the docs for the new low-level gems to see usage changes. In particular:
+
+* Some classes have been renamed, notably the client class itself.
+* The client constructor takes a configuration block instead of configuration
+  keyword arguments.
+* All RPC method arguments are now keyword arguments.
+
 ### 0.39.0 / 2020-07-07
 
 #### Features

--- a/google-cloud-trace/lib/google/cloud/trace/version.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Trace
-      VERSION = "0.39.0".freeze
+      VERSION = "0.40.0".freeze
     end
   end
 end


### PR DESCRIPTION
This is a major update that removes the "low-level" client interface code, and
instead adds the new gems `google-cloud-trace-v1` and `google-cloud-trace-v2`,
as dependencies.
The new dependencies are rewritten low-level clients, produced by a next-
generation client code generator, with improved performance and stability.

This change should have no effect on the high-level interface that most users
will use. The one exception is that the (mostly undocumented) `client_config`
argument, for adjusting low-level parameters such as RPC retry settings on
client objects, has been removed. If you need to adjust these parameters, use
the configuration interface in low-level clients.

Substantial changes have been made in the low-level interfaces, however. If you
are using the low-level classes under the old `Google::Devtools::Cloudtrace`,
`Google::Cloud::Trace::V1`, or `Google::Cloud::Trace::V2` modules, please
review the docs for the new low-level gems to see usage changes. In particular:

* Some classes have been renamed, notably the client class itself.
* The client constructor takes a configuration block instead of configuration
  keyword arguments.
* All RPC method arguments are now keyword arguments.

<details><summary>Commits since previous release</summary><pre><code>commit 672dc6949e8e0dd31700438023c91511172ae336
Author: Viacheslav Rostovtsev <58152857+viacheslav-rostovtsev@users.noreply.github.com>
Date:   Thu Jul 23 12:39:02 2020 -0700

    feat(trace)!: Use new generated client classes
</code></pre></details>

This pull request was generated using releasetool.