### PR TITLE
Release google-cloud-storage 1.28.0

### DIFF
--- a/google-cloud-storage/CHANGELOG.md
+++ b/google-cloud-storage/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Release History
 
+### 1.28.0 / 2020-08-26
+
+* Add Object Lifecycle Management fields
+  * Add custom_time_before to Lifecycle::Rule
+  * Add days_since_custom_time to Lifecycle::Rule
+  * Add days_since_noncurrent_time to Lifecycle::Rule
+  * Add noncurrent_time_before to Lifecycle::Rule
+  * Add File#custom_time and #custom_time=
+
 ### 1.27.0 / 2020-07-29
 
 #### Features

--- a/google-cloud-storage/lib/google/cloud/storage/version.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/version.rb
@@ -16,7 +16,7 @@
 module Google
   module Cloud
     module Storage
-      VERSION = "1.27.0".freeze
+      VERSION = "1.28.0".freeze
     end
   end
 end


### PR DESCRIPTION
* Add Object Lifecycle Management fields
  * Add custom_time_before to Lifecycle::Rule
  * Add days_since_custom_time to Lifecycle::Rule
  * Add days_since_noncurrent_time to Lifecycle::Rule
  * Add noncurrent_time_before to Lifecycle::Rule
  * Add File#custom_time and #custom_time=

<details><summary>Commits since previous release</summary><pre><code>commit 563a123862880ec1c082a14bee02fcaf5d5ec989
Author: Chris Smith <quartzmo@gmail.com>
Date:   Tue Aug 25 19:16:28 2020 -0600

    feat(storage): Add Object Lifecycle Management fields
    
    * Add custom_time_before to Lifecycle::Rule
    * Add days_since_custom_time to Lifecycle::Rule
    * Add days_since_noncurrent_time to Lifecycle::Rule
    * Add noncurrent_time_before to Lifecycle::Rule
    * Add File#custom_time and #custom_time=
    
    closes: #6160
    closes: #6918
    pr:  #6649

commit 230ac963dd9379a8e6357aaeae5a971f3b2c8491
Author: Chris Smith <quartzmo@gmail.com>
Date:   Mon Aug 3 13:57:37 2020 -0600

    feat(pubsub)!: Use new generated client classes
    
    BREAKING CHANGE: Previously included generated client v1 has been removed from this gem. New generated client google-cloud-pubsub-v1 is now a dependency of this gem. Removed client_config parameter from factory methods.
    
    closes: #6488
    pr: #7050
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/google-cloud-storage/Gemfile b/google-cloud-storage/Gemfile
index 042f29842d..b633761a28 100644
--- a/google-cloud-storage/Gemfile
+++ b/google-cloud-storage/Gemfile
@@ -6,6 +6,7 @@ gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-errors", path: "../google-cloud-errors"
 gem "google-cloud-pubsub", path: "../google-cloud-pubsub"
+gem "google-cloud-pubsub-v1", path: "../google-cloud-pubsub-v1"
 
 gem "minitest-reporters", "~> 1.3.5", require: false
 gem "rake"
diff --git a/google-cloud-storage/Rakefile b/google-cloud-storage/Rakefile
index 6aeb6eb708..2692db9387 100644
--- a/google-cloud-storage/Rakefile
+++ b/google-cloud-storage/Rakefile
@@ -48,8 +48,7 @@ task :acceptance, :project, :keyfile do |t, args|
     ENV[path] = nil
   end
   require "google/cloud/pubsub/credentials"
-  (Google::Cloud::Pubsub::Credentials::PATH_ENV_VARS +
-   Google::Cloud::Pubsub::Credentials::JSON_ENV_VARS).each do |path|
+  Google::Cloud::Pubsub::Credentials.env_vars.each do |path|
     ENV[path] = nil
   end
   # always overwrite when running tests
diff --git a/google-cloud-storage/acceptance/storage/bucket_test.rb b/google-cloud-storage/acceptance/storage/bucket_test.rb
index a8d9d71e7e..0f2f61b525 100644
--- a/google-cloud-storage/acceptance/storage/bucket_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_test.rb
@@ -20,6 +20,12 @@ describe Google::Cloud::Storage::Bucket, :storage do
     storage.bucket(bucket_name) ||
     safe_gcs_execute { storage.create_bucket(bucket_name) }
   end
+  let(:created_before) { Date.parse "2019-01-15" }
+  let(:created_before_2) { Date.parse "2019-01-16" }
+  let(:custom_time_before) { Date.parse "2019-02-15" }
+  let(:custom_time_before_2) { Date.parse "2019-02-16" }
+  let(:noncurrent_time_before) { Date.parse "2019-03-15" }
+  let(:noncurrent_time_before_2) { Date.parse "2019-03-16" }
 
   before do
     # always reset the bucket permissions
@@ -143,9 +149,13 @@ describe Google::Cloud::Storage::Bucket, :storage do
     bucket.lifecycle do |l|
       l.add_set_storage_class_rule "NEARLINE",
                                    age: 10,
-                                   created_before: Date.parse("2013-01-15"), # string in RFC 3339 date format also ok
+                                   created_before: created_before, # string in RFC 3339 format with only the date part also ok
+                                   custom_time_before: "2019-02-15", # string in RFC 3339 format with only the date part also ok
+                                   days_since_custom_time: 5,
+                                   days_since_noncurrent_time: 14,
                                    is_live: true,
                                    matches_storage_class: ["STANDARD"],
+                                   noncurrent_time_before: noncurrent_time_before, # string in RFC 3339 format with only the date part also ok
                                    num_newer_versions: 3
 
     end
@@ -155,9 +165,13 @@ describe Google::Cloud::Storage::Bucket, :storage do
     _(bucket.lifecycle.last.action).must_equal "SetStorageClass"
     _(bucket.lifecycle.last.storage_class).must_equal "NEARLINE"
     _(bucket.lifecycle.last.age).must_equal 10
-    _(bucket.lifecycle.last.created_before).must_equal Date.parse("2013-01-15")
+    _(bucket.lifecycle.last.created_before).must_equal created_before
+    _(bucket.lifecycle.last.custom_time_before).must_equal custom_time_before
+    _(bucket.lifecycle.last.days_since_custom_time).must_equal 5
+    _(bucket.lifecycle.last.days_since_noncurrent_time).must_equal 14
     _(bucket.lifecycle.last.is_live).must_equal true
     _(bucket.lifecycle.last.matches_storage_class).must_equal ["STANDARD"]
