### PR TITLE
Ruby gem no doc tweak

### DIFF
--- a/.kokoro/docker/autosynth/Dockerfile
+++ b/.kokoro/docker/autosynth/Dockerfile
@@ -44,7 +44,7 @@ RUN git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ru
 
 # Install ruby
 ENV RUBY_CONFIGURE_OPTS --disable-install-doc
-RUN echo 'gem: --no-rdoc --no-ri' >> /.gemrc
+RUN echo 'gem: --no-document' >> /.gemrc
 RUN rbenv install 2.7.1 && rbenv global 2.7.1 \
     && gem install bundler:1.17.3 bundler:2.1.4 rake
 

--- a/.kokoro/docker/multi/Dockerfile
+++ b/.kokoro/docker/multi/Dockerfile
@@ -31,7 +31,7 @@ RUN git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ru
 # Install ruby
 ENV RUBY_CONFIGURE_OPTS --disable-install-doc
 ENV RUBY_VERSIONS "2.4.10 2.5.8 2.6.6 2.7.1"
-RUN echo 'gem: --no-rdoc --no-ri' >> /.gemrc
+RUN echo 'gem: --no-document' >> /.gemrc
 RUN for version in ${RUBY_VERSIONS}; do \
         rbenv install "$version" && rbenv global "$version" && \
         gem install bundler:1.17.3 bundler:2.1.4 && gem update --system \

--- a/.kokoro/docker/release/Dockerfile
+++ b/.kokoro/docker/release/Dockerfile
@@ -20,7 +20,7 @@ RUN git clone https://github.com/rbenv/ruby-build.git $HOME/.ruby-build
 RUN $HOME/.ruby-build/bin/ruby-build 2.7.1 $HOME/.ruby
 ENV PATH /root/.ruby/bin:$PATH
 ENV RUBY_CONFIGURE_OPTS --disable-install-doc
-RUN echo 'gem: --no-rdoc --no-ri' >> /.gemrc
+RUN echo 'gem: --no-document' >> /.gemrc
 RUN gem install bundler:1.17.3 bundler:2.1.4 && gem update --system
 
 # Install Python

--- a/.kokoro/docker/windows/Dockerfile
+++ b/.kokoro/docker/windows/Dockerfile
@@ -35,6 +35,6 @@ RUN [Net.ServicePointManager]::SecurityProtocol = 'tls12, tls11, tls'; \
 
 RUN C:\Ruby25-x64\bin\ridk install 1 2 3
 
-RUN gem install bundler:1.17.3
+RUN gem install --no-document bundler:1.17.3
 
 RUN gem update --system

--- a/.kokoro/templates/autosynth.Dockerfile.erb
+++ b/.kokoro/templates/autosynth.Dockerfile.erb
@@ -44,7 +44,7 @@ RUN git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ru
 
 # Install ruby
 ENV RUBY_CONFIGURE_OPTS --disable-install-doc
-RUN echo 'gem: --no-rdoc --no-ri' >> /.gemrc
+RUN echo 'gem: --no-document' >> /.gemrc
 RUN rbenv install <%= ruby_versions[-1] %> && rbenv global <%= ruby_versions[-1] %> \
     && gem install bundler:1.17.3 bundler:2.1.4 rake
 

--- a/.kokoro/templates/multi.Dockerfile.erb
+++ b/.kokoro/templates/multi.Dockerfile.erb
@@ -31,7 +31,7 @@ RUN git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ru
 # Install ruby
 ENV RUBY_CONFIGURE_OPTS --disable-install-doc
 ENV RUBY_VERSIONS "<%= ruby_versions.join(" ") %>"
-RUN echo 'gem: --no-rdoc --no-ri' >> /.gemrc
+RUN echo 'gem: --no-document' >> /.gemrc
 RUN for version in ${RUBY_VERSIONS}; do \
         rbenv install "$version" && rbenv global "$version" && \
         gem install bundler:1.17.3 bundler:2.1.4 && gem update --system \

--- a/.kokoro/templates/release.Dockerfile.erb
+++ b/.kokoro/templates/release.Dockerfile.erb
@@ -20,7 +20,7 @@ RUN git clone https://github.com/rbenv/ruby-build.git $HOME/.ruby-build
 RUN $HOME/.ruby-build/bin/ruby-build <%= ruby_versions[-1] %> $HOME/.ruby
 ENV PATH /root/.ruby/bin:$PATH
 ENV RUBY_CONFIGURE_OPTS --disable-install-doc
