### PR TITLE
feat(bigtable): Add Backup-level IAM Policy support

### DIFF
--- a/google-cloud-bigtable/lib/google/cloud/bigtable/service.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/service.rb
@@ -516,6 +516,47 @@ module Google
         end
 
         ##
+        # Gets the access control policy for an backup resource. Returns an empty
+        # policy if an backup exists but does not have a policy set.
+        #
+        # @return [Google::Iam::V1::Policy]
+        #
+        def get_backup_policy instance_id, cluster_id, backup_id
+          tables.get_iam_policy resource: backup_path(instance_id, cluster_id, backup_id)
+        end
+
+        ##
+        # Sets the access control policy on an backup resource. Replaces any
+        # existing policy.
+        #
+        # @param policy [Google::Iam::V1::Policy | Hash]
+        #   REQUIRED: The complete policy to be applied to the +resource+. The size of
+        #   the policy is limited to a few 10s of KB. An empty policy is valid
+        #   for Cloud Bigtable, but certain Cloud Platform services (such as Projects)
+        #   might reject an empty policy.
+        #   Alternatively, provide a hash similar to `Google::Iam::V1::Policy`.
+        # @return [Google::Iam::V1::Policy]
+        #
+        def set_backup_policy instance_id, cluster_id, backup_id, policy
+          tables.set_iam_policy resource: backup_path(instance_id, cluster_id, backup_id), policy: policy
+        end
+
+        ##
+        # Returns permissions that the caller has for the specified backup resource.
+        #
+        # @param permissions [Array<String>]
+        #   The set of permissions to check for the +resource+. Permissions with
+        #   wildcards (such as '*' or 'storage.*') are not allowed. For more
+        #   information see
+        #   [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+        # @return [Google::Iam::V1::TestIamPermissionsResponse]
+        #
+        def test_backup_permissions instance_id, cluster_id, backup_id, permissions
+          tables.test_iam_permissions resource:    backup_path(instance_id, cluster_id, backup_id),
+                                      permissions: permissions
+        end
+
+        ##
         # Gets the access control policy for an instance resource. Returns an empty
         # policy if an instance exists but does not have a policy set.
         #

--- a/google-cloud-bigtable/support/doctest_helper.rb
+++ b/google-cloud-bigtable/support/doctest_helper.rb
@@ -198,6 +198,35 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::Bigtable::Backup#policy" do
+    mock_bigtable do |mock, mocked_instances, mocked_tables, mocked_job|
+      mocked_instances.expect :get_instance, instance_resp, [name: "projects/my-project/instances/my-instance"]
+      mocked_instances.expect :get_cluster, cluster_resp, [name: "projects/my-project/instances/my-instance/clusters/my-cluster"]
+      mocked_tables.expect :get_backup, backup_resp, [name: "projects/my-project/instances/my-instance/clusters/my-cluster/backups/my-backup"]
+      mocked_tables.expect :get_iam_policy, policy_resp, [resource: "projects/my-project/instances/my-instance/clusters/my-cluster/backups/my-backup"]
+      mocked_tables.expect :set_iam_policy, policy_resp, [Hash]
+    end
+  end
+
+  doctest.before "Google::Cloud::Bigtable::Backup#test_iam_permissions" do
+    mock_bigtable do |mock, mocked_instances, mocked_tables, mocked_job|
+      mocked_instances.expect :get_instance, instance_resp, [name: "projects/my-project/instances/my-instance"]
+      mocked_instances.expect :get_cluster, cluster_resp, [name: "projects/my-project/instances/my-instance/clusters/my-cluster"]
+      mocked_tables.expect :get_backup, backup_resp, [name: "projects/my-project/instances/my-instance/clusters/my-cluster/backups/my-backup"]
+      mocked_tables.expect :test_iam_permissions, backup_iam_permissions_resp, [Hash]
+    end
+  end
+
+  doctest.before "Google::Cloud::Bigtable::Backup#update_policy" do
+    mock_bigtable do |mock, mocked_instances, mocked_tables, mocked_job|
+      mocked_instances.expect :get_instance, instance_resp, [name: "projects/my-project/instances/my-instance"]
+      mocked_instances.expect :get_cluster, cluster_resp, [name: "projects/my-project/instances/my-instance/clusters/my-cluster"]
+      mocked_tables.expect :get_backup, backup_resp, [name: "projects/my-project/instances/my-instance/clusters/my-cluster/backups/my-backup"]
+      mocked_tables.expect :get_iam_policy, policy_resp, [resource: "projects/my-project/instances/my-instance/clusters/my-cluster/backups/my-backup"]
+      mocked_tables.expect :set_iam_policy, policy_resp, [Hash]
+    end
+  end
+
   doctest.before "Google::Cloud::Bigtable::Backup#restore" do
     mock_bigtable do |mock, mocked_instances, mocked_tables, mocked_job|
       mocked_instances.expect :get_instance, instance_resp, [name: "projects/my-project/instances/my-instance"]