+    _(bucket.lifecycle.last.noncurrent_time_before).must_equal noncurrent_time_before
     _(bucket.lifecycle.last.num_newer_versions).must_equal 3
 
     bucket.reload!
@@ -165,12 +179,28 @@ describe Google::Cloud::Storage::Bucket, :storage do
     bucket.lifecycle do |l|
       l.last.storage_class = "COLDLINE"
       l.last.age = 20
-      l.last.created_before = "2013-01-20"
+      l.last.created_before = "2019-01-16"
+      l.last.custom_time_before = "2019-02-16"
+      l.last.days_since_custom_time = 6
+      l.last.days_since_noncurrent_time = 15
       l.last.is_live = false
       l.last.matches_storage_class = ["NEARLINE"]
+      l.last.noncurrent_time_before = "2019-03-16"
       l.last.num_newer_versions = 4
+
+
+      _(l.last.created_before).must_be_kind_of String
+      _(l.last.noncurrent_time_before).must_be_kind_of String
     end
 
+    _(bucket.lifecycle.last.created_before).must_be_kind_of Date
+    _(bucket.lifecycle.last.created_before).must_equal created_before_2
+    _(bucket.lifecycle.last.custom_time_before).must_be_kind_of DateTime
+    _(bucket.lifecycle.last.custom_time_before).must_equal custom_time_before_2
+    _(bucket.lifecycle.last.noncurrent_time_before).must_be_kind_of DateTime
+    _(bucket.lifecycle.last.noncurrent_time_before).must_equal noncurrent_time_before_2
+
+
     bucket.reload!
 
     _(bucket.lifecycle).wont_be :empty?
@@ -178,9 +208,16 @@ describe Google::Cloud::Storage::Bucket, :storage do
     _(bucket.lifecycle.last.action).must_equal "SetStorageClass"
     _(bucket.lifecycle.last.storage_class).must_equal "COLDLINE"
     _(bucket.lifecycle.last.age).must_equal 20
-    _(bucket.lifecycle.last.created_before).must_equal Date.parse("2013-01-20")
+    _(bucket.lifecycle.last.created_before).must_be_kind_of Date
+    _(bucket.lifecycle.last.created_before).must_equal created_before_2
+    _(bucket.lifecycle.last.custom_time_before).must_be_kind_of DateTime
+    _(bucket.lifecycle.last.custom_time_before).must_equal custom_time_before_2
+    _(bucket.lifecycle.last.days_since_custom_time).must_equal 6
+    _(bucket.lifecycle.last.days_since_noncurrent_time).must_equal 15
     _(bucket.lifecycle.last.is_live).must_equal false
     _(bucket.lifecycle.last.matches_storage_class).must_equal ["NEARLINE"]
+    _(bucket.lifecycle.last.noncurrent_time_before).must_be_kind_of DateTime
+    _(bucket.lifecycle.last.noncurrent_time_before).must_equal noncurrent_time_before_2
     _(bucket.lifecycle.last.num_newer_versions).must_equal 4
 
     bucket.lifecycle do |l|
diff --git a/google-cloud-storage/acceptance/storage/file_test.rb b/google-cloud-storage/acceptance/storage/file_test.rb
index fea6e9bac4..cfabb1eaa3 100644
--- a/google-cloud-storage/acceptance/storage/file_test.rb
+++ b/google-cloud-storage/acceptance/storage/file_test.rb
@@ -33,6 +33,7 @@ describe Google::Cloud::Storage::File, :storage do
     ENV["GCLOUD_TEST_STORAGE_BUCKET"] || "storage-library-test-bucket"
   }
   let(:file_public_test_gzip_name) { "gzipped-text.txt" }  # content is "hello world"
+  let(:custom_time) { DateTime.new 2020, 2, 3, 4, 5, 6 }
 
   before do
     # always create the bucket
@@ -50,6 +51,7 @@ describe Google::Cloud::Storage::File, :storage do
       content_disposition: "attachment; filename=filename.ext",
       content_language: "en",
       content_type: "text/plain",
+      custom_time: custom_time,
       metadata: { player: "Alice", score: 101 }
 
     Tempfile.open ["google-cloud", ".png"] do |tmpfile|
@@ -78,6 +80,8 @@ describe Google::Cloud::Storage::File, :storage do
     _(uploaded.content_encoding).must_be :nil?
     _(uploaded.content_language).must_equal "en"
     _(uploaded.content_type).must_equal "text/plain"
+    _(uploaded.custom_time).must_be_kind_of DateTime
+    _(uploaded.custom_time).must_equal custom_time
 
     _(uploaded.metadata).must_be_kind_of Hash
     _(uploaded.metadata.size).must_equal 2
@@ -175,6 +179,7 @@ describe Google::Cloud::Storage::File, :storage do
     _(uploaded.content_encoding).must_be :nil?
     _(uploaded.content_language).must_be :nil?
     _(uploaded.content_type).must_equal "image/png"
+    _(uploaded.custom_time).must_be :nil?
 
     _(uploaded.metadata).must_be_kind_of Hash
     _(uploaded.metadata).must_be :empty?
@@ -185,6 +190,7 @@ describe Google::Cloud::Storage::File, :storage do
       f.content_disposition = "attachment; filename=filename.ext"
       f.content_language = "en"
       f.content_type = "text/plain"
+      f.custom_time = custom_time
       f.metadata = { player: "Alice" }
       f.metadata[:score] = 101
     end
@@ -204,6 +210,7 @@ describe Google::Cloud::Storage::File, :storage do
     _(uploaded.content_encoding).must_be :nil?
     _(uploaded.content_language).must_equal "en"
     _(uploaded.content_type).must_equal "text/plain"
+    _(uploaded.custom_time).must_equal custom_time
 
     _(uploaded.metadata).must_be_kind_of Hash
     _(uploaded.metadata.size).must_equal 2
@@ -231,6 +238,7 @@ describe Google::Cloud::Storage::File, :storage do
     _(uploaded.content_encoding).must_be :nil?
     _(uploaded.content_language).must_equal "en"
     _(uploaded.content_type).must_equal "text/plain"
