### PR TITLE
chore(firestore): Add query watch samples

### DIFF
--- a/google-cloud-firestore/samples/.rubocop.yml
+++ b/google-cloud-firestore/samples/.rubocop.yml
@@ -4,6 +4,7 @@ inherit_gem:
 Metrics/AbcSize:
   Exclude:
     - "query_data.rb"
+    - "query_watch.rb"
 Metrics/BlockLength:
   Exclude:
     - "acceptance/*.rb"
@@ -12,6 +13,7 @@ Metrics/MethodLength:
   Exclude:
     - "get_data.rb"
     - "query_data.rb"
+    - "query_watch.rb"
 Naming/AccessorMethodName:
   Exclude:
     - "add_data.rb"

--- a/google-cloud-firestore/samples/acceptance/query_watch_test.rb
+++ b/google-cloud-firestore/samples/acceptance/query_watch_test.rb
@@ -18,19 +18,24 @@ require_relative "../query_watch.rb"
 describe "Google Cloud Firestore API samples - Query Data" do
   before :all do
     @firestore_project = ENV["FIRESTORE_PROJECT"]
+  end
+
+  before do
     @collection_path = random_name "cities"
   end
 
-  after :all do
+  after do
     delete_collection_test collection_name: @collection_path, project_id: ENV["FIRESTORE_PROJECT"]
   end
 
   it "listen_document" do
+    document_path = random_name "SF"
+
     out, _err = capture_io do
-      listen_document project_id: @firestore_project, collection_path: @collection_path
+      listen_document project_id: @firestore_project, collection_path: @collection_path, document_path: document_path
     end
 
-    assert_includes out, "Received document snapshot: SF"
+    assert_includes out, "Received document snapshot: #{document_path}"
   end
 
   it "listen_changes" do

--- a/google-cloud-firestore/samples/acceptance/query_watch_test.rb
+++ b/google-cloud-firestore/samples/acceptance/query_watch_test.rb
@@ -43,6 +43,14 @@ describe "Google Cloud Firestore API samples - Query Data" do
     assert_includes out, "Removed city: MTV"
   end
 
+  it "listen_errors" do
+    out, err = capture_io do
+      listen_errors project_id: @firestore_project, collection_path: @collection_path
+    end
+    assert_empty out
+    assert_empty err
+  end
+
   it "listen_multiple" do
     out, _err = capture_io do
       listen_multiple project_id: @firestore_project, collection_path: @collection_path

--- a/google-cloud-firestore/samples/acceptance/query_watch_test.rb
+++ b/google-cloud-firestore/samples/acceptance/query_watch_test.rb
@@ -16,16 +16,13 @@ require_relative "helper.rb"
 require_relative "../query_watch.rb"
 
 describe "Google Cloud Firestore API samples - Query Data" do
-  before :all do
-    @firestore_project = ENV["FIRESTORE_PROJECT"]
-  end
-
   before do
+    @firestore_project = ENV["FIRESTORE_PROJECT"]
     @collection_path = random_name "cities"
   end
 
   after do
-    delete_collection_test collection_name: @collection_path, project_id: ENV["FIRESTORE_PROJECT"]
+    delete_collection_test collection_name: @collection_path, project_id: @firestore_project
   end
 
   it "listen_document" do

--- a/google-cloud-firestore/samples/acceptance/query_watch_test.rb
+++ b/google-cloud-firestore/samples/acceptance/query_watch_test.rb
@@ -19,6 +19,7 @@ describe "Google Cloud Firestore API samples - Query Data" do
   before :all do
     @firestore_project = ENV["FIRESTORE_PROJECT"]
     @collection_path = random_name "cities"
+    @document_path = random_name "SF"
   end
 
   after :all do
@@ -27,7 +28,7 @@ describe "Google Cloud Firestore API samples - Query Data" do
 
   it "listen_document" do
     out, _err = capture_io do
-      listen_document project_id: @firestore_project, collection_path: @collection_path
+      listen_document project_id: @firestore_project, collection_path: @collection_path, document_path: @document_path
     end
     assert_includes out, "Received document snapshot: SF"
   end

