### PR TITLE
feat(bigquery): Retry on 'internalError'

### DIFF
--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -536,7 +536,7 @@ module Google
             attr_accessor :backoff
           end
           self.retries = 5
-          self.reasons = ["rateLimitExceeded", "backendError"]
+          self.reasons = ["rateLimitExceeded", "backendError", "internalError"]
           self.backoff = lambda do |retries|
             # Max delay is 32 seconds
             # See "Back-off Requirements" here:


### PR DESCRIPTION
The BigQuery documentation suggests to troubleshoot an error with the `internalError` code you should 'retry the operation', but the service backoff mechanism only automatically retries on `rateLimitExceeded` and the similar, but apparently not the same, `backendError` codes.

This adds `internalError` to the set of retryable error codes.

https://cloud.google.com/bigquery/docs/error-messages#errortable

closes: #7846