### PR TITLE
test(pubsub): Increase deadline for acceptance test for ordered keys

### DIFF
--- a/google-cloud-pubsub/acceptance/pubsub/async_test.rb
+++ b/google-cloud-pubsub/acceptance/pubsub/async_test.rb
@@ -14,7 +14,7 @@
 
 require "pubsub_helper"
 
-describe Google::Cloud::PubSub, :async, :pubsub do  
+describe Google::Cloud::PubSub, :async, :pubsub do
   def retrieve_topic topic_name
     pubsub.get_topic(topic_name) || pubsub.create_topic(topic_name)
   end

--- a/google-cloud-pubsub/acceptance/pubsub/async_test.rb
+++ b/google-cloud-pubsub/acceptance/pubsub/async_test.rb
@@ -14,7 +14,7 @@
 
 require "pubsub_helper"
 
-describe Google::Cloud::PubSub, :async, :pubsub do
+describe Google::Cloud::PubSub, :async, :pubsub do  
   def retrieve_topic topic_name
     pubsub.get_topic(topic_name) || pubsub.create_topic(topic_name)
   end
@@ -84,36 +84,44 @@ describe Google::Cloud::PubSub, :async, :pubsub do
     events = sub.pull
     _(events).must_be :empty?
 
-    # Publish a new message
-    publish_result = nil
+    expected_message_hash = {
+      "a" => [
+        "ordered message 0",
+        "ordered message 1",
+        "ordered message 2",
+        "ordered message 3",
+        "ordered message 4"
+      ],
+      "b" => [
+        "ordered message 5",
+        "ordered message 6",
+        "ordered message 7",
+        "ordered message 8",
+        "ordered message 9"
+      ]
+    }
 
-    topic.publish_async "ordered message 0", ordering_key: "a"
-    topic.publish_async "ordered message 1", ordering_key: "a"
-    topic.publish_async "ordered message 2", ordering_key: "a"
-    topic.publish_async "ordered message 3", ordering_key: "a"
-    topic.publish_async "ordered message 4", ordering_key: "a"
-    topic.publish_async "ordered message 5", ordering_key: "a" do |result|
-      publish_result = result
-      assert_equal "ordered message 5", result.msg.data
+    expected_message_hash.keys.each do |key|
+      publish_result = nil
+      expected_message_hash[key].each do |data|
+        # Publish a new message with ordering key
+        topic.publish_async data, ordering_key: key do |result|
+          publish_result = result
+          assert_equal data, result.msg.data
+        end
+      end
+      sleep 1
+      # Verify the final publish_result
+      unpublished_retries = 0
+      while publish_result.nil?
+        fail "publish a has failed" if unpublished_retries >= 5
+        unpublished_retries += 1
+        puts "the async publish a has not completed yet. sleeping for #{unpublished_retries*unpublished_retries} second(s) and retrying."
+        sleep unpublished_retries*unpublished_retries
+      end
+      _(publish_result).wont_be :nil?
+      _(publish_result).must_be :succeeded?
     end
-
-    topic.publish_async "ordered message 6", ordering_key: "b"
-    topic.publish_async "ordered message 7", ordering_key: "b"
-    topic.publish_async "ordered message 8", ordering_key: "b"
-    topic.publish_async "ordered message 9", ordering_key: "b" do |result|
-      publish_result = result
-      assert_equal "ordered message 9", result.msg.data
-    end
-
-    unpublished_retries = 0
-    while publish_result.nil?
-      fail "publish has failed" if unpublished_retries >= 5
-      unpublished_retries += 1
-      puts "the async publish has not completed yet. sleeping for #{unpublished_retries*unpublished_retries} second(s) and retrying."
-      sleep unpublished_retries*unpublished_retries
-    end
-    _(publish_result).wont_be :nil?
-    _(publish_result).must_be :succeeded?
 
     received_message_hash = Hash.new { |hash, key| hash[key] = [] }
     subscriber = sub.listen do |msg|
@@ -121,38 +129,23 @@ describe Google::Cloud::PubSub, :async, :pubsub do
       # Acknowledge the message
       msg.ack!
     end
-    subscriber.start
-
-    subscription_retries = 0
-    while received_message_hash.values.map(&:count).sum < 10
-      fail "published message was never received has failed" if subscription_retries >= 10
-      subscription_retries += 1
-      puts "received_message has not been received. sleeping for #{subscription_retries} second(s) and retrying."
-      sleep subscription_retries
+    subscriber.on_error do |error|
+      fail error.inspect
     end
-
-    expected_message_hash = {
-      "a" => [
-        "ordered message 0",
-        "ordered message 1",
-        "ordered message 2",
-        "ordered message 3",
-        "ordered message 4",
-        "ordered message 5"
-      ],
-      "b" => [
-        "ordered message 6",
-        "ordered message 7",
-        "ordered message 8",
-        "ordered message 9"
-      ]
-    }
-    _(received_message_hash).must_equal expected_message_hash
+    subscriber.start
+    
+    counter = 0
+    deadline = 300 # 5 min
+    while received_message_hash.values.map(&:count).sum < 10 && counter < deadline
+      sleep 1
+      counter += 1
+    end
 
     subscriber.stop
     subscriber.wait!
-
     # Remove the subscription
     sub.delete
+
+    _(received_message_hash).must_equal expected_message_hash
   end
 end


### PR DESCRIPTION
This test can take over 2 minutes to complete, so increase the deadline for waiting for received messages to 5 min.