### PR TITLE
fix(bigquery): Ensure dense encoding of JSON responses

### DIFF
--- a/google-cloud-bigquery/google-cloud-bigquery.gemspec
+++ b/google-cloud-bigquery/google-cloud-bigquery.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "concurrent-ruby", "~> 1.0"
-  gem.add_dependency "google-api-client", "~> 0.33"
+  gem.add_dependency "google-api-client", "~> 0.47"
   gem.add_dependency "google-cloud-core", "~> 1.2"
   gem.add_dependency "googleauth", "~> 0.9"
   gem.add_dependency "mini_mime", "~> 1.0"

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -65,6 +65,8 @@ module Google
             service.request_options.header ||= {}
             service.request_options.header["x-goog-api-client"] = \
               "gl-ruby/#{RUBY_VERSION} gccl/#{Google::Cloud::Bigquery::VERSION}"
+            service.request_options.query ||= {}
+            service.request_options.query["prettyPrint"] = false
             service.request_options.quota_project = @quota_project if @quota_project
             service.authorization = @credentials.client
             service.root_url = host if host


### PR DESCRIPTION
* Set query param prettyPrint=false for all requests.

closes: #7806 

This PR depends on googleapis/google-api-ruby-client#1224, which was released in `v0.47.0`