### PR TITLE
chore(pubsub): Minor follow-up changes to addition of push_config param in Topic#subscribe

### DIFF
--- a/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
+++ b/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
@@ -292,13 +292,13 @@ describe Google::Cloud::PubSub, :pubsub do
 
     it "creates a push subscription with endpoint parameter" do
       subscription = topic.subscribe "simple-push-subscription", endpoint: "https://pub-sub.test.com/pubsub"
+
       _(subscription).must_be_kind_of Google::Cloud::PubSub::Subscription
       _(subscription.push_config.endpoint).must_equal "https://pub-sub.test.com/pubsub"
     end
 
-    it "creates a push subscription with push config" do
-      push_config = Google::Cloud::PubSub::Subscription::PushConfig.new
-      push_config.endpoint = "https://pub-sub.test.com/pubsub"
+    it "creates a push subscription with push_config" do
+      push_config = Google::Cloud::PubSub::Subscription::PushConfig.new endpoint: "https://pub-sub.test.com/pubsub"
       subscription = topic.subscribe "simple-push-config-subscription", push_config: push_config
 
       _(subscription).must_be_kind_of Google::Cloud::PubSub::Subscription

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
@@ -175,22 +175,10 @@ module Google
         ##
         # Creates a subscription on a given topic for a given subscriber.
         def create_subscription topic, subscription_name, options = {}
-          push_config = if options[:push_config]
-                          # Handle if push config is provided when creating the subscription
-                          unless options[:push_config].is_a? Google::Cloud::PubSub::Subscription::PushConfig
-                            raise ArgumentError, "push_config is not a valid pubsub PushConfig object"
-                          end
-                          options[:push_config].to_grpc
-                        elsif options[:endpoint]
-                          Google::Cloud::PubSub::V1::PushConfig.new \
-                            push_endpoint: options[:endpoint],
-                            attributes:    (options[:attributes] || {}).to_h
-                        end
-
           subscriber.create_subscription \
             name:                       subscription_path(subscription_name, options),
             topic:                      topic_path(topic),
-            push_config:                push_config,
+            push_config:                options[:push_config],
             ack_deadline_seconds:       options[:deadline],
             retain_acked_messages:      options[:retain_acked],
             message_retention_duration: Convert.number_to_duration(options[:retention]),

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription/push_config.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription/push_config.rb
@@ -22,7 +22,19 @@ module Google
         ##
         # Configuration for a push delivery endpoint.
         #
-        # @example
+        # @example Create a push config:
+        #   require "google/cloud/pubsub"
+        #
+        #   pubsub = Google::Cloud::PubSub.new
+        #   topic = pubsub.topic "my-topic"
+        #
+        #   push_config = Google::Cloud::PubSub::Subscription::PushConfig.new
+        #   push_config.endpoint = "http://example.net/callback"
+        #   push_config.set_oidc_token "service-account@example.net", "audience-header-value"
+        #
+        #   sub = topic.subscribe "my-subscription", push_config: push_config
+        #
+        # @example Read a push config:
         #   require "google/cloud/pubsub"
         #
         #   pubsub = Google::Cloud::PubSub.new
@@ -32,7 +44,7 @@ module Google
         #   sub.push_config.authentication.email #=> "user@example.com"
         #   sub.push_config.authentication.audience #=> "client-12345"
         #
-        # @example Update the push configuration by passing a block:
+        # @example Update a push config:
         #   require "google/cloud/pubsub"
         #
         #   pubsub = Google::Cloud::PubSub.new
@@ -43,43 +55,33 @@ module Google
         #     pc.set_oidc_token "user@example.net", "client-67890"
         #   end
         #
-        # @example Create a push subscription by passing a push config:
-        #   require "google/cloud/pubsub"
-        #
-        #   pubsub = Google::Cloud::PubSub.new
-        #   topic = pubsub.topic "my-topic"
-        #
-        #   push_config = Google::Cloud::PubSub::Subscription::PushConfig.new
-        #   push_config.endpoint = "http://example.net/callback"
-        #   push_config.set_oidc_token(
-        #     "service-account@example.net", "audience-header-value"
-        #   )
-        #   sub = topic.subscribe "my-subscription", push_config: push_config
-        #
         class PushConfig
           ##
