### PR TITLE
feat(talent)!: Default to version V4 of the service

### DIFF
--- a/google-cloud-talent/AUTHENTICATION.md
+++ b/google-cloud-talent/AUTHENTICATION.md
@@ -27,7 +27,7 @@ export TALENT_CREDENTIALS=path/to/keyfile.json
 ```ruby
 require "google/cloud/talent"
 
-client = Google::Cloud::Talent.application_service
+client = Google::Cloud::Talent.company_service
 ```
 
 ## Credential Lookup
@@ -64,7 +64,7 @@ containers where writing files is difficult or not encouraged.
 
 The environment variables that google-cloud-talent
 checks for credentials are configured on the service Credentials class (such as
-`::Google::Cloud::Talent::V4beta1::ApplicationService::Credentials`):
+`::Google::Cloud::Talent::V4::CompanyService::Credentials`):
 
 1. `TALENT_CREDENTIALS` - Path to JSON file, or JSON contents
 2. `TALENT_KEYFILE` - Path to JSON file, or JSON contents
@@ -77,7 +77,7 @@ require "google/cloud/talent"
 
 ENV["TALENT_CREDENTIALS"] = "path/to/keyfile.json"
 
-client = Google::Cloud::Talent.application_service
+client = Google::Cloud::Talent.company_service
 ```
 
 ### Configuration
@@ -88,7 +88,7 @@ environment variables. Either on an individual client initialization:
 ```ruby
 require "google/cloud/talent"
 
-client = Google::Cloud::Talent.application_service do |config|
+client = Google::Cloud::Talent.company_service do |config|
   config.credentials = "path/to/keyfile.json"
 end
 ```
@@ -102,7 +102,7 @@ Google::Cloud::Talent.configure do |config|
   config.credentials = "path/to/keyfile.json"
 end
 
-client = Google::Cloud::Talent.application_service
+client = Google::Cloud::Talent.company_service
 ```
 
 ### Cloud SDK

--- a/google-cloud-talent/Gemfile
+++ b/google-cloud-talent/Gemfile
@@ -2,4 +2,5 @@ source "https://rubygems.org"
 
 gemspec
 
+gem "google-cloud-talent-v4", path: "../google-cloud-talent-v4"
 gem "google-cloud-talent-v4beta1", path: "../google-cloud-talent-v4beta1"

--- a/google-cloud-talent/README.md
+++ b/google-cloud-talent/README.md
@@ -15,6 +15,7 @@ for this library, google-cloud-talent, to see the convenience methods for
 constructing client objects. Reference documentation for the client objects
 themselves can be found in the client library documentation for the versioned
 client gems:
