### PR TITLE
docs(notebooks-v1beta1): Fix service version to reflect V1beta1

### DIFF
--- a/google-cloud-notebooks-v1beta1/.repo-metadata.json
+++ b/google-cloud-notebooks-v1beta1/.repo-metadata.json
@@ -4,7 +4,7 @@
     "distribution_name": "google-cloud-notebooks-v1beta1",
     "language": "ruby",
     "name": "notebooks",
-    "name_pretty": "AI Platform Notebooks V1 API",
+    "name_pretty": "AI Platform Notebooks V1beta1 API",
     "product_documentation": "https://cloud.google.com/ai-platform-notebooks",
     "repo": "googleapis/google-cloud-ruby",
     "requires_billing": true

--- a/google-cloud-notebooks-v1beta1/.rubocop.yml
+++ b/google-cloud-notebooks-v1beta1/.rubocop.yml
@@ -27,6 +27,8 @@ Metrics/PerceivedComplexity:
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-notebooks-v1beta1.rb"
+Naming/PredicateName:
+  Enabled: false
 Style/AsciiComments:
   Enabled: false
 Style/CaseEquality:

--- a/google-cloud-notebooks-v1beta1/.yardopts
+++ b/google-cloud-notebooks-v1beta1/.yardopts
@@ -1,5 +1,5 @@
 --no-private
---title=AI Platform Notebooks V1 API
+--title=AI Platform Notebooks V1beta1 API
 --exclude _pb\.rb$
 --markup markdown
 --markup-provider redcarpet

--- a/google-cloud-notebooks-v1beta1/README.md
+++ b/google-cloud-notebooks-v1beta1/README.md
@@ -1,6 +1,6 @@
-# Ruby Client for the AI Platform Notebooks V1 API
+# Ruby Client for the AI Platform Notebooks V1beta1 API
 
-API Client library for the AI Platform Notebooks V1 API
+API Client library for the AI Platform Notebooks V1beta1 API
 
 AI Platform Notebooks makes it easy to manage JupyterLab instances through a protected, publicly available notebook instance URL. A JupyterLab instance is a Deep Learning virtual machine instance with the latest machine learning and data science libraries pre-installed.
 

--- a/google-cloud-notebooks-v1beta1/google-cloud-notebooks-v1beta1.gemspec
+++ b/google-cloud-notebooks-v1beta1/google-cloud-notebooks-v1beta1.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"
   gem.description   = "AI Platform Notebooks makes it easy to manage JupyterLab instances through a protected, publicly available notebook instance URL. A JupyterLab instance is a Deep Learning virtual machine instance with the latest machine learning and data science libraries pre-installed."
-  gem.summary       = "API Client library for the AI Platform Notebooks V1 API"
+  gem.summary       = "API Client library for the AI Platform Notebooks V1beta1 API"
   gem.homepage      = "https://github.com/googleapis/google-cloud-ruby"
   gem.license       = "Apache-2.0"
 

--- a/google-cloud-notebooks-v1beta1/proto_docs/README.md
+++ b/google-cloud-notebooks-v1beta1/proto_docs/README.md
@@ -1,4 +1,4 @@
-# AI Platform Notebooks V1 Protocol Buffer Documentation
+# AI Platform Notebooks V1beta1 Protocol Buffer Documentation
 
 These files are for the YARD documentation of the generated protobuf files.
 They are not intended to be required or loaded at runtime.

--- a/google-cloud-notebooks-v1beta1/synth.py
+++ b/google-cloud-notebooks-v1beta1/synth.py
@@ -30,7 +30,7 @@ library = gapic.ruby_library(
     ],
     generator_args={
         "ruby-cloud-gem-name": "google-cloud-notebooks-v1beta1",
-        "ruby-cloud-title": "AI Platform Notebooks V1",
+        "ruby-cloud-title": "AI Platform Notebooks V1beta1",
         "ruby-cloud-description": "AI Platform Notebooks makes it easy to manage JupyterLab instances through a protected, publicly available notebook instance URL. A JupyterLab instance is a Deep Learning virtual machine instance with the latest machine learning and data science libraries pre-installed.",
         "ruby-cloud-env-prefix": "NOTEBOOKS",
         "ruby-cloud-grpc-service-config": "google/cloud/notebooks/v1beta1/notebooks_grpc_service_config.json",
@@ -45,6 +45,6 @@ s.copy(library, merge=ruby.global_merge)
 # Workaround for https://github.com/googleapis/gapic-generator-ruby/issues/507
 s.replace(
     ".rubocop.yml",
-    'Naming/FileName:\n  Exclude:\n    - "lib/google-cloud-notebooks-v1beta1\\.rb"\nStyle/CaseEquality:',
-    'Naming/FileName:\n  Exclude:\n    - "lib/google-cloud-notebooks-v1beta1.rb"\nNaming/PredicateName:\n  Enabled: false\nStyle/CaseEquality:'
+    'Naming/FileName:\n  Exclude:\n    - "lib/google-cloud-notebooks-v1beta1\\.rb"\nStyle/AsciiComments:',
+    'Naming/FileName:\n  Exclude:\n    - "lib/google-cloud-notebooks-v1beta1.rb"\nNaming/PredicateName:\n  Enabled: false\nStyle/AsciiComments:'
 )


### PR DESCRIPTION
Mistakenly labeled as "V1" in the originally generated docs.
Also reinstated a synth hack that was broken by generator updates.