### PR TITLE
docs(pubsub): Update deprecated attribute name limit to max_outstanding_messages

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -823,7 +823,8 @@ module Google
         # @param [Integer] streams The number of concurrent streams to open to
         #   pull messages from the subscription. Default is 4. Optional.
         # @param [Hash, Integer] inventory The settings to control how received messages are to be handled by the
-        #   subscriber. When provided as an Integer instead of a Hash only the `limit` will be set. Optional.
+        #   subscriber. When provided as an Integer instead of a Hash only `max_outstanding_messages` will be set.
+        #   Optional.
         #
         #   Hash keys and values may include the following:
         #

--- a/google-cloud-pubsub/test/google/cloud/pubsub/async_publisher_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/async_publisher_test.rb
@@ -26,6 +26,52 @@ describe Google::Cloud::PubSub::AsyncPublisher, :mock_pubsub do
   let(:msg_encoded2) { message2.encode(Encoding::ASCII_8BIT) }
   let(:msg_encoded3) { message3.encode(Encoding::ASCII_8BIT) }
 
+  it "knows its defaults" do
+    publisher = Google::Cloud::PubSub::AsyncPublisher.new topic_name, pubsub.service
+    _(publisher.max_bytes).must_equal 1_000_000
+    _(publisher.max_messages).must_equal 100
+    _(publisher.interval).must_equal 0.01
+    _(publisher.publish_threads).must_equal 2
+    _(publisher.callback_threads).must_equal 4
+  end
+
+  it "knows its given attributes" do
+    publisher = Google::Cloud::PubSub::AsyncPublisher.new(
+      topic_name,
+      pubsub.service,
+      max_bytes: 2_000_000,
+      max_messages: 200,
+      interval: 0.02,
+      threads: {
+        publish: 3,
+        callback: 5
+      }
+    )
+
+    _(publisher.max_bytes).must_equal 2_000_000
+    _(publisher.max_messages).must_equal 200
+    _(publisher.interval).must_equal 0.02
+    _(publisher.publish_threads).must_equal 3
+    _(publisher.callback_threads).must_equal 5
+  end
+
+  it "knows given attributes and retains its defaults" do
+    publisher = Google::Cloud::PubSub::AsyncPublisher.new(
+      topic_name,
+      pubsub.service,
+      max_bytes: 2_000_000,
+      threads: {
+        publish: 3
+      }
+    )
+
+    _(publisher.max_bytes).must_equal 2_000_000
+    _(publisher.max_messages).must_equal 100
+    _(publisher.interval).must_equal 0.01
+    _(publisher.publish_threads).must_equal 3
+    _(publisher.callback_threads).must_equal 4
+  end
+
   it "publishes a message" do
     publisher = Google::Cloud::PubSub::AsyncPublisher.new topic_name, pubsub.service, interval: 10
     messages = [

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber_test.rb
@@ -19,23 +19,58 @@ describe Google::Cloud::PubSub::Subscriber, :mock_pubsub do
   let(:subscription_name) { "subscription-name-goes-here" }
   let(:deadline) { 120 }
   let(:streams) { 8 }
-  let(:inventory) { 2000 }
+  let(:max_outstanding_messages) { 2000 }
   let(:callback_threads) { 16 }
   let(:push_threads) { 8 }
-  let(:subscriber) { Google::Cloud::PubSub::Subscriber.new subscription_name, callback, deadline: deadline, streams: streams, inventory: inventory, threads: { callback: callback_threads, push: push_threads}, service: pubsub.service }
+  let :subscriber do
+    Google::Cloud::PubSub::Subscriber.new(
+      subscription_name,
+      callback,
+      deadline: deadline,
+      streams: streams,
+      inventory: max_outstanding_messages,
+      threads: {
+        callback: callback_threads,
+        push: push_threads
+      },
+      service: pubsub.service
+    )
+  end
 
-  it "knows itself" do
+  it "knows its defaults" do
+    subscriber = Google::Cloud::PubSub::Subscriber.new(
+      subscription_name,
+      callback,
+      service: pubsub.service
+    )
+    _(subscriber).must_be_kind_of Google::Cloud::PubSub::Subscriber
+    _(subscriber.deadline).must_equal 60
+    _(subscriber.streams).must_equal 2
+    _(subscriber.inventory).must_equal 1000 # deprecated Use #max_outstanding_messages.
+    _(subscriber.inventory_limit).must_equal 1000 # deprecated Use #max_outstanding_messages.
+    _(subscriber.max_outstanding_messages).must_equal 1000
+    _(subscriber.inventory_bytesize).must_equal 100_000_000 # deprecated Use #max_outstanding_bytes.
+    _(subscriber.max_outstanding_bytes).must_equal 100_000_000
+    _(subscriber.inventory_extension).must_equal 3600 # deprecated Use #max_total_lease_duration.
+    _(subscriber.max_total_lease_duration).must_equal 3600
+    _(subscriber.max_duration_per_lease_extension).must_equal 0
+    _(subscriber.stream_inventory).must_equal({limit: 500, bytesize: 50000000, max_duration_per_lease_extension: 0, extension: 3600})
+    _(subscriber.callback_threads).must_equal 8
+    _(subscriber.push_threads).must_equal 4
+  end
+
+  it "knows its given attributes and retains defaults" do
     _(subscriber).must_be_kind_of Google::Cloud::PubSub::Subscriber
     _(subscriber.callback).must_equal callback
     _(subscriber.subscription_name).must_equal subscription_name
     _(subscriber.deadline).must_equal deadline
     _(subscriber.streams).must_equal streams
-    _(subscriber.inventory).must_equal inventory
-    _(subscriber.inventory_limit).must_equal inventory
-    _(subscriber.max_outstanding_messages).must_equal inventory
-    _(subscriber.inventory_bytesize).must_equal 100_000_000
+    _(subscriber.inventory).must_equal max_outstanding_messages # deprecated Use #max_outstanding_messages.
+    _(subscriber.inventory_limit).must_equal max_outstanding_messages # deprecated Use #max_outstanding_messages.
+    _(subscriber.max_outstanding_messages).must_equal max_outstanding_messages
+    _(subscriber.inventory_bytesize).must_equal 100_000_000 # deprecated Use #max_outstanding_bytes.
     _(subscriber.max_outstanding_bytes).must_equal 100_000_000
-    _(subscriber.inventory_extension).must_equal 3600
+    _(subscriber.inventory_extension).must_equal 3600 # deprecated Use #max_total_lease_duration.
     _(subscriber.max_total_lease_duration).must_equal 3600
     _(subscriber.max_duration_per_lease_extension).must_equal 0
     _(subscriber.stream_inventory).must_equal({limit: 250, bytesize: 12500000, max_duration_per_lease_extension: 0, extension: 3600})


### PR DESCRIPTION
* Add tests confirming that defaults are retained when user provides some but not all settings.

closes:  #7939