-          # Creates an empty configuration for a push subscription.
-          # @param [String] endpoint URL to where the subscription will push data to.
-          # @param [String] auth_email The GCP service account email associated with the push subscription.
-          #  Push requests carry the identity of this service account.
-          # @param [String] auth_audience A single, case-insensitive string that can be used by
-          #  the webhook to validate the intended audience of this particular token.
-          # @return [PushConfig]
-          def initialize endpoint: nil, auth_email: nil, auth_audience: nil
+          # Creates a new push configuration.
+          #
+          # @param [String] endpoint A URL locating the endpoint to which messages should be pushed. For
+          #   example, a Webhook endpoint might use `https://example.com/push`.
+          # @param [String] email The service account email to be used for generating the OIDC token.
+          #   The caller must have the `iam.serviceAccounts.actAs` permission for the service account.
+          # @param [String] audience The audience to be used when generating OIDC token. The audience claim identifies
+          #   the recipients that the JWT is intended for. The audience value is a single case-sensitive string. Having
+          #   multiple values (array) for the audience field is not supported. More info about the OIDC JWT token
+          #   audience here: https://tools.ietf.org/html/rfc7519#section-4.1.3 Note: if not specified, the `endpoint`
+          #   URL will be used.
+          #
+          def initialize endpoint: nil, email: nil, audience: nil
             @grpc = Google::Cloud::PubSub::V1::PushConfig.new
 
             self.endpoint = endpoint unless endpoint.nil?
 
-            if auth_audience && !auth_email
-              raise ArgumentError, "auth_audience provided without auth_email. Authentication is invalid"
-            end
+            raise ArgumentError, "audience provided without email. Authentication is invalid" if audience && !email
 
-            set_oidc_token auth_email, auth_audience if auth_email
+            set_oidc_token email, audience if email
           end
 
           ##
-          # A URL locating the endpoint to which messages should be pushed. For
-          # example, a Webhook endpoint might use `https://example.com/push`.
+          # A URL locating the endpoint to which messages should be pushed. For example, a Webhook endpoint might use
+          # `https://example.com/push`.
           #
           # @return [String]
           def endpoint
@@ -87,9 +89,8 @@ module Google
           end
 
           ##
-          # Sets the URL locating the endpoint to which messages should be
-          # pushed. For example, a Webhook endpoint might use
-          # `https://example.com/push`.
+          # Sets the URL locating the endpoint to which messages should be pushed. For example, a Webhook endpoint might
+          # use `https://example.com/push`.
           #
           # @param [String, nil] new_endpoint New URL value
           def endpoint= new_endpoint
@@ -97,8 +98,7 @@ module Google
           end
 
           ##
-          # The authentication method used by push endpoints to verify the
-          # source of push requests.
+          # The authentication method used by push endpoints to verify the source of push requests.
           #
           # @return [OidcToken, nil] An OIDC JWT token if specified, `nil`
           #   otherwise.
@@ -109,8 +109,7 @@ module Google
           end
 
           ##
-          # Sets the authentication method used by push endpoints to verify the
-          # source of push requests.
+          # Sets the authentication method used by push endpoints to verify the source of push requests.
           #
           # @param [OidcToken, nil] new_auth An authentication value.
           def authentication= new_auth
@@ -145,13 +144,12 @@ module Google
           end
 
           ##
-          # The format of the pushed message. This attribute indicates the
-          # version of the data expected by the endpoint. This controls the
-          # shape of the pushed message (i.e., its fields and metadata). The
-          # endpoint version is based on the version of the Pub/Sub API.
+          # The format of the pushed message. This attribute indicates the version of the data expected by the endpoint.
+          # This controls the shape of the pushed message (i.e., its fields and metadata). The endpoint version is based
+          # on the version of the Pub/Sub API.
           #
-          # If not present during the Subscription creation, it will default to
-          # the version of the API used to make such call.
+          # If not present during the Subscription creation, it will default to the version of the API used to make such
+          # call.
           #
           # The possible values for this attribute are:
           #
