### PR TITLE
chore: Undo failed release PRs

### DIFF
--- a/google-cloud-firestore-v1/CHANGELOG.md
+++ b/google-cloud-firestore-v1/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Release History
 
-### 0.2.0 / 2020-08-31
-
-#### Features
-
-* Support inequality operators in structured queries
-
 ### 0.1.2 / 2020-08-10
 
 #### Bug Fixes

--- a/google-cloud-firestore-v1/lib/google/cloud/firestore/v1/version.rb
+++ b/google-cloud-firestore-v1/lib/google/cloud/firestore/v1/version.rb
@@ -21,7 +21,7 @@ module Google
   module Cloud
     module Firestore
       module V1
-        VERSION = "0.2.0"
+        VERSION = "0.1.2"
       end
     end
   end

--- a/google-cloud-kms-v1/CHANGELOG.md
+++ b/google-cloud-kms-v1/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Release History
 
-### 0.3.0 / 2020-08-31
-
-#### Features
-
-* Support for client integrity verification fields
-
 ### 0.2.4 / 2020-08-10
 
 #### Bug Fixes

--- a/google-cloud-kms-v1/lib/google/cloud/kms/v1/version.rb
+++ b/google-cloud-kms-v1/lib/google/cloud/kms/v1/version.rb
@@ -21,7 +21,7 @@ module Google
   module Cloud
     module Kms
       module V1
-        VERSION = "0.3.0"
+        VERSION = "0.2.4"
       end
     end
   end

--- a/google-cloud-security_center-v1/CHANGELOG.md
+++ b/google-cloud-security_center-v1/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Release History
 
-### 0.3.5 / 2020-08-31
-
-#### Documentation
-
-* Clarify Finding#event_time description
-
 ### 0.3.4 / 2020-08-10
 
 #### Bug Fixes

--- a/google-cloud-security_center-v1/lib/google/cloud/security_center/v1/version.rb
+++ b/google-cloud-security_center-v1/lib/google/cloud/security_center/v1/version.rb
@@ -21,7 +21,7 @@ module Google
   module Cloud
     module SecurityCenter
       module V1
-        VERSION = "0.3.5"
+        VERSION = "0.3.4"
       end
     end
   end

--- a/google-cloud-security_center-v1p1beta1/CHANGELOG.md
+++ b/google-cloud-security_center-v1p1beta1/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Release History
 
-### 0.4.0 / 2020-08-31
-
-#### Features
-
-* Support Finding#severity field
-
 #### Documentation
 
 * Clarify Finding#event_time description

--- a/google-cloud-security_center-v1p1beta1/lib/google/cloud/security_center/v1p1beta1/version.rb
+++ b/google-cloud-security_center-v1p1beta1/lib/google/cloud/security_center/v1p1beta1/version.rb
@@ -21,7 +21,7 @@ module Google
   module Cloud
     module SecurityCenter
       module V1p1beta1
-        VERSION = "0.4.0"
+        VERSION = "0.3.4"
       end
     end
   end


### PR DESCRIPTION
This undoes the version and changelog for 4 failed releases, to clean up so that release-please can retry them.