+    _(uploaded.custom_time).must_equal custom_time
 
     _(uploaded.metadata).must_be_kind_of Hash
     _(uploaded.metadata.size).must_equal 2
diff --git a/google-cloud-storage/lib/google/cloud/storage/bucket.rb b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
index 1caebbd799..e1a3e88799 100644
--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -1128,6 +1128,11 @@ module Google
         # @param [String] content_type The
         #   [Content-Type](https://tools.ietf.org/html/rfc2616#section-14.17)
         #   response header to be returned when the file is downloaded.
+        # @param [DateTime] custom_time A custom time specified by the user for
+        #   the file. Once set, custom_time can't be unset, and it can only be
+        #   changed to a time in the future. If custom_time must be unset, you
+        #   must either perform a rewrite operation, or upload the data again
+        #   and create a new file.
         # @param [String] crc32c The CRC32c checksum of the file data, as
         #   described in [RFC 4960, Appendix
         #   B](http://tools.ietf.org/html/rfc4960#appendix-B).
@@ -1249,7 +1254,7 @@ module Google
         #
         def create_file file, path = nil, acl: nil, cache_control: nil,
                         content_disposition: nil, content_encoding: nil,
-                        content_language: nil, content_type: nil,
+                        content_language: nil, content_type: nil, custom_time: nil,
                         crc32c: nil, md5: nil, metadata: nil,
                         storage_class: nil, encryption_key: nil, kms_key: nil,
                         temporary_hold: nil, event_based_hold: nil
@@ -1264,6 +1269,7 @@ module Google
                                                        md5: md5,
                                                        cache_control: cache_control,
                                                        content_type: content_type,
+                                                       custom_time: custom_time,
                                                        content_disposition: content_disposition,
                                                        crc32c: crc32c,
                                                        content_encoding: content_encoding,
diff --git a/google-cloud-storage/lib/google/cloud/storage/bucket/lifecycle.rb b/google-cloud-storage/lib/google/cloud/storage/bucket/lifecycle.rb
index 9b04e25f2a..bd64a8bca0 100644
--- a/google-cloud-storage/lib/google/cloud/storage/bucket/lifecycle.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket/lifecycle.rb
@@ -105,6 +105,21 @@ module Google
           #   only the date part (for instance, "2013-01-15"). This condition is
           #   satisfied when a file is created before midnight of the specified
           #   date in UTC.
+          # @param [String,Date] custom_time_before A date in RFC 3339 format with
+          #   only the date part (for instance, "2013-01-15"). This condition is
+          #   satisfied when the custom time on an object is before this date in UTC.
+          # @param [Integer] days_since_custom_time Represents the number of
+          #   days elapsed since the user-specified timestamp set on an object.
+          #   The condition is satisfied if the days elapsed is at least this
+          #   number. If no custom timestamp is specified on an object, the
+          #   condition does not apply.
+          # @param [Integer] days_since_noncurrent_time Represents the number of
+          #   days elapsed since the noncurrent timestamp of an object. The
+          #   condition is satisfied if the days elapsed is at least this number.
+          #   The value of the field must be a nonnegative integer. If it's zero,
+          #   the object version will become eligible for Lifecycle action as
+          #   soon as it becomes noncurrent. Relevant only for versioning-enabled
+          #   buckets. (See {Bucket#versioning?})
           # @param [Boolean] is_live Relevant only for versioned files. If the
           #   value is `true`, this condition matches live files; if the value
           #   is `false`, it matches archived files.
@@ -115,6 +130,10 @@ module Google
           #   `DURABLE_REDUCED_AVAILABILITY` are supported as legacy storage
           #   classes. Arguments will be converted from symbols and lower-case
           #   to upper-case strings.
+          # @param [String,Date] noncurrent_time_before A date in RFC 3339 format
+          #   with only the date part (for instance, "2013-01-15"). This condition
+          #   is satisfied when the noncurrent time on an object is before this
+          #   date in UTC. This condition is relevant only for versioned objects.
           # @param [Integer] num_newer_versions Relevant only for versioned
           #   files. If the value is N, this condition is satisfied when there
           #   are at least N versions (including the live version) newer than
@@ -129,16 +148,29 @@ module Google
           #     b.lifecycle.add_set_storage_class_rule "COLDLINE", age: 10
           #   end
           #
-          def add_set_storage_class_rule storage_class, age: nil,
-                                         created_before: nil, is_live: nil,
+          def add_set_storage_class_rule storage_class,
+                                         age: nil,
+                                         created_before: nil,
+                                         custom_time_before: nil,
+                                         days_since_custom_time: nil,
+                                         days_since_noncurrent_time: nil,
+                                         is_live: nil,
                                          matches_storage_class: nil,
+                                         noncurrent_time_before: nil,
                                          num_newer_versions: nil
-            push Rule.new \
+            push Rule.new(
               "SetStorageClass",
               storage_class: storage_class_for(storage_class),
-              age: age, created_before: created_before, is_live: is_live,
+              age: age,
+              created_before: created_before,
+              custom_time_before: custom_time_before,
+              days_since_custom_time: days_since_custom_time,
+              days_since_noncurrent_time: days_since_noncurrent_time,
+              is_live: is_live,
               matches_storage_class: storage_class_for(matches_storage_class),
+              noncurrent_time_before: noncurrent_time_before,
               num_newer_versions: num_newer_versions
+            )
           end
 
           ##
@@ -156,6 +188,21 @@ module Google
           #   only the date part (for instance, "2013-01-15"). This condition is
           #   satisfied when a file is created before midnight of the specified
           #   date in UTC.
+          # @param [String,Date] custom_time_before A date in RFC 3339 format with
+          #   only the date part (for instance, "2013-01-15"). This condition is
+          #   satisfied when the custom time on an object is before this date in UTC.
+          # @param [Integer] days_since_custom_time Represents the number of
+          #   days elapsed since the user-specified timestamp set on an object.
+          #   The condition is satisfied if the days elapsed is at least this
+          #   number. If no custom timestamp is specified on an object, the
+          #   condition does not apply.
+          # @param [Integer] days_since_noncurrent_time Represents the number of
+          #   days elapsed since the noncurrent timestamp of an object. The
+          #   condition is satisfied if the days elapsed is at least this number.
+          #   The value of the field must be a nonnegative integer. If it's zero,
+          #   the object version will become eligible for Lifecycle action as
+          #   soon as it becomes noncurrent. Relevant only for versioning-enabled
+          #   buckets. (See {Bucket#versioning?})
           # @param [Boolean] is_live Relevant only for versioned files. If the
           #   value is `true`, this condition matches live files; if the value
           #   is `false`, it matches archived files.