@@ -984,6 +1013,12 @@ def column_families_grpc num: 3
     .each_with_object({}) do |(k,v), r|
     r[k] = Google::Cloud::Bigtable::Admin::V2::ColumnFamily.new(v)
   end
+end
+
+def backup_iam_permissions_resp
+  OpenStruct.new(
+    permissions: ["bigtable.backups.get"]
+  )
 end
 
 def instance_iam_permissions_resp

--- a/google-cloud-bigtable/test/google/cloud/bigtable/backup/iam_policy_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/backup/iam_policy_test.rb
@@ -1,0 +1,154 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "helper"
+
+describe Google::Cloud::Bigtable::Backup, :iam_policy, :mock_bigtable do
+  let(:instance_id) { "test-instance" }
+  let(:cluster_id) { "test-cluster" }
+  let(:backup_id) { "test-backup" }
+  let(:expire_time) { Time.now.round(0) + 60 * 60 * 7 }
+  let(:backup_res) { backup_grpc instance_id, cluster_id, backup_id, "test-table-source", expire_time }
+  let(:backup) { Google::Cloud::Bigtable::Backup.from_grpc backup_res, bigtable.service }
+  let(:viewer_policy_json) do
+    {
+      etag: "YWJj",
+      bindings: [{
+        role: "roles/viewer",
+        members: [
+          "user:viewer@example.com",
+          "serviceAccount:1234567890@developer.gserviceaccount.com"
+         ]
+      }]
+    }.to_json
+  end
+  let(:owner_policy_json) do
+    {
+      etag: "YWJj",
+      bindings: [{
+        role: "roles/owner",
+        members: [
+          "user:owner@example.com",
+          "serviceAccount:0987654321@developer.gserviceaccount.com"
+         ]
+      }]
+    }.to_json
+  end
+
+  it "gets the IAM Policy" do
+    get_res = Google::Iam::V1::Policy.decode_json(viewer_policy_json)
+    mock = Minitest::Mock.new
+    mock.expect :get_iam_policy, get_res, [resource: backup.path]
+    backup.service.mocked_tables = mock
+
+    policy = backup.policy
+
+    mock.verify
+
+    _(policy).must_be_kind_of Google::Cloud::Bigtable::Policy
+    _(policy.etag).must_equal "abc"
+    _(policy.roles).must_be_kind_of Hash
+    _(policy.roles.size).must_equal 1
+    _(policy.roles["roles/viewer"]).must_be_kind_of Array
+    _(policy.roles["roles/viewer"].count).must_equal 2
+    _(policy.roles["roles/viewer"].first).must_equal "user:viewer@example.com"
+    _(policy.roles["roles/viewer"].last).must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+  end
+
+  it "update the iam policy" do
+    get_res = Google::Iam::V1::Policy.decode_json(owner_policy_json)
+    mock = Minitest::Mock.new
+    mock.expect :get_iam_policy, get_res, [resource: backup.path]
+
+    updated_policy_hash = JSON.parse(owner_policy_json)
+    updated_policy_hash["bindings"].first["members"].shift
+    updated_policy_hash["bindings"].first["members"] << "user:newowner@example.com"
+
+    set_req = Google::Iam::V1::Policy.decode_json(updated_policy_hash.to_json)
+    set_res = Google::Iam::V1::Policy.decode_json(updated_policy_hash.merge(etag: "eHl6").to_json)
+    mock.expect :set_iam_policy, set_res, [resource: backup.path, policy: set_req]
+    backup.service.mocked_tables = mock
+
+    policy = backup.policy
+
+    policy.add("roles/owner", "user:newowner@example.com")
+    policy.remove("roles/owner", "user:owner@example.com")
+
+    policy = backup.update_policy(policy)
+
+    mock.verify
+
+    _(policy).must_be_kind_of Google::Cloud::Bigtable::Policy
+    _(policy.etag).must_equal "xyz"
+    _(policy.roles).must_be_kind_of Hash
+    _(policy.roles.size).must_equal 1
+    _(policy.roles["roles/viewer"]).must_be :nil?
+    _(policy.roles["roles/owner"]).must_be_kind_of Array
+    _(policy.roles["roles/owner"].count).must_equal 2
+    _(policy.roles["roles/owner"].first).must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
+    _(policy.roles["roles/owner"].last).must_equal  "user:newowner@example.com"
+  end
+
+  it "get and set policy using block" do
+    get_res = Google::Iam::V1::Policy.decode_json(owner_policy_json)
+    mock = Minitest::Mock.new
+    mock.expect :get_iam_policy, get_res, [resource: backup.path]
+
+    updated_policy_hash = JSON.parse(owner_policy_json)
+    updated_policy_hash["bindings"].first["members"].shift
+    updated_policy_hash["bindings"].first["members"] << "user:newowner@example.com"
+
+    set_req = Google::Iam::V1::Policy.decode_json(updated_policy_hash.to_json)
+    set_res = Google::Iam::V1::Policy.decode_json(updated_policy_hash.merge(etag: "eHl6").to_json)
+    mock.expect :set_iam_policy, set_res, [resource: backup.path, policy: set_req]
+    backup.service.mocked_tables = mock
+
+    policy = backup.policy do |v|
+      v.add("roles/owner", "user:newowner@example.com")
+      v.remove("roles/owner", "user:owner@example.com")
+    end
+
+    mock.verify
+
+    _(policy).must_be_kind_of Google::Cloud::Bigtable::Policy
+    _(policy.etag).must_equal "xyz"
+    _(policy.roles).must_be_kind_of Hash
+    _(policy.roles.size).must_equal 1
+    _(policy.roles["roles/viewer"]).must_be :nil?
+    _(policy.roles["roles/owner"]).must_be_kind_of Array
+    _(policy.roles["roles/owner"].count).must_equal 2
+    _(policy.roles["roles/owner"].first).must_equal "serviceAccount:0987654321@developer.gserviceaccount.com"
+    _(policy.roles["roles/owner"].last).must_equal  "user:newowner@example.com"
+  end
+
+  it "tests the available permissions" do
+   permissions = ["bigtable.backups.create", "bigtable.backups.list"]
+   test_res = Google::Iam::V1::TestIamPermissionsResponse.new(
+     permissions: ["bigtable.backups.list"]
+   )
+   mock = Minitest::Mock.new
+   mock.expect :test_iam_permissions, test_res, [resource: backup.path, permissions: permissions]
+   backup.service.mocked_tables = mock
+
+   permissions = backup.test_iam_permissions(
+     "bigtable.backups.create", "bigtable.backups.list"
+   )
+
+   mock.verify
+
+   _(permissions).must_be_kind_of Array
+   _(permissions).must_equal ["bigtable.backups.list"]
+ end
+end


### PR DESCRIPTION
Similar to #4770, which added Table-level IAM Policy support.

* Add `Backup#policy`
* Add `Backup#update_policy`
* Add `Backup#test_iam_permissions`

closes: #7961