### PR TITLE
optimization in git clone using --depth

### DIFF
--- a/.kokoro/docker/autosynth/Dockerfile
+++ b/.kokoro/docker/autosynth/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && apt-get install -y git curl autoconf bison build-essential
 RUN apt-get -y autoclean
 
 # Install rbenv
-RUN git clone https://github.com/rbenv/rbenv.git /root/.rbenv
+RUN git clone --depth 1 https://github.com/rbenv/rbenv.git /root/.rbenv
 RUN cd /root/.rbenv && src/configure && make -C src
 
 ENV PATH /root/.rbenv/bin:$PATH
@@ -40,7 +40,7 @@ RUN echo 'eval "$(rbenv init -)"' >> .bashrc
 
 # Install ruby-build
 RUN mkdir -p "$(rbenv root)"/plugins
-RUN git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-build
+RUN git clone --depth 1 https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-build
 
 # Install ruby
 ENV RUBY_CONFIGURE_OPTS --disable-install-doc
@@ -49,7 +49,7 @@ RUN rbenv install 2.7.1 && rbenv global 2.7.1 \
     && gem install bundler:1.17.3 bundler:2.1.4 rake
 
 # Install pyenv
-RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv
+RUN git clone --depth 1 https://github.com/pyenv/pyenv.git ~/.pyenv
 RUN cd /root/.rbenv && src/configure && make -C src
 
 ENV PATH /root/.pyenv/bin:$PATH
@@ -64,7 +64,7 @@ RUN pyenv install 3.6.9
 RUN pyenv global 3.6.9
 
 # Install nodenv
-RUN git clone https://github.com/nodenv/nodenv.git ~/.nodenv
+RUN git clone --depth 1 https://github.com/nodenv/nodenv.git ~/.nodenv
 RUN cd /root/.nodenv && src/configure && make -C src
 
 ENV PATH /root/.nodenv/bin:$PATH
@@ -73,7 +73,7 @@ ENV PATH /root/.nodenv/shims:$PATH
 RUN echo 'export PATH="$HOME/.nodenv/bin:$PATH"' >> ~/.bashrc
 RUN echo 'eval "$(nodenv init -)"' >> ~/.bashrc
 RUN mkdir -p "$(nodenv root)"/plugins
-RUN git clone https://github.com/nodenv/node-build.git "$(nodenv root)"/plugins/node-build
+RUN git clone --depth 1 https://github.com/nodenv/node-build.git "$(nodenv root)"/plugins/node-build
 
 # Install nodejs
 RUN nodenv install 10.16.3

--- a/.kokoro/docker/multi/Dockerfile
+++ b/.kokoro/docker/multi/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y git curl autoconf bison build-essential
 RUN apt-get -y autoclean
 
 # Install rbenv
-RUN git clone https://github.com/rbenv/rbenv.git /root/.rbenv
+RUN git clone --depth 1 https://github.com/rbenv/rbenv.git /root/.rbenv
 RUN cd /root/.rbenv && src/configure && make -C src
 
 ENV PATH /root/.rbenv/bin:$PATH
@@ -25,7 +25,7 @@ RUN echo 'eval "$(rbenv init -)"' >> .bashrc
 
 # Install ruby-build
 RUN mkdir -p "$(rbenv root)"/plugins
-RUN git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-build
+RUN git clone --depth 1 https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-build
 
 
 # Install ruby

--- a/.kokoro/docker/release/Dockerfile
+++ b/.kokoro/docker/release/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get -y autoclean
 
 # Install Ruby
 RUN mkdir $HOME/.ruby
-RUN git clone https://github.com/rbenv/ruby-build.git $HOME/.ruby-build
+RUN git clone --depth 1 https://github.com/rbenv/ruby-build.git $HOME/.ruby-build
 RUN $HOME/.ruby-build/bin/ruby-build 2.7.1 $HOME/.ruby
 ENV PATH /root/.ruby/bin:$PATH
 ENV RUBY_CONFIGURE_OPTS --disable-install-doc
@@ -24,7 +24,7 @@ RUN echo 'gem: --no-rdoc --no-ri' >> /.gemrc
 RUN gem install bundler:1.17.3 bundler:2.1.4 && gem update --system
 
 # Install Python
-RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv
+RUN git clone --depth 1 https://github.com/pyenv/pyenv.git ~/.pyenv
 ENV PYENV_ROOT /root/.pyenv
 ENV PATH /root/.pyenv/bin:$PATH
 ENV PATH /root/.pyenv/shims:$PATH

--- a/.kokoro/templates/autosynth.Dockerfile.erb
+++ b/.kokoro/templates/autosynth.Dockerfile.erb
@@ -29,7 +29,7 @@ RUN apt-get update && apt-get install -y git curl autoconf bison build-essential
 RUN apt-get -y autoclean
 
 # Install rbenv
