### PR TITLE
fix(pubsub): Change client config metadata hash keys to symbols

### DIFF
--- a/google-cloud-pubsub/acceptance/pubsub/service_test.rb
+++ b/google-cloud-pubsub/acceptance/pubsub/service_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "pubsub_helper"
+
+describe Google::Cloud::PubSub::Service, :pubsub do
+  let(:config_metadata) { { "google-cloud-resource-prefix": "projects/#{pubsub.project_id}" } }
+
+  it "passes the correct configuration to its v1 subscriber client" do
+    _(pubsub.project_id).wont_be :empty?
+    config = pubsub.service.subscriber.configure
+    _(config).must_be_kind_of Google::Cloud::PubSub::V1::Subscriber::Client::Configuration
+    _(config.lib_name).must_equal "gccl"
+    _(config.lib_version).must_equal Google::Cloud::PubSub::VERSION
+    _(config.metadata).must_equal config_metadata
+  end
+
+  it "passes the correct configuration to its v1 publisher client" do
+    _(pubsub.project_id).wont_be :empty?
+    config = pubsub.service.publisher.configure
+    _(config).must_be_kind_of Google::Cloud::PubSub::V1::Publisher::Client::Configuration
+    _(config.lib_name).must_equal "gccl"
+    _(config.lib_version).must_equal Google::Cloud::PubSub::VERSION
+    _(config.metadata).must_equal config_metadata
+  end
+end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
@@ -53,7 +53,7 @@ module Google
               config.endpoint = host if host
               config.lib_name = "gccl"
               config.lib_version = Google::Cloud::PubSub::VERSION
-              config.metadata = { "google-cloud-resource-prefix" => "projects/#{@project}" }
+              config.metadata = { "google-cloud-resource-prefix": "projects/#{@project}" }
             end
           end
         end
@@ -68,7 +68,7 @@ module Google
               config.endpoint = host if host
               config.lib_name = "gccl"
               config.lib_version = Google::Cloud::PubSub::VERSION
-              config.metadata = { "google-cloud-resource-prefix" => "projects/#{@project}" }
+              config.metadata = { "google-cloud-resource-prefix": "projects/#{@project}" }
             end
           end
         end


### PR DESCRIPTION
As explained in #7131 

> changed the keys to symbols, because it's kinda preferred. The other metadata keys, as set in the generated clients, are symbols. It doesn't really matter—gRPC will take either symbols or strings—but for consistency we'll use symbols.