@@ -209,7 +207,8 @@ module Google
             end
 
             ##
-            # Service account email to be used for generating the OIDC token.
+            # The service account email to be used for generating the OIDC token. The caller must have the
+            # `iam.serviceAccounts.actAs` permission for the service account.
             #
             # @return [String]
             def email
@@ -217,7 +216,8 @@ module Google
             end
 
             ##
-            # Service account email to be used for generating the OIDC token.
+            # Sets the service account email to be used for generating the OIDC token. The caller must have the
+            # `iam.serviceAccounts.actAs` permission for the service account.
             #
             # @param [String] new_email New service account email value.
             def email= new_email
@@ -225,15 +225,10 @@ module Google
             end
 
             ##
-            # Audience to be used when generating OIDC token. The audience claim
-            # identifies the recipients that the JWT is intended for. The
-            # audience value is a single case-sensitive string.
-            #
-            # Having multiple values (array) for the audience field is not
-            # supported.
-            #
-            # More info about the OIDC JWT token audience here:
-            # https://tools.ietf.org/html/rfc7519#section-4.1.3
+            # The audience to be used when generating OIDC token. The audience claim identifies the recipients that
+            # the JWT is intended for. The audience value is a single case-sensitive string. Having multiple values
+            # (array) for the audience field is not supported. More info about the OIDC JWT token audience here:
+            # https://tools.ietf.org/html/rfc7519#section-4.1.3 Note: if not specified, the `endpoint` URL will be used.
             #
             # @return [String]
             def audience
@@ -241,7 +236,10 @@ module Google
             end
 
             ##
-            # Sets the audience to be used when generating OIDC token.
+            # Sets the audience to be used when generating OIDC token. The audience claim identifies the recipients that
+            # the JWT is intended for. The audience value is a single case-sensitive string. Having multiple values
+            # (array) for the audience field is not supported. More info about the OIDC JWT token audience here:
+            # https://tools.ietf.org/html/rfc7519#section-4.1.3 Note: if not specified, the `endpoint` URL will be used.
             #
             # @param [String] new_audience New audience value.
             def audience= new_audience

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription/push_config.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription/push_config.rb
@@ -28,8 +28,7 @@ module Google
         #   pubsub = Google::Cloud::PubSub.new
         #   topic = pubsub.topic "my-topic"
         #
-        #   push_config = Google::Cloud::PubSub::Subscription::PushConfig.new
-        #   push_config.endpoint = "http://example.net/callback"
+        #   push_config = Google::Cloud::PubSub::Subscription::PushConfig.new endpoint: "http://example.net/callback"
         #   push_config.set_oidc_token "service-account@example.net", "audience-header-value"
         #
         #   sub = topic.subscribe "my-subscription", push_config: push_config

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
@@ -275,7 +275,10 @@ module Google
         #   604,800 seconds (7 days) or less than 600 seconds (10 minutes).
         #   Default is 604,800 seconds (7 days).
         # @param [String] endpoint A URL locating the endpoint to which messages
-        #   should be pushed.
+        #   should be pushed. The parameters `push_config` and `endpoint` should not both be provided.
+        # @param [Google::Cloud::PubSub::Subscription::PushConfig] push_config The configuration for a push delivery
+        #   endpoint that should contain the endpoint, and can contain authentication data (OIDC token authentication).
+        #   The parameters `push_config` and `endpoint` should not both be provided.
         # @param [Hash] labels A hash of user-provided labels associated with
         #   the subscription. You can use these to organize and group your
         #   subscriptions. Label keys and values can be no longer than 63
@@ -305,9 +308,6 @@ module Google
         #   this subscription. If not set, the default retry policy is applied. This generally implies that messages
         #   will be retried as soon as possible for healthy subscribers. Retry Policy will be triggered on NACKs or
         #   acknowledgement deadline exceeded events for a given message.
-        # @param [Google::Cloud::PubSub::Subscription::PushConfig] push_config The configuration for a Push subscription
-        #   that should contain the endpoint, and can contain authentication data (OIDC token authentication).
-        #   The parameters push_config and endpoint should not be both provided at the same time.
         #
         #   **EXPERIMENTAL:** This API might be changed in backward-incompatible ways and is not recommended for
         #   production use. It is not subject to any SLA or deprecation policy.
