### PR TITLE
Release google-cloud-bigquery-reservation 0.1.0

### DIFF
--- a/google-cloud-bigquery-reservation/CHANGELOG.md
+++ b/google-cloud-bigquery-reservation/CHANGELOG.md
@@ -1,2 +1,6 @@
 # Release History
 
+### 0.1.0 / 2020-09-23
+
+Initial release.
+

--- a/google-cloud-bigquery-reservation/lib/google/cloud/bigquery/reservation/version.rb
+++ b/google-cloud-bigquery-reservation/lib/google/cloud/bigquery/reservation/version.rb
@@ -21,7 +21,7 @@ module Google
   module Cloud
     module Bigquery
       module Reservation
-        VERSION = "0.0.1"
+        VERSION = "0.1.0"
       end
     end
   end


### PR DESCRIPTION
Initial release.

<details><summary>Commits since previous release</summary><pre><code></code></pre></details>

This pull request was generated using releasetool.