### PR TITLE
Release google-cloud-workflows-v1beta 0.1.0

### DIFF
--- a/google-cloud-workflows-v1beta/CHANGELOG.md
+++ b/google-cloud-workflows-v1beta/CHANGELOG.md
@@ -1,2 +1,6 @@
 # Release History
 
+### 0.1.0 / 2020-10-29
+
+Initial release.
+

--- a/google-cloud-workflows-v1beta/lib/google/cloud/workflows/v1beta/version.rb
+++ b/google-cloud-workflows-v1beta/lib/google/cloud/workflows/v1beta/version.rb
@@ -21,7 +21,7 @@ module Google
   module Cloud
     module Workflows
       module V1beta
-        VERSION = "0.0.1"
+        VERSION = "0.1.0"
       end
     end
   end


### PR DESCRIPTION
Initial release.

<details><summary>Commits since previous release</summary><pre><code></code></pre></details>

This pull request was generated using releasetool.