### PR TITLE
Pubsub docs improvement

### DIFF
--- a/google-cloud-pubsub/OVERVIEW.md
+++ b/google-cloud-pubsub/OVERVIEW.md
@@ -174,16 +174,32 @@ pubsub = Google::Cloud::PubSub.new
 
 sub = pubsub.subscription "my-topic-sub"
 
-subscriber = sub.listen do |received_message|
+# Create a subscriber to listen for available messages.
+# By default, this block will be called on 8 concurrent threads
+# but this can be tuned with the `threads` option.
+# The `streams` and `inventory` parameters allow further tuning.
+subscriber = sub.listen threads: { callback: 16 } do |received_message|
   # process message
+  puts "Data: #{received_message.message.data}, published at #{received_message.message.published_at}"
   received_message.acknowledge!
+end
+
+# Handle exceptions from listener
+subscriber.on_error do |exception|
+  puts "Exception: #{exception.class} #{exception.message}"
+end
+
+# Gracefully shut down the subscriber on program exit, blocking until
+# all received messages have been processed or 10 seconds have passed
+at_exit do
+  subscriber.stop!(10)
 end
 
 # Start background threads that will call the block passed to listen.
 subscriber.start
 
-# Shut down the subscriber when ready to stop receiving messages.
-subscriber.stop.wait!
+# Block, letting processing threads continue in the background
+sleep
 ```
 
 Messages also can be pulled directly in a one-time operation. (See
@@ -462,54 +478,6 @@ received_messages = sub.pull
 sub.acknowledge received_messages
 
 sub.seek snapshot
-```
-
-## Listening for Messages
-
-A subscriber object can be created using `listen`, which streams messages from
-the backend and processes them as they are received. (See
-{Google::Cloud::PubSub::Subscription#listen Subscription#listen} and
-{Google::Cloud::PubSub::Subscriber Subscriber})
-
-```ruby
-require "google/cloud/pubsub"
-
-pubsub = Google::Cloud::PubSub.new
-
-sub = pubsub.subscription "my-topic-sub"
-
-subscriber = sub.listen do |received_message|
-  # process message
-  received_message.acknowledge!
-end
-
-# Start background threads that will call the block passed to listen.
-subscriber.start
-
-# Shut down the subscriber when ready to stop receiving messages.
-subscriber.stop.wait!
-```
-
-The subscriber object can be configured to control the number of concurrent
-streams to open, the number of received messages to be collected, and the number
-of threads each stream opens for concurrent calls made to handle the received
-messages.
-
-```ruby
-require "google/cloud/pubsub"
-
-pubsub = Google::Cloud::PubSub.new
-
-sub = pubsub.subscription "my-topic-sub"
-
-subscriber = sub.listen threads: { callback: 16 } do |received_message|
-  # store the message somewhere before acknowledging
-  store_in_backend received_message.data # takes a few seconds
-  received_message.acknowledge!
-end
-
-# Start background threads that will call the block passed to listen.
-subscriber.start
 ```
 
 ## Working Across Projects

--- a/google-cloud-pubsub/OVERVIEW.md
+++ b/google-cloud-pubsub/OVERVIEW.md
@@ -142,7 +142,7 @@ topic.publish_async "task completed" do |result|
   end
 end
 
-topic.async_publisher.stop.wait!
+topic.async_publisher.stop!
 ```
 
 Or multiple messages can be published in batches at the same time by passing a
@@ -251,7 +251,7 @@ end
 subscriber.start
 
 # Shut down the subscriber when ready to stop receiving messages.
-subscriber.stop.wait!
+subscriber.stop!
 ```
 
 Or, multiple messages can be acknowledged in a single API call: (See
@@ -293,7 +293,7 @@ end
 subscriber.start
 
 # Shut down the subscriber when ready to stop receiving messages.
-subscriber.stop.wait!
+subscriber.stop!
 ```
 
 The message can also be made available for immediate redelivery:
@@ -315,7 +315,7 @@ end
 subscriber.start
 
 # Shut down the subscriber when ready to stop receiving messages.
-subscriber.stop.wait!
+subscriber.stop!
 ```
 
 Multiple messages can be delayed or made available for immediate redelivery:
@@ -369,7 +369,7 @@ topic.publish_async "task completed",
                     ordering_key: "task-key"
 
 # Shut down the publisher when ready to stop publishing messages.
-topic.async_publisher.stop.wait!
+topic.async_publisher.stop!
 ```
 
 ### Handling errors with Ordered Keys
@@ -411,7 +411,7 @@ end
 subscriber.start
 
 # Shut down the subscriber when ready to stop receiving messages.
-subscriber.stop.wait!
+subscriber.stop!
 ```
 
 ## Minimizing API calls before receiving and acknowledging messages
@@ -441,7 +441,7 @@ end
 subscriber.start
 
 # Shut down the subscriber when ready to stop receiving messages.
-subscriber.stop.wait!
+subscriber.stop!
 ```
 
 Skipping API calls may be used to avoid `Google::Cloud::PermissionDeniedError`

--- a/google-cloud-pubsub/README.md
+++ b/google-cloud-pubsub/README.md
@@ -2,9 +2,9 @@
 
 [Google Cloud Pub/Sub](https://cloud.google.com/pubsub/) ([docs](https://cloud.google.com/pubsub/docs/reference/rest/)) is designed to provide reliable, many-to-many, asynchronous messaging between applications. Publisher applications can send messages to a “topic” and other applications can subscribe to that topic to receive the messages. By decoupling senders and receivers, Google Cloud Pub/Sub allows developers to communicate between independently written applications.
 
-- [google-cloud-pubsub API documentation](https://googleapis.dev/ruby/google-cloud-pubsub/latest)
+- Full set of examples and detailed docs in the [google-cloud-pubsub API documentation](https://googleapis.dev/ruby/google-cloud-pubsub/latest)
 - [google-cloud-pubsub on RubyGems](https://rubygems.org/gems/google-cloud-pubsub)
-- [Google Cloud Pub/Sub documentation](https://cloud.google.com/pubsub/docs)
+- [General Google Cloud Pub/Sub documentation](https://cloud.google.com/pubsub/docs)
 
 ## Quick Start
 

--- a/google-cloud-pubsub/README.md
+++ b/google-cloud-pubsub/README.md
@@ -38,17 +38,32 @@ msg = topic.publish "new-message"
 sub = pubsub.subscription "my-topic-sub"
 
 # Create a subscriber to listen for available messages
+# By default, this block will be called on 8 concurrent threads.
+# This can be changed with the :threads option
 subscriber = sub.listen do |received_message|
   # process message
+  puts "Data: #{received_message.message.data}, published at #{received_message.message.published_at}"
   received_message.acknowledge!
+end
+
+# Handle exceptions from listener
+subscriber.on_error do |exception|
+  puts "Exception: #{exception.class} #{exception.message}"
+end
+
+# Gracefully shut down the subscriber on program exit, blocking until
+# all received messages have been processed or 10 seconds have passed
+at_exit do
+	subscriber.stop!(10)
 end
 
 # Start background threads that will call the block passed to listen.
 subscriber.start
 
-# Shut down the subscriber when ready to stop receiving messages.
-subscriber.stop.wait!
+# Block, letting processing threads continue in the background
+sleep
 ```
+
 
 ## Enabling Logging
 

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/async_publisher.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/async_publisher.rb
@@ -42,7 +42,7 @@ module Google
       #     end
       #   end
       #
-      #   topic.async_publisher.stop.wait!
+      #   topic.async_publisher.stop!
       #
       # @attr_reader [String] topic_name The name of the topic the messages are published to. In the form of
       #   "/projects/project-identifier/topics/topic-name".

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/message.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/message.rb
@@ -50,7 +50,7 @@ module Google
       #   subscriber.start
       #
       #   # Shut down the subscriber when ready to stop receiving messages.
-      #   subscriber.stop.wait!
+      #   subscriber.stop!
       #
       class Message
         ##

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/project.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/project.rb
@@ -141,7 +141,7 @@ module Google
         #     end
         #   end
         #
-        #   topic.async_publisher.stop.wait!
+        #   topic.async_publisher.stop!
         #
         def topic topic_name, project: nil, skip_lookup: nil, async: nil
           ensure_service!

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/received_message.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/received_message.rb
@@ -39,7 +39,7 @@ module Google
       #   subscriber.start
       #
       #   # Shut down the subscriber when ready to stop receiving messages.
-      #   subscriber.stop.wait!
+      #   subscriber.stop!
       #
       class ReceivedMessage
         ##
@@ -177,7 +177,7 @@ module Google
         #   subscriber.start
         #
         #   # Shut down the subscriber when ready to stop receiving messages.
-        #   subscriber.stop.wait!
+        #   subscriber.stop!
         #
         def acknowledge!
           ensure_subscription!
@@ -214,7 +214,7 @@ module Google
         #   subscriber.start
         #
         #   # Shut down the subscriber when ready to stop receiving messages.
-        #   subscriber.stop.wait!
+        #   subscriber.stop!
         #
         def modify_ack_deadline! new_deadline
           ensure_subscription!
@@ -244,7 +244,7 @@ module Google
         #   subscriber.start
         #
         #   # Shut down the subscriber when ready to stop receiving messages.
-        #   subscriber.stop.wait!
+        #   subscriber.stop!
         #
         def reject!
           modify_ack_deadline! 0

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb
@@ -41,7 +41,7 @@ module Google
       #   subscriber.start
       #
       #   # Shut down the subscriber when ready to stop receiving messages.
-      #   subscriber.stop.wait!
+      #   subscriber.stop!
       #
       # @attr_reader [String] subscription_name The name of the subscription the
       #   messages are pulled from.
@@ -240,7 +240,7 @@ module Google
         #   subscriber.start
         #
         #   # Shut down the subscriber when ready to stop receiving messages.
-        #   subscriber.stop.wait!
+        #   subscriber.stop!
         #
         def on_error &block
           synchronize do
@@ -276,7 +276,7 @@ module Google
         #   subscriber.last_error #=> nil
         #
         #   # Shut down the subscriber when ready to stop receiving messages.
-        #   subscriber.stop.wait!
+        #   subscriber.stop!
         #
         def last_error
           synchronize { @last_error }

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -50,7 +50,7 @@ module Google
       #
       #   # Gracefully shut down the subscriber
       #   at_exit do
-      #     subscriber.stop.wait!
+      #     subscriber.stop!
       #   end
       #
       #   # Start background threads that will call the block passed to listen.
@@ -871,7 +871,7 @@ module Google
         #   subscriber.start
         #
         #   # Shut down the subscriber when ready to stop receiving messages.
-        #   subscriber.stop.wait!
+        #   subscriber.stop!
         #
         # @example Configuring to increase concurrent callbacks:
         #   require "google/cloud/pubsub"
@@ -890,7 +890,7 @@ module Google
         #   subscriber.start
         #
         #   # Shut down the subscriber when ready to stop receiving messages.
-        #   subscriber.stop.wait!
+        #   subscriber.stop!
         #
         # @example Ordered messages are supported using ordering_key:
         #   require "google/cloud/pubsub"
@@ -910,7 +910,7 @@ module Google
         #   subscriber.start
         #
         #   # Shut down the subscriber when ready to stop receiving messages.
-        #   subscriber.stop.wait!
+        #   subscriber.stop!
         #
         # @example Set the maximum amount of time before redelivery if the subscriber fails to extend the deadline:
         #   require "google/cloud/pubsub"
@@ -929,7 +929,7 @@ module Google
         #   subscriber.start
         #
         #   # Shut down the subscriber when ready to stop receiving messages.
-        #   subscriber.stop.wait!
+        #   subscriber.stop!
         #
         def listen deadline: nil, message_ordering: nil, streams: nil, inventory: nil, threads: {}, &block
           ensure_service!

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -43,12 +43,19 @@ module Google
       #     received_message.acknowledge!
       #   end
       #
+      #   # Handle exceptions from listener
+      #   subscriber.on_error do |exception|
+      #      puts "Exception: #{exception.class} #{exception.message}"
+      #   end
+      #
+      #   # Gracefully shut down the subscriber
+      #   at_exit do
+      #     subscriber.stop.wait!
+      #   end
+      #
       #   # Start background threads that will call the block passed to listen.
       #   subscriber.start
-      #
-      #   # Shut down the subscriber when ready to stop receiving messages.
-      #   subscriber.stop.wait!
-      #
+      #   sleep
       class Subscription
         ##
         # @private The Service object.
@@ -856,6 +863,7 @@ module Google
         #
         #   subscriber = sub.listen do |received_message|
         #     # process message
+        #     puts "Data: #{received_message.message.data}, published at #{received_message.message.published_at}"
         #     received_message.acknowledge!
         #   end
         #

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
@@ -78,7 +78,7 @@ module Google
         #     end
         #   end
         #
-        #   topic.async_publisher.stop.wait!
+        #   topic.async_publisher.stop!
         #
         def async_publisher
           @async_publisher
@@ -590,7 +590,7 @@ module Google
         #   end
         #
         #   # Shut down the publisher when ready to stop publishing messages.
-        #   topic.async_publisher.stop.wait!
+        #   topic.async_publisher.stop!
         #
         # @example A message can be published using a File object:
         #   require "google/cloud/pubsub"
@@ -602,7 +602,7 @@ module Google
         #   topic.publish_async file
         #
         #   # Shut down the publisher when ready to stop publishing messages.
-        #   topic.async_publisher.stop.wait!
+        #   topic.async_publisher.stop!
         #
         # @example Additionally, a message can be published with attributes:
         #   require "google/cloud/pubsub"
@@ -614,7 +614,7 @@ module Google
         #                       foo: :bar, this: :that
         #
         #   # Shut down the publisher when ready to stop publishing messages.
-        #   topic.async_publisher.stop.wait!
+        #   topic.async_publisher.stop!
         #
         # @example Ordered messages are supported using ordering_key:
         #   require "google/cloud/pubsub"
@@ -631,7 +631,7 @@ module Google
         #                       ordering_key: "task-key"
         #
         #   # Shut down the publisher when ready to stop publishing messages.
-        #   topic.async_publisher.stop.wait!
+        #   topic.async_publisher.stop!
         #
         def publish_async data = nil, attributes = nil, ordering_key: nil, **extra_attrs, &callback
           ensure_service!

--- a/google-cloud-pubsub/support/doctest_helper.rb
+++ b/google-cloud-pubsub/support/doctest_helper.rb
@@ -22,6 +22,10 @@ class File
   end
 end
 
+def sleep
+  "sleeping"
+end
+
 module Google
   module Cloud
     module PubSub

--- a/google-cloud-pubsub/test/google/cloud/pubsub/async_publisher/message_ordering_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/async_publisher/message_ordering_test.rb
@@ -35,7 +35,7 @@ describe Google::Cloud::PubSub::AsyncPublisher, :message_ordering, :mock_pubsub 
     _(publisher).wont_be :stopped?
 
     # force the queued messages to be published
-    publisher.stop.wait!
+    publisher.stop!
 
     _(publisher).wont_be :started?
     _(publisher).must_be :stopped?
@@ -65,7 +65,7 @@ describe Google::Cloud::PubSub::AsyncPublisher, :message_ordering, :mock_pubsub 
     _(publisher).wont_be :stopped?
 
     # force the queued messages to be published
-    publisher.stop.wait!
+    publisher.stop!
 
     _(publisher).wont_be :started?
     _(publisher).must_be :stopped?
@@ -97,7 +97,7 @@ describe Google::Cloud::PubSub::AsyncPublisher, :message_ordering, :mock_pubsub 
     _(publisher).wont_be :stopped?
 
     # force the queued messages to be published
-    publisher.stop.wait!
+    publisher.stop!
 
     _(publisher).wont_be :started?
     _(publisher).must_be :stopped?
@@ -125,7 +125,7 @@ describe Google::Cloud::PubSub::AsyncPublisher, :message_ordering, :mock_pubsub 
     _(publisher).wont_be :stopped?
 
     # force the queued messages to be published
-    publisher.stop.wait!
+    publisher.stop!
 
     _(publisher).wont_be :started?
     _(publisher).must_be :stopped?
@@ -153,7 +153,7 @@ describe Google::Cloud::PubSub::AsyncPublisher, :message_ordering, :mock_pubsub 
     _(publisher).wont_be :stopped?
 
     # force the queued messages to be published
-    publisher.stop.wait!
+    publisher.stop!
 
     _(publisher).wont_be :started?
     _(publisher).must_be :stopped?

--- a/google-cloud-pubsub/test/google/cloud/pubsub/async_publisher_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/async_publisher_test.rb
@@ -40,7 +40,7 @@ describe Google::Cloud::PubSub::AsyncPublisher, :mock_pubsub do
     _(publisher).wont_be :stopped?
 
     # force the queued messages to be published
-    publisher.stop.wait!
+    publisher.stop!
 
     _(publisher).wont_be :started?
     _(publisher).must_be :stopped?
@@ -64,7 +64,7 @@ describe Google::Cloud::PubSub::AsyncPublisher, :mock_pubsub do
     _(publisher).wont_be :stopped?
 
     # force the queued messages to be published
-    publisher.stop.wait!
+    publisher.stop!
 
     _(publisher).wont_be :started?
     _(publisher).must_be :stopped?
@@ -92,7 +92,7 @@ describe Google::Cloud::PubSub::AsyncPublisher, :mock_pubsub do
     _(publisher).wont_be :stopped?
 
     # force the queued messages to be published
-    publisher.stop.wait!
+    publisher.stop!
 
     _(publisher).wont_be :started?
     _(publisher).must_be :stopped?
@@ -121,7 +121,7 @@ describe Google::Cloud::PubSub::AsyncPublisher, :mock_pubsub do
     _(publisher).wont_be :stopped?
 
     # force the queued messages to be published
-    publisher.stop.wait!
+    publisher.stop!
 
     _(publisher).wont_be :started?
     _(publisher).must_be :stopped?
@@ -159,7 +159,7 @@ describe Google::Cloud::PubSub::AsyncPublisher, :mock_pubsub do
     _(publisher).wont_be :stopped?
 
     # force the queued messages to be published
-    publisher.stop.wait!
+    publisher.stop!
 
     _(publisher).wont_be :started?
     _(publisher).must_be :stopped?
@@ -190,7 +190,7 @@ describe Google::Cloud::PubSub::AsyncPublisher, :mock_pubsub do
     _(publisher).wont_be :stopped?
 
     # force the queued messages to be published
-    publisher.stop.wait!
+    publisher.stop!
 
     _(publisher).wont_be :started?
     _(publisher).must_be :stopped?
@@ -225,7 +225,7 @@ describe Google::Cloud::PubSub::AsyncPublisher, :mock_pubsub do
     _(publisher).wont_be :stopped?
 
     # force the queued messages to be published
-    publisher.stop.wait!
+    publisher.stop!
 
     _(publisher).wont_be :started?
     _(publisher).must_be :stopped?
@@ -261,7 +261,7 @@ describe Google::Cloud::PubSub::AsyncPublisher, :mock_pubsub do
     _(publisher).wont_be :stopped?
 
     # force the queued messages to be published
-    publisher.stop.wait!
+    publisher.stop!
 
     _(publisher).wont_be :started?
     _(publisher).must_be :stopped?

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/ordered_messages_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/ordered_messages_test.rb
@@ -36,7 +36,7 @@ describe Google::Cloud::PubSub::Topic, :publish_async, :ordered_messages, :mock_
     _(topic.async_publisher).wont_be :stopped?
 
     # force the queued messages to be published
-    topic.async_publisher.stop.wait!
+    topic.async_publisher.stop!
 
     _(topic.async_publisher).wont_be :started?
     _(topic.async_publisher).must_be :stopped?
@@ -65,7 +65,7 @@ describe Google::Cloud::PubSub::Topic, :publish_async, :ordered_messages, :mock_
     _(topic.async_publisher).wont_be :stopped?
 
     # force the queued messages to be published
-    topic.async_publisher.stop.wait!
+    topic.async_publisher.stop!
 
     _(topic.async_publisher).wont_be :started?
     _(topic.async_publisher).must_be :stopped?
@@ -96,7 +96,7 @@ describe Google::Cloud::PubSub::Topic, :publish_async, :ordered_messages, :mock_
     _(topic.async_publisher).wont_be :stopped?
 
     # force the queued messages to be published
-    topic.async_publisher.stop.wait!
+    topic.async_publisher.stop!
 
     _(topic.async_publisher).wont_be :started?
     _(topic.async_publisher).must_be :stopped?
@@ -123,7 +123,7 @@ describe Google::Cloud::PubSub::Topic, :publish_async, :ordered_messages, :mock_
     _(topic.async_publisher).wont_be :stopped?
 
     # force the queued messages to be published
-    topic.async_publisher.stop.wait!
+    topic.async_publisher.stop!
 
     _(topic.async_publisher).wont_be :started?
     _(topic.async_publisher).must_be :stopped?
@@ -150,7 +150,7 @@ describe Google::Cloud::PubSub::Topic, :publish_async, :ordered_messages, :mock_
     _(topic.async_publisher).wont_be :stopped?
 
     # force the queued messages to be published
-    topic.async_publisher.stop.wait!
+    topic.async_publisher.stop!
 
     _(topic.async_publisher).wont_be :started?
     _(topic.async_publisher).must_be :stopped?

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/publish_async_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/publish_async_test.rb
@@ -31,7 +31,7 @@ describe Google::Cloud::PubSub::Topic, :publish_async, :mock_pubsub do
     _(topic.async_publisher).wont_be :stopped?
 
     # force the queued messages to be published
-    topic.async_publisher.stop.wait!
+    topic.async_publisher.stop!
 
     _(topic.async_publisher).wont_be :started?
     _(topic.async_publisher).must_be :stopped?
@@ -68,7 +68,7 @@ describe Google::Cloud::PubSub::Topic, :publish_async, :mock_pubsub do
     _(topic.async_publisher).wont_be :stopped?
 
     # force the queued messages to be published
-    topic.async_publisher.stop.wait!
+    topic.async_publisher.stop!
 
     _(topic.async_publisher).wont_be :started?
     _(topic.async_publisher).must_be :stopped?
@@ -100,7 +100,7 @@ describe Google::Cloud::PubSub::Topic, :publish_async, :mock_pubsub do
     _(topic.async_publisher).wont_be :stopped?
 
     # force the queued messages to be published
-    topic.async_publisher.stop.wait!
+    topic.async_publisher.stop!
 
     _(topic.async_publisher).wont_be :started?
     _(topic.async_publisher).must_be :stopped?
@@ -142,7 +142,7 @@ describe Google::Cloud::PubSub::Topic, :publish_async, :mock_pubsub do
     _(topic.async_publisher).wont_be :stopped?
 
     # force the queued messages to be published
-    topic.async_publisher.stop.wait!
+    topic.async_publisher.stop!
 
     _(topic.async_publisher).wont_be :started?
     _(topic.async_publisher).must_be :stopped?
@@ -179,7 +179,7 @@ describe Google::Cloud::PubSub::Topic, :publish_async, :mock_pubsub do
     _(topic.async_publisher).wont_be :stopped?
 
     # force the queued messages to be published
-    topic.async_publisher.stop.wait!
+    topic.async_publisher.stop!
 
     _(topic.async_publisher).wont_be :started?
     _(topic.async_publisher).must_be :stopped?
@@ -212,7 +212,7 @@ describe Google::Cloud::PubSub::Topic, :publish_async, :mock_pubsub do
       _(topic.async_publisher).wont_be :stopped?
 
       # force the queued messages to be published
-      topic.async_publisher.stop.wait!
+      topic.async_publisher.stop!
 
       _(topic.async_publisher).wont_be :started?
       _(topic.async_publisher).must_be :stopped?
@@ -248,7 +248,7 @@ describe Google::Cloud::PubSub::Topic, :publish_async, :mock_pubsub do
       _(topic.async_publisher).wont_be :stopped?
 
       # force the queued messages to be published
-      topic.async_publisher.stop.wait!
+      topic.async_publisher.stop!
 
       _(topic.async_publisher).wont_be :started?
       _(topic.async_publisher).must_be :stopped?
@@ -296,7 +296,7 @@ describe Google::Cloud::PubSub::Topic, :publish_async, :mock_pubsub do
       _(topic.async_publisher).wont_be :nil?
 
       # force the queued messages to be published
-      topic.async_publisher.stop.wait!
+      topic.async_publisher.stop!
 
       _(topic.async_publisher).wont_be :started?
       _(topic.async_publisher).must_be :stopped?


### PR DESCRIPTION
This PR:
  * surfaces `subscriber#on_error` in the top-level README example, since this is a key element when debugging
  * incorporates example code that can be used to listen to a Pub/Sub queue on an ongoing basis
  * includes an example of the `at_exit` handler suggested here for cleanup: https://github.com/googleapis/google-cloud-ruby/issues/4155#issuecomment-539639048


- [X] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-ruby/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea.
- [X] Follow the instructions in [CONTRIBUTING](CONTRIBUTING.md). Most importantly, ensure the tests and linter pass by running `bundle exec rake ci` in the gem subdirectory.
- [X] Update code documentation if necessary.

closes: #7603