### PR TITLE
feat(firestore): Add error callbacks for listener threads

### DIFF
--- a/google-cloud-bigquery-reservation-v1/AUTHENTICATION.md
+++ b/google-cloud-bigquery-reservation-v1/AUTHENTICATION.md
@@ -1,4 +1,4 @@
-# Authentication
+ # Authentication
 
 In general, the google-cloud-bigquery-reservation-v1 library uses
 [Service Account](https://cloud.google.com/iam/docs/creating-managing-service-accounts)

--- a/google-cloud-bigquery-reservation-v1/AUTHENTICATION.md
+++ b/google-cloud-bigquery-reservation-v1/AUTHENTICATION.md
@@ -1,4 +1,4 @@
- # Authentication
+# Authentication
 
 In general, the google-cloud-bigquery-reservation-v1 library uses
 [Service Account](https://cloud.google.com/iam/docs/creating-managing-service-accounts)

--- a/google-cloud-firestore/lib/google/cloud/firestore/document_listener.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/document_listener.rb
@@ -71,7 +71,7 @@ module Google
         ##
         # @private
         def start
-          synchronize { @listener.start }
+          @listener.start
           self
         end
 
@@ -95,7 +95,7 @@ module Google
         #   listener.stop
         #
         def stop
-          synchronize { @listener.stop }
+          @listener.stop
         end
 
         ##
@@ -124,7 +124,7 @@ module Google
         #   listener.stopped? #=> true
         #
         def stopped?
-          synchronize { @listener.stopped? }
+          @listener.stopped?
         end
 
         ##

--- a/google-cloud-firestore/lib/google/cloud/firestore/document_listener.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/document_listener.rb
@@ -156,6 +156,7 @@ module Google
         #   listener.stop
         #
         def on_error &block
+          raise ArgumentError, "on_error must be called with a block" unless block_given?
           synchronize { @error_callbacks << block }
         end
 

--- a/google-cloud-firestore/lib/google/cloud/firestore/document_listener.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/document_listener.rb
@@ -48,8 +48,9 @@ module Google
 
           @callback = callback
           raise ArgumentError if @callback.nil?
+          @error_callbacks = []
 
-          @listener = Watch::Listener.for_doc_ref doc_ref do |query_snp|
+          @listener = Watch::Listener.for_doc_ref self, doc_ref do |query_snp|
             doc_snp = query_snp.docs.find { |doc| doc.path == @doc_ref.path }
 
             if doc_snp.nil?
@@ -118,6 +119,80 @@ module Google
         #
         def stopped?
           @listener.stopped?
+        end
+
+        ##
+        # Register to be notified of errors when raised.
+        #
+        # If an unhandled error has occurred the listener will attempt to
+        # recover from the error and resume listening.
+        #
+        # Multiple error handlers can be added.
+        #
+        # @yield [callback] The block to be called when an error is raised.
+        # @yieldparam [Exception] error The error raised.
+        #
+        # @example
+        #   require "google/cloud/firestore"
+        #
+        #   firestore = Google::Cloud::Firestore.new
+        #
+        #   # Get a document reference
+        #   nyc_ref = firestore.doc "cities/NYC"
+        #
+        #   listener = nyc_ref.listen do |snapshot|
+        #     puts "The population of #{snapshot[:name]} "
+        #     puts "is #{snapshot[:population]}."
+        #   end
+        #
+        #   # Register to be notified when unhandled errors occur.
+        #   listener.on_error do |error|
+        #     # log error
+        #     puts error
+        #   end
+        #
+        #   # When ready, stop the listen operation and close the stream.
+        #   listener.stop
+        #
+        def on_error &block
+          @error_callbacks << block
+        end
+
+        ##
+        # The most recent unhandled error to occur while listening for changes.
+        #
+        # If an unhandled error has occurred the listener will attempt to
+        # recover from the error and resume listening.
+        #
+        # @return [Exception, nil] error The most recent error raised.
+        #
+        # @example
+        #   require "google/cloud/firestore"
+        #
+        #   firestore = Google::Cloud::Firestore.new
+        #
+        #   # Get a document reference
+        #   nyc_ref = firestore.doc "cities/NYC"
+        #
+        #   listener = nyc_ref.listen do |snapshot|
+        #     puts "The population of #{snapshot[:name]} "
+        #     puts "is #{snapshot[:population]}."
+        #   end
+        #
+        #   # If an error was raised, it can be retrieved here:
+        #   listener.last_error #=> nil
+        #
+        #   # When ready, stop the listen operation and close the stream.
+        #   listener.stop
+        #
+        def last_error
+          @last_error
+        end
+
+        # @private returns error object from the stream thread.
+        def error! error
+          @last_error = error
+          @error_callbacks.each { |error_callback| error_callback.call error }
         end
       end
     end

--- a/google-cloud-firestore/lib/google/cloud/firestore/document_listener.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/document_listener.rb
@@ -34,8 +34,7 @@ module Google
       #   nyc_ref = firestore.doc "cities/NYC"
       #
       #   listener = nyc_ref.listen do |snapshot|
-      #     puts "The population of #{snapshot[:name]} "
-      #     puts "is #{snapshot[:population]}."
+      #     puts "The population of #{snapshot[:name]} is #{snapshot[:population]}."
       #   end
       #
       #   # When ready, stop the listen operation and close the stream.
@@ -87,8 +86,7 @@ module Google
         #   nyc_ref = firestore.doc "cities/NYC"
         #
         #   listener = nyc_ref.listen do |snapshot|
-        #     puts "The population of #{snapshot[:name]} "
-        #     puts "is #{snapshot[:population]}."
+        #     puts "The population of #{snapshot[:name]} is #{snapshot[:population]}."
         #   end
         #
         #   # When ready, stop the listen operation and close the stream.
@@ -110,8 +108,7 @@ module Google
         #   nyc_ref = firestore.doc "cities/NYC"
         #
         #   listener = nyc_ref.listen do |snapshot|
-        #     puts "The population of #{snapshot[:name]} "
-        #     puts "is #{snapshot[:population]}."
+        #     puts "The population of #{snapshot[:name]} is #{snapshot[:population]}."
         #   end
         #
         #   # Checks if the listener is stopped.
@@ -147,13 +144,11 @@ module Google
         #   nyc_ref = firestore.doc "cities/NYC"
         #
         #   listener = nyc_ref.listen do |snapshot|
-        #     puts "The population of #{snapshot[:name]} "
-        #     puts "is #{snapshot[:population]}."
+        #     puts "The population of #{snapshot[:name]} is #{snapshot[:population]}."
         #   end
         #
         #   # Register to be notified when unhandled errors occur.
         #   listener.on_error do |error|
-        #     # log error
         #     puts error
         #   end
         #
@@ -181,8 +176,7 @@ module Google
         #   nyc_ref = firestore.doc "cities/NYC"
         #
         #   listener = nyc_ref.listen do |snapshot|
-        #     puts "The population of #{snapshot[:name]} "
-        #     puts "is #{snapshot[:population]}."
+        #     puts "The population of #{snapshot[:name]} is #{snapshot[:population]}."
         #   end
         #
         #   # If an error was raised, it can be retrieved here:
@@ -195,7 +189,7 @@ module Google
           synchronize { @last_error }
         end
 
-        # @private returns error object from the stream thread.
+        # @private Pass the error to user-provided error callbacks.
         def error! error
           error_callbacks = synchronize do
             @last_error = error

--- a/google-cloud-firestore/lib/google/cloud/firestore/document_reference.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/document_reference.rb
@@ -168,8 +168,7 @@ module Google
         #   nyc_ref = firestore.doc "cities/NYC"
         #
         #   listener = nyc_ref.listen do |snapshot|
-        #     puts "The population of #{snapshot[:name]} "
-        #     puts "is #{snapshot[:population]}."
+        #     puts "The population of #{snapshot[:name]} is #{snapshot[:population]}."
         #   end
         #
         #   # When ready, stop the listen operation and close the stream.

--- a/google-cloud-firestore/lib/google/cloud/firestore/document_snapshot.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/document_snapshot.rb
@@ -53,7 +53,7 @@ module Google
       #   nyc_ref = firestore.doc "cities/NYC"
       #
       #   listener = nyc_ref.listen do |snapshot|
-        #     puts "The population of #{snapshot[:name]} is #{snapshot[:population]}."
+      #     puts "The population of #{snapshot[:name]} is #{snapshot[:population]}."
       #   end
       #
       #   # When ready, stop the listen operation and close the stream.

--- a/google-cloud-firestore/lib/google/cloud/firestore/document_snapshot.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/document_snapshot.rb
@@ -53,8 +53,7 @@ module Google
       #   nyc_ref = firestore.doc "cities/NYC"
       #
       #   listener = nyc_ref.listen do |snapshot|
-      #     puts "The population of #{snapshot[:name]} "
-      #     puts "is #{snapshot[:population]}."
+        #     puts "The population of #{snapshot[:name]} is #{snapshot[:population]}."
       #   end
       #
       #   # When ready, stop the listen operation and close the stream.

--- a/google-cloud-firestore/lib/google/cloud/firestore/query_listener.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/query_listener.rb
@@ -61,7 +61,7 @@ module Google
         ##
         # @private
         def start
-          synchronize { @listener.start }
+          @listener.start
           self
         end
 
@@ -85,7 +85,7 @@ module Google
         #   listener.stop
         #
         def stop
-          synchronize { @listener.stop }
+          @listener.stop
         end
 
         ##
@@ -114,7 +114,7 @@ module Google
         #   listener.stopped? #=> true
         #
         def stopped?
-          synchronize { @listener.stopped? }
+          @listener.stopped?
         end
 
         ##

--- a/google-cloud-firestore/lib/google/cloud/firestore/query_listener.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/query_listener.rb
@@ -150,6 +150,7 @@ module Google
         #   listener.stop
         #
         def on_error &block
+          raise ArgumentError, "on_error must be called with a block" unless block_given?
           synchronize { @error_callbacks << block }
         end
 

--- a/google-cloud-firestore/lib/google/cloud/firestore/query_listener.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/query_listener.rb
@@ -143,7 +143,6 @@ module Google
         #
         #   # Register to be notified when unhandled errors occur.
         #   listener.on_error do |error|
-        #     # log error
         #     puts error
         #   end
         #
@@ -185,7 +184,7 @@ module Google
           synchronize { @last_error }
         end
 
-        # @private returns error object from the stream thread.
+        # @private Pass the error to user-provided error callbacks.
         def error! error
           error_callbacks = synchronize do
             @last_error = error

--- a/google-cloud-firestore/lib/google/cloud/firestore/watch/listener.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/watch/listener.rb
@@ -280,6 +280,7 @@ module Google
             # Raise if retried more than the max
             if @backoff[:current] > @backoff[:max]
               @parent.error! e
+              raise e
             else
               # Sleep with incremental backoff before restarting
               sleep @backoff[:delay]
@@ -294,6 +295,7 @@ module Google
             retry
           rescue StandardError => e
             @parent.error! e
+            raise e
           end
         end
       end

--- a/google-cloud-firestore/support/doctest_helper.rb
+++ b/google-cloud-firestore/support/doctest_helper.rb
@@ -57,6 +57,12 @@ module Google
         def stopped?
           @stopped
         end
+
+        def on_error &block
+        end
+
+        def last_error
+        end
       end
       DocumentListener = StubbedListener
       QueryListener = StubbedListener

--- a/google-cloud-firestore/test/google/cloud/firestore/collection_reference/listen_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/collection_reference/listen_test.rb
@@ -404,7 +404,6 @@ describe Google::Cloud::Firestore::CollectionReference, :listen, :watch_firestor
 
       listener.stop
     end
-    _(err).must_include err_msg
 
     _(errors_1.count).must_equal 1
     _(errors_1[0]).must_be_kind_of ArgumentError

--- a/google-cloud-firestore/test/google/cloud/firestore/collection_reference/listen_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/collection_reference/listen_test.rb
@@ -418,4 +418,16 @@ describe Google::Cloud::Firestore::CollectionReference, :listen, :watch_firestor
     _(query_snapshots[0].changes.map(&:type)).must_equal [:added, :added]
     _(query_snapshots[0].changes.map(&:doc).map(&:document_id)).must_equal ["int 1", "int 2"]
   end
+
+  it "raises when on_error is called without a block" do
+    listener = collection.order(:val).listen do |query_snp|
+    end
+
+    error = expect do
+      listener.on_error
+    end.must_raise ArgumentError
+    _(error.message).must_equal "on_error must be called with a block"
+
+    listener.stop
+  end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/collection_reference/listen_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/collection_reference/listen_test.rb
@@ -364,13 +364,14 @@ describe Google::Cloud::Firestore::CollectionReference, :listen, :watch_firestor
   end
 
   it "invokes on_error callbacks when the listener receives errors" do
+    err_msg = "test listener error"
     listen_responses = [
       [
         doc_change_resp("int 1", 0, val: 1),
         doc_change_resp("int 2", 0, val: 2),
         current_resp("DOCUMENTSHAVEBEENCHANGED", 0.1),
         no_change_resp("THISTOKENWILLNEVERBESEEN", 1),
-        ArgumentError.new("listen error")
+        ArgumentError.new(err_msg)
       ],[
         doc_change_resp("int 1", 0, val: 1),
         doc_change_resp("int 2", 0, val: 2),
@@ -404,11 +405,11 @@ describe Google::Cloud::Firestore::CollectionReference, :listen, :watch_firestor
 
     _(errors_1.count).must_equal 1
     _(errors_1[0]).must_be_kind_of ArgumentError
-    _(errors_1[0].message).must_equal "listen error"
+    _(errors_1[0].message).must_equal err_msg
 
     _(errors_2.count).must_equal 1
     _(errors_2[0]).must_be_kind_of ArgumentError
-    _(errors_2[0].message).must_equal "listen error"
+    _(errors_2[0].message).must_equal err_msg
 
     # assert snapshots
     _(query_snapshots.count).must_equal 1
@@ -421,6 +422,7 @@ describe Google::Cloud::Firestore::CollectionReference, :listen, :watch_firestor
 
   it "raises when on_error is called without a block" do
     listener = collection.order(:val).listen do |query_snp|
+      raise "should not be called"
     end
 
     error = expect do

--- a/google-cloud-firestore/test/google/cloud/firestore/document_reference/listen_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/document_reference/listen_test.rb
@@ -275,7 +275,6 @@ describe Google::Cloud::Firestore::DocumentReference, :listen, :watch_firestore 
 
       listener.stop
     end
-    _(err).must_include err_msg
 
     _(errors_1.count).must_equal 1
     _(errors_1[0]).must_be_kind_of ArgumentError

--- a/google-cloud-firestore/test/google/cloud/firestore/document_reference/listen_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/document_reference/listen_test.rb
@@ -289,4 +289,16 @@ describe Google::Cloud::Firestore::DocumentReference, :listen, :watch_firestore 
     _(doc_snapshots[0]).must_be :exists?
     _(doc_snapshots[0][:val]).must_equal 1
   end
+
+  it "raises when on_error is called without a block" do
+    listener = document.listen do |doc_snp|
+    end
+
+    error = expect do
+      listener.on_error
+    end.must_raise ArgumentError
+    _(error.message).must_equal "on_error must be called with a block"
+
+    listener.stop
+  end
 end

--- a/google-cloud-firestore/test/google/cloud/firestore/document_reference/listen_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/document_reference/listen_test.rb
@@ -236,12 +236,13 @@ describe Google::Cloud::Firestore::DocumentReference, :listen, :watch_firestore 
   end
 
   it "invokes on_error callbacks when the listener receives errors" do
+    err_msg = "test listener error"
     listen_responses = [
       [
         doc_change_resp("doc", 0, val: 1),
         current_resp("DOCUMENTSHAVEBEENCHANGED", 0.1),
         no_change_resp("THISTOKENWILLNEVERBESEEN", 1),
-        ArgumentError.new("listen error")
+        ArgumentError.new(err_msg)
       ],
       [
         doc_change_resp("doc", 0, val: 1),
@@ -275,11 +276,11 @@ describe Google::Cloud::Firestore::DocumentReference, :listen, :watch_firestore 
 
     _(errors_1.count).must_equal 1
     _(errors_1[0]).must_be_kind_of ArgumentError
-    _(errors_1[0].message).must_equal "listen error"
+    _(errors_1[0].message).must_equal err_msg
 
     _(errors_2.count).must_equal 1
     _(errors_2[0]).must_be_kind_of ArgumentError
-    _(errors_2[0].message).must_equal "listen error"
+    _(errors_2[0].message).must_equal err_msg
 
     # assert snapshots
     _(doc_snapshots.count).must_equal 1
@@ -292,6 +293,7 @@ describe Google::Cloud::Firestore::DocumentReference, :listen, :watch_firestore 
 
   it "raises when on_error is called without a block" do
     listener = document.listen do |doc_snp|
+      raise "should not be called"
     end
 
     error = expect do

--- a/google-cloud-firestore/test/helper.rb
+++ b/google-cloud-firestore/test/helper.rb
@@ -88,7 +88,7 @@ class StreamingListenStub
 
       loop do
         obj = @queue.pop
-        # This is the only way to raise and have it be handled by the steam thread
+        # This is the only way to raise and have it be handled by the listener thread
         raise obj if obj.is_a? StandardError
         break if obj.equal? @sentinel
         yield obj


### PR DESCRIPTION
* Add DocumentListener#last_error
* Add DocumentListener#on_error
* Add QueryListener#last_error
* Add QueryListener#on_error

closes: #7637

/cc @schmidt-sebastian