### PR TITLE
Release google-cloud-notebooks 0.1.0

### DIFF
--- a/google-cloud-notebooks/CHANGELOG.md
+++ b/google-cloud-notebooks/CHANGELOG.md
@@ -1,2 +1,6 @@
 # Release History
 
+### 0.1.0 / 2020-09-23
+
+Initial release.
+

--- a/google-cloud-notebooks/lib/google/cloud/notebooks/version.rb
+++ b/google-cloud-notebooks/lib/google/cloud/notebooks/version.rb
@@ -20,7 +20,7 @@
 module Google
   module Cloud
     module Notebooks
-      VERSION = "0.0.1"
+      VERSION = "0.1.0"
     end
   end
 end


### PR DESCRIPTION
Initial release.

<details><summary>Commits since previous release</summary><pre><code></code></pre></details>

This pull request was generated using releasetool.