--- a/google-cloud-firestore/samples/acceptance/query_watch_test.rb
+++ b/google-cloud-firestore/samples/acceptance/query_watch_test.rb
@@ -1,0 +1,54 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "helper.rb"
+require_relative "../query_watch.rb"
+
+describe "Google Cloud Firestore API samples - Query Data" do
+  before :all do
+    @firestore_project = ENV["FIRESTORE_PROJECT"]
+    @collection_path = random_name "cities"
+  end
+
+  after :all do
+    delete_collection_test collection_name: @collection_path, project_id: ENV["FIRESTORE_PROJECT"]
+  end
+
+  it "listen_document" do
+    out, _err = capture_io do
+      listen_document project_id: @firestore_project, collection_path: @collection_path
+    end
+    assert_includes out, "Received document snapshot: SF"
+  end
+
+  it "listen_changes" do
+    out, _err = capture_io do
+      listen_changes project_id: @firestore_project, collection_path: @collection_path
+    end
+    assert_includes out, "Callback received query snapshot."
+    assert_includes out, "Current cities in California:"
+    assert_includes out, "New city: MTV"
+    assert_includes out, "Modified city: MTV"
+    assert_includes out, "Removed city: MTV"
+  end
+
+  it "listen_multiple" do
+    out, _err = capture_io do
+      listen_multiple project_id: @firestore_project, collection_path: @collection_path
+    end
+    assert_includes out, "Callback received query snapshot."
+    assert_includes out, "Current cities in California:"
+    assert_includes out, "SF"
+  end
+end

--- a/google-cloud-firestore/samples/acceptance/query_watch_test.rb
+++ b/google-cloud-firestore/samples/acceptance/query_watch_test.rb
@@ -19,7 +19,6 @@ describe "Google Cloud Firestore API samples - Query Data" do
   before :all do
     @firestore_project = ENV["FIRESTORE_PROJECT"]
     @collection_path = random_name "cities"
-    @document_path = random_name "SF"
   end
 
   after :all do
@@ -28,8 +27,9 @@ describe "Google Cloud Firestore API samples - Query Data" do
 
   it "listen_document" do
     out, _err = capture_io do
-      listen_document project_id: @firestore_project, collection_path: @collection_path, document_path: @document_path
+      listen_document project_id: @firestore_project, collection_path: @collection_path
     end
+
     assert_includes out, "Received document snapshot: SF"
   end
 

--- a/google-cloud-firestore/samples/query_watch.rb
+++ b/google-cloud-firestore/samples/query_watch.rb
@@ -106,6 +106,27 @@ def listen_changes project_id:, collection_path: "cities"
   listener.stop
 end
 
+def listen_errors project_id:, collection_path: "cities"
+  # project_id = "Your Google Cloud Project ID"
+  # collection_path = "cities"
+
+  firestore = Google::Cloud::Firestore.new project_id: project_id
+  # [START fs_listen_errors]
+  listener = firestore.col(collection_path).listen do |snapshot|
+    snapshot.changes.each do |change|
+      # Process the snapshot.
+      puts "New city: #{change.doc.document_id}" if change.added?
+    end
+  end
+
+  # Register to be notified when unhandled errors occur.
+  listener.on_error do |error|
+    puts "Listen failed: #{error.message}"
+  end
+  # [END fs_listen_errors]
+  listener.stop
+end
+
 def listen_multiple project_id:, collection_path: "cities"
   # project_id = "Your Google Cloud Project ID"
   # collection_path = "cities"

--- a/google-cloud-firestore/samples/query_watch.rb
+++ b/google-cloud-firestore/samples/query_watch.rb
@@ -14,14 +14,13 @@
 
 require "google/cloud/firestore"
 
-def listen_document project_id:, collection_path: "cities", document_path: "SF"
+def listen_document project_id:, collection_path: "cities"
   # project_id = "Your Google Cloud Project ID"
   # collection_path = "cities"
-  # document_path = "SF"
 
   firestore = Google::Cloud::Firestore.new project_id: project_id
   # [START fs_listen_document]
-  doc_ref = firestore.col(collection_path).doc document_path
+  doc_ref = firestore.col(collection_path).doc "SF"
   snapshots = []
 
   # Watch the document.
@@ -31,6 +30,8 @@ def listen_document project_id:, collection_path: "cities", document_path: "SF"
     snapshots << snapshot
   end
   # [END fs_listen_document]