@@ -166,6 +213,10 @@ module Google
           #   `DURABLE_REDUCED_AVAILABILITY` are supported as legacy storage
           #   classes. Arguments will be converted from symbols and lower-case
           #   to upper-case strings.
+          # @param [String,Date] noncurrent_time_before A date in RFC 3339 format
+          #   with only the date part (for instance, "2013-01-15"). This condition
+          #   is satisfied when the noncurrent time on an object is before this
+          #   date in UTC. This condition is relevant only for versioned objects.
           # @param [Integer] num_newer_versions Relevant only for versioned
           #   files. If the value is N, this condition is satisfied when there
           #   are at least N versions (including the live version) newer than
@@ -180,14 +231,27 @@ module Google
           #     b.lifecycle.add_delete_rule age: 30, is_live: false
           #   end
           #
-          def add_delete_rule age: nil, created_before: nil, is_live: nil,
+          def add_delete_rule age: nil,
+                              created_before: nil,
+                              custom_time_before: nil,
+                              days_since_custom_time: nil,
+                              days_since_noncurrent_time: nil,
+                              is_live: nil,
                               matches_storage_class: nil,
+                              noncurrent_time_before: nil,
                               num_newer_versions: nil
-            push Rule.new \
+            push Rule.new(
               "Delete",
-              age: age, created_before: created_before, is_live: is_live,
+              age: age,
+              created_before: created_before,
+              custom_time_before: custom_time_before,
+              days_since_custom_time: days_since_custom_time,
+              days_since_noncurrent_time: days_since_noncurrent_time,
+              is_live: is_live,
               matches_storage_class: storage_class_for(matches_storage_class),
+              noncurrent_time_before: noncurrent_time_before,
               num_newer_versions: num_newer_versions
+            )
           end
 
           # @private
@@ -231,10 +295,26 @@ module Google
           #   action. Required only if the action is `SetStorageClass`.
           # @attr [Integer] age The age of a file (in days). This condition is
           #   satisfied when a file reaches the specified age.
-          # @attr [String,Date] created_before A date in RFC 3339 format with
+          # @attr [String,Date,nil] created_before A date in RFC 3339 format with
           #   only the date part (for instance, "2013-01-15"). This condition is
           #   satisfied when a file is created before midnight of the specified
-          #   date in UTC.
+          #   date in UTC. When returned by the service, a non-empty value will
+          #   always be a Date object.
+          # @attr [String,Date,nil] custom_time_before A date in RFC 3339 format with
+          #   only the date part (for instance, "2013-01-15"). This condition is
+          #   satisfied when the custom time on an object is before this date in UTC.
+          # @attr [Integer,nil] days_since_custom_time Represents the number of
+          #   days elapsed since the user-specified timestamp set on an object.
+          #   The condition is satisfied if the days elapsed is at least this
+          #   number. If no custom timestamp is specified on an object, the
+          #   condition does not apply.
+          # @attr [Integer] days_since_noncurrent_time Represents the number of
+          #   days elapsed since the noncurrent timestamp of an object. The
+          #   condition is satisfied if the days elapsed is at least this number.
+          #   The value of the field must be a nonnegative integer. If it's zero,
+          #   the object version will become eligible for Lifecycle action as
+          #   soon as it becomes noncurrent. Relevant only for versioning-enabled
+          #   buckets. (See {Bucket#versioning?})
           # @attr [Boolean] is_live Relevant only for versioned files. If the
           #   value is `true`, this condition matches live files; if the value
           #   is `false`, it matches archived files.
@@ -243,6 +323,12 @@ module Google
           #   Values include `STANDARD`, `NEARLINE`, `COLDLINE`, and `ARCHIVE`.
           #   `REGIONAL`, `MULTI_REGIONAL`, and `DURABLE_REDUCED_AVAILABILITY`
           #   are supported as legacy storage classes.
+          # @attr [String,Date,nil] noncurrent_time_before A date in RFC 3339 format
+          #   with only the date part (for instance, "2013-01-15"). This condition
+          #   is satisfied when the noncurrent time on an object is before this
+          #   date in UTC. This condition is relevant only for versioned objects.
+          #   When returned by the service, a non-empty value will always be a
+          #   Date object.
           # @attr [Integer] num_newer_versions Relevant only for versioned
           #   files. If the value is N, this condition is satisfied when there
           #   are at least N versions (including the live version) newer than
@@ -285,28 +371,57 @@ module Google
           #   end
           #
           class Rule
-            attr_accessor :action, :storage_class, :age, :created_before,
-                          :is_live, :matches_storage_class, :num_newer_versions
+            attr_accessor :action,
+                          :storage_class,
+                          :age,
+                          :created_before,
+                          :custom_time_before,
+                          :days_since_custom_time,
+                          :days_since_noncurrent_time,
+                          :is_live,
+                          :matches_storage_class,
+                          :noncurrent_time_before,
+                          :num_newer_versions
 
             # @private
-            def initialize action, storage_class: nil, age: nil,
-                           created_before: nil, is_live: nil,
-                           matches_storage_class: nil, num_newer_versions: nil
+            def initialize action,
+                           storage_class: nil,
+                           age: nil,
+                           created_before: nil,
+                           custom_time_before: nil,
+                           days_since_custom_time: nil,
+                           days_since_noncurrent_time: nil,
+                           is_live: nil,
+                           matches_storage_class: nil,
+                           noncurrent_time_before: nil,
+                           num_newer_versions: nil
               @action = action
               @storage_class = storage_class
               @age = age
               @created_before = created_before
+              @custom_time_before = custom_time_before
+              @days_since_custom_time = days_since_custom_time
+              @days_since_noncurrent_time = days_since_noncurrent_time
               @is_live = is_live
               @matches_storage_class = Array(matches_storage_class)
