### PR TITLE
Release google-analytics-data-v1alpha 0.1.0

### DIFF
--- a/google-analytics-data-v1alpha/CHANGELOG.md
+++ b/google-analytics-data-v1alpha/CHANGELOG.md
@@ -1,2 +1,6 @@
 # Release History
 
+### 0.1.0 / 2020-09-18
+
+Initial release.
+

--- a/google-analytics-data-v1alpha/lib/google/analytics/data/v1alpha/version.rb
+++ b/google-analytics-data-v1alpha/lib/google/analytics/data/v1alpha/version.rb
@@ -21,7 +21,7 @@ module Google
   module Analytics
     module Data
       module V1alpha
-        VERSION = "0.0.1"
+        VERSION = "0.1.0"
       end
     end
   end


### PR DESCRIPTION
Initial release.

<details><summary>Commits since previous release</summary><pre><code></code></pre></details>

This pull request was generated using releasetool.