+
+  sleep 1
 
   # Create the document.
   doc_ref.set(
@@ -76,6 +77,8 @@ def listen_changes project_id:, collection_path: "cities"
   # [END fs_listen_changes]
 
   mtv_doc = firestore.col(collection_path).doc("MTV")
+
+  sleep 1
 
   # Create the document.
   mtv_doc.set(

--- a/google-cloud-firestore/samples/query_watch.rb
+++ b/google-cloud-firestore/samples/query_watch.rb
@@ -26,7 +26,6 @@ def listen_document project_id:, collection_path: "cities", document_path: "SF"
 
   # Watch the document.
   listener = doc_ref.listen do |snapshot|
-    # Process the snapshot.
     puts "Received document snapshot: #{snapshot.document_id}"
     snapshots << snapshot
   end
@@ -65,7 +64,6 @@ def listen_changes project_id:, collection_path: "cities"
     puts "Callback received query snapshot."
     puts "Current cities in California:"
     snapshot.changes.each do |change|
-      # Process the snapshot.
       if change.added?
         puts "New city: #{change.doc.document_id}"
         added << snapshot
@@ -120,7 +118,6 @@ def listen_errors project_id:, collection_path: "cities"
   # [START fs_listen_errors]
   listener = firestore.col(collection_path).listen do |snapshot|
     snapshot.changes.each do |change|
-      # Process the snapshot.
       puts "New city: #{change.doc.document_id}" if change.added?
     end
   end
@@ -148,7 +145,6 @@ def listen_multiple project_id:, collection_path: "cities"
     puts "Callback received query snapshot."
     puts "Current cities in California:"
     snapshot.docs.each do |doc|
-      # Process the snapshot.
       puts doc.document_id
       snapshots << snapshot
     end

--- a/google-cloud-firestore/samples/query_watch.rb
+++ b/google-cloud-firestore/samples/query_watch.rb
@@ -138,7 +138,7 @@ def listen_multiple project_id:, collection_path: "cities"
   firestore = Google::Cloud::Firestore.new project_id: project_id
   # [START fs_listen_multiple]
   query = firestore.col(collection_path).where :state, :==, "CA"
-  snapshots = []
+  docs = []
 
   # Watch the collection query.
   listener = query.listen do |snapshot|
@@ -146,7 +146,7 @@ def listen_multiple project_id:, collection_path: "cities"
     puts "Current cities in California:"
     snapshot.docs.each do |doc|
       puts doc.document_id
-      snapshots << snapshot
+      docs << doc
     end
   end
   # [END fs_listen_multiple]
@@ -161,7 +161,7 @@ def listen_multiple project_id:, collection_path: "cities"
   )
 
   # Wait for the callback.
-  wait_until { !snapshots.empty? }
+  wait_until { !docs.empty? }
 
   listener.stop
 end

--- a/google-cloud-firestore/samples/query_watch.rb
+++ b/google-cloud-firestore/samples/query_watch.rb
@@ -1,0 +1,174 @@
+# Copyright 2020 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "google/cloud/firestore"
+
+def listen_document project_id:, collection_path: "cities"
+  # project_id = "Your Google Cloud Project ID"
+  # collection_path = "cities"
+
+  firestore = Google::Cloud::Firestore.new project_id: project_id
+  # [START fs_listen_document]
+
+  # Create an Event for notifying main thread.
+  require "concurrent"
+  event = Concurrent::Event.new
+
+  doc_ref = firestore.col(collection_path).doc "SF"
+
+  # Watch the document.
+  listener = doc_ref.listen do |snapshot|
+    puts "Received document snapshot: #{snapshot.document_id}"
+    event.set
+  end
+  # [END fs_listen_document]
+
+  # Create the document.
+  doc_ref.set(
+    name:       "San Francisco",
+    state:      "CA",
+    country:    "USA",
+    capital:    false,
+    population: 860_000
+  )
+  # Wait for the callback.
+  event.wait 60
+
+  # [START fs_detach_listener]
+  listener.stop
+  # [END fs_detach_listener]
+end
+
+def listen_changes project_id:, collection_path: "cities"
+  # project_id = "Your Google Cloud Project ID"
+  # collection_path = "cities"
+
+  firestore = Google::Cloud::Firestore.new project_id: project_id
+  # [START fs_listen_changes]
+
+  # Create an Event for notifying main thread.
+  require "concurrent"
+  event = Concurrent::Event.new
+
+  query = firestore.col(collection_path).where :state, :==, "CA"
+
+  # Watch the collection query.
+  listener = query.listen do |snapshot|
+    puts "Callback received query snapshot."
+    puts "Current cities in California:"
+    snapshot.changes.each do |change|
+      if change.added?
+        puts "New city: #{change.doc.document_id}"
+      elsif change.modified?
+        puts "Modified city: #{change.doc.document_id}"
+      elsif change.removed?
+        puts "Removed city: #{change.doc.document_id}"
+        event.set
+      end
+    end
+  end
+  # [END fs_listen_changes]
+
+  mtv_doc = firestore.col(collection_path).doc("MTV")
+
+  # Create the document.
+  mtv_doc.set(
+    name:       "Mountain View",
+    state:      "CA",
+    country:    "USA",
+    capital:    false,
+    population: 80_000
+  )
+
+  sleep 1
+
+  # Update the document.
+  mtv_doc.update(
+    name:       "Mountain View",
+    state:      "CA",
+    country:    "USA",
+    capital:    false,
+    population: 90_000
+  )
+
+  sleep 1
+
+  # Delete the document.
+  mtv_doc.delete exists: true
+
+  # Wait for the callback that captures the deletion.
+  event.wait 60
+  listener.stop
+end
+
+def listen_multiple project_id:, collection_path: "cities"
+  # project_id = "Your Google Cloud Project ID"
+  # collection_path = "cities"
+
+  firestore = Google::Cloud::Firestore.new project_id: project_id
+  # [START fs_listen_multiple]
+
+  # Create an Event for notifying main thread.
+  require "concurrent"
+  event = Concurrent::Event.new
+
+  query = firestore.col(collection_path).where :state, :==, "CA"
+
+  # Watch the collection query.
+  listener = query.listen do |snapshot|
+    puts "Callback received query snapshot."
+    puts "Current cities in California:"
+    snapshot.docs.each do |doc|
+      puts doc.document_id
+      event.set
+    end
+  end
+  # [END fs_listen_multiple]
+
+  # Create the document.
+  firestore.col(collection_path).doc("SF").set(
+    name:       "San Francisco",
+    state:      "CA",
+    country:    "USA",
+    capital:    false,
+    population: 860_000
+  )
+  # Wait for the callback.
+  event.wait 60
+  listener.stop
+end
+
+if $PROGRAM_NAME == __FILE__
+  project = ENV["FIRESTORE_PROJECT"]
+  case ARGV.shift
+  when "listen_document"
+    listen_document project_id: project
+  when "listen_changes"
+    listen_changes project_id: project
+  when "listen_multiple"
+    listen_multiple project_id: project
+  when "listen_errors"
+    listen_errors project_id: project
+  else
+    puts <<~USAGE
+      Usage: bundle exec ruby query_data.rb [command]
+
+      Commands:
+        listen_document  Listen for changes to a document.
+        listen_changes   Listen for changes to a query.
+        listen_multiple  Listen for changes to a query, returning the names of all cities for a state.
+        listen_errors    Handle listening errors.
+    USAGE
+  end
+end

--- a/google-cloud-firestore/samples/query_watch.rb
+++ b/google-cloud-firestore/samples/query_watch.rb
@@ -14,13 +14,14 @@
 
 require "google/cloud/firestore"
 
-def listen_document project_id:, collection_path: "cities"
+def listen_document project_id:, collection_path: "cities", document_path: "SF"
   # project_id = "Your Google Cloud Project ID"
   # collection_path = "cities"
+  # document_path = "SF"
 
   firestore = Google::Cloud::Firestore.new project_id: project_id
   # [START fs_listen_document]
-  doc_ref = firestore.col(collection_path).doc "SF"
+  doc_ref = firestore.col(collection_path).doc document_path
   snapshots = []
 
   # Watch the document.


### PR DESCRIPTION
Known region tags:

- [x] `fs_listen_changes`
- [x] `fs_listen_document`
- [x] `fs_listen_errors`
- [x] `fs_listen_multiple`

closes: #7595