+              @noncurrent_time_before = noncurrent_time_before
               @num_newer_versions = num_newer_versions
             end
 
             # @private
             # @return [Google::Apis::StorageV1::Bucket::Lifecycle]
             def to_gapi
-              condition = condition_gapi(age, created_before, is_live,
-                                         matches_storage_class,
-                                         num_newer_versions)
+              condition = condition_gapi(
+                age,
+                created_before,
+                custom_time_before,
+                days_since_custom_time,
+                days_since_noncurrent_time,
+                is_live,
+                matches_storage_class,
+                noncurrent_time_before,
+                num_newer_versions
+              )
               Google::Apis::StorageV1::Bucket::Lifecycle::Rule.new(
                 action: action_gapi(action, storage_class),
                 condition: condition
@@ -316,18 +431,30 @@ module Google
             # @private
             def action_gapi action, storage_class
               Google::Apis::StorageV1::Bucket::Lifecycle::Rule::Action.new(
-                type: action, storage_class: storage_class
+                type: action,
+                storage_class: storage_class
               )
             end
 
             # @private
-            def condition_gapi age, created_before, is_live,
-                               matches_storage_class, num_newer_versions
+            def condition_gapi age,
+                               created_before,
+                               custom_time_before,
+                               days_since_custom_time,
+                               days_since_noncurrent_time,
+                               is_live,
+                               matches_storage_class,
+                               noncurrent_time_before,
+                               num_newer_versions
               Google::Apis::StorageV1::Bucket::Lifecycle::Rule::Condition.new(
                 age: age,
                 created_before: created_before,
+                custom_time_before: custom_time_before,
+                days_since_custom_time: days_since_custom_time,
+                days_since_noncurrent_time: days_since_noncurrent_time,
                 is_live: is_live,
                 matches_storage_class: Array(matches_storage_class),
+                noncurrent_time_before: noncurrent_time_before,
                 num_newer_versions: num_newer_versions
               )
             end
@@ -337,12 +464,19 @@ module Google
             def self.from_gapi gapi
               action = gapi.action
               c = gapi.condition
-              new action.type, storage_class: action.storage_class,
-                               age: c.age,
-                               created_before: c.created_before,
-                               is_live: c.is_live,
-                               matches_storage_class: c.matches_storage_class,
-                               num_newer_versions: c.num_newer_versions
+              new(
+                action.type,
+                storage_class: action.storage_class,
+                age: c.age,
+                created_before: c.created_before,
+                custom_time_before: c.custom_time_before,
+                days_since_custom_time: c.days_since_custom_time,
+                days_since_noncurrent_time: c.days_since_noncurrent_time,
+                is_live: c.is_live,
+                matches_storage_class: c.matches_storage_class,
+                noncurrent_time_before: c.noncurrent_time_before,
+                num_newer_versions: c.num_newer_versions
+              )
             end
 
             # @private
diff --git a/google-cloud-storage/lib/google/cloud/storage/file.rb b/google-cloud-storage/lib/google/cloud/storage/file.rb
index 525ef4741b..5c8f0673b0 100644
--- a/google-cloud-storage/lib/google/cloud/storage/file.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file.rb
@@ -355,6 +355,29 @@ module Google
           update_gapi! :content_type
         end
 
+        ##
+        # A custom time specified by the user for the file, or `nil`.
+        #
+        # @return [DateTime, nil]
+        #
+        def custom_time
+          @gapi.custom_time
+        end
+
+        ##
+        # Updates the custom time specified by the user for the file. Once set,
+        # custom_time can't be unset, and it can only be changed to a time in the
+        # future. If custom_time must be unset, you must either perform a rewrite
+        # operation, or upload the data again and create a new file.
+        #
+        # @param [DateTime] custom_time A custom time specified by the user
+        #   for the file.
+        #
+        def custom_time= custom_time
+          @gapi.custom_time = custom_time
+          update_gapi! :custom_time
+        end
+
         ##
         # A hash of custom, user-provided web-safe keys and arbitrary string
         # values that will returned with requests for the file as "x-goog-meta-"
@@ -746,8 +769,9 @@ module Google
         # Updates the file with changes made in the given block in a single
         # PATCH request. The following attributes may be set: {#cache_control=},
         # {#content_disposition=}, {#content_encoding=}, {#content_language=},
-        # {#content_type=}, and {#metadata=}. The {#metadata} hash accessible in
-        # the block is completely mutable and will be included in the request.
+        # {#content_type=}, {#custom_time=} and {#metadata=}. The {#metadata} hash
+        # accessible in the block is completely mutable and will be included in the
+        # request.
         #
         # @yield [file] a block yielding a delegate object for updating the file
         #
@@ -766,6 +790,7 @@ module Google
         #     f.content_encoding = "deflate"
         #     f.content_language = "de"
         #     f.content_type = "application/json"
+        #     f.custom_time = DateTime.new 2025, 12, 31
         #     f.metadata["player"] = "Bob"
         #     f.metadata["score"] = "10"
         #   end
diff --git a/google-cloud-storage/lib/google/cloud/storage/service.rb b/google-cloud-storage/lib/google/cloud/storage/service.rb
index 7064d7fd7e..c3ef3cc6fb 100644
--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -292,12 +292,12 @@ module Google
         def insert_file bucket_name, source, path = nil, acl: nil,
                         cache_control: nil, content_disposition: nil,
                         content_encoding: nil, content_language: nil,
-                        content_type: nil, crc32c: nil, md5: nil, metadata: nil,
+                        content_type: nil, custom_time: nil, crc32c: nil, md5: nil, metadata: nil,
                         storage_class: nil, key: nil, kms_key: nil,
                         temporary_hold: nil, event_based_hold: nil,
                         user_project: nil
           params =
-            { cache_control: cache_control, content_type: content_type,
+            { cache_control: cache_control, content_type: content_type, custom_time: custom_time,
               content_disposition: content_disposition, md5_hash: md5,
               content_encoding: content_encoding, crc32c: crc32c,
               content_language: content_language, metadata: metadata,
diff --git a/google-cloud-storage/support/doctest_helper.rb b/google-cloud-storage/support/doctest_helper.rb
index 46185483d3..34ed50f300 100644
--- a/google-cloud-storage/support/doctest_helper.rb
+++ b/google-cloud-storage/support/doctest_helper.rb
@@ -166,8 +166,9 @@ def mock_pubsub
 
     pubsub.service.mocked_publisher = Minitest::Mock.new
     pubsub.service.mocked_subscriber = Minitest::Mock.new
+    pubsub.service.mocked_iam = Minitest::Mock.new
     if block_given?
-      yield pubsub.service.mocked_publisher, pubsub.service.mocked_subscriber
+      yield pubsub.service.mocked_publisher, pubsub.service.mocked_subscriber, pubsub.service.mocked_iam
     end
 
     pubsub
@@ -283,10 +284,10 @@ YARD::Doctest.configure do |doctest|
   end
 
   doctest.before "Google::Cloud::Storage::Bucket#create_notification" do
-    mock_pubsub do |mock_publisher, mock_subscriber|
-      mock_publisher.expect :create_topic, topic_gapi, ["projects/my-project/topics/my-topic", Hash]
-      mock_publisher.expect :get_iam_policy, policy_gapi_v1, ["projects/my-project/topics/my-topic", Hash]
-      mock_publisher.expect :set_iam_policy, policy_gapi_v1, ["projects/my-project/topics/my-topic", Google::Iam::V1::Policy, Hash]
+    mock_pubsub do |mock_publisher, mock_subscriber, mock_iam|
+      mock_publisher.expect :create_topic, topic_gapi, [Hash]
+      mock_iam.expect :get_iam_policy, policy_gapi_v1, [Hash]
+      mock_iam.expect :set_iam_policy, policy_gapi_v1, [Hash]
     end
     mock_storage do |mock|
       mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
@@ -1093,10 +1094,10 @@ YARD::Doctest.configure do |doctest|
   # Notification
 
   doctest.before "Google::Cloud::Storage::Notification" do
-    mock_pubsub do |mock_publisher, mock_subscriber|
-      mock_publisher.expect :create_topic, topic_gapi, ["projects/my-project/topics/my-topic", Hash]
-      mock_publisher.expect :get_iam_policy, policy_gapi_v1, ["projects/my-project/topics/my-topic", Hash]
-      mock_publisher.expect :set_iam_policy, policy_gapi_v1, ["projects/my-project/topics/my-topic", Google::Iam::V1::Policy, Hash]
+    mock_pubsub do |mock_publisher, mock_subscriber, mock_iam|
+      mock_publisher.expect :create_topic, topic_gapi, [Hash]
+      mock_iam.expect :get_iam_policy, policy_gapi_v1, [Hash]
+      mock_iam.expect :set_iam_policy, policy_gapi_v1, [Hash]
     end
     mock_storage do |mock|
       mock.expect :get_bucket, bucket_gapi, ["my-bucket", Hash]
diff --git a/google-cloud-storage/test/google/cloud/storage/bucket_update_test.rb b/google-cloud-storage/test/google/cloud/storage/bucket_update_test.rb
index cd1c63e552..db3012b25a 100644
--- a/google-cloud-storage/test/google/cloud/storage/bucket_update_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_update_test.rb
@@ -31,14 +31,20 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
     http_method: ["*"],
     response_header: ["X-My-Custom-Header"]) }
   let(:bucket_cors_hash) { JSON.parse bucket_cors_gapi.to_json }
-  let(:bucket_lifecycle_created_before) { Date.parse("2013-01-15") }
+  let(:bucket_lifecycle_created_before) { Date.parse "2013-01-15" }
+  let(:bucket_lifecycle_custom_time_before) { Date.parse "2019-01-15" }
+  let(:bucket_lifecycle_noncurrent_time_before) { Date.parse "2020-01-15" }
   let(:bucket_lifecycle_gapi) do
     lifecycle_gapi lifecycle_rule_gapi("SetStorageClass",
                                        storage_class: "NEARLINE",
                                        age: 32,
                                        created_before: bucket_lifecycle_created_before,
+                                       custom_time_before: bucket_lifecycle_custom_time_before,
+                                       days_since_custom_time: 4,
+                                       days_since_noncurrent_time: 14,
                                        is_live: true,
                                        matches_storage_class: ["STANDARD"],
+                                       noncurrent_time_before: bucket_lifecycle_noncurrent_time_before,
                                        num_newer_versions: 3)
   end
   let(:bucket_lifecycle_hash) { JSON.parse bucket_lifecycle_gapi.to_json }
@@ -496,8 +502,12 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
         l.add_set_storage_class_rule "NEARLINE",
                                      age: 32,
                                      created_before: bucket_lifecycle_created_before,
+                                     custom_time_before: bucket_lifecycle_custom_time_before,
+                                     days_since_custom_time: 4,
+                                     days_since_noncurrent_time: 14,
                                      is_live: true,
                                      matches_storage_class: ["STANDARD"],
+                                     noncurrent_time_before: bucket_lifecycle_noncurrent_time_before,
                                      num_newer_versions: 3
       end
 
@@ -509,8 +519,12 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
       _(rule.storage_class).must_equal "NEARLINE"
       _(rule.age).must_equal 32
       _(rule.created_before).must_equal bucket_lifecycle_created_before
+      _(rule.custom_time_before).must_equal bucket_lifecycle_custom_time_before
+      _(rule.days_since_custom_time).must_equal 4
+      _(rule.days_since_noncurrent_time).must_equal 14
       _(rule.is_live).must_equal true
       _(rule.matches_storage_class).must_equal ["STANDARD"]
+      _(rule.noncurrent_time_before).must_equal bucket_lifecycle_noncurrent_time_before
       _(rule.num_newer_versions).must_equal 3
     end
 
@@ -529,8 +543,12 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
                               storage_class: "COLDLINE",
                               age: 32,
                               created_before: bucket_lifecycle_created_before,
+                              custom_time_before: bucket_lifecycle_custom_time_before,
+                              days_since_custom_time: 4,
+                              days_since_noncurrent_time: 14,
                               is_live: true,
                               matches_storage_class: ["STANDARD"],
+                              noncurrent_time_before: bucket_lifecycle_noncurrent_time_before,
                               num_newer_versions: 3),
           lifecycle_rule_gapi("Delete", age: 40, is_live: false)
         )
