### PR TITLE
chore: Fix ContainerAnalysis synth scripts to handle proto special cases

### DIFF
--- a/google-cloud-container_analysis-v1/synth.py
+++ b/google-cloud-container_analysis-v1/synth.py
@@ -18,6 +18,7 @@ import synthtool as s
 import synthtool.gcp as gcp
 import synthtool.languages.ruby as ruby
 import logging
+import shutil
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -25,7 +26,13 @@ gapic = gcp.GAPICMicrogenerator()
 library = gapic.ruby_library(
     "containeranalysis", "v1",
     proto_path="google/devtools/containeranalysis/v1",
-    extra_proto_files=["google/cloud/common_resources.proto"],
+    extra_proto_files=[
+        "google/cloud/common_resources.proto",
+        "grafeas/v1/common.proto",
+        "grafeas/v1/cvss.proto",
+        "grafeas/v1/package.proto",
+        "grafeas/v1/vulnerability.proto",
+    ],
     generator_args={
         "ruby-cloud-gem-name": "google-cloud-container_analysis-v1",
         "ruby-cloud-title": "Container Analysis V1",
@@ -38,6 +45,9 @@ library = gapic.ruby_library(
         "ruby-cloud-extra-dependencies": "grafeas-v1=~> 0.0",
     }
 )
+
+# Remove grafeas protos since they will be brought in via the grafeas-v1 gem
+shutil.rmtree(library / "lib/grafeas")
 
 s.copy(library, merge=ruby.global_merge)
 

--- a/google-cloud-container_analysis/synth.py
+++ b/google-cloud-container_analysis/synth.py
@@ -25,6 +25,12 @@ gapic = gcp.GAPICMicrogenerator()
 library = gapic.ruby_library(
     "containeranalysis", "v1",
     proto_path="google/devtools/containeranalysis/v1",
+    extra_proto_files=[
+        "grafeas/v1/common.proto",
+        "grafeas/v1/cvss.proto",
+        "grafeas/v1/package.proto",
+        "grafeas/v1/vulnerability.proto",
+    ],
     generator_args={
         "ruby-cloud-gem-name": "google-cloud-container_analysis",
         "ruby-cloud-title": "Container Analysis",


### PR DESCRIPTION
Alas, ContainerAnalysis is even more of a snowflake now. It [recently took](https://github.com/googleapis/googleapis/commit/cb7fc620590382a4a2ea6ffdf6f51ae0e77bbbb5) a direct dependency on a Grafeas proto, in violation of [AIP 213](https://google.aip.dev/213). As a result, we need to hack the synth script to give access to the needed Grafeas `.proto` files, and hack it again to prevent said files from generating actual proto classes in the generated ContainerAnalysis library that could conflict with the classes from the generated Grafeas library. This is to prevent synthtool from breaking as it has in #7945 and #7946.

This PR includes only the synth changes (which were tested locally). It does not include the resulting updates to generated code. We want regeneration to take place in autosynth so it can update the `generatedFiles` metadata field properly.