### PR TITLE
Release google-cloud-datastore-v1 0.1.0

### DIFF
--- a/google-cloud-datastore-v1/CHANGELOG.md
+++ b/google-cloud-datastore-v1/CHANGELOG.md
@@ -1,2 +1,6 @@
 # Release History
 
+### 0.1.0 / 2020-07-27
+
+Initial release.
+

--- a/google-cloud-datastore-v1/lib/google/cloud/datastore/v1/version.rb
+++ b/google-cloud-datastore-v1/lib/google/cloud/datastore/v1/version.rb
@@ -21,7 +21,7 @@ module Google
   module Cloud
     module Datastore
       module V1
-        VERSION = "0.0.1"
+        VERSION = "0.1.0"
       end
     end
   end


### PR DESCRIPTION
Initial release.

<details><summary>Commits since previous release</summary><pre><code></code></pre></details>

This pull request was generated using releasetool.