@@ -587,8 +605,12 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
                                 storage_class: "NEARLINE",
                                 age: 32,
                                 created_before: bucket_lifecycle_created_before,
+                                custom_time_before: bucket_lifecycle_custom_time_before,
+                                days_since_custom_time: 4,
+                                days_since_noncurrent_time: 14,
                                 is_live: true,
                                 matches_storage_class: ["STANDARD"],
+                                noncurrent_time_before: bucket_lifecycle_noncurrent_time_before,
                                 num_newer_versions: 3),
               lifecycle_rule_gapi("Delete", age: 40, is_live: false),
               lifecycle_rule_gapi("Delete", is_live: false, num_newer_versions: 8),
@@ -620,8 +642,12 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
                                 storage_class: "NEARLINE",
                                 age: 32,
                                 created_before: bucket_lifecycle_created_before,
+                                custom_time_before: bucket_lifecycle_custom_time_before,
+                                days_since_custom_time: 4,
+                                days_since_noncurrent_time: 14,
                                 is_live: true,
                                 matches_storage_class: ["STANDARD"],
+                                noncurrent_time_before: bucket_lifecycle_noncurrent_time_before,
                                 num_newer_versions: 3),
               lifecycle_rule_gapi("Delete", age: 40, is_live: false)
           )
diff --git a/google-cloud-storage/test/google/cloud/storage/file_test.rb b/google-cloud-storage/test/google/cloud/storage/file_test.rb
index e11b3a72a3..b2073ab583 100644
--- a/google-cloud-storage/test/google/cloud/storage/file_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_test.rb
@@ -19,7 +19,8 @@ describe Google::Cloud::Storage::File, :mock_storage do
   let(:bucket) { Google::Cloud::Storage::Bucket.from_gapi bucket_gapi, storage.service }
   let(:bucket_user_project) { Google::Cloud::Storage::Bucket.from_gapi bucket_gapi, storage.service, user_project: true }
 
