### PR TITLE
Fixed escaping of space characters as query params on signer_v4

### DIFF
--- a/google-cloud-storage/lib/google/cloud/storage/file/signer_v4.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/signer_v4.rb
@@ -273,7 +273,7 @@ module Google
           # Only the characters in the regex set [A-Za-z0-9.~_-] must be left un-escaped; all others must be
           # percent-encoded using %XX UTF-8 style.
           def escape_query_param str
-            CGI.escape(str.to_s).gsub("%7E", "~")
+            CGI.escape(str.to_s).gsub("%7E", "~").gsub("+", "%20")
           end
 
           def host_name virtual_hosted_style, bucket_bound_hostname

--- a/google-cloud-storage/test/google/cloud/storage/bucket_signed_url_v4_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_signed_url_v4_test.rb
@@ -202,7 +202,7 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :mock_storage do
     Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
       signing_key_mock = Minitest::Mock.new
       signing_key_mock.expect :is_a?, false, [Proc]
-      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\n0a72e261a6f1877de0d1708ca26aba6f3116a12e569f564346b96dd96d2c9bd6"]
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\n3411dfa972b175ec287a97876a29c2652f633698eba7e4e6930b197812131ba3"]
       credentials.issuer = "native_client_email"
       credentials.signing_key = signing_key_mock
 

--- a/google-cloud-storage/test/google/cloud/storage/file_signed_url_v4_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_signed_url_v4_test.rb
@@ -176,7 +176,7 @@ describe Google::Cloud::Storage::File, :signed_url, :v4, :mock_storage do
     Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
       signing_key_mock = Minitest::Mock.new
       signing_key_mock.expect :is_a?, false, [Proc]
-      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\n0a72e261a6f1877de0d1708ca26aba6f3116a12e569f564346b96dd96d2c9bd6"]
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\n3411dfa972b175ec287a97876a29c2652f633698eba7e4e6930b197812131ba3"]
       credentials.issuer = "native_client_email"
       credentials.signing_key = signing_key_mock
 

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_signed_url_v4_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_signed_url_v4_test.rb
@@ -141,7 +141,7 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :lazy, :mock_storage 
     Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
       signing_key_mock = Minitest::Mock.new
       signing_key_mock.expect :is_a?, false, [Proc]
-      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\n0a72e261a6f1877de0d1708ca26aba6f3116a12e569f564346b96dd96d2c9bd6"]
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\n3411dfa972b175ec287a97876a29c2652f633698eba7e4e6930b197812131ba3"]
       credentials.issuer = "native_client_email"
       credentials.signing_key = signing_key_mock
 

--- a/google-cloud-storage/test/google/cloud/storage/lazy/file_signed_url_v4_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/file_signed_url_v4_test.rb
@@ -140,7 +140,7 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :lazy, :mock_storage
     Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
       signing_key_mock = Minitest::Mock.new
       signing_key_mock.expect :is_a?, false, [Proc]
-      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\n0a72e261a6f1877de0d1708ca26aba6f3116a12e569f564346b96dd96d2c9bd6"]
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\n3411dfa972b175ec287a97876a29c2652f633698eba7e4e6930b197812131ba3"]
       credentials.issuer = "native_client_email"
       credentials.signing_key = signing_key_mock
 

--- a/google-cloud-storage/test/google/cloud/storage/project_signed_url_v4_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/project_signed_url_v4_test.rb
@@ -177,7 +177,7 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :mock_storage do
     Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
       signing_key_mock = Minitest::Mock.new
       signing_key_mock.expect :is_a?, false, [Proc]
-      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\n0a72e261a6f1877de0d1708ca26aba6f3116a12e569f564346b96dd96d2c9bd6"]
+      signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GOOG4-RSA-SHA256\n20120101T000000Z\n20120101/auto/storage/goog4_request\n3411dfa972b175ec287a97876a29c2652f633698eba7e4e6930b197812131ba3"]
       credentials.issuer = "native_client_email"
       credentials.signing_key = signing_key_mock
 


### PR DESCRIPTION
Issue ticket opened: https://github.com/googleapis/google-cloud-ruby/issues/7655

Context on this PR:
- Change any `+` characters in the query params to `%XX UTF-8 style`