-RUN echo 'gem: --no-rdoc --no-ri' >> /.gemrc
+RUN echo 'gem: --no-document' >> /.gemrc
 RUN gem install bundler:1.17.3 bundler:2.1.4 && gem update --system
 
 # Install Python

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,7 +23,7 @@ rvm --default use 2.3
 
 # Install git and bundler and grpc gem
 sudo apt-get install git -y
-gem install bundler grpc
+gem install --no-document bundler grpc
 SCRIPT
 
 Vagrant.configure("2") do |config|

--- a/integration/rails4_app/Dockerfile.example
+++ b/integration/rails4_app/Dockerfile.example
@@ -22,7 +22,7 @@ RUN if test -n "$REQUESTED_RUBY_VERSION" -a \
         && git pull \
         && rbenv install -s $REQUESTED_RUBY_VERSION) \
       && rbenv global $REQUESTED_RUBY_VERSION \
-      && gem install -q --no-rdoc --no-ri bundler --version $BUNDLER_VERSION \
+      && gem install --no-document -q  bundler --version $BUNDLER_VERSION \
       && apt-get clean \
       && rm -f /var/lib/apt/lists/*_*; \
     fi

--- a/integration/rails4_app/bin/setup
+++ b/integration/rails4_app/bin/setup
@@ -9,7 +9,7 @@ Dir.chdir APP_ROOT do
   # Add necessary setup steps to this file:
 
   puts "== Installing dependencies =="
-  system "gem install bundler --conservative"
+  system "gem install --no-document bundler --conservative"
   system "bundle check || bundle install"
 
   # puts "\n== Copying sample files =="

--- a/integration/rails5_app/Dockerfile.example
+++ b/integration/rails5_app/Dockerfile.example
@@ -22,7 +22,7 @@ RUN if test -n "$REQUESTED_RUBY_VERSION" -a \
         && git pull \
         && rbenv install -s $REQUESTED_RUBY_VERSION) \
       && rbenv global $REQUESTED_RUBY_VERSION \
-      && gem install -q --no-rdoc --no-ri bundler --version $BUNDLER_VERSION \
+      && gem install --no-document -q bundler --version $BUNDLER_VERSION \
       && apt-get clean \
       && rm -f /var/lib/apt/lists/*_*; \
     fi

--- a/integration/rails5_app/bin/setup
+++ b/integration/rails5_app/bin/setup
@@ -15,7 +15,7 @@ chdir APP_ROOT do
   # Add necessary setup steps to this file.
 
   puts '== Installing dependencies =='
-  system! 'gem install bundler --conservative'
+  system! 'gem install --no-document bundler --conservative'
   system('bundle check') || system!('bundle install')
 
   # puts "\n== Copying sample files =="

--- a/integration/rails5_app/bin/update
+++ b/integration/rails5_app/bin/update
@@ -15,7 +15,7 @@ chdir APP_ROOT do
   # Add necessary update steps to this file.
 
   puts '== Installing dependencies =='
-  system! 'gem install bundler --conservative'
+  system! 'gem install --no-document bundler --conservative'
   system('bundle check') || system!('bundle install')
 
   puts "\n== Updating database =="

--- a/integration/sinatra2_app/Dockerfile.example
+++ b/integration/sinatra2_app/Dockerfile.example
@@ -22,7 +22,7 @@ RUN if test -n "$REQUESTED_RUBY_VERSION" -a \
         && git pull \
         && rbenv install -s $REQUESTED_RUBY_VERSION) \
       && rbenv global $REQUESTED_RUBY_VERSION \
-      && gem install -q --no-rdoc --no-ri bundler --version $BUNDLER_VERSION \
+      && gem install --no-document -q bundler --version $BUNDLER_VERSION \
       && apt-get clean \
       && rm -f /var/lib/apt/lists/*_*; \
     fi


### PR DESCRIPTION
Optimization tweak for ruby gems no doc while gems installation using
 "--no-document" . Also removal of deprecated "--no-ri" and "--no-rdoc".

Further , in case of Docker Containers , by restricting
--no-document , we can reduce image size.
In term of stats , it depends upon the number of packages
multiplied by their respective doc files size .

 More detail can be found at
 https://guides.rubygems.org/command-reference/#installupdate-options-2

 Signed-off-by: Pratik raj <rajpratik71@gmail.com>

closes: #7579