### PR TITLE
fix(grafeas-v1): Fix retry logic by checking the correct numeric error codes

### DIFF
--- a/grafeas-v1/lib/grafeas/v1/grafeas/client.rb
+++ b/grafeas-v1/lib/grafeas/v1/grafeas/client.rb
@@ -81,7 +81,7 @@ module Grafeas
               initial_delay: 0.1,
               max_delay:     60.0,
               multiplier:    1.3,
-              retry_codes:   ["UNAVAILABLE", "DEADLINE_EXCEEDED"]
+              retry_codes:   [14, 4]
             }
 
             default_config.rpcs.list_occurrences.timeout = 30.0
@@ -89,7 +89,7 @@ module Grafeas
               initial_delay: 0.1,
               max_delay:     60.0,
               multiplier:    1.3,
-              retry_codes:   ["UNAVAILABLE", "DEADLINE_EXCEEDED"]
+              retry_codes:   [14, 4]
             }
 
             default_config.rpcs.delete_occurrence.timeout = 30.0
@@ -97,7 +97,7 @@ module Grafeas
               initial_delay: 0.1,
               max_delay:     60.0,
               multiplier:    1.3,
-              retry_codes:   ["UNAVAILABLE", "DEADLINE_EXCEEDED"]
+              retry_codes:   [14, 4]
             }
 
             default_config.rpcs.create_occurrence.timeout = 30.0
@@ -111,7 +111,7 @@ module Grafeas
               initial_delay: 0.1,
               max_delay:     60.0,
               multiplier:    1.3,
-              retry_codes:   ["UNAVAILABLE", "DEADLINE_EXCEEDED"]
+              retry_codes:   [14, 4]
             }
 
             default_config.rpcs.get_note.timeout = 30.0
@@ -119,7 +119,7 @@ module Grafeas
               initial_delay: 0.1,
               max_delay:     60.0,
               multiplier:    1.3,
-              retry_codes:   ["UNAVAILABLE", "DEADLINE_EXCEEDED"]
+              retry_codes:   [14, 4]
             }
 
             default_config.rpcs.list_notes.timeout = 30.0
@@ -127,7 +127,7 @@ module Grafeas
               initial_delay: 0.1,
               max_delay:     60.0,
               multiplier:    1.3,
-              retry_codes:   ["UNAVAILABLE", "DEADLINE_EXCEEDED"]
+              retry_codes:   [14, 4]
             }
 
             default_config.rpcs.delete_note.timeout = 30.0
@@ -135,7 +135,7 @@ module Grafeas
               initial_delay: 0.1,
               max_delay:     60.0,
               multiplier:    1.3,
-              retry_codes:   ["UNAVAILABLE", "DEADLINE_EXCEEDED"]
+              retry_codes:   [14, 4]
             }
 
             default_config.rpcs.create_note.timeout = 30.0
@@ -149,7 +149,7 @@ module Grafeas
               initial_delay: 0.1,
               max_delay:     60.0,
               multiplier:    1.3,
-              retry_codes:   ["UNAVAILABLE", "DEADLINE_EXCEEDED"]
+              retry_codes:   [14, 4]
             }
 
             default_config

--- a/grafeas-v1/lib/grafeas/v1/grafeas_services_pb.rb
+++ b/grafeas-v1/lib/grafeas/v1/grafeas_services_pb.rb
@@ -45,38 +45,38 @@ module Grafeas
         self.service_name = 'grafeas.v1.Grafeas'
 
         # Gets the specified occurrence.
-        rpc :GetOccurrence, GetOccurrenceRequest, Occurrence
+        rpc :GetOccurrence, ::Grafeas::V1::GetOccurrenceRequest, ::Grafeas::V1::Occurrence
         # Lists occurrences for the specified project.
-        rpc :ListOccurrences, ListOccurrencesRequest, ListOccurrencesResponse
+        rpc :ListOccurrences, ::Grafeas::V1::ListOccurrencesRequest, ::Grafeas::V1::ListOccurrencesResponse
         # Deletes the specified occurrence. For example, use this method to delete an
         # occurrence when the occurrence is no longer applicable for the given
         # resource.
-        rpc :DeleteOccurrence, DeleteOccurrenceRequest, Google::Protobuf::Empty
+        rpc :DeleteOccurrence, ::Grafeas::V1::DeleteOccurrenceRequest, ::Google::Protobuf::Empty
         # Creates a new occurrence.
-        rpc :CreateOccurrence, CreateOccurrenceRequest, Occurrence
+        rpc :CreateOccurrence, ::Grafeas::V1::CreateOccurrenceRequest, ::Grafeas::V1::Occurrence
         # Creates new occurrences in batch.
