### PR TITLE
chore: Remove os_login synth hacks that are no longer needed

### DIFF
--- a/google-cloud-os_login-v1/synth.py
+++ b/google-cloud-os_login-v1/synth.py
@@ -42,10 +42,3 @@ library = gapic.ruby_library(
 )
 
 s.copy(library, merge=ruby.global_merge)
-
-# Workaround for https://github.com/grpc/grpc/issues/23490
-s.replace(
-    "lib/**/*_pb.rb",
-    'Google::Cloud::OsLogin::Common::Google::Cloud::Oslogin::Common::',
-    'Google::Cloud::OsLogin::Common::'
-)

--- a/google-cloud-os_login-v1beta/synth.py
+++ b/google-cloud-os_login-v1beta/synth.py
@@ -42,10 +42,3 @@ library = gapic.ruby_library(
 )
 
 s.copy(library, merge=ruby.global_merge)
-
-# Workaround for https://github.com/grpc/grpc/issues/23490
-s.replace(
-    "lib/**/*_pb.rb",
-    'Google::Cloud::OsLogin::Common::Google::Cloud::Oslogin::Common::',
-    'Google::Cloud::OsLogin::Common::'
-)


### PR DESCRIPTION
The gRPC protoc plugin issue that was being worked around, is now fixed and the updated grpc release is now in the current generator image. These synth hacks are no longer needed.