### PR TITLE
Release google-cloud-bigtable-v2 0.1.0

### DIFF
--- a/google-cloud-bigtable-v2/CHANGELOG.md
+++ b/google-cloud-bigtable-v2/CHANGELOG.md
@@ -1,2 +1,6 @@
 # Release History
 
+### 0.1.0 / 2020-07-27
+
+Initial release.
+

--- a/google-cloud-bigtable-v2/lib/google/cloud/bigtable/v2/version.rb
+++ b/google-cloud-bigtable-v2/lib/google/cloud/bigtable/v2/version.rb
@@ -21,7 +21,7 @@ module Google
   module Cloud
     module Bigtable
       module V2
-        VERSION = "0.0.1"
+        VERSION = "0.1.0"
       end
     end
   end


### PR DESCRIPTION
Initial release.

<details><summary>Commits since previous release</summary><pre><code></code></pre></details>

This pull request was generated using releasetool.