### PR TITLE
Release google-cloud-billing-budgets-v1beta1 0.1.0

### DIFF
--- a/google-cloud-billing-budgets-v1beta1/CHANGELOG.md
+++ b/google-cloud-billing-budgets-v1beta1/CHANGELOG.md
@@ -1,2 +1,6 @@
 # Release History
 
+### 0.1.0 / 2020-09-10
+
+Initial release.
+

--- a/google-cloud-billing-budgets-v1beta1/lib/google/cloud/billing/budgets/v1beta1/version.rb
+++ b/google-cloud-billing-budgets-v1beta1/lib/google/cloud/billing/budgets/v1beta1/version.rb
@@ -22,7 +22,7 @@ module Google
     module Billing
       module Budgets
         module V1beta1
-          VERSION = "0.0.1"
+          VERSION = "0.1.0"
         end
       end
     end


### PR DESCRIPTION
Initial release.

<details><summary>Commits since previous release</summary><pre><code></code></pre></details>

This pull request was generated using releasetool.