+[google-cloud-talent-v4](https://googleapis.dev/ruby/google-cloud-talent-v4/latest),
 [google-cloud-talent-v4beta1](https://googleapis.dev/ruby/google-cloud-talent-v4beta1/latest).
 
 See also the [Product Documentation](https://cloud.google.com/solutions/talent-solution)

--- a/google-cloud-talent/Rakefile
+++ b/google-cloud-talent/Rakefile
@@ -85,8 +85,8 @@ task :acceptance, :project, :keyfile do |t, args|
   if project.nil? || keyfile.nil?
     fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or TALENT_TEST_PROJECT=test123 TALENT_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
-  require "google/cloud/talent/v4beta1/application_service/credentials"
-  ::Google::Cloud::Talent::V4beta1::ApplicationService::Credentials.env_vars.each do |path|
+  require "google/cloud/talent/v4/company_service/credentials"
+  ::Google::Cloud::Talent::V4::CompanyService::Credentials.env_vars.each do |path|
     ENV[path] = nil
   end
   ENV["TALENT_PROJECT"] = project

--- a/google-cloud-talent/google-cloud-talent.gemspec
+++ b/google-cloud-talent/google-cloud-talent.gemspec
@@ -23,7 +23,8 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "google-cloud-core", "~> 1.5"
-  gem.add_dependency "google-cloud-talent-v4beta1", "~> 0.0"
+  gem.add_dependency "google-cloud-talent-v4", "~> 0.2"
+  gem.add_dependency "google-cloud-talent-v4beta1", "~> 0.2"
 
   gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "minitest", "~> 5.14"

--- a/google-cloud-talent/lib/google/cloud/talent.rb
+++ b/google-cloud-talent/lib/google/cloud/talent.rb
@@ -45,42 +45,11 @@ module Google
   module Cloud
     module Talent
       ##
-      # Create a new client object for ApplicationService.
-      #
-      # By default, this returns an instance of
-      # [Google::Cloud::Talent::V4beta1::ApplicationService::Client](https://googleapis.dev/ruby/google-cloud-talent-v4beta1/latest/Google/Cloud/Talent/V4beta1/ApplicationService/Client.html)
-      # for version V4beta1 of the API.
-      # However, you can specify specify a different API version by passing it in the
-      # `version` parameter. If the ApplicationService service is
-      # supported by that API version, and the corresponding gem is available, the
-      # appropriate versioned client will be returned.
-      #
-      # ## About ApplicationService
-      #
-      # A service that handles application management, including CRUD and
-      # enumeration.
-      #
-      # @param version [::String, ::Symbol] The API version to connect to. Optional.
-      #   Defaults to `:v4beta1`.
-      # @return [ApplicationService::Client] A client object for the specified version.
-      #
-      def self.application_service version: :v4beta1, &block
-        require "google/cloud/talent/#{version.to_s.downcase}"
-
-        package_name = Google::Cloud::Talent
-                       .constants
-                       .select { |sym| sym.to_s.downcase == version.to_s.downcase.tr("_", "") }
-                       .first
-        package_module = Google::Cloud::Talent.const_get package_name
-        package_module.const_get(:ApplicationService).const_get(:Client).new(&block)
-      end
-
-      ##
       # Create a new client object for CompanyService.
       #
       # By default, this returns an instance of
-      # [Google::Cloud::Talent::V4beta1::CompanyService::Client](https://googleapis.dev/ruby/google-cloud-talent-v4beta1/latest/Google/Cloud/Talent/V4beta1/CompanyService/Client.html)
-      # for version V4beta1 of the API.
+      # [Google::Cloud::Talent::V4::CompanyService::Client](https://googleapis.dev/ruby/google-cloud-talent-v4/latest/Google/Cloud/Talent/V4/CompanyService/Client.html)
+      # for version V4 of the API.
       # However, you can specify specify a different API version by passing it in the
       # `version` parameter. If the CompanyService service is
       # supported by that API version, and the corresponding gem is available, the
@@ -91,10 +60,10 @@ module Google
       # A service that handles company management, including CRUD and enumeration.
       #
       # @param version [::String, ::Symbol] The API version to connect to. Optional.
-      #   Defaults to `:v4beta1`.
+      #   Defaults to `:v4`.
       # @return [CompanyService::Client] A client object for the specified version.
       #
-      def self.company_service version: :v4beta1, &block
+      def self.company_service version: :v4, &block
         require "google/cloud/talent/#{version.to_s.downcase}"
 
         package_name = Google::Cloud::Talent
@@ -109,8 +78,8 @@ module Google
       # Create a new client object for Completion.
       #
       # By default, this returns an instance of
-      # [Google::Cloud::Talent::V4beta1::Completion::Client](https://googleapis.dev/ruby/google-cloud-talent-v4beta1/latest/Google/Cloud/Talent/V4beta1/Completion/Client.html)
-      # for version V4beta1 of the API.
+      # [Google::Cloud::Talent::V4::Completion::Client](https://googleapis.dev/ruby/google-cloud-talent-v4/latest/Google/Cloud/Talent/V4/Completion/Client.html)
+      # for version V4 of the API.
       # However, you can specify specify a different API version by passing it in the
       # `version` parameter. If the Completion service is
       # supported by that API version, and the corresponding gem is available, the
@@ -121,10 +90,10 @@ module Google
       # A service handles auto completion.
       #
       # @param version [::String, ::Symbol] The API version to connect to. Optional.
-      #   Defaults to `:v4beta1`.
+      #   Defaults to `:v4`.
       # @return [Completion::Client] A client object for the specified version.
       #
-      def self.completion version: :v4beta1, &block
+      def self.completion version: :v4, &block
         require "google/cloud/talent/#{version.to_s.downcase}"
 
         package_name = Google::Cloud::Talent
@@ -139,8 +108,8 @@ module Google
       # Create a new client object for EventService.
       #
       # By default, this returns an instance of
-      # [Google::Cloud::Talent::V4beta1::EventService::Client](https://googleapis.dev/ruby/google-cloud-talent-v4beta1/latest/Google/Cloud/Talent/V4beta1/EventService/Client.html)
-      # for version V4beta1 of the API.
+      # [Google::Cloud::Talent::V4::EventService::Client](https://googleapis.dev/ruby/google-cloud-talent-v4/latest/Google/Cloud/Talent/V4/EventService/Client.html)
+      # for version V4 of the API.
       # However, you can specify specify a different API version by passing it in the
       # `version` parameter. If the EventService service is
       # supported by that API version, and the corresponding gem is available, the
@@ -151,10 +120,10 @@ module Google
       # A service handles client event report.
       #
       # @param version [::String, ::Symbol] The API version to connect to. Optional.
-      #   Defaults to `:v4beta1`.
+      #   Defaults to `:v4`.
       # @return [EventService::Client] A client object for the specified version.
       #
-      def self.event_service version: :v4beta1, &block
+      def self.event_service version: :v4, &block
         require "google/cloud/talent/#{version.to_s.downcase}"
 
         package_name = Google::Cloud::Talent
@@ -169,8 +138,8 @@ module Google
       # Create a new client object for JobService.
       #
       # By default, this returns an instance of
-      # [Google::Cloud::Talent::V4beta1::JobService::Client](https://googleapis.dev/ruby/google-cloud-talent-v4beta1/latest/Google/Cloud/Talent/V4beta1/JobService/Client.html)
-      # for version V4beta1 of the API.
+      # [Google::Cloud::Talent::V4::JobService::Client](https://googleapis.dev/ruby/google-cloud-talent-v4/latest/Google/Cloud/Talent/V4/JobService/Client.html)
+      # for version V4 of the API.
       # However, you can specify specify a different API version by passing it in the
       # `version` parameter. If the JobService service is
       # supported by that API version, and the corresponding gem is available, the
@@ -181,10 +150,10 @@ module Google
       # A service handles job management, including job CRUD, enumeration and search.
       #
       # @param version [::String, ::Symbol] The API version to connect to. Optional.
-      #   Defaults to `:v4beta1`.
+      #   Defaults to `:v4`.
       # @return [JobService::Client] A client object for the specified version.
       #
-      def self.job_service version: :v4beta1, &block
+      def self.job_service version: :v4, &block
         require "google/cloud/talent/#{version.to_s.downcase}"
 
         package_name = Google::Cloud::Talent
@@ -196,42 +165,11 @@ module Google
       end
 
       ##
-      # Create a new client object for ProfileService.
-      #
-      # By default, this returns an instance of
-      # [Google::Cloud::Talent::V4beta1::ProfileService::Client](https://googleapis.dev/ruby/google-cloud-talent-v4beta1/latest/Google/Cloud/Talent/V4beta1/ProfileService/Client.html)
-      # for version V4beta1 of the API.
-      # However, you can specify specify a different API version by passing it in the
-      # `version` parameter. If the ProfileService service is
-      # supported by that API version, and the corresponding gem is available, the
-      # appropriate versioned client will be returned.
-      #
-      # ## About ProfileService
-      #
-      # A service that handles profile management, including profile CRUD,
-      # enumeration and search.
-      #
-      # @param version [::String, ::Symbol] The API version to connect to. Optional.
-      #   Defaults to `:v4beta1`.
-      # @return [ProfileService::Client] A client object for the specified version.
-      #
-      def self.profile_service version: :v4beta1, &block
-        require "google/cloud/talent/#{version.to_s.downcase}"
-
-        package_name = Google::Cloud::Talent
-                       .constants
-                       .select { |sym| sym.to_s.downcase == version.to_s.downcase.tr("_", "") }
-                       .first
-        package_module = Google::Cloud::Talent.const_get package_name
-        package_module.const_get(:ProfileService).const_get(:Client).new(&block)
-      end
-
-      ##
       # Create a new client object for TenantService.
       #
       # By default, this returns an instance of
-      # [Google::Cloud::Talent::V4beta1::TenantService::Client](https://googleapis.dev/ruby/google-cloud-talent-v4beta1/latest/Google/Cloud/Talent/V4beta1/TenantService/Client.html)
-      # for version V4beta1 of the API.
+      # [Google::Cloud::Talent::V4::TenantService::Client](https://googleapis.dev/ruby/google-cloud-talent-v4/latest/Google/Cloud/Talent/V4/TenantService/Client.html)
+      # for version V4 of the API.
       # However, you can specify specify a different API version by passing it in the
       # `version` parameter. If the TenantService service is
       # supported by that API version, and the corresponding gem is available, the
@@ -242,10 +180,10 @@ module Google
       # A service that handles tenant management, including CRUD and enumeration.
       #
       # @param version [::String, ::Symbol] The API version to connect to. Optional.
-      #   Defaults to `:v4beta1`.
+      #   Defaults to `:v4`.
       # @return [TenantService::Client] A client object for the specified version.
       #
-      def self.tenant_service version: :v4beta1, &block
+      def self.tenant_service version: :v4, &block
         require "google/cloud/talent/#{version.to_s.downcase}"
 
         package_name = Google::Cloud::Talent

--- a/google-cloud-talent/samples/Gemfile
+++ b/google-cloud-talent/samples/Gemfile
@@ -16,6 +16,7 @@ source "https://rubygems.org"
 
 if ENV["GOOGLE_CLOUD_SAMPLES_TEST"] == "master"
   gem "google-cloud-talent", path: "../../google-cloud-talent"
+  gem "google-cloud-talent-v4", path: "../../google-cloud-talent-v4"
   gem "google-cloud-talent-v4beta1", path: "../../google-cloud-talent-v4beta1"
 else
   # rubocop:disable Bundler/DuplicatedGem

--- a/google-cloud-talent/samples/acceptance/helper.rb
+++ b/google-cloud-talent/samples/acceptance/helper.rb
@@ -18,7 +18,7 @@ require "securerandom"
 
 require_relative "../autocomplete_job_title"
 require_relative "../batch_create_jobs"
-require_relative "../batch_delete_job"
+require_relative "../batch_delete_jobs"
 require_relative "../batch_update_jobs"
 require_relative "../commute_search"
 require_relative "../create_client_event"
@@ -50,10 +50,8 @@ def company_service
   Google::Cloud::Talent.company_service
 end
 
-def create_tenant_helper tenant_name, external_id
-  tenant_path = tenant_service.tenant_path project: project_id, tenant: tenant_name
+def create_tenant_helper external_id
   tenant = {
-    name:        tenant_path,
     external_id: external_id
   }
 
@@ -155,4 +153,41 @@ end
 
 def project_path
   tenant_service.project_path project: project_id
+end
+
+if ENV["USE_CTS_STAGING_ENV"]
+  require "google/cloud/talent/v4"
+
+  ::Google::Cloud::Talent::V4::CompanyService::Client.configure do |config|
+    config.endpoint = "staging-jobs.googleapis.com"
+  end
+  ::Google::Cloud::Talent::V4::Completion::Client.configure do |config|
+    config.endpoint = "staging-jobs.googleapis.com"
+  end
+  ::Google::Cloud::Talent::V4::EventService::Client.configure do |config|
+    config.endpoint = "staging-jobs.googleapis.com"
+  end
+  ::Google::Cloud::Talent::V4::JobService::Client.configure do |config|
+    config.endpoint = "staging-jobs.googleapis.com"
+  end
+  ::Google::Cloud::Talent::V4::TenantService::Client.configure do |config|
+    config.endpoint = "staging-jobs.googleapis.com"
+  end
+
+  require "google/cloud/talent/v4beta1"
+  ::Google::Cloud::Talent::V4beta1::CompanyService::Client.configure do |config|
+    config.endpoint = "staging-jobs.googleapis.com"
+  end
+  ::Google::Cloud::Talent::V4beta1::Completion::Client.configure do |config|
+    config.endpoint = "staging-jobs.googleapis.com"
+  end
+  ::Google::Cloud::Talent::V4beta1::EventService::Client.configure do |config|
+    config.endpoint = "staging-jobs.googleapis.com"
+  end
+  ::Google::Cloud::Talent::V4beta1::JobService::Client.configure do |config|
+    config.endpoint = "staging-jobs.googleapis.com"
+  end
+  ::Google::Cloud::Talent::V4beta1::TenantService::Client.configure do |config|
+    config.endpoint = "staging-jobs.googleapis.com"
+  end
 end

--- a/google-cloud-talent/samples/acceptance/talent_test.rb
+++ b/google-cloud-talent/samples/acceptance/talent_test.rb
@@ -6,8 +6,10 @@ describe "Job Search Samples" do
   let(:prefix) { "talent_samples_" }
   let(:rando) { SecureRandom.hex }
   let(:rando_two) { SecureRandom.hex }
+  let(:rando_batch_delete_1) { SecureRandom.hex }
+  let(:rando_batch_delete_2) { SecureRandom.hex }
 
-  let(:tenant) { create_tenant_helper "#{prefix}tenant_#{rando}", rando }
+  let(:tenant) { create_tenant_helper "#{prefix}tenant_#{rando}" }
   let(:tenant_id) { tenant.name.split("/").last }
 
   let(:company_name) { "#{prefix}company_#{rando}" }
@@ -36,7 +38,7 @@ describe "Job Search Samples" do
       # autocomplete suggestions, so just check for a response.
       out, _err = capture_io do
         complete_query project_id,
-                       nil,
+                       tenant_id,
                        "Talent",
                        100,
                        language_code
@@ -87,12 +89,22 @@ describe "Job Search Samples" do
   describe "batch_delete_job" do
     after { delete_tenant_helper tenant }
 
-    it "deletes jobs matching a filter" do
-      filter = "companyName = \"#{company.name}\" AND requisitionId = \"#{job.requisition_id}\""
-      assert_output "Batch deleted jobs from filter\n" do
-        sample_batch_delete_jobs project_id, tenant_id, filter
+    it "deletes jobs" do
+      job_1 = create_job_helper(tenant_id, company_id,
+                                "#{prefix}job_#{rando_batch_delete_1}",
+                                rando_batch_delete_1)
+      job_2 = create_job_helper(tenant_id, company_id,
+                                "#{prefix}job_#{rando_batch_delete_2}",
+                                rando_batch_delete_2)
+
+      out, _err = capture_io do
+        sample_batch_delete_jobs project_id, tenant_id, job_1.name, job_2.name
       end
-      assert_raises(Google::Cloud::NotFoundError) { get_job_helper job.name }
+      assert_includes out, "Batch response:"
+      assert_includes out, "Job: name: \"#{job_1.name}\""
+      assert_includes out, "Job: name: \"#{job_2.name}\""
+      assert_raises(Google::Cloud::NotFoundError) { get_job_helper job_1.name }
+      assert_raises(Google::Cloud::NotFoundError) { get_job_helper job_2.name }
     end
   end
 

--- a/google-cloud-talent/samples/acceptance/talent_test.rb
+++ b/google-cloud-talent/samples/acceptance/talent_test.rb
@@ -53,8 +53,8 @@ describe "Job Search Samples" do
     after { delete_tenant_helper tenant }
 
     it "creates two jobs" do
-      company_path_one = company_service.company_path project: project_id, company: company_id
-      company_path_two = company_service.company_path project: project_id, company: company_id_two
+      company_path_one = company_service.company_path project: project_id, tenant: tenant_id, company: company_id
+      company_path_two = company_service.company_path project: project_id, tenant: tenant_id, company: company_id_two
       requisition_id = rando
       requisition_id_two = rando_two
       title_one = "ruby_sample_title_#{rando}"
@@ -180,7 +180,7 @@ describe "Job Search Samples" do
       match = out.match %r{Name: ([\w/-]*)}
       assert match[1]
       matched_company = get_company_helper match[1]
-      assert_instance_of Google::Cloud::Talent::V4beta1::Company, matched_company
+      assert_instance_of Google::Cloud::Talent::V4::Company, matched_company
     end
   end
 
@@ -202,7 +202,7 @@ describe "Job Search Samples" do
       match = out.match %r{Created job: ([\w/-]*)}
       assert match[1]
       matched_job = get_job_helper match[1]
-      assert_instance_of Google::Cloud::Talent::V4beta1::Job, matched_job
+      assert_instance_of Google::Cloud::Talent::V4::Job, matched_job
     end
   end
 
@@ -222,7 +222,7 @@ describe "Job Search Samples" do
       match = out.match %r{Created job: ([\w/-]*)}
       assert match[1]
       matched_job = get_job_helper match[1]
-      assert_instance_of Google::Cloud::Talent::V4beta1::Job, matched_job
+      assert_instance_of Google::Cloud::Talent::V4::Job, matched_job
     end
   end
 
@@ -234,7 +234,7 @@ describe "Job Search Samples" do
       match = out.match %r{Name: ([\w/-]*)}
       assert match[1]
       matched_tenant = get_tenant_helper match[1]
-      assert_instance_of Google::Cloud::Talent::V4beta1::Tenant, matched_tenant
+      assert_instance_of Google::Cloud::Talent::V4::Tenant, matched_tenant
       delete_tenant_helper matched_tenant
     end
   end

--- a/google-cloud-talent/samples/autocomplete_job_title.rb
+++ b/google-cloud-talent/samples/autocomplete_job_title.rb
@@ -20,7 +20,7 @@ def complete_query project_id, tenant_id, query, page_size, language_code
   completion_service = Google::Cloud::Talent.completion
 
   # project_id = "Your Google Cloud Project ID"
-  # tenant_id = "Your Tenant ID (using tenancy is optional)"
+  # tenant_id = "Your Tenant ID (using tenancy is required)"
   formatted_parent = completion_service.tenant_path project: project_id, tenant: tenant_id
 
   # language_code = "en-US"
@@ -28,13 +28,14 @@ def complete_query project_id, tenant_id, query, page_size, language_code
 
   # query = "[partially typed job title]"
   # page_size: page_size = 5
-  response = completion_service.complete_query parent:         formatted_parent,
+  response = completion_service.complete_query tenant:         formatted_parent,
                                                query:          query,
                                                page_size:      page_size,
                                                language_codes: language_codes
+
   response.completion_results.each do |result|
     puts "Suggested title: #{result.suggestion}"
-    # Suggestion type is JOB_TITLE or COMPANY_TITLE
+    # Suggestion type is JOB_TITLE or COMPANY_NAME
     puts "Suggestion type: #{result.type}"
   end
   # [END job_search_autocomplete_job_title]
@@ -45,7 +46,7 @@ require "optparse"
 if $PROGRAM_NAME == __FILE__
 
   project_id = "Your Google Cloud Project ID"
-  tenant_id = "Your Tenant ID (using tenancy is optional)"
+  tenant_id = "Your Tenant ID (using tenancy is required)"
   query = "[partially typed job title]"
   page_size = 5
   language_code = "en-US"

--- a/google-cloud-talent/samples/batch_create_jobs.rb
+++ b/google-cloud-talent/samples/batch_create_jobs.rb
@@ -25,7 +25,7 @@ def sample_batch_create_jobs project_id, tenant_id, company_name_one,
   job_service = Google::Cloud::Talent.job_service
 
   # project_id = "Your Google Cloud Project ID"
-  # tenant_id = "Your Tenant ID (using tenancy is optional)"
+  # tenant_id = "Your Tenant ID (using tenancy is required)"
   formatted_parent = job_service.tenant_path project: project_id, tenant: tenant_id
 
   # job_application_url_one = "https://www.example.org/job-posting/123"
@@ -93,7 +93,7 @@ require "optparse"
 if $PROGRAM_NAME == __FILE__
 
   project_id = "Your Google Cloud Project ID"
-  tenant_id = "Your Tenant ID (using tenancy is optional)"
+  tenant_id = "Your Tenant ID (using tenancy is required)"
   company_name_one = "Company name, e.g. projects/your-project/companies/company-id"
   requisition_id_one = "Job requisition ID, aka Posting ID. Unique per job."
   title_one = "Software Engineer"

--- a/google-cloud-talent/samples/batch_delete_jobs.rb
+++ b/google-cloud-talent/samples/batch_delete_jobs.rb
@@ -12,22 +12,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-def sample_batch_delete_jobs project_id, tenant_id, filter
-  # [START job_search_batch_delete_job]
+def sample_batch_delete_jobs project_id, tenant_id, job_name_one, job_name_two
+  # [START job_search_batch_delete_jobs]
   require "google/cloud/talent"
 
   # Instantiate a client
   job_service = Google::Cloud::Talent.job_service
 
   # project_id = "Your Google Cloud Project ID"
-  # tenant_id = "Your Tenant ID (using tenancy is optional)"
+  # tenant_id = "Your Tenant ID (using tenancy is required)"
   formatted_parent = job_service.tenant_path project: project_id, tenant: tenant_id
 
-  # filter = "[Query]"
-  job_service.batch_delete_jobs parent: formatted_parent, filter: filter
+  # the name of jobs to be deleted.
+  names = [job_name_one, job_name_two]
 
-  puts "Batch deleted jobs from filter"
-  # [END job_search_batch_delete_job]
+  # Make the long-running operation request
+  operation = job_service.batch_delete_jobs parent: formatted_parent, names: names
+
+  # Block until operation complete
+  operation.wait_until_done!
+
+  raise operation.results.message if operation.error?
+
+  response = operation.response
+
+  puts "Batch response: #{response.inspect}"
+  # [END job_search_batch_delete_jobs]
 end
 
 require "optparse"
@@ -35,16 +45,17 @@ require "optparse"
 if $PROGRAM_NAME == __FILE__
 
   project_id = "Your Google Cloud Project ID"
-  tenant_id = "Your Tenant ID (using tenancy is optional)"
-  filter = "[Query]"
-
+  tenant_id = "Your Tenant ID (using tenancy is required)"
+  job_name_one = "Job name 1, e.g. projects/your-project/tenant/tenant-id/jobs/job-id-1"
+  job_name_two = "Job name 2, e.g. projects/your-project/tenant/tenant-id/jobs/job-id-2"
+  s
   ARGV.options do |opts|
     opts.on("--project_id=val") { |val| project_id = val }
     opts.on("--tenant_id=val") { |val| tenant_id = val }
-    opts.on("--filter=val") { |val| filter = val }
+    opts.on("--job_name_one=val") { |val| job_name_one = val }
+    opts.on("--job_name_two=val") { |val| job_name_two = val }
     opts.parse!
   end
 
-
-  sample_batch_delete_jobs project_id, tenant_id, filter
+  sample_batch_delete_jobs project_id, tenant_id, job_name_one, job_name_two
 end

--- a/google-cloud-talent/samples/batch_update_jobs.rb
+++ b/google-cloud-talent/samples/batch_update_jobs.rb
@@ -28,7 +28,7 @@ def sample_batch_update_jobs project_id, tenant_id, job_name_one,
   job_service = Google::Cloud::Talent.job_service
 
   # project_id = "Your Google Cloud Project ID"
-  # tenant_id = "Your Tenant ID (using tenancy is optional)"
+  # tenant_id = "Your Tenant ID (using tenancy is required)"
   formatted_parent = job_service.tenant_path project: project_id, tenant: tenant_id
 
   # job_application_url_one = "https://www.example.org/job-posting/123"
@@ -99,7 +99,7 @@ require "optparse"
 if $PROGRAM_NAME == __FILE__
 
   project_id = "Your Google Cloud Project ID"
-  tenant_id = "Your Tenant ID (using tenancy is optional)"
+  tenant_id = "Your Tenant ID (using tenancy is required)"
   job_name_one = "job name, e.g. projects/your-project/tenants/tenant-id/jobs/job-id"
   company_name_one = "Company name, e.g. projects/your-project/companies/company-id"
   requisition_id_one = "Job requisition ID, aka Posting ID. Unique per job."

--- a/google-cloud-talent/samples/commute_search.rb
+++ b/google-cloud-talent/samples/commute_search.rb
@@ -20,7 +20,7 @@ def sample_commute_search_jobs project_id, tenant_id
   job_service = Google::Cloud::Talent.job_service
 
   # project_id = "Your Google Cloud Project ID"
-  # tenant_id = "Your Tenant ID (using tenancy is optional)"
+  # tenant_id = "Your Tenant ID (using tenancy is required)"
   formatted_parent = job_service.tenant_path project: project_id, tenant: tenant_id
   domain = "www.example.com"
   session_id = "Hashed session identifier"
@@ -62,7 +62,7 @@ require "optparse"
 if $PROGRAM_NAME == __FILE__
 
   project_id = "Your Google Cloud Project ID"
-  tenant_id = "Your Tenant ID (using tenancy is optional)"
+  tenant_id = "Your Tenant ID (using tenancy is required)"
 
   ARGV.options do |opts|
     opts.on("--project_id=val") { |val| project_id = val }
@@ -71,5 +71,5 @@ if $PROGRAM_NAME == __FILE__
   end
 
 
-  sample_search_jobs project_id, tenant_id
+  sample_commute_search_jobs project_id, tenant_id
 end

--- a/google-cloud-talent/samples/create_client_event.rb
+++ b/google-cloud-talent/samples/create_client_event.rb
@@ -25,7 +25,7 @@ def sample_create_client_event project_id,
   event_client = Google::Cloud::Talent.event_service
 
   # project_id = "Your Google Cloud Project ID"
-  # tenant_id = "Your Tenant ID (using tenancy is optional)"
+  # tenant_id = "Your Tenant ID (using tenancy is required)"
   parent = event_client.tenant_path project: project_id, tenant: tenant_id
 
   # The timestamp of the event as seconds of UTC time since Unix epoch
@@ -62,7 +62,7 @@ require "optparse"
 if $PROGRAM_NAME == __FILE__
 
   project_id = "Your Google Cloud Project ID"
-  tenant_id = "Your Tenant ID (using tenancy is optional)"
+  tenant_id = "Your Tenant ID (using tenancy is required)"
   request_id = "[request_id from ResponseMetadata]"
   event_id = "[Set this to a unique identifier]"
   job_one = "The name of a job"

--- a/google-cloud-talent/samples/create_company.rb
+++ b/google-cloud-talent/samples/create_company.rb
@@ -20,7 +20,7 @@ def sample_create_company project_id, tenant_id, display_name, external_id
   company_service = Google::Cloud::Talent.company_service
 
   # project_id = "Your Google Cloud Project ID"
-  # tenant_id = "Your Tenant ID (using tenancy is optional)"
+  # tenant_id = "Your Tenant ID (using tenancy is required)"
   parent = company_service.tenant_path project: project_id, tenant: tenant_id
 
   # display_name = "My Company Name"
@@ -40,7 +40,7 @@ require "optparse"
 if $PROGRAM_NAME == __FILE__
 
   project_id = "Your Google Cloud Project ID"
-  tenant_id = "Your Tenant ID (using tenancy is optional)"
+  tenant_id = "Your Tenant ID (using tenancy is required)"
   display_name = "My Company Name"
   external_id = "Identifier of this company in my system"
 

--- a/google-cloud-talent/samples/create_job.rb
+++ b/google-cloud-talent/samples/create_job.rb
@@ -28,7 +28,7 @@ def sample_create_job project_id,
   job_service = Google::Cloud::Talent.job_service
 
   # project_id = "Your Google Cloud Project ID"
-  # tenant_id = "Your Tenant ID (using tenancy is optional)"
+  # tenant_id = "Your Tenant ID (using tenancy is required)"
   parent = job_service.tenant_path project: project_id, tenant: tenant_id
 
   # job_application_url = "https://www.example.org/job-posting/123"
@@ -63,7 +63,7 @@ require "optparse"
 if $PROGRAM_NAME == __FILE__
 
   project_id = "Your Google Cloud Project ID"
-  tenant_id = "Your Tenant ID (using tenancy is optional)"
+  tenant_id = "Your Tenant ID (using tenancy is required)"
   company_name = "Company name, e.g. projects/your-project/companies/company-id"
   requisition_id = "Job requisition ID, aka Posting ID. Unique per job."
   title = "Software Engineer"
@@ -88,5 +88,5 @@ if $PROGRAM_NAME == __FILE__
 
   sample_create_job project_id, tenant_id, company_name, requisition_id,
                     title, description, job_application_url, address,
-                    address_two, language_code
+                    language_code
 end

--- a/google-cloud-talent/samples/create_job_custom_attributes.rb
+++ b/google-cloud-talent/samples/create_job_custom_attributes.rb
@@ -26,7 +26,7 @@ def sample_create_job_with_custom_attributes project_id,
   job_service = Google::Cloud::Talent.job_service
 
   # project_id = "Your Google Cloud Project ID"
-  # tenant_id = "Your Tenant ID (using tenancy is optional)"
+  # tenant_id = "Your Tenant ID (using tenancy is required)"
   parent = job_service.tenant_path project: project_id, tenant: tenant_id
 
   # title = "Software Engineer"
@@ -52,7 +52,7 @@ require "optparse"
 if $PROGRAM_NAME == __FILE__
 
   project_id = "Your Google Cloud Project ID"
-  tenant_id = "Your Tenant ID (using tenancy is optional)"
+  tenant_id = "Your Tenant ID (using tenancy is required)"
   company_name = "Company name, e.g. projects/your-project/companies/company-id"
   requisition_id = "Job requisition ID, aka Posting ID. Unique per job."
   language_code = "en-US"

--- a/google-cloud-talent/samples/custom_ranking_search.rb
+++ b/google-cloud-talent/samples/custom_ranking_search.rb
@@ -20,7 +20,7 @@ def sample_custom_ranking_search project_id, tenant_id
   job_service = Google::Cloud::Talent.job_service
 
   # project_id = "Your Google Cloud Project ID"
-  # tenant_id = "Your Tenant ID (using tenancy is optional)"
+  # tenant_id = "Your Tenant ID (using tenancy is required)"
   parent = job_service.tenant_path project: project_id, tenant: tenant_id
   domain = "www.example.com"
   session_id = "Hashed session identifier"
@@ -58,7 +58,7 @@ require "optparse"
 if $PROGRAM_NAME == __FILE__
 
   project_id = "Your Google Cloud Project ID"
-  tenant_id = "Your Tenant ID (using tenancy is optional)"
+  tenant_id = "Your Tenant ID (using tenancy is required)"
 
   ARGV.options do |opts|
     opts.on("--project_id=val") { |val| project_id = val }
@@ -67,5 +67,5 @@ if $PROGRAM_NAME == __FILE__
   end
 
 
-  sample_search_jobs project_id, tenant_id
+  sample_custom_ranking_search project_id, tenant_id
 end

--- a/google-cloud-talent/samples/delete_company.rb
+++ b/google-cloud-talent/samples/delete_company.rb
@@ -20,7 +20,7 @@ def sample_delete_company project_id, tenant_id, company_id
   company_service = Google::Cloud::Talent.company_service
 
   # project_id = "Your Google Cloud Project ID"
-  # tenant_id = "Your Tenant ID (using tenancy is optional)"
+  # tenant_id = "Your Tenant ID (using tenancy is required)"
   # company_id = "ID of the company to delete"
   formatted_name = company_service.company_path project: project_id,
                                                 tenant:  tenant_id,
@@ -37,7 +37,7 @@ require "optparse"
 if $PROGRAM_NAME == __FILE__
 
   project_id = "Your Google Cloud Project ID"
-  tenant_id = "Your Tenant ID (using tenancy is optional)"
+  tenant_id = "Your Tenant ID (using tenancy is required)"
   company_id = "ID of the company to delete"
 
   ARGV.options do |opts|

--- a/google-cloud-talent/samples/delete_job.rb
+++ b/google-cloud-talent/samples/delete_job.rb
@@ -20,7 +20,7 @@ def sample_delete_job project_id, tenant_id, job_id
   job_service = Google::Cloud::Talent.job_service
 
   # project_id = "Your Google Cloud Project ID"
-  # tenant_id = "Your Tenant ID (using tenancy is optional)"
+  # tenant_id = "Your Tenant ID (using tenancy is required)"
   # job_id = "Company ID"
   formatted_name = job_service.job_path project: project_id,
                                         tenant:  tenant_id,
@@ -37,7 +37,7 @@ require "optparse"
 if $PROGRAM_NAME == __FILE__
 
   project_id = "Your Google Cloud Project ID"
-  tenant_id = "Your Tenant ID (using tenancy is optional)"
+  tenant_id = "Your Tenant ID (using tenancy is required)"
   job_id = "Company ID"
 
   ARGV.options do |opts|

--- a/google-cloud-talent/samples/get_company.rb
+++ b/google-cloud-talent/samples/get_company.rb
@@ -20,7 +20,7 @@ def sample_get_company project_id, tenant_id, company_id
   company_service = Google::Cloud::Talent.company_service
 
   # project_id = "Your Google Cloud Project ID"
-  # tenant_id = "Your Tenant ID (using tenancy is optional)"
+  # tenant_id = "Your Tenant ID (using tenancy is required)"
   # company_id = "Company ID"
   formatted_name = company_service.company_path project: project_id,
                                                 tenant:  tenant_id,
@@ -37,7 +37,7 @@ require "optparse"
 if $PROGRAM_NAME == __FILE__
 
   project_id = "Your Google Cloud Project ID"
-  tenant_id = "Your Tenant ID (using tenancy is optional)"
+  tenant_id = "Your Tenant ID (using tenancy is required)"
   company_id = "Company ID"
 
   ARGV.options do |opts|

--- a/google-cloud-talent/samples/get_job.rb
+++ b/google-cloud-talent/samples/get_job.rb
@@ -20,7 +20,7 @@ def sample_get_job project_id, tenant_id, job_id
   job_service = Google::Cloud::Talent.job_service
 
   # project_id = "Your Google Cloud Project ID"
-  # tenant_id = "Your Tenant ID (using tenancy is optional)"
+  # tenant_id = "Your Tenant ID (using tenancy is required)"
   # job_id = "Job ID"
   formatted_name = job_service.job_path project: project_id,
                                         tenant:  tenant_id,
@@ -49,7 +49,7 @@ require "optparse"
 if $PROGRAM_NAME == __FILE__
 
   project_id = "Your Google Cloud Project ID"
-  tenant_id = "Your Tenant ID (using tenancy is optional)"
+  tenant_id = "Your Tenant ID (using tenancy is required)"
   job_id = "Job ID"
 
   ARGV.options do |opts|

--- a/google-cloud-talent/samples/histogram_search.rb
+++ b/google-cloud-talent/samples/histogram_search.rb
@@ -20,7 +20,7 @@ def sample_search_jobs project_id, tenant_id, query
   job_service = Google::Cloud::Talent.job_service
 
   # project_id = "Your Google Cloud Project ID"
-  # tenant_id = "Your Tenant ID (using tenancy is optional)"
+  # tenant_id = "Your Tenant ID (using tenancy is required)"
   formatted_parent = job_service.tenant_path project: project_id, tenant: tenant_id
   domain = "www.example.com"
   session_id = "Hashed session identifier"
@@ -54,7 +54,7 @@ require "optparse"
 if $PROGRAM_NAME == __FILE__
 
   project_id = "Your Google Cloud Project ID"
-  tenant_id = "Your Tenant ID (using tenancy is optional)"
+  tenant_id = "Your Tenant ID (using tenancy is required)"
   query = "count(base_compensation, [bucket(12, 20)])"
 
   ARGV.options do |opts|

--- a/google-cloud-talent/samples/list_companies.rb
+++ b/google-cloud-talent/samples/list_companies.rb
@@ -20,7 +20,7 @@ def sample_list_companies project_id, tenant_id
   company_service = Google::Cloud::Talent.company_service
 
   # project_id = "Your Google Cloud Project ID"
-  # tenant_id = "Your Tenant ID (using tenancy is optional)"
+  # tenant_id = "Your Tenant ID (using tenancy is required)"
   formatted_parent = company_service.tenant_path project: project_id, tenant: tenant_id
 
   # Iterate over all results.
@@ -39,7 +39,7 @@ require "optparse"
 if $PROGRAM_NAME == __FILE__
 
   project_id = "Your Google Cloud Project ID"
-  tenant_id = "Your Tenant ID (using tenancy is optional)"
+  tenant_id = "Your Tenant ID (using tenancy is required)"
 
   ARGV.options do |opts|
     opts.on("--project_id=val") { |val| project_id = val }

--- a/google-cloud-talent/samples/list_jobs.rb
+++ b/google-cloud-talent/samples/list_jobs.rb
@@ -20,7 +20,7 @@ def sample_list_jobs project_id, tenant_id, filter
   job_service = Google::Cloud::Talent.job_service
 
   # project_id = "Your Google Cloud Project ID"
-  # tenant_id = "Your Tenant ID (using tenancy is optional)"
+  # tenant_id = "Your Tenant ID (using tenancy is required)"
   formatted_parent = job_service.tenant_path project: project_id, tenant: tenant_id
 
   # Iterate over all results.
@@ -39,7 +39,7 @@ require "optparse"
 if $PROGRAM_NAME == __FILE__
 
   project_id = "Your Google Cloud Project ID"
-  tenant_id = "Your Tenant ID (using tenancy is optional)"
+  tenant_id = "Your Tenant ID (using tenancy is required)"
   filter = "companyName=projects/my-project/companies/company-id"
 
   ARGV.options do |opts|

--- a/google-cloud-talent/synth.metadata
+++ b/google-cloud-talent/synth.metadata
@@ -3,16 +3,16 @@
     {
       "git": {
         "name": ".",
-        "remote": "https://github.com/googleapis/google-cloud-ruby.git",
-        "sha": "e1d661afe7586d44a29821d44fe8a4cc6d0a34a9"
+        "remote": "git@github.com:googleapis/google-cloud-ruby.git",
+        "sha": "ef1c42fc65c890c7fa8cd5ef023a033cb9219a3d"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "874846a1917ee5c3fe271449f3cb9a06e75407be",
-        "internalRef": "326288259"
+        "sha": "80eada6dbc452b58b4663fa3ab4f0b6746f49f80",
+        "internalRef": "335745163"
       }
     }
   ],
@@ -21,7 +21,7 @@
       "client": {
         "source": "googleapis",
         "apiName": "talent",
-        "apiVersion": "v4beta1",
+        "apiVersion": "v4",
         "language": "ruby",
         "generator": "gapic-generator-ruby"
       }

--- a/google-cloud-talent/synth.py
+++ b/google-cloud-talent/synth.py
@@ -23,13 +23,13 @@ logging.basicConfig(level=logging.DEBUG)
 
 gapic = gcp.GAPICMicrogenerator()
 library = gapic.ruby_library(
-    "talent", "v4beta1",
+    "talent", "v4",
     generator_args={
         "ruby-cloud-gem-name": "google-cloud-talent",
         "ruby-cloud-title": "Cloud Talent Solution",
         "ruby-cloud-description": "Transform your job search and candidate matching capabilities with Cloud Talent Solution, designed to support enterprise talent acquisition technology and evolve with your growing needs. This AI solution includes features such as Job Search and Profile Search (Beta) to provide candidates and employers with an enhanced talent acquisition experience.",
         "ruby-cloud-env-prefix": "TALENT",
-        "ruby-cloud-wrapper-of": "v4beta1:0.0",
+        "ruby-cloud-wrapper-of": "v4:0.2;v4beta1:0.2",
         "ruby-cloud-product-url": "https://cloud.google.com/solutions/talent-solution",
         "ruby-cloud-api-id": "jobs.googleapis.com",
         "ruby-cloud-api-shortname": "jobs",

--- a/google-cloud-talent/test/google/cloud/talent/client_test.rb
+++ b/google-cloud-talent/test/google/cloud/talent/client_test.rb
@@ -22,23 +22,13 @@ require "gapic/common"
 require "gapic/grpc"
 
 class Google::Cloud::Talent::ClientConstructionMinitest < Minitest::Test
-  def test_application_service
-    Gapic::ServiceStub.stub :new, :stub do
-      grpc_channel = GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
-      client = Google::Cloud::Talent.application_service do |config|
-        config.credentials = grpc_channel
-      end
-      assert_kind_of Google::Cloud::Talent::V4beta1::ApplicationService::Client, client
-    end
-  end
-
   def test_company_service
     Gapic::ServiceStub.stub :new, :stub do
       grpc_channel = GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
       client = Google::Cloud::Talent.company_service do |config|
         config.credentials = grpc_channel
       end
-      assert_kind_of Google::Cloud::Talent::V4beta1::CompanyService::Client, client
+      assert_kind_of Google::Cloud::Talent::V4::CompanyService::Client, client
     end
   end
 
@@ -48,7 +38,7 @@ class Google::Cloud::Talent::ClientConstructionMinitest < Minitest::Test
       client = Google::Cloud::Talent.completion do |config|
         config.credentials = grpc_channel
       end
-      assert_kind_of Google::Cloud::Talent::V4beta1::Completion::Client, client
+      assert_kind_of Google::Cloud::Talent::V4::Completion::Client, client
     end
   end
 
@@ -58,7 +48,7 @@ class Google::Cloud::Talent::ClientConstructionMinitest < Minitest::Test
       client = Google::Cloud::Talent.event_service do |config|
         config.credentials = grpc_channel
       end
-      assert_kind_of Google::Cloud::Talent::V4beta1::EventService::Client, client
+      assert_kind_of Google::Cloud::Talent::V4::EventService::Client, client
     end
   end
 
@@ -68,17 +58,7 @@ class Google::Cloud::Talent::ClientConstructionMinitest < Minitest::Test
       client = Google::Cloud::Talent.job_service do |config|
         config.credentials = grpc_channel
       end
-      assert_kind_of Google::Cloud::Talent::V4beta1::JobService::Client, client
-    end
-  end
-
-  def test_profile_service
-    Gapic::ServiceStub.stub :new, :stub do
-      grpc_channel = GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
-      client = Google::Cloud::Talent.profile_service do |config|
-        config.credentials = grpc_channel
-      end
-      assert_kind_of Google::Cloud::Talent::V4beta1::ProfileService::Client, client
+      assert_kind_of Google::Cloud::Talent::V4::JobService::Client, client
     end
   end
 
@@ -88,7 +68,7 @@ class Google::Cloud::Talent::ClientConstructionMinitest < Minitest::Test
       client = Google::Cloud::Talent.tenant_service do |config|
         config.credentials = grpc_channel
       end
-      assert_kind_of Google::Cloud::Talent::V4beta1::TenantService::Client, client
+      assert_kind_of Google::Cloud::Talent::V4::TenantService::Client, client
     end
   end
 end


### PR DESCRIPTION
Switches the google-cloud-talent wrapper to default to version V4 of the service.

Note: V4 drops two interfaces: ApplicationService and ProfileService. The wrapper generation accordingly removes those two methods