### PR TITLE
Release google-cloud-bigtable-admin-v2 0.1.0

### DIFF
--- a/google-cloud-bigtable-admin-v2/CHANGELOG.md
+++ b/google-cloud-bigtable-admin-v2/CHANGELOG.md
@@ -1,2 +1,6 @@
 # Release History
 
+### 0.1.0 / 2020-07-27
+
+Initial release.
+

--- a/google-cloud-bigtable-admin-v2/lib/google/cloud/bigtable/admin/v2/version.rb
+++ b/google-cloud-bigtable-admin-v2/lib/google/cloud/bigtable/admin/v2/version.rb
@@ -22,7 +22,7 @@ module Google
     module Bigtable
       module Admin
         module V2
-          VERSION = "0.0.1"
+          VERSION = "0.1.0"
         end
       end
     end


### PR DESCRIPTION
Initial release.

<details><summary>Commits since previous release</summary><pre><code></code></pre></details>

This pull request was generated using releasetool.