### PR TITLE
fix(bigtable): Include correct project in resource prefix headers

### DIFF
--- a/google-cloud-bigtable/acceptance/bigtable/service_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/service_test.rb
@@ -19,7 +19,7 @@ require "bigtable_helper"
 
 describe Google::Cloud::Bigtable::Service, :bigtable do
   let(:config_metadata) { { :"google-cloud-resource-prefix" => "projects/#{bigtable.project_id}" } }
-focus
+
   it "passes the correct configuration to its v2 instance admin client" do
     _(bigtable.project_id).wont_be :empty?
     config = bigtable.service.instances.configure
@@ -28,7 +28,7 @@ focus
     _(config.lib_version).must_equal Google::Cloud::Bigtable::VERSION
     _(config.metadata).must_equal config_metadata
   end
-focus
+
   it "passes the correct configuration to its v2 table admin client" do
     _(bigtable.project_id).wont_be :empty?
     config = bigtable.service.tables.configure
@@ -37,7 +37,7 @@ focus
     _(config.lib_version).must_equal Google::Cloud::Bigtable::VERSION
     _(config.metadata).must_equal config_metadata
   end
-focus
+
   it "passes the correct configuration to its v2 client" do
     _(bigtable.project_id).wont_be :empty?
     config = bigtable.service.client.configure

--- a/google-cloud-bigtable/acceptance/bigtable/service_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/service_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "bigtable_helper"
+
+describe Google::Cloud::Bigtable::Service, :bigtable do
+  let(:config_metadata) { { :"google-cloud-resource-prefix" => "projects/#{bigtable.project_id}" } }
+focus
+  it "passes the correct configuration to its v2 instance admin client" do
+    _(bigtable.project_id).wont_be :empty?
+    config = bigtable.service.instances.configure
+    _(config).must_be_kind_of Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdmin::Client::Configuration
+    _(config.lib_name).must_equal "gccl"
+    _(config.lib_version).must_equal Google::Cloud::Bigtable::VERSION
+    _(config.metadata).must_equal config_metadata
+  end
+focus
+  it "passes the correct configuration to its v2 table admin client" do
+    _(bigtable.project_id).wont_be :empty?
+    config = bigtable.service.tables.configure
+    _(config).must_be_kind_of Google::Cloud::Bigtable::Admin::V2::BigtableTableAdmin::Client::Configuration
+    _(config.lib_name).must_equal "gccl"
+    _(config.lib_version).must_equal Google::Cloud::Bigtable::VERSION
+    _(config.metadata).must_equal config_metadata
+  end
+focus
+  it "passes the correct configuration to its v2 client" do
+    _(bigtable.project_id).wont_be :empty?
+    config = bigtable.service.client.configure
+    _(config).must_be_kind_of Google::Cloud::Bigtable::V2::Bigtable::Client::Configuration
+    _(config.lib_name).must_equal "gccl"
+    _(config.lib_version).must_equal Google::Cloud::Bigtable::VERSION
+    _(config.metadata).must_equal config_metadata
+  end
+end

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/service.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/service.rb
@@ -65,7 +65,7 @@ module Google
             config.endpoint = host_admin if host_admin
             config.lib_name = "gccl"
             config.lib_version = Google::Cloud::Bigtable::VERSION
-            config.metadata = { "google-cloud-resource-prefix" => "projects/#{@project}" }
+            config.metadata = { "google-cloud-resource-prefix": "projects/#{@project_id}" }
           end
         end
         attr_accessor :mocked_instances
@@ -78,7 +78,7 @@ module Google
             config.endpoint = host_admin if host_admin
             config.lib_name = "gccl"
             config.lib_version = Google::Cloud::Bigtable::VERSION
-            config.metadata = { "google-cloud-resource-prefix" => "projects/#{@project}" }
+            config.metadata = { "google-cloud-resource-prefix": "projects/#{@project_id}" }
           end
         end
         attr_accessor :mocked_tables
@@ -91,7 +91,7 @@ module Google
             config.endpoint = host if host
             config.lib_name = "gccl"
             config.lib_version = Google::Cloud::Bigtable::VERSION
-            config.metadata = { "google-cloud-resource-prefix" => "projects/#{@project}" }
+            config.metadata = { "google-cloud-resource-prefix": "projects/#{@project_id}" }
           end
         end
         attr_accessor :mocked_client


### PR DESCRIPTION
The instance variable is `@project_id` rather than `@project` in bigtable. (This is different from most libraries.)

Also changed the keys to symbols, because it's kinda preferred. The other metadata keys, as set in the generated clients, are symbols. It doesn't really matter—gRPC will take either symbols or strings—but for consistency we'll use symbols.