-  let(:file_hash) { random_file_hash bucket.name, "file.ext" }
+  let(:custom_time) { DateTime.new 2020, 2, 3, 4, 5, 6 }
+  let(:file_hash) { random_file_hash bucket.name, "file.ext", custom_time: custom_time }
   let(:file_gapi) { Google::Apis::StorageV1::Object.from_json file_hash.to_json }
   let(:file) { Google::Cloud::Storage::File.from_gapi file_gapi, storage.service }
   let(:file_user_project) { Google::Cloud::Storage::File.from_gapi file_gapi, storage.service, user_project: true }
@@ -73,6 +74,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
     _(file.content_encoding).must_equal "gzip"
     _(file.content_language).must_equal "en"
     _(file.content_type).must_equal "text/plain"
+    _(file.custom_time).must_equal custom_time
 
     _(file.metadata).must_be_kind_of Hash
     _(file.metadata.size).must_equal 2
diff --git a/google-cloud-storage/test/google/cloud/storage/file_update_test.rb b/google-cloud-storage/test/google/cloud/storage/file_update_test.rb
index 9950ff5609..6ee5efe587 100644
--- a/google-cloud-storage/test/google/cloud/storage/file_update_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_update_test.rb
@@ -16,7 +16,9 @@ require "helper"
 
 describe Google::Cloud::Storage::File, :update, :mock_storage do
   let(:bucket_name) { "new-bucket-#{Time.now.to_i}" }
-  let(:file_hash) { random_file_hash bucket_name, "file.ext" }
+  let(:custom_time) { DateTime.new 2020, 2, 3, 4, 5, 6 }
+  let(:custom_time_2) { DateTime.new 2020, 3, 4, 5, 6, 7 }
+  let(:file_hash) { random_file_hash bucket_name, "file.ext", custom_time: custom_time }
   let(:file_gapi) { Google::Apis::StorageV1::Object.from_json file_hash.to_json }
   let(:file) { Google::Cloud::Storage::File.from_gapi file_gapi, storage.service }
   let(:file_user_project) { Google::Cloud::Storage::File.from_gapi file_gapi, storage.service, user_project: true }
@@ -91,6 +93,20 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
     mock.verify
   end
 
+  it "updates its custom_time" do
+    mock = Minitest::Mock.new
+    patch_file_gapi = Google::Apis::StorageV1::Object.new custom_time: custom_time_2
+    mock.expect :patch_object, file_gapi,
+      [bucket_name, file.name, patch_file_gapi, predefined_acl: nil, user_project: nil]
+
+    file.service.mocked_service = mock
+
+    _(file.custom_time).must_equal custom_time
+    file.custom_time = custom_time_2
+
+    mock.verify
+  end
+
   it "updates its metadata" do
     mock = Minitest::Mock.new
     patch_file_gapi = Google::Apis::StorageV1::Object.new metadata: { "player" => "Bob", score: 10 }
@@ -229,6 +245,7 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
       content_encoding: "deflate",
       content_language: "de",
       content_type: "application/json",
+      custom_time: custom_time_2,
       metadata: { "player" => "Bob", "score" => "10" }
     )
     mock.expect :patch_object, file_gapi,
@@ -242,6 +259,7 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
       f.content_encoding = "deflate"
       f.content_language = "de"
       f.content_type = "application/json"
+      f.custom_time = custom_time_2
       f.metadata["player"] = "Bob"
       f.metadata["score"] = "10"
     end
@@ -257,6 +275,7 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
       content_encoding: "deflate",
       content_language: "de",
       content_type: "application/json",
+      custom_time: custom_time_2,
       metadata: { "player" => "Bob", "score" => "10" }
     )
     mock.expect :patch_object, file_gapi,
@@ -270,6 +289,7 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
       f.content_encoding = "deflate"
       f.content_language = "de"
       f.content_type = "application/json"
+      f.custom_time = custom_time_2
       f.metadata["player"] = "Bob"
       f.metadata["score"] = "10"
     end
diff --git a/google-cloud-storage/test/google/cloud/storage/lazy/file_test.rb b/google-cloud-storage/test/google/cloud/storage/lazy/file_test.rb
index 2a17a6d1cb..b4ae53c87e 100644
--- a/google-cloud-storage/test/google/cloud/storage/lazy/file_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/file_test.rb
@@ -80,6 +80,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
     _(file.content_encoding).must_be :nil?
     _(file.content_language).must_be :nil?
     _(file.content_type).must_be :nil?