-RUN git clone https://github.com/rbenv/rbenv.git /root/.rbenv
+RUN git clone --depth 1 https://github.com/rbenv/rbenv.git /root/.rbenv
 RUN cd /root/.rbenv && src/configure && make -C src
 
 ENV PATH /root/.rbenv/bin:$PATH
@@ -40,7 +40,7 @@ RUN echo 'eval "$(rbenv init -)"' >> .bashrc
 
 # Install ruby-build
 RUN mkdir -p "$(rbenv root)"/plugins
-RUN git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-build
+RUN git clone --depth 1 https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-build
 
 # Install ruby
 ENV RUBY_CONFIGURE_OPTS --disable-install-doc
@@ -49,7 +49,7 @@ RUN rbenv install <%= ruby_versions[-1] %> && rbenv global <%= ruby_versions[-1]
     && gem install bundler:1.17.3 bundler:2.1.4 rake
 
 # Install pyenv
-RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv
+RUN git clone --depth 1 https://github.com/pyenv/pyenv.git ~/.pyenv
 RUN cd /root/.rbenv && src/configure && make -C src
 
 ENV PATH /root/.pyenv/bin:$PATH
@@ -64,7 +64,7 @@ RUN pyenv install 3.6.9
 RUN pyenv global 3.6.9
 
 # Install nodenv
-RUN git clone https://github.com/nodenv/nodenv.git ~/.nodenv
+RUN git clone --depth 1 https://github.com/nodenv/nodenv.git ~/.nodenv
 RUN cd /root/.nodenv && src/configure && make -C src
 
 ENV PATH /root/.nodenv/bin:$PATH
@@ -73,7 +73,7 @@ ENV PATH /root/.nodenv/shims:$PATH
 RUN echo 'export PATH="$HOME/.nodenv/bin:$PATH"' >> ~/.bashrc
 RUN echo 'eval "$(nodenv init -)"' >> ~/.bashrc
 RUN mkdir -p "$(nodenv root)"/plugins
-RUN git clone https://github.com/nodenv/node-build.git "$(nodenv root)"/plugins/node-build
+RUN git clone --depth 1 https://github.com/nodenv/node-build.git "$(nodenv root)"/plugins/node-build
 
 # Install nodejs
 RUN nodenv install 10.16.3

--- a/.kokoro/templates/multi.Dockerfile.erb
+++ b/.kokoro/templates/multi.Dockerfile.erb
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y git curl autoconf bison build-essential
 RUN apt-get -y autoclean
 
 # Install rbenv
-RUN git clone https://github.com/rbenv/rbenv.git /root/.rbenv
+RUN git clone --depth 1 https://github.com/rbenv/rbenv.git /root/.rbenv
 RUN cd /root/.rbenv && src/configure && make -C src
 
 ENV PATH /root/.rbenv/bin:$PATH
@@ -25,7 +25,7 @@ RUN echo 'eval "$(rbenv init -)"' >> .bashrc
 
 # Install ruby-build
 RUN mkdir -p "$(rbenv root)"/plugins
-RUN git clone https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-build
+RUN git clone --depth 1 https://github.com/rbenv/ruby-build.git "$(rbenv root)"/plugins/ruby-build
 
 
 # Install ruby

--- a/.kokoro/templates/release.Dockerfile.erb
+++ b/.kokoro/templates/release.Dockerfile.erb
@@ -16,7 +16,7 @@ RUN apt-get -y autoclean
 
 # Install Ruby
 RUN mkdir $HOME/.ruby
-RUN git clone https://github.com/rbenv/ruby-build.git $HOME/.ruby-build
+RUN git clone --depth 1 https://github.com/rbenv/ruby-build.git $HOME/.ruby-build
 RUN $HOME/.ruby-build/bin/ruby-build <%= ruby_versions[-1] %> $HOME/.ruby
 ENV PATH /root/.ruby/bin:$PATH
 ENV RUBY_CONFIGURE_OPTS --disable-install-doc
@@ -24,7 +24,7 @@ RUN echo 'gem: --no-rdoc --no-ri' >> /.gemrc
 RUN gem install bundler:1.17.3 bundler:2.1.4 && gem update --system
 
 # Install Python
-RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv
+RUN git clone --depth 1 https://github.com/pyenv/pyenv.git ~/.pyenv
 ENV PYENV_ROOT /root/.pyenv
 ENV PATH /root/.pyenv/bin:$PATH
 ENV PATH /root/.pyenv/shims:$PATH


### PR DESCRIPTION
optimize the git clone using --depth flag in term of size of clone
and also in term's of time taken to fetch the files and commit history
of whole repository .

Further , in case of Docker Containers , by restricting --depth flag,
we can reduce image size. In term of stats , it depends upon the repository size .

More detail can be found at blog
https://www.atlassian.com/git/tutorials/big-repositories

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>

closes: #7581 