@@ -364,14 +364,30 @@ module Google
         #   retry_policy = Google::Cloud::PubSub::RetryPolicy.new minimum_backoff: 5, maximum_backoff: 300
         #   sub = topic.subscribe "my-topic-sub", retry_policy: retry_policy
         #
-        def subscribe subscription_name, deadline: nil, retain_acked: false, retention: nil, endpoint: nil, labels: nil,
-                      message_ordering: nil, filter: nil, dead_letter_topic: nil,
-                      dead_letter_max_delivery_attempts: nil, retry_policy: nil, push_config: nil
+        def subscribe subscription_name,
+                      deadline: nil,
+                      retain_acked: false,
+                      retention: nil,
+                      endpoint: nil,
+                      push_config: nil,
+                      labels: nil,
+                      message_ordering: nil,
+                      filter: nil,
+                      dead_letter_topic: nil,
+                      dead_letter_max_delivery_attempts: nil,
+                      retry_policy: nil
           ensure_service!
-          options = { deadline: deadline, retain_acked: retain_acked, retention: retention, endpoint: endpoint,
-                      labels: labels, message_ordering: message_ordering, filter: filter,
-                      dead_letter_max_delivery_attempts: dead_letter_max_delivery_attempts,
-                      push_config: push_config }
+          options = {
+            deadline:                          deadline,
+            retain_acked:                      retain_acked,
+            retention:                         retention,
+            endpoint:                          endpoint,
+            push_config:                       push_config,
+            labels:                            labels,
+            message_ordering:                  message_ordering,
+            filter:                            filter,
+            dead_letter_max_delivery_attempts: dead_letter_max_delivery_attempts
+          }
 
           options[:dead_letter_topic_name] = dead_letter_topic.name if dead_letter_topic
           if options[:dead_letter_max_delivery_attempts] && !options[:dead_letter_topic_name]
@@ -379,7 +395,7 @@ module Google
             raise ArgumentError, "dead_letter_topic is required with dead_letter_max_delivery_attempts"
           end
           if options[:push_config] && options[:endpoint]
-            raise ArgumentError, "Push endpoint and push config were both provided. Please provide only one"
+            raise ArgumentError, "endpoint and push_config were both provided. Please provide only one."
           end
           options[:retry_policy] = retry_policy.to_grpc if retry_policy
           grpc = service.create_subscription name, subscription_name, options

--- a/google-cloud-pubsub/support/doctest_helper.rb
+++ b/google-cloud-pubsub/support/doctest_helper.rb
@@ -258,6 +258,7 @@ YARD::Doctest.configure do |doctest|
       mock_subscriber.expect :streaming_pull, [].to_enum, [Enumerator, Hash]
     end
   end
+
   doctest.before "Google::Cloud::PubSub::ReceivedMessage#nack!" do
     mock_pubsub do |mock_publisher, mock_subscriber|
       mock_subscriber.expect :get_subscription, subscription_resp, [Hash]
@@ -268,6 +269,7 @@ YARD::Doctest.configure do |doctest|
       mock_subscriber.expect :modify_ack_deadline, nil, [Hash]
     end
   end
+
   doctest.before "Google::Cloud::PubSub::ReceivedMessage#ignore!" do
     mock_pubsub do |mock_publisher, mock_subscriber|
       mock_subscriber.expect :get_subscription, subscription_resp, [Hash]
@@ -347,6 +349,7 @@ YARD::Doctest.configure do |doctest|
       mock_subscriber.expect :modify_ack_deadline, nil, [Hash]
     end
   end
+
   doctest.before "Google::Cloud::PubSub::Subscription#pull" do
     mock_pubsub do |mock_publisher, mock_subscriber|
       mock_subscriber.expect :get_subscription, subscription_resp("my-topic-sub"), [Hash]
@@ -354,6 +357,7 @@ YARD::Doctest.configure do |doctest|
       mock_subscriber.expect :acknowledge, nil, [Hash]
     end
   end
