### PR TITLE
fix(datastore): Change client config metadata hash keys to symbols

### DIFF
--- a/google-cloud-datastore/acceptance/datastore/datastore_test.rb
+++ b/google-cloud-datastore/acceptance/datastore/datastore_test.rb
@@ -16,7 +16,7 @@ require "datastore_helper"
 
 # This test is a ruby version of gcloud-node's datastore test.
 
-describe "Datastore", :datastore do
+describe Google::Cloud::Datastore::Dataset, :datastore do
   let(:prefix) { "#{Time.now.utc.iso8601.gsub ":", "_"}_#{SecureRandom.hex(4)}" }
 
   it "should allocate IDs" do

--- a/google-cloud-datastore/acceptance/datastore/service_test.rb
+++ b/google-cloud-datastore/acceptance/datastore/service_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "datastore_helper"
+
+describe Google::Cloud::Datastore::Service, :datastore do
+  let(:config_metadata) { { "google-cloud-resource-prefix": "projects/#{dataset.project_id}" } }
+
+  it "passes the correct configuration to its v1 client" do
+    _(dataset.project_id).wont_be :empty?
+    config = dataset.service.service.configure
+    _(config).must_be_kind_of Google::Cloud::Datastore::V1::Datastore::Client::Configuration
+    _(config.lib_name).must_equal "gccl"
+    _(config.lib_version).must_equal Google::Cloud::Datastore::VERSION
+    _(config.metadata).must_equal config_metadata
+  end
+end

--- a/google-cloud-datastore/lib/google/cloud/datastore/service.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/service.rb
@@ -44,7 +44,7 @@ module Google
             config.endpoint = host if host
             config.lib_name = "gccl"
             config.lib_version = Google::Cloud::Datastore::VERSION
-            config.metadata = { "google-cloud-resource-prefix" => "projects/#{@project}" }
+            config.metadata = { "google-cloud-resource-prefix": "projects/#{@project}" }
           end
         end
         attr_accessor :mocked_service


### PR DESCRIPTION
As explained in #7131 

> changed the keys to symbols, because it's kinda preferred. The other metadata keys, as set in the generated clients, are symbols. It doesn't really matter—gRPC will take either symbols or strings—but for consistency we'll use symbols.