### PR TITLE
Release google-cloud-security-private_ca 0.1.0

### DIFF
--- a/google-cloud-security-private_ca/CHANGELOG.md
+++ b/google-cloud-security-private_ca/CHANGELOG.md
@@ -1,2 +1,6 @@
 # Release History
 
+### 0.1.0 / 2020-10-19
+
+Initial release.
+

--- a/google-cloud-security-private_ca/lib/google/cloud/security/private_ca/version.rb
+++ b/google-cloud-security-private_ca/lib/google/cloud/security/private_ca/version.rb
@@ -21,7 +21,7 @@ module Google
   module Cloud
     module Security
       module PrivateCA
-        VERSION = "0.0.1"
+        VERSION = "0.1.0"
       end
     end
   end


### PR DESCRIPTION
Initial release.

<details><summary>Commits since previous release</summary><pre><code></code></pre></details>

This pull request was generated using releasetool.