-        rpc :BatchCreateOccurrences, BatchCreateOccurrencesRequest, BatchCreateOccurrencesResponse
+        rpc :BatchCreateOccurrences, ::Grafeas::V1::BatchCreateOccurrencesRequest, ::Grafeas::V1::BatchCreateOccurrencesResponse
         # Updates the specified occurrence.
-        rpc :UpdateOccurrence, UpdateOccurrenceRequest, Occurrence
+        rpc :UpdateOccurrence, ::Grafeas::V1::UpdateOccurrenceRequest, ::Grafeas::V1::Occurrence
         # Gets the note attached to the specified occurrence. Consumer projects can
         # use this method to get a note that belongs to a provider project.
-        rpc :GetOccurrenceNote, GetOccurrenceNoteRequest, Note
+        rpc :GetOccurrenceNote, ::Grafeas::V1::GetOccurrenceNoteRequest, ::Grafeas::V1::Note
         # Gets the specified note.
-        rpc :GetNote, GetNoteRequest, Note
+        rpc :GetNote, ::Grafeas::V1::GetNoteRequest, ::Grafeas::V1::Note
         # Lists notes for the specified project.
-        rpc :ListNotes, ListNotesRequest, ListNotesResponse
+        rpc :ListNotes, ::Grafeas::V1::ListNotesRequest, ::Grafeas::V1::ListNotesResponse
         # Deletes the specified note.
-        rpc :DeleteNote, DeleteNoteRequest, Google::Protobuf::Empty
+        rpc :DeleteNote, ::Grafeas::V1::DeleteNoteRequest, ::Google::Protobuf::Empty
         # Creates a new note.
-        rpc :CreateNote, CreateNoteRequest, Note
+        rpc :CreateNote, ::Grafeas::V1::CreateNoteRequest, ::Grafeas::V1::Note
         # Creates new notes in batch.
-        rpc :BatchCreateNotes, BatchCreateNotesRequest, BatchCreateNotesResponse
+        rpc :BatchCreateNotes, ::Grafeas::V1::BatchCreateNotesRequest, ::Grafeas::V1::BatchCreateNotesResponse
         # Updates the specified note.
-        rpc :UpdateNote, UpdateNoteRequest, Note
+        rpc :UpdateNote, ::Grafeas::V1::UpdateNoteRequest, ::Grafeas::V1::Note
         # Lists occurrences referencing the specified note. Provider projects can use
         # this method to get all occurrences across consumer projects referencing the
         # specified note.
-        rpc :ListNoteOccurrences, ListNoteOccurrencesRequest, ListNoteOccurrencesResponse
+        rpc :ListNoteOccurrences, ::Grafeas::V1::ListNoteOccurrencesRequest, ::Grafeas::V1::ListNoteOccurrencesResponse
       end
 
       Stub = Service.rpc_stub_class

--- a/grafeas-v1/synth.metadata
+++ b/grafeas-v1/synth.metadata
@@ -3,16 +3,16 @@
     {
       "git": {
         "name": ".",
-        "remote": "https://github.com/googleapis/google-cloud-ruby.git",
-        "sha": "f8378095fa3814db457a7533e6d643476f0bf12e"
+        "remote": "git@github.com:googleapis/google-cloud-ruby.git",
+        "sha": "c6c091a37c3a8c71a896c95c15d6dc552d72b2fe"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "907754d70ec714ab0e8282fe6ff4988221c64130",
-        "internalRef": "314217336"
+        "sha": "96ef637adf148d54236ad83fefa30c7f75f29737",
+        "internalRef": "325052820"
       }
     }
   ],

--- a/grafeas-v1/synth.py
+++ b/grafeas-v1/synth.py
@@ -37,3 +37,10 @@ library = gapic.ruby_library(
 )
 
 s.copy(library, merge=ruby.global_merge)
+
+# Workaround for https://github.com/grpc/grpc/issues/23746
+s.replace(
+    "lib/grafeas/v1/grafeas_services_pb.rb",
+    "rpc :(\w+), (Grafeas::[\w:]+), (G[a-z]+::[\w:]+)",
+    "rpc :\\1, ::\\2, ::\\3"
+)


### PR DESCRIPTION
Replaces #7208.

Adds a workaround for https://github.com/grpc/grpc/issues/23746 to the synth script. It forces the request and response class names in the grpc-generated service class to be absolute, to prevent errors that happen because there is a `Grafeas::V1::Grafeas` module.