+    _(file.custom_time).must_be :nil?
 
     _(file.metadata).must_be_kind_of Hash
     _(file.metadata).must_be :empty?
diff --git a/google-cloud-storage/test/google/cloud/storage/lazy/file_update_test.rb b/google-cloud-storage/test/google/cloud/storage/lazy/file_update_test.rb
index cf4a3b9f36..35954cf3ae 100644
--- a/google-cloud-storage/test/google/cloud/storage/lazy/file_update_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/file_update_test.rb
@@ -19,6 +19,7 @@ describe Google::Cloud::Storage::File, :update, :lazy, :mock_storage do
   let(:file_name) { "file.ext" }
   let(:file) { Google::Cloud::Storage::File.new_lazy bucket_name, file_name, storage.service }
   let(:file_user_project) { Google::Cloud::Storage::File.new_lazy bucket_name, file_name, storage.service, user_project: true }
+  let(:custom_time) { DateTime.new 2020, 2, 3, 4, 5, 6 }
 
   it "updates its cache control" do
     mock = Minitest::Mock.new
@@ -90,6 +91,20 @@ describe Google::Cloud::Storage::File, :update, :lazy, :mock_storage do
     mock.verify
   end
 
+  it "updates its custom_time" do
+    mock = Minitest::Mock.new
+    patch_file_gapi = Google::Apis::StorageV1::Object.new custom_time: custom_time
+    mock.expect :patch_object, Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket_name, file_name).to_json),
+      [bucket_name, file_name, patch_file_gapi, predefined_acl: nil, user_project: nil]
+
+    file.service.mocked_service = mock
+
+    _(file.custom_time).must_be :nil?
+    file.custom_time = custom_time
+
+    mock.verify
+  end
+
   it "updates its metadata" do
     mock = Minitest::Mock.new
     patch_file_gapi = Google::Apis::StorageV1::Object.new metadata: { "player" => "Bob", score: 10 }
@@ -200,6 +215,7 @@ describe Google::Cloud::Storage::File, :update, :lazy, :mock_storage do
       content_encoding: "deflate",
       content_language: "de",
       content_type: "application/json",
+      custom_time: custom_time,
       metadata: { "player" => "Bob", "score" => "10" }
     )
     mock.expect :patch_object, Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket_name, file_name).to_json),
@@ -213,6 +229,7 @@ describe Google::Cloud::Storage::File, :update, :lazy, :mock_storage do
       f.content_encoding = "deflate"
       f.content_language = "de"
       f.content_type = "application/json"
+      f.custom_time = custom_time
       f.metadata["player"] = "Bob"
       f.metadata["score"] = "10"
     end
@@ -228,6 +245,7 @@ describe Google::Cloud::Storage::File, :update, :lazy, :mock_storage do
       content_encoding: "deflate",
       content_language: "de",
       content_type: "application/json",
+      custom_time: custom_time,
       metadata: { "player" => "Bob", "score" => "10" }
     )
     mock.expect :patch_object, Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket_name, file_name).to_json),
@@ -241,6 +259,7 @@ describe Google::Cloud::Storage::File, :update, :lazy, :mock_storage do
       f.content_encoding = "deflate"
       f.content_language = "de"
       f.content_type = "application/json"
+      f.custom_time = custom_time
       f.metadata["player"] = "Bob"
       f.metadata["score"] = "10"
     end
diff --git a/google-cloud-storage/test/helper.rb b/google-cloud-storage/test/helper.rb
index 2926853cd7..e0d6a46fa6 100644
--- a/google-cloud-storage/test/helper.rb
+++ b/google-cloud-storage/test/helper.rb
@@ -90,7 +90,7 @@ class MockStorage < Minitest::Spec
     { "requesterPays" => requester_pays} unless requester_pays.nil?
   end
 
-  def random_file_hash bucket=random_bucket_name, name=random_file_path, generation="1234567890", kms_key_name="path/to/encryption_key_name"
+  def random_file_hash bucket=random_bucket_name, name=random_file_path, generation="1234567890", kms_key_name="path/to/encryption_key_name", custom_time: nil
     { "kind" => "storage#object",
       "id" => "#{bucket}/#{name}/1234567890",
       "selfLink" => "https://www.googleapis.com/storage/v1/b/#{bucket}/o/#{name}",
@@ -104,6 +104,7 @@ class MockStorage < Minitest::Spec
       "contentEncoding" => "gzip",
       "contentLanguage" => "en",
       "contentType" => "text/plain",
+      "customTime" => custom_time,
       "updated" => Time.now,
       "storageClass" => "STANDARD",
       "size" => rand(10_000),
@@ -164,9 +165,17 @@ class MockStorage < Minitest::Spec
     Google::Apis::StorageV1::Bucket::Lifecycle.new rule: Array(rules)
   end
 
-  def lifecycle_rule_gapi action, storage_class: nil, age: nil,
-                     created_before: nil, is_live: nil,
-                     matches_storage_class: nil, num_newer_versions: nil
+  def lifecycle_rule_gapi action,
+                          storage_class: nil,
+                          age: nil,
+                          created_before: nil,
+                          custom_time_before: nil,
+                          days_since_custom_time: nil,
+                          days_since_noncurrent_time: nil,
+                          is_live: nil,
+                          matches_storage_class: nil,
+                          noncurrent_time_before: nil,
+                          num_newer_versions: nil
     Google::Apis::StorageV1::Bucket::Lifecycle::Rule.new(
       action: Google::Apis::StorageV1::Bucket::Lifecycle::Rule::Action.new(
         storage_class: storage_class,
@@ -175,8 +184,12 @@ class MockStorage < Minitest::Spec
       condition: Google::Apis::StorageV1::Bucket::Lifecycle::Rule::Condition.new(
         age: age,
         created_before: created_before,
+        custom_time_before: custom_time_before,
+        days_since_custom_time: days_since_custom_time,
+        days_since_noncurrent_time: days_since_noncurrent_time,
         is_live: is_live,
         matches_storage_class: Array(matches_storage_class),
+        noncurrent_time_before: noncurrent_time_before,
         num_newer_versions: num_newer_versions
       )
     )

```

</details>

This pull request was generated using releasetool.