### PR TITLE
chore: Normalize Setup instructions in samples READMEs

### DIFF
--- a/google-cloud-dialogflow/samples/README.md
+++ b/google-cloud-dialogflow/samples/README.md
@@ -13,7 +13,7 @@ Authentication is typically done through [Application Default Credentials](https
 environment has credentials. You have a few options for setting up
 authentication:
 
-1. When running locally, use the [Google Cloud SDK](https://cloud.google.com/sdk/)
+1. When running locally, use the [Google Cloud SDK](https://cloud.google.com/sdk/):
 
        gcloud auth application-default login
 

--- a/google-cloud-dialogflow/samples/README.md
+++ b/google-cloud-dialogflow/samples/README.md
@@ -21,8 +21,8 @@ authentication:
 However, you may need to configure your Compute Engine instance with
 [additional scopes](https://cloud.google.com/compute/docs/authentication#using).
 
-1. You can create a [Service Account key file](https://cloud.google.com/docs/authentication#service_accounts)
-. This file can be used to authenticate to Google Cloud Platform services from
+1. You can create a [Service Account key file](https://cloud.google.com/docs/authentication#service_accounts).
+This file can be used to authenticate to Google Cloud Platform services from
 any environment. To use the file, set the `GOOGLE_APPLICATION_CREDENTIALS`
 environment variable to the path to the key file, for example:
 

--- a/google-cloud-dialogflow/samples/README.md
+++ b/google-cloud-dialogflow/samples/README.md
@@ -15,7 +15,7 @@ authentication:
 
 1. When running locally, use the [Google Cloud SDK](https://cloud.google.com/sdk/)
 
-    `gcloud auth application-default login`
+       gcloud auth application-default login
 
 1. When running on App Engine or Compute Engine, credentials are already set-up.
 However, you may need to configure your Compute Engine instance with
@@ -26,7 +26,15 @@ However, you may need to configure your Compute Engine instance with
 any environment. To use the file, set the `GOOGLE_APPLICATION_CREDENTIALS`
 environment variable to the path to the key file, for example:
 
-    `export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service_account.json`
+       export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service_account.json
+
+### Set Project ID
+
+Next, set the `GOOGLE_CLOUD_PROJECT` environment variable to the project name
+set in the
+[Google Cloud Platform Developer Console](https://console.cloud.google.com):
+
+    export GOOGLE_CLOUD_PROJECT="YOUR-PROJECT-ID"
 
 ### Install Dependencies
 
@@ -34,7 +42,7 @@ environment variable to the path to the key file, for example:
 
 1. Install dependencies using:
 
-    `bundle install`
+       bundle install
 
 ## Run samples
 
@@ -131,19 +139,6 @@ Usage: ruby session_entity_type_management.rb [commang] [arguments]
 
 ## Run tests
 
-You will need a project with Dialogflow enabled, and a service account key with
-permissions to call Dialogflow.
+Run the acceptance tests for these samples:
 
-To run against the latest library releases:
-
-    bundle install && \
-      GOOGLE_CLOUD_PROJECT=your-project-id \
-      GOOGLE_APPLICATION_CREDENTIALS=/path/to/your/keyfile.json \
-      bundle exec rake test
-
-To run against the current git master:
-
-    GOOGLE_CLOUD_SAMPLES_TEST=master bundle install && \
-      GOOGLE_CLOUD_SAMPLES_TEST=master GOOGLE_CLOUD_PROJECT=your-project-id \
-      GOOGLE_APPLICATION_CREDENTIALS=/path/to/your/keyfile.json \
-      bundle exec rake test
+    bundle exec rake test

--- a/google-cloud-firestore/samples/README.md
+++ b/google-cloud-firestore/samples/README.md
@@ -39,7 +39,9 @@ used to authenticate to Google Cloud Platform services from any environment. To 
 
     `bundle install`
 
-## Run Quickstart
+## Run samples
+
+### Run Quickstart
 
     Usage: bundle exec ruby quickstart.rb [command]
 
@@ -49,7 +51,7 @@ used to authenticate to Google Cloud Platform services from any environment. To 
       add_data_2  Add a sample document.
       get_all     Retrieve all documents from a collection.
 
-## Run Add Data
+### Run Add Data
 
     Usage: bundle exec ruby add_data.rb [command]
 
@@ -65,7 +67,7 @@ used to authenticate to Google Cloud Platform services from any environment. To 
       update_server_timestamp     Update field with server timestamp.
       update_document_increment   Update a document number field using Increment.
 
-## Run Query Data
+### Run Query Data
 
     Usage: bundle exec ruby query_data.rb [command]
 
@@ -79,7 +81,7 @@ used to authenticate to Google Cloud Platform services from any environment. To 
       range_query                    Create a query with range clauses.
       invalid_range_query            An example of an invalid range query.
 
-## Run Data Model
+### Run Data Model
 
     Usage: bundle exec ruby data_model.rb [command]
 
@@ -89,7 +91,7 @@ used to authenticate to Google Cloud Platform services from any environment. To 
       document_path_ref  Create a document path reference.
       subcollection_ref  Create a subcollection reference.
 
-## Run Delete Data
+### Run Delete Data
 
     Usage: bundle exec ruby delete_data.rb [command]
 
@@ -98,7 +100,7 @@ used to authenticate to Google Cloud Platform services from any environment. To 
       delete_field       Delete a field.
       delete_collection  Delete an entire collection.
 
-## Run Get Data
+### Run Get Data
 
     Usage: bundle exec ruby get_data.rb [command]
 
@@ -110,7 +112,7 @@ used to authenticate to Google Cloud Platform services from any environment. To 
       add_subcollection         Add a document to a subcollection.
       list_subcollections       List subcollections of a document.
 
-## Run Order Limit Data
+### Run Order Limit Data
 
     Usage: bundle exec ruby order_limit_data.rb [command]
 
@@ -122,7 +124,7 @@ used to authenticate to Google Cloud Platform services from any environment. To 
       range_order_by_query                 Create a range with order by query.
       invalid_range_order_by_query         An example of an invalid range with order by query.
 
-## Run Paginate Data
+### Run Paginate Data
 
     Usage: bundle exec ruby paginate_data.rb [command]
 
@@ -132,7 +134,7 @@ used to authenticate to Google Cloud Platform services from any environment. To 
       paginated_query_cursor       Paginate using query cursors.
       multiple_cursor_conditions   Set multiple cursor conditions.
 
-## Run Transactions And Batched Writes
+### Run Transactions And Batched Writes
 
     Usage: bundle exec ruby transactions_and_batched_writes.rb [command]
 
@@ -140,3 +142,9 @@ used to authenticate to Google Cloud Platform services from any environment. To 
       run_simple_transaction   Run a simple transaction.
       return_info_transaction  Run a transaction and get information returned.
       batch_write              Perform a batch write.
+
+## Run tests
+
+Run the acceptance tests for these samples:
+
+    bundle exec rake test

--- a/google-cloud-language/samples/README.md
+++ b/google-cloud-language/samples/README.md
@@ -25,8 +25,8 @@ authentication:
 However, you may need to configure your Compute Engine instance with
 [additional scopes](https://cloud.google.com/compute/docs/authentication#using).
 
-1. You can create a [Service Account key file](https://cloud.google.com/docs/authentication#service_accounts)
-. This file can be used to authenticate to Google Cloud Platform services from
+1. You can create a [Service Account key file](https://cloud.google.com/docs/authentication#service_accounts).
+This file can be used to authenticate to Google Cloud Platform services from
 any environment. To use the file, set the `GOOGLE_APPLICATION_CREDENTIALS`
 environment variable to the path to the key file, for example:
 

--- a/google-cloud-language/samples/README.md
+++ b/google-cloud-language/samples/README.md
@@ -17,7 +17,7 @@ Authentication is typically done through [Application Default Credentials](https
 environment has credentials. You have a few options for setting up
 authentication:
 
-1. When running locally, use the [Google Cloud SDK](https://cloud.google.com/sdk/)
+1. When running locally, use the [Google Cloud SDK](https://cloud.google.com/sdk/):
 
        gcloud auth application-default login
 

--- a/google-cloud-language/samples/README.md
+++ b/google-cloud-language/samples/README.md
@@ -19,7 +19,7 @@ authentication:
 
 1. When running locally, use the [Google Cloud SDK](https://cloud.google.com/sdk/)
 
-    `gcloud auth application-default login`
+       gcloud auth application-default login
 
 1. When running on App Engine or Compute Engine, credentials are already set-up.
 However, you may need to configure your Compute Engine instance with
@@ -30,15 +30,15 @@ However, you may need to configure your Compute Engine instance with
 any environment. To use the file, set the `GOOGLE_APPLICATION_CREDENTIALS`
 environment variable to the path to the key file, for example:
 
-    `export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service_account.json`
+       export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service_account.json
 
 ### Set Project ID
 
-Next, set the *GOOGLE_CLOUD_PROJECT* environment variable to the project name
+Next, set the `GOOGLE_CLOUD_PROJECT` environment variable to the project name
 set in the
 [Google Cloud Platform Developer Console](https://console.cloud.google.com):
 
-    `export GOOGLE_CLOUD_PROJECT="YOUR-PROJECT-ID"`
+    export GOOGLE_CLOUD_PROJECT="YOUR-PROJECT-ID"
 
 ### Install Dependencies
 
@@ -46,7 +46,7 @@ set in the
 
 1. Install dependencies using:
 
-    `bundle install`
+       bundle install
 
 ## Run samples
 
@@ -124,3 +124,9 @@ Example:
     Name: /Computers & Electronics Confidence: 0.6100000143051147
     Name: /Internet & Telecom/Mobile & Wireless Confidence: 0.5299999713897705
     Name: /News Confidence: 0.5299999713897705
+
+## Run tests
+
+Run the acceptance tests for these samples:
+
+    bundle exec rake test

--- a/google-cloud-monitoring/samples/README.md
+++ b/google-cloud-monitoring/samples/README.md
@@ -23,8 +23,8 @@ authentication:
 However, you may need to configure your Compute Engine instance with
 [additional scopes](https://cloud.google.com/compute/docs/authentication#using).
 
-1. You can create a [Service Account key file](https://cloud.google.com/docs/authentication#service_accounts)
-. This file can be used to authenticate to Google Cloud Platform services from
+1. You can create a [Service Account key file](https://cloud.google.com/docs/authentication#service_accounts).
+This file can be used to authenticate to Google Cloud Platform services from
 any environment. To use the file, set the `GOOGLE_APPLICATION_CREDENTIALS`
 environment variable to the path to the key file, for example:
 

--- a/google-cloud-monitoring/samples/README.md
+++ b/google-cloud-monitoring/samples/README.md
@@ -17,7 +17,7 @@ authentication:
 
 1. When running locally, use the [Google Cloud SDK](https://cloud.google.com/sdk/)
 
-    `gcloud auth application-default login`
+       gcloud auth application-default login
 
 1. When running on App Engine or Compute Engine, credentials are already set-up.
 However, you may need to configure your Compute Engine instance with
@@ -28,7 +28,15 @@ However, you may need to configure your Compute Engine instance with
 any environment. To use the file, set the `GOOGLE_APPLICATION_CREDENTIALS`
 environment variable to the path to the key file, for example:
 
-    `export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service_account.json`
+       export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service_account.json
+
+### Set Project ID
+
+Next, set the `GOOGLE_CLOUD_PROJECT` environment variable to the project name
+set in the
+[Google Cloud Platform Developer Console](https://console.cloud.google.com):
+
+    export GOOGLE_CLOUD_PROJECT="YOUR-PROJECT-ID"
 
 ### Install Dependencies
 
@@ -36,14 +44,14 @@ environment variable to the path to the key file, for example:
 
 1. Install dependencies using:
 
-    `bundle install`
+       bundle install
 
 ## Run Quickstart
 
     bundle exec ruby quickstart.rb
 
-## Running the tests
+## Run tests
 
-* Authenticate by setting the `GOOGLE_APPLICATION_CREDENTIALS` environment variable as described above.
-* Set the `GOOGLE_CLOUD_PROJECT` environment variable to the project ID used for testing.
-* Run the acceptance tests for the samples by running `bundle exec rake test`.
+Run the acceptance tests for these samples:
+
+    bundle exec rake test

--- a/google-cloud-monitoring/samples/README.md
+++ b/google-cloud-monitoring/samples/README.md
@@ -15,7 +15,7 @@ Authentication is typically done through [Application Default Credentials](https
 environment has credentials. You have a few options for setting up
 authentication:
 
-1. When running locally, use the [Google Cloud SDK](https://cloud.google.com/sdk/)
+1. When running locally, use the [Google Cloud SDK](https://cloud.google.com/sdk/):
 
        gcloud auth application-default login
 

--- a/google-cloud-speech/samples/README.md
+++ b/google-cloud-speech/samples/README.md
@@ -16,7 +16,7 @@ authentication:
 
 1. When running locally, use the [Google Cloud SDK](https://cloud.google.com/sdk/)
 
-    `gcloud auth application-default login`
+       gcloud auth application-default login
 
 1. When running on App Engine or Compute Engine, credentials are already set-up.
 However, you may need to configure your Compute Engine instance with
@@ -27,7 +27,15 @@ However, you may need to configure your Compute Engine instance with
 any environment. To use the file, set the `GOOGLE_APPLICATION_CREDENTIALS`
 environment variable to the path to the key file, for example:
 
-    `export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service_account.json`
+       export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service_account.json
+
+### Set Project ID
+
+Next, set the `GOOGLE_CLOUD_PROJECT` environment variable to the project name
+set in the
+[Google Cloud Platform Developer Console](https://console.cloud.google.com):
+
+    export GOOGLE_CLOUD_PROJECT="YOUR-PROJECT-ID"
 
 ### Install Dependencies
 
@@ -35,7 +43,7 @@ environment variable to the path to the key file, for example:
 
 1. Install dependencies using:
 
-    `bundle install`
+       bundle install
 
 ## Run samples
 
@@ -61,3 +69,9 @@ Examples:
 
     $ bundle exec ruby speech_samples.rb recognize resources/audio.raw
     Text: how old is the Brooklyn Bridge
+
+## Run tests
+
+Run the acceptance tests for these samples:
+
+    bundle exec rake test

--- a/google-cloud-speech/samples/README.md
+++ b/google-cloud-speech/samples/README.md
@@ -22,8 +22,8 @@ authentication:
 However, you may need to configure your Compute Engine instance with
 [additional scopes](https://cloud.google.com/compute/docs/authentication#using).
 
-1. You can create a [Service Account key file](https://cloud.google.com/docs/authentication#service_accounts)
-. This file can be used to authenticate to Google Cloud Platform services from
+1. You can create a [Service Account key file](https://cloud.google.com/docs/authentication#service_accounts).
+This file can be used to authenticate to Google Cloud Platform services from
 any environment. To use the file, set the `GOOGLE_APPLICATION_CREDENTIALS`
 environment variable to the path to the key file, for example:
 

--- a/google-cloud-speech/samples/README.md
+++ b/google-cloud-speech/samples/README.md
@@ -14,7 +14,7 @@ Authentication is typically done through [Application Default Credentials](https
 environment has credentials. You have a few options for setting up
 authentication:
 
-1. When running locally, use the [Google Cloud SDK](https://cloud.google.com/sdk/)
+1. When running locally, use the [Google Cloud SDK](https://cloud.google.com/sdk/):
 
        gcloud auth application-default login
 

--- a/google-cloud-text_to_speech/samples/README.md
+++ b/google-cloud-text_to_speech/samples/README.md
@@ -25,8 +25,8 @@ authentication:
 However, you may need to configure your Compute Engine instance with
 [additional scopes](https://cloud.google.com/compute/docs/authentication#using).
 
-1. You can create a [Service Account key file](https://cloud.google.com/docs/authentication#service_accounts)
-. This file can be used to authenticate to Google Cloud Platform services from
+1. You can create a [Service Account key file](https://cloud.google.com/docs/authentication#service_accounts).
+This file can be used to authenticate to Google Cloud Platform services from
 any environment. To use the file, set the `GOOGLE_APPLICATION_CREDENTIALS`
 environment variable to the path to the key file, for example:
 

--- a/google-cloud-text_to_speech/samples/README.md
+++ b/google-cloud-text_to_speech/samples/README.md
@@ -17,7 +17,7 @@ Authentication is typically done through [Application Default Credentials](https
 environment has credentials. You have a few options for setting up
 authentication:
 
-1. When running locally, use the [Google Cloud SDK](https://cloud.google.com/sdk/)
+1. When running locally, use the [Google Cloud SDK](https://cloud.google.com/sdk/):
 
        gcloud auth application-default login
 

--- a/google-cloud-text_to_speech/samples/README.md
+++ b/google-cloud-text_to_speech/samples/README.md
@@ -19,7 +19,7 @@ authentication:
 
 1. When running locally, use the [Google Cloud SDK](https://cloud.google.com/sdk/)
 
-    `gcloud auth application-default login`
+       gcloud auth application-default login
 
 1. When running on App Engine or Compute Engine, credentials are already set-up.
 However, you may need to configure your Compute Engine instance with
@@ -30,15 +30,15 @@ However, you may need to configure your Compute Engine instance with
 any environment. To use the file, set the `GOOGLE_APPLICATION_CREDENTIALS`
 environment variable to the path to the key file, for example:
 
-    `export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service_account.json`
+       export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service_account.json
 
 ### Set Project ID
 
-Next, set the *GOOGLE_CLOUD_PROJECT* environment variable to the project name
+Next, set the `GOOGLE_CLOUD_PROJECT` environment variable to the project name
 set in the
 [Google Cloud Platform Developer Console](https://console.cloud.google.com):
 
-    `export GOOGLE_CLOUD_PROJECT="YOUR-PROJECT-ID"`
+    export GOOGLE_CLOUD_PROJECT="YOUR-PROJECT-ID"
 
 ### Install Dependencies
 
@@ -46,7 +46,7 @@ set in the
 
 1. Install dependencies using:
 
-    `bundle install`
+       bundle install
 
 ## Run samples
 
@@ -73,3 +73,9 @@ set in the
     Example usage:
         ruby synthesize_file.rb text resources/hello.txt
         ruby synthesize_file.rb ssml resources/hello.ssml
+
+## Run tests
+
+Run the acceptance tests for these samples:
+
+    bundle exec rake test

--- a/google-cloud-translate/samples/README.md
+++ b/google-cloud-translate/samples/README.md
@@ -25,8 +25,8 @@ authentication:
 However, you may need to configure your Compute Engine instance with
 [additional scopes](https://cloud.google.com/compute/docs/authentication#using).
 
-1. You can create a [Service Account key file](https://cloud.google.com/docs/authentication#service_accounts)
-. This file can be used to authenticate to Google Cloud Platform services from
+1. You can create a [Service Account key file](https://cloud.google.com/docs/authentication#service_accounts).
+This file can be used to authenticate to Google Cloud Platform services from
 any environment. To use the file, set the `GOOGLE_APPLICATION_CREDENTIALS`
 environment variable to the path to the key file, for example:
 

--- a/google-cloud-translate/samples/README.md
+++ b/google-cloud-translate/samples/README.md
@@ -17,24 +17,24 @@ Authentication is typically done through [Application Default Credentials](https
 environment has credentials. You have a few options for setting up
 authentication:
 
-1.  When running locally, use the [Google Cloud SDK](https://cloud.google.com/sdk/)
+1. When running locally, use the [Google Cloud SDK](https://cloud.google.com/sdk/)
 
-        gcloud auth application-default login
+       gcloud auth application-default login
 
-1.  When running on App Engine or Compute Engine, credentials are already set-up.
-    However, you may need to configure your Compute Engine instance with
-    [additional scopes](https://cloud.google.com/compute/docs/authentication#using).
+1. When running on App Engine or Compute Engine, credentials are already set-up.
+However, you may need to configure your Compute Engine instance with
+[additional scopes](https://cloud.google.com/compute/docs/authentication#using).
 
-1.  You can create a [Service Account key file](https://cloud.google.com/docs/authentication#service_accounts).
-    This file can be used to authenticate to Google Cloud Platform services from
-    any environment. To use the file, set the `GOOGLE_APPLICATION_CREDENTIALS`
-    environment variable to the path to the key file, for example:
+1. You can create a [Service Account key file](https://cloud.google.com/docs/authentication#service_accounts)
+. This file can be used to authenticate to Google Cloud Platform services from
+any environment. To use the file, set the `GOOGLE_APPLICATION_CREDENTIALS`
+environment variable to the path to the key file, for example:
 
-        export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service_account.json
+       export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service_account.json
 
 ### Set Project ID
 
-Next, set the *GOOGLE_CLOUD_PROJECT* environment variable to the project name
+Next, set the `GOOGLE_CLOUD_PROJECT` environment variable to the project name
 set in the
 [Google Cloud Platform Developer Console](https://console.cloud.google.com):
 
@@ -42,18 +42,11 @@ set in the
 
 ### Install Dependencies
 
-1.  Install the [Bundler](http://bundler.io/) gem.
+1. Install the [Bundler](http://bundler.io/) gem.
 
-2.  Decide whether to run against the current code in git, or the latest gem
-    release. To run against the current git code:
+1. Install dependencies using:
 
-        export GOOGLE_CLOUD_SAMPLES_TEST=master
-
-    To run against the latest gem release, unset that variable.
-
-3.  Install dependencies using:
-
-        bundle install
+       bundle install
 
 ### Install fixtures
 
@@ -65,6 +58,8 @@ To install this fixture:
 
 This is a task that needs to be run only once per project.
 
-## Testing samples
+## Run tests
+
+Run the acceptance tests for these samples:
 
     bundle exec rake test

--- a/google-cloud-translate/samples/README.md
+++ b/google-cloud-translate/samples/README.md
@@ -17,7 +17,7 @@ Authentication is typically done through [Application Default Credentials](https
 environment has credentials. You have a few options for setting up
 authentication:
 
-1. When running locally, use the [Google Cloud SDK](https://cloud.google.com/sdk/)
+1. When running locally, use the [Google Cloud SDK](https://cloud.google.com/sdk/):
 
        gcloud auth application-default login
 

--- a/google-cloud-video_intelligence/samples/README.md
+++ b/google-cloud-video_intelligence/samples/README.md
@@ -23,8 +23,8 @@ authentication:
 However, you may need to configure your Compute Engine instance with
 [additional scopes](https://cloud.google.com/compute/docs/authentication#using).
 
-1. You can create a [Service Account key file](https://cloud.google.com/docs/authentication#service_accounts)
-. This file can be used to authenticate to Google Cloud Platform services from
+1. You can create a [Service Account key file](https://cloud.google.com/docs/authentication#service_accounts).
+This file can be used to authenticate to Google Cloud Platform services from
 any environment. To use the file, set the `GOOGLE_APPLICATION_CREDENTIALS`
 environment variable to the path to the key file, for example:
 

--- a/google-cloud-video_intelligence/samples/README.md
+++ b/google-cloud-video_intelligence/samples/README.md
@@ -15,7 +15,7 @@ Authentication is typically done through [Application Default Credentials](https
 environment has credentials. You have a few options for setting up
 authentication:
 
-1. When running locally, use the [Google Cloud SDK](https://cloud.google.com/sdk/)
+1. When running locally, use the [Google Cloud SDK](https://cloud.google.com/sdk/):
 
        gcloud auth application-default login
 

--- a/google-cloud-video_intelligence/samples/README.md
+++ b/google-cloud-video_intelligence/samples/README.md
@@ -17,7 +17,7 @@ authentication:
 
 1. When running locally, use the [Google Cloud SDK](https://cloud.google.com/sdk/)
 
-    `gcloud auth application-default login`
+       gcloud auth application-default login
 
 1. When running on App Engine or Compute Engine, credentials are already set-up.
 However, you may need to configure your Compute Engine instance with
@@ -28,7 +28,15 @@ However, you may need to configure your Compute Engine instance with
 any environment. To use the file, set the `GOOGLE_APPLICATION_CREDENTIALS`
 environment variable to the path to the key file, for example:
 
-    `export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service_account.json`
+       export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service_account.json
+
+### Set Project ID
+
+Next, set the `GOOGLE_CLOUD_PROJECT` environment variable to the project name
+set in the
+[Google Cloud Platform Developer Console](https://console.cloud.google.com):
+
+    export GOOGLE_CLOUD_PROJECT="YOUR-PROJECT-ID"
 
 ### Install Dependencies
 
@@ -36,7 +44,7 @@ environment variable to the path to the key file, for example:
 
 1. Install dependencies using:
 
-    `bundle install`
+       bundle install
 
 ## Run Quickstart
 

--- a/google-cloud-vision/samples/README.md
+++ b/google-cloud-vision/samples/README.md
@@ -28,8 +28,8 @@ authentication:
 However, you may need to configure your Compute Engine instance with
 [additional scopes](https://cloud.google.com/compute/docs/authentication#using).
 
-1. You can create a [Service Account key file](https://cloud.google.com/docs/authentication#service_accounts)
-. This file can be used to authenticate to Google Cloud Platform services from
+1. You can create a [Service Account key file](https://cloud.google.com/docs/authentication#service_accounts).
+This file can be used to authenticate to Google Cloud Platform services from
 any environment. To use the file, set the `GOOGLE_APPLICATION_CREDENTIALS`
 environment variable to the path to the key file, for example:
 

--- a/google-cloud-vision/samples/README.md
+++ b/google-cloud-vision/samples/README.md
@@ -22,7 +22,7 @@ authentication:
 
 1. When running locally, use the [Google Cloud SDK](https://cloud.google.com/sdk/)
 
-    `gcloud auth application-default login`
+       gcloud auth application-default login
 
 1. When running on App Engine or Compute Engine, credentials are already set-up.
 However, you may need to configure your Compute Engine instance with
@@ -33,15 +33,15 @@ However, you may need to configure your Compute Engine instance with
 any environment. To use the file, set the `GOOGLE_APPLICATION_CREDENTIALS`
 environment variable to the path to the key file, for example:
 
-    `export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service_account.json`
+       export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service_account.json
 
 ### Set Project ID
 
-Next, set the *GOOGLE_CLOUD_PROJECT* environment variable to the project name
+Next, set the `GOOGLE_CLOUD_PROJECT` environment variable to the project name
 set in the
 [Google Cloud Platform Developer Console](https://console.cloud.google.com):
 
-    `export GOOGLE_CLOUD_PROJECT="YOUR-PROJECT-ID"`
+    export GOOGLE_CLOUD_PROJECT="YOUR-PROJECT-ID"
 
 ### Install Dependencies
 
@@ -49,7 +49,7 @@ set in the
 
 1. Install dependencies using:
 
-    `bundle install`
+       bundle install
 
 ## Run samples
 
@@ -158,3 +158,9 @@ set in the
       ruby localize_objects.rb image.png
       ruby localize_objects.rb https://public-url/image.png
       ruby localize_objects.rb gs://my-bucket/image.png
+
+## Run tests
+
+Run the acceptance tests for these samples:
+
+    bundle exec rake test

--- a/google-cloud-vision/samples/README.md
+++ b/google-cloud-vision/samples/README.md
@@ -20,7 +20,7 @@ Authentication is typically done through [Application Default Credentials](https
 environment has credentials. You have a few options for setting up
 authentication:
 
-1. When running locally, use the [Google Cloud SDK](https://cloud.google.com/sdk/)
+1. When running locally, use the [Google Cloud SDK](https://cloud.google.com/sdk/):
 
        gcloud auth application-default login
 


### PR DESCRIPTION
As commented in GoogleCloudPlatform/ruby-docs-samples#679, update the `Setup` section of the samples READMEs where needed. Also, add/update `Run tests` section.