### PR TITLE
chore: remove sample as it's no longer used and is failing due an ext…

### DIFF
--- a/google-cloud-vision/samples/acceptance/detect_labels_test.rb
+++ b/google-cloud-vision/samples/acceptance/detect_labels_test.rb
@@ -27,9 +27,5 @@ describe "Detect Labels" do
     assert_output(/traffic sign/i) do
       detect_labels_gcs image_path: gs_url("otter_crossing.jpg")
     end
-
-    assert_output(/suit/i) do
-      detect_labels_gcs_migration
-    end
   end
 end

--- a/google-cloud-vision/samples/detect_labels.rb
+++ b/google-cloud-vision/samples/detect_labels.rb
@@ -61,26 +61,6 @@ def detect_labels_gcs image_path:
   # [END vision_label_detection_gcs]
 end
 
-def detect_labels_gcs_migration
-  require "google/cloud/vision"
-  # [START image_annotator_labels_gcs_migration]
-
-  image_annotator = Google::Cloud::Vision.image_annotator
-
-  response = image_annotator.label_detection(
-    image:       "gs://gapic-toolkit/President_Barack_Obama.jpg",
-    max_results: 15 # optional, defaults to 10
-  )
-
-  puts "Labels:"
-  response.responses.each do |res|
-    res.label_annotations.each do |label|
-      puts label.description
-    end
-  end
-  # [END image_annotator_labels_gcs_migration]
-end
-
 if $PROGRAM_NAME == __FILE__
   image_path = ARGV.shift
 

--- a/google-cloud-vision/samples/product_search/Gemfile
+++ b/google-cloud-vision/samples/product_search/Gemfile
@@ -18,5 +18,6 @@ gem "google-cloud-vision"
 
 group :test do
   gem "minitest", "~> 5.13"
+  gem "minitest-focus", "~> 1.1"
   gem "rake"
 end


### PR DESCRIPTION
…ernal resource

Sample was created for a migration guide that has since been removed. 