### PR TITLE
Release google-cloud-bigquery-connection 0.1.0

### DIFF
--- a/google-cloud-bigquery-connection/CHANGELOG.md
+++ b/google-cloud-bigquery-connection/CHANGELOG.md
@@ -1,2 +1,6 @@
 # Release History
 
+### 0.1.0 / 2020-09-23
+
+Initial release.
+

--- a/google-cloud-bigquery-connection/lib/google/cloud/bigquery/connection/version.rb
+++ b/google-cloud-bigquery-connection/lib/google/cloud/bigquery/connection/version.rb
@@ -21,7 +21,7 @@ module Google
   module Cloud
     module Bigquery
       module Connection
-        VERSION = "0.0.1"
+        VERSION = "0.1.0"
       end
     end
   end


### PR DESCRIPTION
Initial release.

<details><summary>Commits since previous release</summary><pre><code></code></pre></details>

This pull request was generated using releasetool.