+
   doctest.before "Google::Cloud::PubSub::Subscription#wait_for_messages" do
     mock_pubsub do |mock_publisher, mock_subscriber|
       mock_subscriber.expect :get_subscription, subscription_resp("my-topic-sub"), [Hash]
@@ -461,6 +465,7 @@ YARD::Doctest.configure do |doctest|
       mock_subscriber.expect :get_subscription, subscription_resp, [Hash]
     end
   end
+
   doctest.before "Google::Cloud::PubSub::Subscription#push_config@Update the push configuration by passing a block:" do
     mock_pubsub do |mock_publisher, mock_subscriber|
       mock_subscriber.expect :get_subscription, subscription_resp, [Hash]
@@ -491,7 +496,8 @@ YARD::Doctest.configure do |doctest|
       mock_subscriber.expect :get_subscription, subscription_resp, [Hash]
     end
   end
-  doctest.before "Google::Cloud::PubSub::Subscription::PushConfig@Update the push configuration by passing a block:" do
+
+  doctest.before "Google::Cloud::PubSub::Subscription::PushConfig@Update a push config:" do
     mock_pubsub do |mock_publisher, mock_subscriber|
       mock_subscriber.expect :get_subscription, subscription_resp, [Hash]
       mock_subscriber.expect :update_subscription, subscription_resp, [Hash]

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/push_config_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/push_config_test.rb
@@ -15,22 +15,22 @@
 require "helper"
 
 describe Google::Cloud::PubSub::Subscription::PushConfig do
-  let(:endpoint)      { "https://pub-sub.test.com/pubsub" }
-  let(:auth_email)     { "service-account@example.net" }
-  let(:auth_audience) { "audience-header-value" }
+  let(:endpoint) { "https://pub-sub.test.com/pubsub" }
+  let(:email) { "service-account@example.net" }
+  let(:audience) { "audience-header-value" }
 
-  it "constructor arguments appropriately constructs PushConfig" do
-
-    push_config = Google::Cloud::PubSub::Subscription::PushConfig.new endpoint: endpoint, auth_email: auth_email, auth_audience: auth_audience
+  it "constructs a PushConfig with arguments" do
+    push_config = Google::Cloud::PubSub::Subscription::PushConfig.new endpoint: endpoint, email: email, audience: audience
 
     _(push_config.endpoint).must_equal endpoint
     _(push_config.authentication).must_be_kind_of Google::Cloud::PubSub::Subscription::PushConfig::OidcToken
+    _(push_config.authentication.email).must_equal email
+    _(push_config.authentication.audience).must_equal audience
   end
 
-  it "does not accept audeince without an auth_email" do
+  it "does not accept audience without an email" do
     assert_raises ArgumentError do
-      Google::Cloud::PubSub::Subscription::PushConfig.new endpoint: endpoint, auth_email: nil, auth_audience: auth_audience
+      Google::Cloud::PubSub::Subscription::PushConfig.new endpoint: endpoint, email: nil, audience: audience
     end
   end
-
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic_test.rb
@@ -182,20 +182,7 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
     _(sub).must_be_kind_of Google::Cloud::PubSub::Subscription
   end
 
-  it "does not accept invalid push configs when creating a subscription" do
-    new_sub_name = "new-sub-#{Time.now.to_i}"
-
-    # Push config should be an object, not a hash.
-    push_config = {
-        service_account_email: "service-account@example.net",
-        audience: "audience-header-value"
-    }
-    assert_raises ArgumentError do
-        topic.subscribe new_sub_name, push_config: push_config
-    end
-  end
-
-  it "rejects subscription that provides both config and endpoint" do
+  it "raises if both push_config and endpoint are provided" do
     new_sub_name = "new-sub-#{Time.now.to_i}"
     endpoint = "http://foo.bar/baz" 
     push_config = Google::Cloud::PubSub::Subscription::PushConfig.new


### PR DESCRIPTION
- Update docs and inline sample code.
- Rename `PushConfig` constructor params to match `OidcToken` accessors.
- Move the construction of the `PushConfig` and `to_grpc` upstream to `Topic#subscribe` to match the handling of `RetryPolicy`.

refs: #7600

/cc @sergioisidoro