### PR TITLE
feat(bigquery): Add support for Table ACLS (IAM Policy)

### DIFF
--- a/google-cloud-bigquery/acceptance/bigquery/table_policy_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_policy_test.rb
@@ -51,7 +51,7 @@ describe Google::Cloud::Bigquery::Table, :policy, :bigquery do
     _(etag_1).must_be :frozen?
     _(policy.bindings).must_be :empty?
     _(policy.bindings).must_be :frozen?
-    _(policy.binding_for(role)).must_be :nil?
+    _(policy.bindings.find { |b| b.role == role }).must_be :nil?
 
     # update
     policy = table.update_policy do |p|
@@ -59,7 +59,8 @@ describe Google::Cloud::Bigquery::Table, :policy, :bigquery do
       _(p.bindings).wont_be :frozen?
       _(p).wont_be :frozen?
       p.set_binding role, member
-      p.binding_for(role).members << member # duplicate member will not be added to request
+      binding = p.bindings.find { |b| b.role == role }
+      binding.members << member # duplicate member will not be added to request
     end
 
     _(policy).must_be :frozen?
@@ -70,7 +71,7 @@ describe Google::Cloud::Bigquery::Table, :policy, :bigquery do
     _(policy.bindings).must_be :frozen?
     _(policy.bindings.count).must_equal 1
     _(policy.bindings[0]).must_be :frozen?
-    binding = policy.binding_for role
+    binding = policy.bindings.find { |b| b.role == role }
     _(binding).must_equal policy.bindings[0]
     _(binding).must_be_kind_of Google::Cloud::Bigquery::Policy::Binding
     _(binding).must_be :frozen?
@@ -88,6 +89,6 @@ describe Google::Cloud::Bigquery::Table, :policy, :bigquery do
 
     policy = table.policy # get
     _(policy.bindings).must_be :empty?
-    _(policy.binding_for(role)).must_be :nil?
+    _(policy.bindings.find { |b| b.role == role }).must_be :nil?
   end
 end

--- a/google-cloud-bigquery/acceptance/bigquery/table_policy_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_policy_test.rb
@@ -58,7 +58,7 @@ describe Google::Cloud::Bigquery::Table, :policy, :bigquery do
       _(p.bindings).must_be :empty?
       _(p.bindings).wont_be :frozen?
       _(p).wont_be :frozen?
-      p.set_binding role, member
+      p.grant members: member, role: role
       binding = p.bindings.find { |b| b.role == role }
       binding.members << member # duplicate member will not be added to request
     end

--- a/google-cloud-bigquery/acceptance/bigquery/table_policy_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_policy_test.rb
@@ -1,0 +1,66 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "bigquery_helper"
+
+describe Google::Cloud::Bigquery::Table, :policy, :bigquery do
+  let(:dataset_id) { "#{prefix}_dataset" }
+  let(:dataset) do
+    d = bigquery.dataset dataset_id
+    if d.nil?
+      d = bigquery.create_dataset dataset_id
+    end
+    d
+  end
+  let(:table_id) { "kittens" }
+  let(:table) do
+    t = dataset.table table_id
+    if t.nil?
+      t = dataset.create_table table_id do |schema|
+        schema.integer   "id",    description: "id description",    mode: :required
+      end
+    end
+    t
+  end
+
+  it "allows permissions to be tested and policy to be updated" do
+    roles = ["bigquery.tables.delete", "bigquery.tables.get"]
+    permissions = table.test_iam_permissions roles
+    _(permissions).must_equal roles
+
+    policy = table.policy # get
+    _(policy).must_be_kind_of Google::Cloud::Bigquery::Policy
+    _(policy.roles).must_be :empty?
+
+    # We need a valid service account in order to update the policy
+    service_account = bigquery.service.credentials.client.issuer
+    _(service_account).wont_be :nil?
+    role = "roles/bigquery.dataOwner"
+    member = "serviceAccount:#{service_account}"
+
+    # update
+    table.policy do |p|
+      p.add role, member
+      p.add role, member # duplicate member will not be added to request
+    end
+
+    policy = table.policy # get
+
+    _(policy.roles.count).must_equal 1
+    members = policy.role(role)
+    _(members).must_be_kind_of Array
+    _(members.count).must_equal 1
+    _(members[0]).must_equal member
+  end
+end

--- a/google-cloud-bigquery/acceptance/bigquery/table_policy_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_policy_test.rb
@@ -58,7 +58,7 @@ describe Google::Cloud::Bigquery::Table, :policy, :bigquery do
       _(p.bindings).must_be :empty?
       _(p.bindings).wont_be :frozen?
       _(p).wont_be :frozen?
-      p.grant members: member, role: role
+      p.grant role: role, members: member
       binding = p.bindings.find { |b| b.role == role }
       binding.members << member # duplicate member will not be added to request
     end
@@ -84,7 +84,7 @@ describe Google::Cloud::Bigquery::Table, :policy, :bigquery do
 
     # update
     policy = table.update_policy do |p|
-      p.revoke role: role
+      p.revoke role: role, members: member
     end
 
     policy = table.policy # get

--- a/google-cloud-bigquery/acceptance/bigquery/table_policy_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_policy_test.rb
@@ -56,7 +56,7 @@ describe Google::Cloud::Bigquery::Table, :policy, :bigquery do
     member = "serviceAccount:#{service_account}"
 
     # update
-    policy = table.policy do |p|
+    policy = table.update_policy do |p|
       _(p.roles).must_be :empty?
       _(p.roles).wont_be :frozen?
       _(p).wont_be :frozen?

--- a/google-cloud-bigquery/acceptance/bigquery/table_policy_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_policy_test.rb
@@ -33,12 +33,12 @@ describe Google::Cloud::Bigquery::Table, :policy, :bigquery do
     end
     t
   end
+  let(:roles) { ["bigquery.tables.delete", "bigquery.tables.get"] }
   let(:role) { "roles/bigquery.dataOwner" }
   let(:service_account) { bigquery.service.credentials.client.issuer }
   let(:member) { "serviceAccount:#{service_account}" }
 
   it "allows permissions to be tested and policy to be updated" do
-    roles = ["bigquery.tables.delete", "bigquery.tables.get"]
     permissions = table.test_iam_permissions roles
     _(permissions).must_equal roles
     _(permissions).must_be :frozen?
@@ -49,14 +49,14 @@ describe Google::Cloud::Bigquery::Table, :policy, :bigquery do
     etag_1 = policy.etag
     _(etag_1).wont_be :empty?
     _(etag_1).must_be :frozen?
-    # _(policy.roles).must_be :empty?
-    # _(policy.roles).must_be :frozen?
+    _(policy.bindings).must_be :empty?
+    _(policy.bindings).must_be :frozen?
     _(policy.binding(role)).must_be :nil?
 
     # update
     policy = table.update_policy do |p|
-      # _(p.roles).must_be :empty?
-      # _(p.roles).wont_be :frozen?
+      _(p.bindings).must_be :empty?
+      _(p.bindings).wont_be :frozen?
       _(p).wont_be :frozen?
       p.set_binding role, member
       p.binding(role).members << member # duplicate member will not be added to request
@@ -67,14 +67,19 @@ describe Google::Cloud::Bigquery::Table, :policy, :bigquery do
     _(etag_2).wont_be :empty?
     _(etag_2).must_be :frozen?
     _(etag_2).wont_equal etag_1
-    # _(policy.roles).must_be :frozen?
-    # _(policy.roles.count).must_equal 1
+    _(policy.bindings).must_be :frozen?
+    _(policy.bindings.count).must_equal 1
+    _(policy.bindings[0]).must_be :frozen?
     binding = policy.binding role
+    _(binding).must_equal policy.bindings[0]
     _(binding).must_be_kind_of Google::Cloud::Bigquery::Policy::Binding
+    _(binding).must_be :frozen?
     members = binding.members
     _(members).must_be_kind_of Array
+    _(members).must_be :frozen?
     _(members.count).must_equal 1
     _(members[0]).must_equal member
+    _(members[0]).must_be :frozen?
 
     # update
     policy = table.update_policy do |p|
@@ -82,7 +87,7 @@ describe Google::Cloud::Bigquery::Table, :policy, :bigquery do
     end
 
     policy = table.policy # get
-    # _(policy.roles).must_be :empty?
+    _(policy.bindings).must_be :empty?
     _(policy.binding(role)).must_be :nil?
   end
 end

--- a/google-cloud-bigquery/acceptance/bigquery/table_policy_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_policy_test.rb
@@ -38,10 +38,16 @@ describe Google::Cloud::Bigquery::Table, :policy, :bigquery do
     roles = ["bigquery.tables.delete", "bigquery.tables.get"]
     permissions = table.test_iam_permissions roles
     _(permissions).must_equal roles
+    _(permissions).must_be :frozen?
 
     policy = table.policy # get
     _(policy).must_be_kind_of Google::Cloud::Bigquery::Policy
+    _(policy).must_be :frozen?
+    etag_1 = policy.etag
+    _(etag_1).wont_be :empty?
+    _(etag_1).must_be :frozen?
     _(policy.roles).must_be :empty?
+    _(policy.roles).must_be :frozen?
 
     # We need a valid service account in order to update the policy
     service_account = bigquery.service.credentials.client.issuer
@@ -50,13 +56,21 @@ describe Google::Cloud::Bigquery::Table, :policy, :bigquery do
     member = "serviceAccount:#{service_account}"
 
     # update
-    table.policy do |p|
+    policy = table.policy do |p|
+      _(p.roles).must_be :empty?
+      _(p.roles).wont_be :frozen?
+      _(p).wont_be :frozen?
+
       p.add role, member
       p.add role, member # duplicate member will not be added to request
     end
 
-    policy = table.policy # get
-
+    _(policy).must_be :frozen?
+    etag_2 = policy.etag
+    _(etag_2).wont_be :empty?
+    _(etag_2).must_be :frozen?
+    _(etag_2).wont_equal etag_1
+    _(policy.roles).must_be :frozen?
     _(policy.roles.count).must_equal 1
     members = policy.role(role)
     _(members).must_be_kind_of Array

--- a/google-cloud-bigquery/acceptance/bigquery/table_policy_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_policy_test.rb
@@ -51,7 +51,7 @@ describe Google::Cloud::Bigquery::Table, :policy, :bigquery do
     _(etag_1).must_be :frozen?
     _(policy.bindings).must_be :empty?
     _(policy.bindings).must_be :frozen?
-    _(policy.binding(role)).must_be :nil?
+    _(policy.binding_for(role)).must_be :nil?
 
     # update
     policy = table.update_policy do |p|
@@ -59,7 +59,7 @@ describe Google::Cloud::Bigquery::Table, :policy, :bigquery do
       _(p.bindings).wont_be :frozen?
       _(p).wont_be :frozen?
       p.set_binding role, member
-      p.binding(role).members << member # duplicate member will not be added to request
+      p.binding_for(role).members << member # duplicate member will not be added to request
     end
 
     _(policy).must_be :frozen?
@@ -70,7 +70,7 @@ describe Google::Cloud::Bigquery::Table, :policy, :bigquery do
     _(policy.bindings).must_be :frozen?
     _(policy.bindings.count).must_equal 1
     _(policy.bindings[0]).must_be :frozen?
-    binding = policy.binding role
+    binding = policy.binding_for role
     _(binding).must_equal policy.bindings[0]
     _(binding).must_be_kind_of Google::Cloud::Bigquery::Policy::Binding
     _(binding).must_be :frozen?
@@ -88,6 +88,6 @@ describe Google::Cloud::Bigquery::Table, :policy, :bigquery do
 
     policy = table.policy # get
     _(policy.bindings).must_be :empty?
-    _(policy.binding(role)).must_be :nil?
+    _(policy.binding_for(role)).must_be :nil?
   end
 end

--- a/google-cloud-bigquery/acceptance/bigquery/table_policy_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_policy_test.rb
@@ -84,7 +84,7 @@ describe Google::Cloud::Bigquery::Table, :policy, :bigquery do
 
     # update
     policy = table.update_policy do |p|
-      p.remove_binding role
+      p.revoke role: role
     end
 
     policy = table.policy # get

--- a/google-cloud-bigquery/acceptance/bigquery_helper.rb
+++ b/google-cloud-bigquery/acceptance/bigquery_helper.rb
@@ -141,16 +141,16 @@ module Acceptance
       addl.include? :bigquery
     end
 
-    def self.run_one_method klass, method_name, reporter
-      result = nil
-      reporter.prerecord klass, method_name
-      (1..3).each do |try|
-        result = Minitest.run_one_method(klass, method_name)
-        break if (result.passed? || result.skipped?)
-        puts "Retrying #{klass}##{method_name} (#{try})"
-      end
-      reporter.record result
-    end
+    # def self.run_one_method klass, method_name, reporter
+    #   result = nil
+    #   reporter.prerecord klass, method_name
+    #   (1..3).each do |try|
+    #     result = Minitest.run_one_method(klass, method_name)
+    #     break if (result.passed? || result.skipped?)
+    #     puts "Retrying #{klass}##{method_name} (#{try})"
+    #   end
+    #   reporter.record result
+    # end
   end
 end
 

--- a/google-cloud-bigquery/acceptance/bigquery_helper.rb
+++ b/google-cloud-bigquery/acceptance/bigquery_helper.rb
@@ -141,16 +141,16 @@ module Acceptance
       addl.include? :bigquery
     end
 
-    # def self.run_one_method klass, method_name, reporter
-    #   result = nil
-    #   reporter.prerecord klass, method_name
-    #   (1..3).each do |try|
-    #     result = Minitest.run_one_method(klass, method_name)
-    #     break if (result.passed? || result.skipped?)
-    #     puts "Retrying #{klass}##{method_name} (#{try})"
-    #   end
-    #   reporter.record result
-    # end
+    def self.run_one_method klass, method_name, reporter
+      result = nil
+      reporter.prerecord klass, method_name
+      (1..3).each do |try|
+        result = Minitest.run_one_method(klass, method_name)
+        break if (result.passed? || result.skipped?)
+        puts "Retrying #{klass}##{method_name} (#{try})"
+      end
+      reporter.record result
+    end
   end
 end
 

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/policy.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/policy.rb
@@ -258,7 +258,7 @@ module Google
         # @private Deep freeze the policy including its bindings.
         def freeze
           super
-          @bindings.values.map(&:freeze)
+          @bindings.values.each(&:freeze)
           @bindings.freeze
           self
         end
@@ -364,7 +364,7 @@ module Google
           def freeze
             super
             role.freeze
-            members.map(&:freeze)
+            members.each(&:freeze)
             members.freeze
             self
           end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/policy.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/policy.rb
@@ -63,7 +63,7 @@ module Google
       #   table = dataset.table "my_table"
       #
       #   table.update_policy do |p|
-      #     p.set_binding "roles/viewer", "user:viewer@example.com"
+      #     p.grant members: "user:viewer@example.com", role: "roles/viewer"
       #     binding = p.bindings.find { |b| b.role == "roles/editor" }
       #     binding.members << "user:new-editor@example.com"
       #     binding.members.delete "user:old-editor@example.com"
@@ -154,10 +154,10 @@ module Google
         #   table = dataset.table "my_table"
         #
         #   table.update_policy do |p|
-        #     p.set_binding "roles/viewer", "user:viewer@example.com"
+        #     p.grant members: "user:viewer@example.com", role: "roles/viewer"
         #   end # 2 API calls
         #
-        def set_binding role, members
+        def grant members:, role:
           new_binding = Binding.new role, members
           if (i = @bindings.find_index { |b| b.role == role })
             @bindings[i] = new_binding
@@ -235,7 +235,7 @@ module Google
         # @see https://cloud.google.com/bigquery/docs/table-access-controls-intro Controlling access to tables
         #
         # @attr [String] role The role that is assigned to `members`. For example, `roles/viewer`, `roles/editor`, or
-        #   `roles/owner`.
+        #   `roles/owner`. Required.
         # @attr [Array<String>] members Specifies the identities requesting access for a Cloud Platform resource.
         #   `members` can have the following values. Required.
         #
@@ -294,8 +294,7 @@ module Google
         #   end # 2 API calls
         #
         class Binding
-          attr_reader :role
-          attr_accessor :members
+          attr_accessor :role, :members
 
           # @private
           def initialize role, members

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/policy.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/policy.rb
@@ -155,9 +155,9 @@ module Google
         #   end
         #
         def grant role:, members:
-          binding_existing = bindings.find { |b| b.role == role }
-          if binding_existing
-            binding_existing.members.concat Array(members)
+          existing_binding = bindings.find { |b| b.role == role }
+          if existing_binding
+            existing_binding.members.concat Array(members)
           else
             bindings << Binding.new(role, members)
           end
@@ -240,7 +240,7 @@ module Google
           bindings_for_role = role ? bindings.select { |b| b.role == role } : bindings
           bindings_for_role.each do |b|
             if members
-              b.members.delete_if { |m| members.include? m }
+              b.members -= Array(members)
               bindings.delete b if b.members.empty?
             else
               bindings.delete b

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/policy.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/policy.rb
@@ -23,26 +23,16 @@ module Google
       #
       # Represents a Cloud IAM Policy for BigQuery resources.
       #
-      # A common pattern for updating a resource's metadata, such as its policy,
-      # is to read the current data from the service, update the data locally,
-      # and then write the modified data back to the resource. This pattern may
-      # result in a conflict if two or more processes attempt the sequence simultaneously.
-      # IAM solves this problem with the {Google::Cloud::Bigquery::Policy#etag}
-      # property, which is used to verify whether the policy has changed since
-      # the last request. When you make a request with an `etag` value, Cloud
-      # IAM compares the `etag` value in the request with the existing `etag`
-      # value associated with the policy. It writes the policy only if the
-      # `etag` values match.
+      # A Policy is a collection of bindings. A {Policy::Binding} binds one or more members to a single role. Member
+      # strings can describe user accounts, service accounts, Google groups, and domains. A role string represents a
+      # named list of permissions; each role can be an IAM predefined role or a user-created custom role.
       #
+      # @see https://cloud.google.com/iam/docs/managing-policies Managing Policies
       # @see https://cloud.google.com/bigquery/docs/table-access-controls-intro Controlling access to tables
       #
-      # @attr [String] etag Used to check if the policy has changed since
-      #   the last request. The policy will be written only if the `etag` values
-      #   match.
-      # @attr [Hash{String => Array<String>}] roles The bindings that associate
-      #   roles with an array of members. See [Understanding
-      #   Roles](https://cloud.google.com/iam/docs/understanding-roles) for a
-      #   listing of primitive and curated roles.
+      # @attr [String] etag Used to check if the policy has changed since the last request. When you make a request with
+      #   an `etag` value, Cloud IAM compares the `etag` value in the request with the existing `etag` value associated
+      #   with the policy. It writes the policy only if the `etag` values match.
       #
       # @example
       #   require "google/cloud/bigquery"
@@ -50,12 +40,17 @@ module Google
       #   bigquery = Google::Cloud::Bigquery.new
       #   dataset = bigquery.dataset "my_dataset"
       #   table = dataset.table "my_table"
-      #
       #   policy = table.policy
-      #   policy.role "roles/owner" #=> ["user:owner@example.com"]
-      #   policy.frozen? #=> true
       #
-      # @example Update the policy by passing a block.
+      #   policy.frozen? #=> true
+      #   binding = policy.binding "roles/owner"
+      #
+      #   binding.role #=> "roles/owner"
+      #   binding.members #=> ["user:owner@example.com"]
+      #   binding.frozen? #=> true
+      #   binding.members.frozen? #=> true
+      #
+      # @example Update mutable bindings in the policy with {Table#update_policy}.
       #   require "google/cloud/bigquery"
       #
       #   bigquery = Google::Cloud::Bigquery.new
@@ -63,34 +58,52 @@ module Google
       #   table = dataset.table "my_table"
       #
       #   table.update_policy do |p|
-      #     p.remove "roles/owner", "user:owner@example.com"
-      #     p.add "roles/owner", "user:newowner@example.com"
-      #     p.roles["roles/viewer"] = ["allUsers"]
+      #     p.set_binding "roles/viewer", "user:viewer@example.com"
+      #     p.binding("roles/editor").members << "user:new-editor@example.com"
+      #     p.binding("roles/editor").members.delete "user:old-editor@example.com"
+      #     p.remove_binding "roles/owner"
       #   end # 2 API calls
       #
       class Policy
-        attr_reader :etag, :roles
+        attr_reader :etag
 
         # @private
-        def initialize etag, roles = nil
+        def initialize etag, bindings
           @etag = etag.freeze
-          @roles = roles
+          @bindings = bindings
         end
 
         ##
-        # Convenience method for adding a member to a binding on this policy.
-        # See [Understanding
-        # Roles](https://cloud.google.com/iam/docs/understanding-roles) for a
-        # list of primitive and curated roles. See [BigQuery Table ACL
-        # permissions](https://cloud.google.com/bigquery/docs/table-access-controls-intro#permissions)
-        # for a list of values and patterns for members.
+        # Convenience method returning a binding value object that contains the array of members bound to a role
+        # in the policy. Returns `nil` if no binding is present for the role in the policy. See
+        # [Understanding Roles](https://cloud.google.com/iam/docs/understanding-roles) for a list of primitive and
+        # curated roles. See [BigQuery Table ACL
+        # permissions](https://cloud.google.com/bigquery/docs/table-access-controls-intro#permissions) for a list of
+        # values and patterns for members.
         #
-        # @param [String] role_name A Cloud IAM role, such as
-        #   `"roles/bigquery.admin"`.
-        # @param [String] member A Cloud IAM identity, such as
-        #   `"user:owner@example.com"`.
+        # @param [String] role A role that is bound to members in the policy. For example, `roles/viewer`,
+        #   `roles/editor`, or `roles/owner`. Required.
         #
-        # @example Update the policy by passing a block.
+        # @return [Binding, nil] The binding object, which may be mutable or frozen depending on the context; or `nil`
+        #   if no binding exists for the given role.
+        #
+        # @example
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #   table = dataset.table "my_table"
+        #   policy = table.policy
+        #
+        #   policy.frozen? #=> true
+        #   binding = policy.binding "roles/owner"
+        #
+        #   binding.role #=> "roles/owner"
+        #   binding.members #=> ["user:owner@example.com"]
+        #   binding.frozen? #=> true
+        #   binding.members.frozen? #=> true
+        #
+        # @example Update mutable bindings in the policy with {Table#update_policy}.
         #   require "google/cloud/bigquery"
         #
         #   bigquery = Google::Cloud::Bigquery.new
@@ -98,29 +111,55 @@ module Google
         #   table = dataset.table "my_table"
         #
         #   table.update_policy do |p|
-        #     p.remove "roles/owner", "user:owner@example.com"
-        #     p.add "roles/owner", "user:newowner@example.com"
-        #     p.roles["roles/viewer"] = ["allUsers"]
+        #     p.binding("roles/editor").members << "user:new-editor@example.com"
+        #     p.binding("roles/editor").members.delete "user:old-editor@example.com"
         #   end # 2 API calls
         #
-        def add role_name, member
-          role(role_name) << member
+        def binding role
+          @bindings[role]
         end
 
         ##
-        # Convenience method for removing a member from a binding on this
-        # policy. See [Understanding
-        # Roles](https://cloud.google.com/iam/docs/understanding-roles) for a
-        # list of primitive and curated roles. See [BigQuery Table ACL
-        # permissions](https://cloud.google.com/bigquery/docs/table-access-controls-intro#permissions)
-        # for a list of values and patterns for members.
+        # Convenience method adding or replacing a binding in the policy. See [Understanding
+        # Roles](https://cloud.google.com/iam/docs/understanding-roles) for a list of primitive and curated roles. See
+        # [BigQuery Table ACL
+        # permissions](https://cloud.google.com/bigquery/docs/table-access-controls-intro#permissions) for a list of
+        # values and patterns for members.
         #
-        # @param [String] role_name A Cloud IAM role, such as
-        #   `"roles/Bigquery.admin"`.
-        # @param [String] member A Cloud IAM identity, such as
-        #   `"user:owner@example.com"`.
+        # @param [String] role The role that is bound to members in the binding. For example, `roles/viewer`,
+        #   `roles/editor`, or `roles/owner`. Required.
+        # @param [String, Array<String>] members Specifies the identities requesting access for a Cloud Platform
+        #   resource. `members` can have the following values. Required.
         #
-        # @example Update the policy by passing a block.
+        #   * `allUsers`: A special identifier that represents anyone who is on the internet; with or without a Google
+        #     account.
+        #   * `allAuthenticatedUsers`: A special identifier that represents anyone who is authenticated with a Google
+        #     account or a service account.
+        #   * `user:<emailid>`: An email address that represents a specific Google account. For example,
+        #     `alice@example.com`.
+        #   * `serviceAccount:<emailid>`: An email address that represents a service account. For example,
+        #     `my-other-app@appspot.gserviceaccount.com`.
+        #   * `group:<emailid>`: An email address that represents a Google group. For example, `admins@example.com`.
+        #   * `deleted:user:<emailid>?uid=<uniqueid>`: An email address (plus unique identifier) representing a user
+        #     that has been recently deleted. For example, `alice@example.com?uid=123456789012345678901`. If the user
+        #     is recovered, this value reverts to `user:<emailid>` and the recovered user retains the role in the
+        #     binding.
+        #   * `deleted: serviceAccount:<emailid>?uid=<uniqueid>`: An email address (plus unique identifier) representing
+        #     a service account that has been recently deleted. For example,
+        #     `my-other-app@appspot.gserviceaccount.com?uid=123456789012345678901`. If the service account is undeleted,
+        #     this value reverts to `serviceAccount:<emailid>` and the undeleted service account retains the role in
+        #     the binding.
+        #   * `deleted:group:<emailid>?uid=<uniqueid>`: An email address (plus unique identifier) representing a Google
+        #     group that has been recently deleted. For example, `admins@example.com?uid=123456789012345678901`. If the
+        #     group is recovered, this value reverts to `group:<emailid>` and the recovered group retains the role in
+        #     the binding.
+        #   * `domain:<domain>`: The G Suite domain (primary) that represents all the users of that domain. For example,
+        #     `google.com` or `example.com`.
+        #
+        # @return [Binding, nil] The binding object that was added to the policy. This object is mutable and may be used
+        #   to add or remove members within the context of a block passed to {Table.update_policy}.
+        #
+        # @example Update a mutable policy with {Table#update_policy}.
         #   require "google/cloud/bigquery"
         #
         #   bigquery = Google::Cloud::Bigquery.new
@@ -128,25 +167,110 @@ module Google
         #   table = dataset.table "my_table"
         #
         #   table.update_policy do |p|
-        #     p.remove "roles/owner", "user:owner@example.com"
-        #     p.add "roles/owner", "user:newowner@example.com"
-        #     p.roles["roles/viewer"] = ["allUsers"]
+        #     p.set_binding "roles/viewer", "user:viewer@example.com"
         #   end # 2 API calls
         #
-        def remove role_name, member
-          role(role_name).delete member
+        def set_binding role, members
+          new_binding = Binding.new role, members
+          @bindings[role] = new_binding
+          new_binding
         end
 
         ##
-        # Convenience method returning the array of members bound to a role in
-        # this policy. Returns an empty array if no value is present for the role in
-        # {#roles}. See [Understanding
-        # Roles](https://cloud.google.com/iam/docs/understanding-roles) for a
-        # list of primitive and curated roles. See [BigQuery Table ACL
-        # permissions](https://cloud.google.com/bigquery/docs/table-access-controls-intro#permissions)
-        # for a list of values and patterns for members.
+        # Convenience method deleting a binding in the policy. Returns `nil` if no binding is present for the role. See
+        # [Understanding Roles](https://cloud.google.com/iam/docs/understanding-roles) for a list of primitive and
+        # curated roles. See [BigQuery Table ACL
+        # permissions](https://cloud.google.com/bigquery/docs/table-access-controls-intro#permissions) for a list of
+        # values and patterns for members.
         #
-        # @return [Array<String>] The members strings, or an empty array.
+        # @param [String] role A role that is bound to members in the policy. For example, `roles/viewer`,
+        #   `roles/editor`, or `roles/owner`. Required.
+        #
+        # @return [Binding, nil] The frozen binding object, or `nil` if no binding exists for the given role.
+        #
+        # @example Update a mutable policy with {Table#update_policy}.
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #   table = dataset.table "my_table"
+        #
+        #   table.update_policy do |p|
+        #     p.remove_binding "roles/owner"
+        #   end # 2 API calls
+        #
+        def remove_binding role
+          @bindings.delete(role).freeze
+        end
+
+        ##
+        # @private Convert the Policy to a Google::Apis::BigqueryV2::Policy.
+        def to_gapi
+          Google::Apis::BigqueryV2::Policy.new(
+            bindings: bindings_to_gapi,
+            etag:     etag,
+            version:  1
+          )
+        end
+
+        ##
+        # @private Deep freeze the policy including its bindings.
+        def freeze
+          super
+          @bindings.values.map(&:freeze)
+          @bindings.freeze
+          self
+        end
+
+        ##
+        # @private New Policy from a Google::Apis::BigqueryV2::Policy object.
+        def self.from_gapi gapi
+          bindings_hash = Array(gapi.bindings).each_with_object({}) do |binding, memo|
+            memo[binding.role] = Binding.new binding.role, binding.members.to_a
+          end
+          new gapi.etag, bindings_hash
+        end
+
+        ##
+        # # Policy::Binding
+        #
+        # Represents a Cloud IAM Binding for BigQuery resources within the context of a {Policy}.
+        #
+        # A binding binds one or more members to a single role. Member strings can describe user accounts, service
+        # accounts, Google groups, and domains. A role is a named list of permissions; each role can be an IAM
+        # predefined role or a user-created custom role.
+        #
+        # @see https://cloud.google.com/bigquery/docs/table-access-controls-intro Controlling access to tables
+        #
+        # @attr [String] role The role that is assigned to `members`. For example, `roles/viewer`, `roles/editor`, or
+        #   `roles/owner`.
+        # @attr [Array<String>] members Specifies the identities requesting access for a Cloud Platform resource.
+        #   `members` can have the following values. Required.
+        #
+        #   * `allUsers`: A special identifier that represents anyone who is on the internet; with or without a Google
+        #     account.
+        #   * `allAuthenticatedUsers`: A special identifier that represents anyone who is authenticated with a Google
+        #     account or a service account.
+        #   * `user:<emailid>`: An email address that represents a specific Google account. For example,
+        #     `alice@example.com`.
+        #   * `serviceAccount:<emailid>`: An email address that represents a service account. For example,
+        #     `my-other-app@appspot.gserviceaccount.com`.
+        #   * `group:<emailid>`: An email address that represents a Google group. For example, `admins@example.com`.
+        #   * `deleted:user:<emailid>?uid=<uniqueid>`: An email address (plus unique identifier) representing a user
+        #     that has been recently deleted. For example, `alice@example.com?uid=123456789012345678901`. If the user
+        #     is recovered, this value reverts to `user:<emailid>` and the recovered user retains the role in the
+        #     binding.
+        #   * `deleted: serviceAccount:<emailid>?uid=<uniqueid>`: An email address (plus unique identifier) representing
+        #     a service account that has been recently deleted. For example,
+        #     `my-other-app@appspot.gserviceaccount.com?uid=123456789012345678901`. If the service account is undeleted,
+        #     this value reverts to `serviceAccount:<emailid>` and the undeleted service account retains the role in
+        #     the binding.
+        #   * `deleted:group:<emailid>?uid=<uniqueid>`: An email address (plus unique identifier) representing a Google
+        #     group that has been recently deleted. For example, `admins@example.com?uid=123456789012345678901`. If the
+        #     group is recovered, this value reverts to `group:<emailid>` and the recovered group retains the role in
+        #     the binding.
+        #   * `domain:<domain>`: The G Suite domain (primary) that represents all the users of that domain. For example,
+        #     `google.com` or `example.com`.
         #
         # @example
         #   require "google/cloud/bigquery"
@@ -156,48 +280,67 @@ module Google
         #   table = dataset.table "my_table"
         #
         #   policy = table.policy
-        #   policy.role "roles/owner" #=> ["user:owner@example.com"]
-        #   policy.frozen? #=> true
+        #   binding = policy.binding "roles/owner"
         #
-        def role role_name
-          roles[role_name] ||= []
-        end
+        #   binding.role #=> "roles/owner"
+        #   binding.members #=> ["user:owner@example.com"]
+        #
+        #   binding.frozen? #=> true
+        #   binding.members.frozen? #=> true
+        #
+        # @example Update mutable bindings with {Table#update_policy}.
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #   table = dataset.table "my_table"
+        #
+        #   table.update_policy do |p|
+        #     p.binding("roles/editor").members << "user:new-editor@example.com"
+        #     p.binding("roles/editor").members.delete "user:old-editor@example.com"
+        #   end # 2 API calls
+        #
+        class Binding
+          attr_reader :role
+          attr_accessor :members
 
-        ##
-        # @private Convert the Policy to a Google::Apis::BigqueryV2::Policy.
-        def to_gapi
-          Google::Apis::BigqueryV2::Policy.new(
-            bindings: roles_to_gapi,
-            etag:     etag,
-            version:  1
-          )
-        end
-
-        ##
-        # @private Freeze the policy including its roles hash.
-        def freeze
-          super
-          roles.freeze
-          self
-        end
-
-        ##
-        # @private New Policy from a Google::Apis::BigqueryV2::Policy object.
-        def self.from_gapi gapi
-          roles = Array(gapi.bindings).each_with_object({}) do |binding, memo|
-            memo[binding.role] = binding.members.to_a
+          # @private
+          def initialize role, members
+            members = Array members
+            raise ArgumentError, "members cannot be empty" if members.empty?
+            @role = role.freeze
+            @members = members
           end
-          new gapi.etag, roles
+
+          ##
+          # @private Convert the Binding to a Google::Apis::BigqueryV2::Binding.
+          def to_gapi
+            Google::Apis::BigqueryV2::Binding.new role: role, members: members
+          end
+
+          ##
+          # @private Deep freeze the policy including its members.
+          def freeze
+            super
+            members.freeze
+            self
+          end
+
+          ##
+          # @private New Binding from a Google::Apis::BigqueryV2::Binding object.
+          def self.from_gapi gapi
+            new gapi.etag, gapi.members.to_a
+          end
         end
 
         protected
 
-        def roles_to_gapi
-          roles.keys.map do |role_name|
-            next if roles[role_name].empty?
+        def bindings_to_gapi
+          @bindings.keys.map do |role_name|
+            next if @bindings[role_name].nil? || @bindings[role_name].members.empty?
             Google::Apis::BigqueryV2::Binding.new(
               role:    role_name,
-              members: roles[role_name].uniq
+              members: @bindings[role_name].members.uniq
             )
           end
         end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/policy.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/policy.rb
@@ -1,0 +1,179 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "google/apis/bigquery_v2"
+
+module Google
+  module Cloud
+    module Bigquery
+      ##
+      # # Policy
+      #
+      # Represents a Cloud IAM Policy for BigQuery resources.
+      #
+      # A common pattern for updating a resource's metadata, such as its policy,
+      # is to read the current data from the service, update the data locally,
+      # and then write the modified data back to the resource. This pattern may
+      # result in a conflict if two or more processes attempt the sequence simultaneously.
+      # IAM solves this problem with the {Google::Cloud::Bigquery::Policy#etag}
+      # property, which is used to verify whether the policy has changed since
+      # the last request. When you make a request with an `etag` value, Cloud
+      # IAM compares the `etag` value in the request with the existing `etag`
+      # value associated with the policy. It writes the policy only if the
+      # `etag` values match.
+      #
+      # @see https://cloud.google.com/bigquery/docs/table-access-controls-intro Controlling access to tables
+      #
+      # @attr [String] etag Used to check if the policy has changed since
+      #   the last request. The policy will be written only if the `etag` values
+      #   match.
+      # @attr [Hash{String => Array<String>}] roles The bindings that associate
+      #   roles with an array of members. See [Understanding
+      #   Roles](https://cloud.google.com/iam/docs/understanding-roles) for a
+      #   listing of primitive and curated roles.
+      #
+      # @example
+      #   require "google/cloud/bigquery"
+      #
+      #   bigquery = Google::Cloud::Bigquery.new
+      #   dataset = bigquery.dataset "my_dataset"
+      #   table = dataset.table "my_table"
+      #
+      #   policy = table.policy
+      #   policy.remove("roles/owner", "user:owner@example.com")
+      #   policy.add("roles/owner", "user:newowner@example.com")
+      #   policy.roles["roles/viewer"] = ["allUsers"]
+      #
+      class Policy
+        attr_reader :etag, :roles
+
+        # @private
+        def initialize etag, roles = nil
+          @etag = etag
+          @roles = roles
+        end
+
+        ##
+        # Convenience method for adding a member to a binding on this policy.
+        # See [Understanding
+        # Roles](https://cloud.google.com/iam/docs/understanding-roles) for a
+        # list of primitive and curated roles. See [BigQuery Table ACL
+        # permissions](https://cloud.google.com/bigquery/docs/table-access-controls-intro#permissions)
+        # for a list of values and patterns for members.
+        #
+        # @param [String] role_name A Cloud IAM role, such as
+        #   `"roles/bigquery.admin"`.
+        # @param [String] member A Cloud IAM identity, such as
+        #   `"user:owner@example.com"`.
+        #
+        # @example
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #   table = dataset.table "my_table"
+        #
+        #   policy = table.policy
+        #   policy.add("roles/owner", "user:newowner@example.com")
+        #
+        def add role_name, member
+          role(role_name) << member
+        end
+
+        ##
+        # Convenience method for removing a member from a binding on this
+        # policy. See [Understanding
+        # Roles](https://cloud.google.com/iam/docs/understanding-roles) for a
+        # list of primitive and curated roles. See [BigQuery Table ACL
+        # permissions](https://cloud.google.com/bigquery/docs/table-access-controls-intro#permissions)
+        # for a list of values and patterns for members.
+        #
+        # @param [String] role_name A Cloud IAM role, such as
+        #   `"roles/Bigquery.admin"`.
+        # @param [String] member A Cloud IAM identity, such as
+        #   `"user:owner@example.com"`.
+        #
+        # @example
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #   table = dataset.table "my_table"
+        #
+        #   policy = table.policy
+        #   policy.remove("roles/owner", "user:newowner@example.com")
+        #
+        def remove role_name, member
+          role(role_name).delete member
+        end
+
+        ##
+        # Convenience method returning the array of members bound to a role in
+        # this policy. Returns an empty array if no value is present for the role in
+        # {#roles}. See [Understanding
+        # Roles](https://cloud.google.com/iam/docs/understanding-roles) for a
+        # list of primitive and curated roles. See [BigQuery Table ACL
+        # permissions](https://cloud.google.com/bigquery/docs/table-access-controls-intro#permissions)
+        # for a list of values and patterns for members.
+        #
+        # @return [Array<String>] The members strings, or an empty array.
+        #
+        # @example
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #   table = dataset.table "my_table"
+        #
+        #   policy = table.policy
+        #   policy.role("roles/viewer") << "user:viewer@example.com"
+        #
+        def role role_name
+          roles[role_name] ||= []
+        end
+
+        ##
+        # @private Convert the Policy to a Google::Apis::BigqueryV2::Policy.
+        def to_gapi
+          Google::Apis::BigqueryV2::Policy.new(
+            etag:     etag,
+            bindings: roles_to_gapi
+          )
+        end
+
+        ##
+        # @private New Policy from a Google::Apis::BigqueryV2::Policy object.
+        def self.from_gapi gapi
+          roles = Array(gapi.bindings).each_with_object({}) do |binding, memo|
+            memo[binding.role] = binding.members.to_a
+          end
+          new gapi.etag, roles
+        end
+
+        protected
+
+        def roles_to_gapi
+          roles.keys.map do |role_name|
+            next if roles[role_name].empty?
+            Google::Apis::BigqueryV2::Binding.new(
+              role:    role_name,
+              members: roles[role_name].uniq
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/policy.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/policy.rb
@@ -62,7 +62,7 @@ module Google
       #   dataset = bigquery.dataset "my_dataset"
       #   table = dataset.table "my_table"
       #
-      #   table.policy do |p|
+      #   table.update_policy do |p|
       #     p.remove "roles/owner", "user:owner@example.com"
       #     p.add "roles/owner", "user:newowner@example.com"
       #     p.roles["roles/viewer"] = ["allUsers"]
@@ -97,7 +97,7 @@ module Google
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
-        #   table.policy do |p|
+        #   table.update_policy do |p|
         #     p.remove "roles/owner", "user:owner@example.com"
         #     p.add "roles/owner", "user:newowner@example.com"
         #     p.roles["roles/viewer"] = ["allUsers"]
@@ -127,7 +127,7 @@ module Google
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
-        #   table.policy do |p|
+        #   table.update_policy do |p|
         #     p.remove "roles/owner", "user:owner@example.com"
         #     p.add "roles/owner", "user:newowner@example.com"
         #     p.roles["roles/viewer"] = ["allUsers"]
@@ -167,8 +167,9 @@ module Google
         # @private Convert the Policy to a Google::Apis::BigqueryV2::Policy.
         def to_gapi
           Google::Apis::BigqueryV2::Policy.new(
+            bindings: roles_to_gapi,
             etag:     etag,
-            bindings: roles_to_gapi
+            version:  1
           )
         end
 

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/policy.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/policy.rb
@@ -43,7 +43,7 @@ module Google
       #   policy = table.policy
       #
       #   policy.frozen? #=> true
-      #   binding = policy.binding "roles/owner"
+      #   binding = policy.binding_for "roles/owner"
       #
       #   binding.role #=> "roles/owner"
       #   binding.members #=> ["user:owner@example.com"]
@@ -59,8 +59,8 @@ module Google
       #
       #   table.update_policy do |p|
       #     p.set_binding "roles/viewer", "user:viewer@example.com"
-      #     p.binding("roles/editor").members << "user:new-editor@example.com"
-      #     p.binding("roles/editor").members.delete "user:old-editor@example.com"
+      #     p.binding_for("roles/editor").members << "user:new-editor@example.com"
+      #     p.binding_for("roles/editor").members.delete "user:old-editor@example.com"
       #     p.remove_binding "roles/owner"
       #   end # 2 API calls
       #
@@ -96,7 +96,7 @@ module Google
         #   policy = table.policy
         #
         #   policy.frozen? #=> true
-        #   binding = policy.binding "roles/owner"
+        #   binding = policy.binding_for "roles/owner"
         #
         #   binding.role #=> "roles/owner"
         #   binding.members #=> ["user:owner@example.com"]
@@ -111,11 +111,11 @@ module Google
         #   table = dataset.table "my_table"
         #
         #   table.update_policy do |p|
-        #     p.binding("roles/editor").members << "user:new-editor@example.com"
-        #     p.binding("roles/editor").members.delete "user:old-editor@example.com"
+        #     p.binding_for("roles/editor").members << "user:new-editor@example.com"
+        #     p.binding_for("roles/editor").members.delete "user:old-editor@example.com"
         #   end # 2 API calls
         #
-        def binding role
+        def binding_for role
           @bindings[role]
         end
 
@@ -321,7 +321,7 @@ module Google
         #   table = dataset.table "my_table"
         #
         #   policy = table.policy
-        #   binding = policy.binding "roles/owner"
+        #   binding = policy.binding_for "roles/owner"
         #
         #   binding.role #=> "roles/owner"
         #   binding.members #=> ["user:owner@example.com"]
@@ -337,8 +337,8 @@ module Google
         #   table = dataset.table "my_table"
         #
         #   table.update_policy do |p|
-        #     p.binding("roles/editor").members << "user:new-editor@example.com"
-        #     p.binding("roles/editor").members.delete "user:old-editor@example.com"
+        #     p.binding_for("roles/editor").members << "user:new-editor@example.com"
+        #     p.binding_for("roles/editor").members.delete "user:old-editor@example.com"
         #   end # 2 API calls
         #
         class Binding

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/policy.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/policy.rb
@@ -158,6 +158,7 @@ module Google
           existing_binding = bindings.find { |b| b.role == role }
           if existing_binding
             existing_binding.members.concat Array(members)
+            existing_binding.members.uniq!
           else
             bindings << Binding.new(role, members)
           end
@@ -351,7 +352,7 @@ module Google
 
           # @private
           def initialize role, members
-            members = Array members
+            members = Array(members).uniq
             raise ArgumentError, "members cannot be empty" if members.empty?
             @role = role
             @members = members

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/policy.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/policy.rb
@@ -48,7 +48,7 @@ module Google
       #   policy = table.policy
       #
       #   policy.frozen? #=> true
-      #   binding = policy.binding_for "roles/owner"
+      #   binding = policy.bindings.find { |b| b.role == "roles/owner" }
       #
       #   binding.role #=> "roles/owner"
       #   binding.members #=> ["user:owner@example.com"]
@@ -64,8 +64,9 @@ module Google
       #
       #   table.update_policy do |p|
       #     p.set_binding "roles/viewer", "user:viewer@example.com"
-      #     p.binding_for("roles/editor").members << "user:new-editor@example.com"
-      #     p.binding_for("roles/editor").members.delete "user:old-editor@example.com"
+      #     binding = p.bindings.find { |b| b.role == "roles/editor" }
+      #     binding.members << "user:new-editor@example.com"
+      #     binding.members.delete "user:old-editor@example.com"
       #     p.remove_binding "roles/owner"
       #   end # 2 API calls
       #
@@ -103,52 +104,6 @@ module Google
         def initialize etag, bindings
           @etag = etag.freeze
           @bindings = bindings
-        end
-
-        ##
-        # Convenience method returning a binding value object that contains the array of members bound to a role
-        # in the policy. Returns `nil` if no binding is present for the role in the policy. See
-        # [Understanding Roles](https://cloud.google.com/iam/docs/understanding-roles) for a list of primitive and
-        # curated roles. See [BigQuery Table ACL
-        # permissions](https://cloud.google.com/bigquery/docs/table-access-controls-intro#permissions) for a list of
-        # values and patterns for members.
-        #
-        # @param [String] role A role that is bound to members in the policy. For example, `roles/viewer`,
-        #   `roles/editor`, or `roles/owner`. Required.
-        #
-        # @return [Binding, nil] The binding object, which may be mutable or frozen depending on the context; or `nil`
-        #   if no binding exists for the given role.
-        #
-        # @example
-        #   require "google/cloud/bigquery"
-        #
-        #   bigquery = Google::Cloud::Bigquery.new
-        #   dataset = bigquery.dataset "my_dataset"
-        #   table = dataset.table "my_table"
-        #   policy = table.policy
-        #
-        #   policy.frozen? #=> true
-        #   binding = policy.binding_for "roles/owner"
-        #
-        #   binding.role #=> "roles/owner"
-        #   binding.members #=> ["user:owner@example.com"]
-        #   binding.frozen? #=> true
-        #   binding.members.frozen? #=> true
-        #
-        # @example Update mutable bindings in the policy with {Table#update_policy}.
-        #   require "google/cloud/bigquery"
-        #
-        #   bigquery = Google::Cloud::Bigquery.new
-        #   dataset = bigquery.dataset "my_dataset"
-        #   table = dataset.table "my_table"
-        #
-        #   table.update_policy do |p|
-        #     p.binding_for("roles/editor").members << "user:new-editor@example.com"
-        #     p.binding_for("roles/editor").members.delete "user:old-editor@example.com"
-        #   end # 2 API calls
-        #
-        def binding_for role
-          @bindings.find { |b| b.role == role }
         end
 
         ##
@@ -317,7 +272,7 @@ module Google
         #   table = dataset.table "my_table"
         #
         #   policy = table.policy
-        #   binding = policy.binding_for "roles/owner"
+        #   binding = policy.bindings.find { |b| b.role == "roles/owner" }
         #
         #   binding.role #=> "roles/owner"
         #   binding.members #=> ["user:owner@example.com"]
@@ -333,8 +288,9 @@ module Google
         #   table = dataset.table "my_table"
         #
         #   table.update_policy do |p|
-        #     p.binding_for("roles/editor").members << "user:new-editor@example.com"
-        #     p.binding_for("roles/editor").members.delete "user:old-editor@example.com"
+        #     binding = p.bindings.find { |b| b.role == "roles/editor" }
+        #     binding.members << "user:new-editor@example.com"
+        #     binding.members.delete "user:old-editor@example.com"
         #   end # 2 API calls
         #
         class Binding

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/policy.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/policy.rb
@@ -33,6 +33,11 @@ module Google
       # @attr [String] etag Used to check if the policy has changed since the last request. When you make a request with
       #   an `etag` value, Cloud IAM compares the `etag` value in the request with the existing `etag` value associated
       #   with the policy. It writes the policy only if the `etag` values match.
+      # @attr [Array<Binding>] bindings The bindings in the policy, which may be mutable or frozen depending on the
+      #   context. See [Understanding Roles](https://cloud.google.com/iam/docs/understanding-roles) for a list of
+      #   primitive and curated roles. See [BigQuery Table ACL
+      #   permissions](https://cloud.google.com/bigquery/docs/table-access-controls-intro#permissions) for a list of
+      #   values and patterns for members.
       #
       # @example
       #   require "google/cloud/bigquery"
@@ -64,8 +69,35 @@ module Google
       #     p.remove_binding "roles/owner"
       #   end # 2 API calls
       #
+      # @example Iterate over frozen bindings.
+      #   require "google/cloud/bigquery"
+      #
+      #   bigquery = Google::Cloud::Bigquery.new
+      #   dataset = bigquery.dataset "my_dataset"
+      #   table = dataset.table "my_table"
+      #   policy = table.policy
+      #
+      #   policy.frozen? #=> true
+      #   policy.bindings.each do |binding|
+      #     puts binding.role
+      #     puts binding.members
+      #   end
+      #
+      # @example Update mutable bindings with {Table#update_policy}.
+      #   require "google/cloud/bigquery"
+      #
+      #   bigquery = Google::Cloud::Bigquery.new
+      #   dataset = bigquery.dataset "my_dataset"
+      #   table = dataset.table "my_table"
+      #
+      #   table.update_policy do |p|
+      #     p.bindings.each do |binding|
+      #       binding.members.clear
+      #     end
+      #   end # 2 API calls
+      #
       class Policy
-        attr_reader :etag
+        attr_reader :etag, :bindings
 
         # @private
         def initialize etag, bindings
@@ -117,47 +149,6 @@ module Google
         #
         def binding_for role
           @bindings.find { |b| b.role == role }
-        end
-
-        ##
-        # The bindings in the policy, which may be mutable or frozen depending on the context. See
-        # [Understanding Roles](https://cloud.google.com/iam/docs/understanding-roles) for a list of primitive and
-        # curated roles. See [BigQuery Table ACL
-        # permissions](https://cloud.google.com/bigquery/docs/table-access-controls-intro#permissions) for a list of
-        # values and patterns for members.
-        #
-        # @return [Array<Binding>] The array of binding objects, which may be mutable or frozen depending on the
-        #   context.
-        #
-        # @example Iterate over frozen bindings.
-        #   require "google/cloud/bigquery"
-        #
-        #   bigquery = Google::Cloud::Bigquery.new
-        #   dataset = bigquery.dataset "my_dataset"
-        #   table = dataset.table "my_table"
-        #   policy = table.policy
-        #
-        #   policy.frozen? #=> true
-        #   policy.bindings.each do |binding|
-        #     puts binding.role
-        #     puts binding.members
-        #   end
-        #
-        # @example Update mutable bindings with {Table#update_policy}.
-        #   require "google/cloud/bigquery"
-        #
-        #   bigquery = Google::Cloud::Bigquery.new
-        #   dataset = bigquery.dataset "my_dataset"
-        #   table = dataset.table "my_table"
-        #
-        #   table.update_policy do |p|
-        #     p.bindings.each do |binding|
-        #       binding.members.clear
-        #     end
-        #   end # 2 API calls
-        #
-        def bindings
-          frozen? ? @bindings.freeze : @bindings
         end
 
         ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/policy.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/policy.rb
@@ -348,7 +348,8 @@ module Google
         #   end
         #
         class Binding
-          attr_accessor :role, :members
+          attr_accessor :role
+          attr_reader :members
 
           # @private
           def initialize role, members
@@ -356,6 +357,41 @@ module Google
             raise ArgumentError, "members cannot be empty" if members.empty?
             @role = role
             @members = members
+          end
+
+          ##
+          # Sets the binding members.
+          #
+          # @param [Array<String>] new_members Specifies the identities requesting access for a Cloud Platform resource.
+          #   `new_members` can have the following values. Required.
+          #
+          #   * `allUsers`: A special identifier that represents anyone who is on the internet; with or without a Google
+          #     account.
+          #   * `allAuthenticatedUsers`: A special identifier that represents anyone who is authenticated with a Google
+          #     account or a service account.
+          #   * `user:<emailid>`: An email address that represents a specific Google account. For example,
+          #     `alice@example.com`.
+          #   * `serviceAccount:<emailid>`: An email address that represents a service account. For example,
+          #     `my-other-app@appspot.gserviceaccount.com`.
+          #   * `group:<emailid>`: An email address that represents a Google group. For example, `admins@example.com`.
+          #   * `deleted:user:<emailid>?uid=<uniqueid>`: An email address (plus unique identifier) representing a user
+          #     that has been recently deleted. For example, `alice@example.com?uid=123456789012345678901`. If the user
+          #     is recovered, this value reverts to `user:<emailid>` and the recovered user retains the role in the
+          #     binding.
+          #   * `deleted: serviceAccount:<emailid>?uid=<uniqueid>`: An email address (plus unique identifier)
+          #     representing a service account that has been recently deleted. For example,
+          #     `my-other-app@appspot.gserviceaccount.com?uid=123456789012345678901`. If the service account is
+          #     undeleted, this value reverts to `serviceAccount:<emailid>` and the undeleted service account retains
+          #     the role in the binding.
+          #   * `deleted:group:<emailid>?uid=<uniqueid>`: An email address (plus unique identifier) representing a
+          #     Google group that has been recently deleted. For example,
+          #     `admins@example.com?uid=123456789012345678901`. If the group is recovered, this value reverts to
+          #     `group:<emailid>` and the recovered group retains the role in the binding.
+          #   * `domain:<domain>`: The G Suite domain (primary) that represents all the users of that domain. For
+          #     example, `google.com` or `example.com`.
+          #
+          def members= new_members
+            @members = Array(new_members).uniq
           end
 
           ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/policy.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/policy.rb
@@ -67,7 +67,7 @@ module Google
       #     binding = p.bindings.find { |b| b.role == "roles/editor" }
       #     binding.members << "user:new-editor@example.com"
       #     binding.members.delete "user:old-editor@example.com"
-      #     p.remove_binding "roles/owner"
+      #     p.revoke role: "roles/owner"
       #   end # 2 API calls
       #
       # @example Iterate over frozen bindings.
@@ -187,10 +187,10 @@ module Google
         #   table = dataset.table "my_table"
         #
         #   table.update_policy do |p|
-        #     p.remove_binding "roles/owner"
+        #     p.revoke role: "roles/owner"
         #   end # 2 API calls
         #
-        def remove_binding role
+        def revoke role:
           i = @bindings.find_index { |b| b.role == role }
           @bindings.delete_at(i).freeze if i
         end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -183,6 +183,34 @@ module Google
         end
 
         ##
+        # Returns Google::Apis::BigqueryV2::Policy
+        def get_table_policy dataset_id, table_id
+          policy_options = API::GetPolicyOptions.new requested_policy_version: 1
+          execute do
+            service.get_table_iam_policy table_path(dataset_id, table_id),
+                                         API::GetIamPolicyRequest.new(options: policy_options)
+          end
+        end
+
+        ##
+        # @param [Google::Apis::BigqueryV2::Policy] new_policy
+        def set_table_policy dataset_id, table_id, new_policy
+          execute do
+            service.set_table_iam_policy table_path(dataset_id, table_id),
+                                         API::SetIamPolicyRequest.new(policy: new_policy)
+          end
+        end
+
+        ##
+        # Returns Google::Apis::BigqueryV2::TestIamPermissionsResponse
+        def test_table_permissions dataset_id, table_id, permissions
+          execute do
+            service.test_table_iam_permissions table_path(dataset_id, table_id),
+                                               API::TestIamPermissionsRequest.new(permissions: permissions)
+          end
+        end
+
+        ##
         # Deletes the table specified by tableId from the dataset.
         # If the table contains data, all the data will be deleted.
         def delete_table dataset_id, table_id
@@ -507,6 +535,11 @@ module Google
         end
 
         protected
+
+        # Creates a formatted table path.
+        def table_path dataset_id, table_id
+          "projects/#{@project}/datasets/#{dataset_id}/tables/#{table_id}"
+        end
 
         # Generate a random string similar to the BigQuery service job IDs.
         def generate_id

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -1332,7 +1332,7 @@ module Google
         #     binding = p.bindings.find { |b| b.role == "roles/editor" }
         #     binding.members << "user:new-editor@example.com"
         #     binding.members.delete "user:old-editor@example.com"
-        #     p.remove_binding "roles/owner"
+        #     p.revoke role: "roles/owner"
         #   end # 2 API calls
         #
         def update_policy

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -1328,7 +1328,7 @@ module Google
         #   table = dataset.table "my_table"
         #
         #   table.update_policy do |p|
-        #     p.set_binding "roles/viewer", "user:viewer@example.com"
+        #     p.grant members: "user:viewer@example.com", role: "roles/viewer"
         #     binding = p.bindings.find { |b| b.role == "roles/editor" }
         #     binding.members << "user:new-editor@example.com"
         #     binding.members.delete "user:old-editor@example.com"

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -1276,14 +1276,13 @@ module Google
         end
 
         ##
-        # Gets the [Cloud IAM](https://cloud.google.com/iam/) access control
-        # policy for the table. The latest policy will be read from the service.
-        # See also {#update_policy}.
+        # Gets the Cloud IAM access control policy for the table. The latest policy will be read from the service. See
+        # also {#update_policy}.
         #
         # @see https://cloud.google.com/iam/docs/managing-policies Managing Policies
         # @see https://cloud.google.com/bigquery/docs/table-access-controls-intro Controlling access to tables
         #
-        # @return [Policy] The frozen Policy for the table.
+        # @return [Policy] The frozen policy for the table.
         #
         # @example
         #   require "google/cloud/bigquery"
@@ -1292,9 +1291,14 @@ module Google
         #   dataset = bigquery.dataset "my_dataset"
         #   table = dataset.table "my_table"
         #
-        #   policy = table.policy # RPC
-        #   policy.role "roles/owner" #=> ["user:owner@example.com"]
+        #   policy = table.policy
+        #
         #   policy.frozen? #=> true
+        #   binding = policy.binding "roles/owner"
+        #   binding.role #=> "roles/owner"
+        #   binding.members #=> ["user:owner@example.com"]
+        #   binding.frozen? #=> true
+        #   binding.members.frozen? #=> true
         #
         def policy
           raise ArgumentError, "Block argument not supported: Use #update_policy instead." if block_given?
@@ -1304,19 +1308,17 @@ module Google
         end
 
         ##
-        # Updates the [Cloud IAM](https://cloud.google.com/iam/) access control
-        # policy for the table. The latest policy will be read from the service.
+        # Updates the Cloud IAM access control policy for the table. The latest policy will be read from the service.
         # See also {#policy}.
         #
         # @see https://cloud.google.com/iam/docs/managing-policies Managing Policies
         # @see https://cloud.google.com/bigquery/docs/table-access-controls-intro Controlling access to tables
         #
-        # @yield [policy] A block for updating the policy. The latest policy
-        #   will be read from the service and passed to the block. After the
-        #   block completes, the modified policy will be written to the service.
+        # @yield [policy] A block for updating the policy. The latest policy will be read from the service and passed to
+        #   the block. After the block completes, the modified policy will be written to the service.
         # @yieldparam [Policy] policy The mutable Policy for the table.
         #
-        # @return [Policy] The updated and frozen Policy for the table.
+        # @return [Policy] The updated and frozen policy for the table.
         #
         # @example Update the policy by passing a block.
         #   require "google/cloud/bigquery"
@@ -1326,9 +1328,10 @@ module Google
         #   table = dataset.table "my_table"
         #
         #   table.update_policy do |p|
-        #     p.remove "roles/owner", "user:owner@example.com"
-        #     p.add "roles/owner", "user:newowner@example.com"
-        #     p.roles["roles/viewer"] = ["allUsers"]
+        #     p.set_binding "roles/viewer", "user:viewer@example.com"
+        #     p.binding("roles/editor").members << "user:new-editor@example.com"
+        #     p.binding("roles/editor").members.delete "user:old-editor@example.com"
+        #     p.remove_binding "roles/owner"
         #   end # 2 API calls
         #
         def update_policy

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -1294,7 +1294,7 @@ module Google
         #   policy = table.policy
         #
         #   policy.frozen? #=> true
-        #   binding = policy.binding_for "roles/owner"
+        #   binding = policy.bindings.find { |b| b.role == "roles/owner" }
         #   binding.role #=> "roles/owner"
         #   binding.members #=> ["user:owner@example.com"]
         #   binding.frozen? #=> true
@@ -1329,8 +1329,9 @@ module Google
         #
         #   table.update_policy do |p|
         #     p.set_binding "roles/viewer", "user:viewer@example.com"
-        #     p.binding_for("roles/editor").members << "user:new-editor@example.com"
-        #     p.binding_for("roles/editor").members.delete "user:old-editor@example.com"
+        #     binding = p.bindings.find { |b| b.role == "roles/editor" }
+        #     binding.members << "user:new-editor@example.com"
+        #     binding.members.delete "user:old-editor@example.com"
         #     p.remove_binding "roles/owner"
         #   end # 2 API calls
         #

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -1294,7 +1294,7 @@ module Google
         #   policy = table.policy
         #
         #   policy.frozen? #=> true
-        #   binding = policy.binding "roles/owner"
+        #   binding = policy.binding_for "roles/owner"
         #   binding.role #=> "roles/owner"
         #   binding.members #=> ["user:owner@example.com"]
         #   binding.frozen? #=> true
@@ -1329,8 +1329,8 @@ module Google
         #
         #   table.update_policy do |p|
         #     p.set_binding "roles/viewer", "user:viewer@example.com"
-        #     p.binding("roles/editor").members << "user:new-editor@example.com"
-        #     p.binding("roles/editor").members.delete "user:old-editor@example.com"
+        #     p.binding_for("roles/editor").members << "user:new-editor@example.com"
+        #     p.binding_for("roles/editor").members.delete "user:old-editor@example.com"
         #     p.remove_binding "roles/owner"
         #   end # 2 API calls
         #

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -1294,11 +1294,11 @@ module Google
         #   policy = table.policy
         #
         #   policy.frozen? #=> true
-        #   binding = policy.bindings.find { |b| b.role == "roles/owner" }
-        #   binding.role #=> "roles/owner"
-        #   binding.members #=> ["user:owner@example.com"]
-        #   binding.frozen? #=> true
-        #   binding.members.frozen? #=> true
+        #   binding_owner = policy.bindings.find { |b| b.role == "roles/owner" }
+        #   binding_owner.role #=> "roles/owner"
+        #   binding_owner.members #=> ["user:owner@example.com"]
+        #   binding_owner.frozen? #=> true
+        #   binding_owner.members.frozen? #=> true
         #
         def policy
           raise ArgumentError, "Block argument not supported: Use #update_policy instead." if block_given?
@@ -1328,10 +1328,8 @@ module Google
         #   table = dataset.table "my_table"
         #
         #   table.update_policy do |p|
-        #     p.grant members: "user:viewer@example.com", role: "roles/viewer"
-        #     binding = p.bindings.find { |b| b.role == "roles/editor" }
-        #     binding.members << "user:new-editor@example.com"
-        #     binding.members.delete "user:old-editor@example.com"
+        #     p.grant role: "roles/viewer", members: "user:viewer@example.com"
+        #     p.revoke role: "roles/editor", members: "user:editor@example.com"
         #     p.revoke role: "roles/owner"
         #   end # 2 API calls
         #

--- a/google-cloud-bigquery/support/doctest_helper.rb
+++ b/google-cloud-bigquery/support/doctest_helper.rb
@@ -82,7 +82,6 @@ YARD::Doctest.configure do |doctest|
   doctest.skip "Google::Cloud::Bigquery::Dataset#refresh!"
   doctest.skip "Google::Cloud::Bigquery::Job#refresh!"
   doctest.skip "Google::Cloud::Bigquery::QueryJob#query_results"
-  doctest.skip "Google::Cloud::Bigquery::Table#policy="
 
 
   # Google::Cloud#bigquery@The default scope can be overridden with the `scope` option:
@@ -607,6 +606,7 @@ YARD::Doctest.configure do |doctest|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
       mock.expect :get_table_iam_policy, policy_gapi, ["projects/my-project/datasets/my_dataset/tables/my_table", Google::Apis::BigqueryV2::GetIamPolicyRequest]
+      mock.expect :set_table_iam_policy, policy_gapi, ["projects/my-project/datasets/my_dataset/tables/my_table", Google::Apis::BigqueryV2::SetIamPolicyRequest]
     end
   end
 
@@ -1081,15 +1081,6 @@ YARD::Doctest.configure do |doctest|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
       mock.expect :test_table_iam_permissions, test_iam_permissions_gapi, ["projects/my-project/datasets/my_dataset/tables/my_table", Google::Apis::BigqueryV2::TestIamPermissionsRequest]
-    end
-  end
-
-  doctest.before "Google::Cloud::Bigquery::Table#update_policy" do
-    mock_bigquery do |mock|
-      mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
-      mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
-      mock.expect :get_table_iam_policy, policy_gapi, ["projects/my-project/datasets/my_dataset/tables/my_table", Google::Apis::BigqueryV2::GetIamPolicyRequest]
-      mock.expect :set_table_iam_policy, policy_gapi, ["projects/my-project/datasets/my_dataset/tables/my_table", Google::Apis::BigqueryV2::SetIamPolicyRequest]
     end
   end
 
@@ -1667,9 +1658,9 @@ def policy_gapi etag: "CAE="
     version: 1,
     bindings: [
       Google::Apis::StorageV1::Policy::Binding.new(
-        role: "roles/storage.objectViewer",
+        role: "roles/owner",
         members: [
-          "user:viewer@example.com"
+          "user:owner@example.com"
         ]
       )
     ]

--- a/google-cloud-bigquery/support/doctest_helper.rb
+++ b/google-cloud-bigquery/support/doctest_helper.rb
@@ -1666,6 +1666,12 @@ def policy_gapi etag: "CAE="
     version: 1,
     bindings: [
       Google::Apis::StorageV1::Policy::Binding.new(
+        role: "roles/editor",
+        members: [
+          "user:old-editor@example.com"
+        ]
+      ),
+      Google::Apis::StorageV1::Policy::Binding.new(
         role: "roles/owner",
         members: [
           "user:owner@example.com"

--- a/google-cloud-bigquery/support/doctest_helper.rb
+++ b/google-cloud-bigquery/support/doctest_helper.rb
@@ -82,6 +82,7 @@ YARD::Doctest.configure do |doctest|
   doctest.skip "Google::Cloud::Bigquery::Dataset#refresh!"
   doctest.skip "Google::Cloud::Bigquery::Job#refresh!"
   doctest.skip "Google::Cloud::Bigquery::QueryJob#query_results"
+  doctest.skip "Google::Cloud::Bigquery::Table#policy="
 
 
   # Google::Cloud#bigquery@The default scope can be overridden with the `scope` option:
@@ -601,6 +602,14 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::Bigquery::Policy" do
+    mock_bigquery do |mock|
+      mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
+      mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
+      mock.expect :get_table_iam_policy, policy_gapi, ["projects/my-project/datasets/my_dataset/tables/my_table", Google::Apis::BigqueryV2::GetIamPolicyRequest]
+    end
+  end
+
   # Google::Cloud::Bigquery::Project#dataset
   # Google::Cloud::Bigquery::Project#job
   # Google::Cloud::Bigquery::Project#project
@@ -981,6 +990,15 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::Bigquery::Table#policy" do
+    mock_bigquery do |mock|
+      mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
+      mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
+      mock.expect :get_table_iam_policy, policy_gapi, ["projects/my-project/datasets/my_dataset/tables/my_table", Google::Apis::BigqueryV2::GetIamPolicyRequest]
+      mock.expect :set_table_iam_policy, policy_gapi, ["projects/my-project/datasets/my_dataset/tables/my_table", Google::Apis::BigqueryV2::SetIamPolicyRequest]
+    end
+  end
+
   doctest.before "Google::Cloud::Bigquery::Table#query=" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
@@ -1055,6 +1073,23 @@ YARD::Doctest.configure do |doctest|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :list_tables, list_tables_gapi, ["my-project", "my_dataset", Hash]
       mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
+    end
+  end
+
+  doctest.before "Google::Cloud::Bigquery::Table#test_iam_permissions" do
+    mock_bigquery do |mock|
+      mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
+      mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
+      mock.expect :test_table_iam_permissions, test_iam_permissions_gapi, ["projects/my-project/datasets/my_dataset/tables/my_table", Google::Apis::BigqueryV2::TestIamPermissionsRequest]
+    end
+  end
+
+  doctest.before "Google::Cloud::Bigquery::Table#update_policy" do
+    mock_bigquery do |mock|
+      mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
+      mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
+      mock.expect :get_table_iam_policy, policy_gapi, ["projects/my-project/datasets/my_dataset/tables/my_table", Google::Apis::BigqueryV2::GetIamPolicyRequest]
+      mock.expect :set_table_iam_policy, policy_gapi, ["projects/my-project/datasets/my_dataset/tables/my_table", Google::Apis::BigqueryV2::SetIamPolicyRequest]
     end
   end
 
@@ -1624,4 +1659,23 @@ end
 
 def other_dataset_view_object
   "foo"
+end
+
+def policy_gapi etag: "CAE="
+  Google::Apis::StorageV1::Policy.new(
+    etag: etag,
+    version: 1,
+    bindings: [
+      Google::Apis::StorageV1::Policy::Binding.new(
+        role: "roles/storage.objectViewer",
+        members: [
+          "user:viewer@example.com"
+        ]
+      )
+    ]
+  )
+end
+
+def test_iam_permissions_gapi permissions: ["bigquery.tables.get"]
+  Google::Apis::BigqueryV2::TestIamPermissionsResponse.new permissions: permissions
 end

--- a/google-cloud-bigquery/support/doctest_helper.rb
+++ b/google-cloud-bigquery/support/doctest_helper.rb
@@ -995,7 +995,6 @@ YARD::Doctest.configure do |doctest|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
       mock.expect :get_table_iam_policy, policy_gapi, ["projects/my-project/datasets/my_dataset/tables/my_table", Google::Apis::BigqueryV2::GetIamPolicyRequest]
-      mock.expect :set_table_iam_policy, policy_gapi, ["projects/my-project/datasets/my_dataset/tables/my_table", Google::Apis::BigqueryV2::SetIamPolicyRequest]
     end
   end
 
@@ -1081,6 +1080,15 @@ YARD::Doctest.configure do |doctest|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
       mock.expect :test_table_iam_permissions, test_iam_permissions_gapi, ["projects/my-project/datasets/my_dataset/tables/my_table", Google::Apis::BigqueryV2::TestIamPermissionsRequest]
+    end
+  end
+
+  doctest.before "Google::Cloud::Bigquery::Table#update_policy" do
+    mock_bigquery do |mock|
+      mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
+      mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
+      mock.expect :get_table_iam_policy, policy_gapi, ["projects/my-project/datasets/my_dataset/tables/my_table", Google::Apis::BigqueryV2::GetIamPolicyRequest]
+      mock.expect :set_table_iam_policy, policy_gapi, ["projects/my-project/datasets/my_dataset/tables/my_table", Google::Apis::BigqueryV2::SetIamPolicyRequest]
     end
   end
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/policy_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/policy_test.rb
@@ -16,82 +16,167 @@
 require "helper"
 
 describe Google::Cloud::Bigquery::Policy, :mock_bigquery do
-  let(:role) { "roles/bigquery.dataViewer" }
-  let(:member) { "user:viewer@example.com" }
-  let :viewer_policy_gapi do
+  let(:role_viewer) { "roles/bigquery.dataViewer" }
+  let(:member_viewer) { "user:viewer@example.com" }
+  let(:role_editor) { "roles/bigquery.dataEditor" }
+  let(:member_editor) { "user:editor@example.com" }
+  let(:role_owner) { "roles/bigquery.dataOwner" }
+  let(:member_owner) { "user:owner@example.com" }
+  let :policy_viewer_gapi do
     policy_gapi(
       bindings: [
         Google::Apis::BigqueryV2::Binding.new(
-          role: role,
-          members: [member]
+          role: role_viewer,
+          members: [member_viewer]
         )
       ]
     )
   end
-  let(:policy) { Google::Cloud::Bigquery::Policy.from_gapi viewer_policy_gapi }
 
-  it "knows its etag" do
-    _(policy).must_be_kind_of Google::Cloud::Bigquery::Policy
-    _(policy).wont_be :frozen?
-    _(policy.etag).must_equal "CAE="
-    _(policy.etag).must_be :frozen?
-  end
-
-  it "returns mutable bindings when not frozen" do
-    bindings = policy.bindings
-    _(bindings).must_be_kind_of Array
-    _(bindings).wont_be :frozen?
-    _(bindings.size).must_equal 1
-    _(bindings[0]).wont_be :frozen?
-    _(bindings[0].role).wont_be :frozen?
-    _(bindings[0].role).must_equal role
-    _(bindings[0].members).must_be_kind_of Array
-    _(bindings[0].members).wont_be :frozen?
-    _(bindings[0].members.size).must_equal 1
-    _(bindings[0].members[0]).must_equal member
-  end
-
-  it "grants roles" do
-    _(policy.bindings.find { |b| b.role == "roles/bigquery.dataOwner" }).must_be :nil?
-
-    policy.grant members: "user:owner@example.com", role: "roles/bigquery.dataOwner"
-    binding_owner = policy.bindings.find { |b| b.role == "roles/bigquery.dataOwner" }
-    _(binding_owner).wont_be :nil?
-    _(binding_owner.members.size).must_equal 1
-    _(binding_owner.members[0]).must_equal "user:owner@example.com"
-  end
-
-  it "revokes roles" do
-    _(policy.bindings.size).must_equal 1
-    _(policy.bindings.find { |b| b.role == role }).wont_be :nil?
-
-    policy.revoke role: role
-
-    _(policy.bindings.size).must_equal 0
-  end
-
-  describe "freeze" do
-    let(:policy_frozen) { policy.freeze }
-
+  describe "not frozen" do
+    let(:policy) { Google::Cloud::Bigquery::Policy.from_gapi policy_viewer_gapi }
     it "knows its etag" do
-      _(policy_frozen).must_be_kind_of Google::Cloud::Bigquery::Policy
-      _(policy_frozen).must_be :frozen?
-      _(policy_frozen.etag).must_equal "CAE="
-      _(policy_frozen.etag).must_be :frozen?
+      _(policy).must_be_kind_of Google::Cloud::Bigquery::Policy
+      _(policy).wont_be :frozen?
+      _(policy.etag).must_equal "CAE="
+      _(policy.etag).must_be :frozen?
     end
 
+    it "returns mutable bindings when not frozen" do
+      bindings = policy.bindings
+      _(bindings).must_be_kind_of Array
+      _(bindings).wont_be :frozen?
+      _(bindings.size).must_equal 1
+      _(bindings[0]).wont_be :frozen?
+      _(bindings[0].role).wont_be :frozen?
+      _(bindings[0].role).must_equal role_viewer
+      _(bindings[0].members).must_be_kind_of Array
+      _(bindings[0].members).wont_be :frozen?
+      _(bindings[0].members.size).must_equal 1
+      _(bindings[0].members[0]).must_equal member_viewer
+    end
+
+    it "grants a new role to a new member" do
+      policy.grant role: role_editor, members: member_editor
+
+      binding_owner = policy.bindings.find { |b| b.role == role_editor }
+      _(binding_owner).wont_be :nil?
+      _(binding_owner.role).must_equal role_editor
+      _(binding_owner.members.size).must_equal 1
+      _(binding_owner.members[0]).must_equal member_editor
+    end
+
+    it "grants new roles to a new member" do
+      policy.grant role: role_editor, members: [member_editor, member_owner]
+
+      binding_owner = policy.bindings.find { |b| b.role == role_editor }
+      _(binding_owner).wont_be :nil?
+      _(binding_owner.members.size).must_equal 2
+      _(binding_owner.members).must_include member_editor
+      _(binding_owner.members).must_include member_owner
+    end
+
+    it "grants an existing role to a new member" do
+      policy.grant role: role_viewer, members: member_editor
+
+      binding_viewer = policy.bindings.find { |b| b.role == role_viewer }
+      _(binding_viewer).wont_be :nil?
+      _(binding_viewer.members.size).must_equal 2
+      _(binding_viewer.members).must_include member_viewer
+      _(binding_viewer.members).must_include member_editor
+    end
+
+    it "grants an existing role to new members" do
+      policy.grant role: role_viewer, members: [member_editor, member_owner]
+
+      binding_viewer = policy.bindings.find { |b| b.role == role_viewer }
+      _(binding_viewer).wont_be :nil?
+      _(binding_viewer.role).must_equal role_viewer
+      _(binding_viewer.members.size).must_equal 3
+      _(binding_viewer.members).must_include member_viewer
+      _(binding_viewer.members).must_include member_editor
+      _(binding_viewer.members).must_include member_owner
+    end
+
+    it "revokes an existing role with one member for all members" do
+      policy.revoke role: role_viewer
+
+      _(policy.bindings.size).must_equal 0
+    end
+
+    it "revokes an existing role with multiple members for all members" do
+      policy.grant role: role_viewer, members: member_editor
+
+      policy.revoke role: role_viewer
+
+      _(policy.bindings.size).must_equal 0
+    end
+
+    it "revokes an existing role for a subset of members" do
+      policy.grant role: role_viewer, members: member_editor
+
+      policy.revoke role: role_viewer, members: member_editor
+
+      binding_viewer = policy.bindings.find { |b| b.role == role_viewer }
+      _(binding_viewer.members.size).must_equal 1
+      _(binding_viewer.members).must_include member_viewer
+    end
+
+    it "revokes a member for multiple roles" do
+      policy.grant role: role_viewer, members: member_editor
+      policy.grant role: role_editor, members: member_editor
+
+      policy.revoke members: member_editor
+
+      _(policy.bindings.size).must_equal 1
+      _(policy.bindings[0].role).must_equal role_viewer
+      _(policy.bindings[0].members.size).must_equal 1
+      _(policy.bindings[0].members).must_include member_viewer
+    end
+
+    it "revokes multiple members for multiple roles" do
+      policy.grant role: role_viewer, members: [member_editor, member_owner]
+      policy.grant role: role_editor, members: [member_editor, member_owner]
+
+      policy.revoke members: [member_editor, member_owner]
+
+      _(policy.bindings.size).must_equal 1
+      _(policy.bindings[0].role).must_equal role_viewer
+      _(policy.bindings[0].members.size).must_equal 1
+      _(policy.bindings[0].members).must_include member_viewer
+    end
+  end
+
+  describe "frozen" do
+    let(:policy) { Google::Cloud::Bigquery::Policy.from_gapi(policy_viewer_gapi).freeze }
+
     it "returns deeply frozen bindings when frozen" do
-      bindings = policy_frozen.bindings
+      _(policy).must_be_kind_of Google::Cloud::Bigquery::Policy
+      _(policy).must_be :frozen?
+
+      bindings = policy.bindings
       _(bindings).must_be_kind_of Array
       _(bindings).must_be :frozen?
       _(bindings.size).must_equal 1
       _(bindings[0]).must_be :frozen?
       _(bindings[0].role).must_be :frozen?
-      _(bindings[0].role).must_equal role
+      _(bindings[0].role).must_equal role_viewer
       _(bindings[0].members).must_be_kind_of Array
       _(bindings[0].members).must_be :frozen?
       _(bindings[0].members.size).must_equal 1
-      _(bindings[0].members[0]).must_equal member
+      _(bindings[0].members[0]).must_equal member_viewer
+    end
+
+    it "raises when grant would change the bindings" do
+      expect do
+        policy.grant role: role_editor, members: member_editor
+      end.must_raise FrozenError
+    end
+
+    it "raises when revoke would change the bindings" do
+      expect do
+        policy.revoke role: role_viewer
+      end.must_raise FrozenError
     end
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/policy_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/policy_test.rb
@@ -1,0 +1,97 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "helper"
+
+describe Google::Cloud::Bigquery::Policy, :mock_bigquery do
+  let(:role) { "roles/bigquery.dataViewer" }
+  let(:member) { "user:viewer@example.com" }
+  let :viewer_policy_gapi do
+    policy_gapi(
+      bindings: [
+        Google::Apis::BigqueryV2::Binding.new(
+          role: role,
+          members: [member]
+        )
+      ]
+    )
+  end
+  let(:policy) { Google::Cloud::Bigquery::Policy.from_gapi viewer_policy_gapi }
+
+  it "knows its etag" do
+    _(policy).must_be_kind_of Google::Cloud::Bigquery::Policy
+    _(policy).wont_be :frozen?
+    _(policy.etag).must_equal "CAE="
+    _(policy.etag).must_be :frozen?
+  end
+
+  it "returns mutable bindings when not frozen" do
+    bindings = policy.bindings
+    _(bindings).must_be_kind_of Array
+    _(bindings).wont_be :frozen?
+    _(bindings.size).must_equal 1
+    _(bindings[0]).wont_be :frozen?
+    _(bindings[0].role).wont_be :frozen?
+    _(bindings[0].role).must_equal role
+    _(bindings[0].members).must_be_kind_of Array
+    _(bindings[0].members).wont_be :frozen?
+    _(bindings[0].members.size).must_equal 1
+    _(bindings[0].members[0]).must_equal member
+  end
+
+  it "grants roles" do
+    _(policy.bindings.find { |b| b.role == "roles/bigquery.dataOwner" }).must_be :nil?
+
+    policy.grant members: "user:owner@example.com", role: "roles/bigquery.dataOwner"
+    binding_owner = policy.bindings.find { |b| b.role == "roles/bigquery.dataOwner" }
+    _(binding_owner).wont_be :nil?
+    _(binding_owner.members.size).must_equal 1
+    _(binding_owner.members[0]).must_equal "user:owner@example.com"
+  end
+
+  it "revokes roles" do
+    _(policy.bindings.size).must_equal 1
+    _(policy.bindings.find { |b| b.role == role }).wont_be :nil?
+
+    policy.revoke role: role
+
+    _(policy.bindings.size).must_equal 0
+  end
+
+  describe "freeze" do
+    let(:policy_frozen) { policy.freeze }
+
+    it "knows its etag" do
+      _(policy_frozen).must_be_kind_of Google::Cloud::Bigquery::Policy
+      _(policy_frozen).must_be :frozen?
+      _(policy_frozen.etag).must_equal "CAE="
+      _(policy_frozen.etag).must_be :frozen?
+    end
+
+    it "returns deeply frozen bindings when frozen" do
+      bindings = policy_frozen.bindings
+      _(bindings).must_be_kind_of Array
+      _(bindings).must_be :frozen?
+      _(bindings.size).must_equal 1
+      _(bindings[0]).must_be :frozen?
+      _(bindings[0].role).must_be :frozen?
+      _(bindings[0].role).must_equal role
+      _(bindings[0].members).must_be_kind_of Array
+      _(bindings[0].members).must_be :frozen?
+      _(bindings[0].members.size).must_equal 1
+      _(bindings[0].members[0]).must_equal member
+    end
+  end
+end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/policy_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/policy_test.rb
@@ -120,6 +120,15 @@ describe Google::Cloud::Bigquery::Policy, :mock_bigquery do
       _(binding_viewer.members).must_include member_owner
     end
 
+    it "does not allow duplicate members to be set in a binding" do
+      binding_viewer = policy.bindings.find { |b| b.role == role_viewer }
+
+      binding_viewer.members = [member_viewer, member_editor, member_editor, member_owner]
+      _(binding_viewer.members.size).must_equal 3
+      _(binding_viewer.members).must_include member_viewer
+      _(binding_viewer.members).must_include member_editor
+      _(binding_viewer.members).must_include member_owner
+    end
 
     it "revokes an existing role with one member for all members" do
       policy.revoke role: role_viewer

--- a/google-cloud-bigquery/test/google/cloud/bigquery/policy_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/policy_test.rb
@@ -170,13 +170,13 @@ describe Google::Cloud::Bigquery::Policy, :mock_bigquery do
     it "raises when grant would change the bindings" do
       expect do
         policy.grant role: role_editor, members: member_editor
-      end.must_raise FrozenError
+      end.must_raise RuntimeError # TODO replace with FrozenError when Ruby > 2.4
     end
 
     it "raises when revoke would change the bindings" do
       expect do
         policy.revoke role: role_viewer
-      end.must_raise FrozenError
+      end.must_raise RuntimeError # TODO replace with FrozenError when Ruby > 2.4
     end
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/policy_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/policy_test.rb
@@ -98,6 +98,29 @@ describe Google::Cloud::Bigquery::Policy, :mock_bigquery do
       _(binding_viewer.members).must_include member_owner
     end
 
+    it "does not grant a new role to duplicate members" do
+      policy.grant role: role_editor, members: [member_editor, member_owner, member_editor]
+
+      binding_owner = policy.bindings.find { |b| b.role == role_editor }
+      _(binding_owner).wont_be :nil?
+      _(binding_owner.role).must_equal role_editor
+      _(binding_owner.members.size).must_equal 2
+      _(binding_owner.members[0]).must_equal member_editor
+    end
+
+    it "does not grant an existing role to duplicate members" do
+      policy.grant role: role_viewer, members: [member_viewer, member_editor, member_editor, member_owner]
+
+      binding_viewer = policy.bindings.find { |b| b.role == role_viewer }
+      _(binding_viewer).wont_be :nil?
+      _(binding_viewer.role).must_equal role_viewer
+      _(binding_viewer.members.size).must_equal 3
+      _(binding_viewer.members).must_include member_viewer
+      _(binding_viewer.members).must_include member_editor
+      _(binding_viewer.members).must_include member_owner
+    end
+
+
     it "revokes an existing role with one member for all members" do
       policy.revoke role: role_viewer
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_policy_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_policy_test.rb
@@ -91,7 +91,8 @@ describe Google::Cloud::Bigquery::Table, :policy, :mock_bigquery do
   it "raises if a block is provided to #policy" do
     expect do
       table.policy do |p|
-        p.binding_for("roles/bigquery.dataViewer").members << "serviceAccount:1234567890@developer.gserviceaccount.com"
+        binding = p.bindings.find { |b| b.role == "roles/bigquery.dataViewer" }
+        binding.members << "serviceAccount:1234567890@developer.gserviceaccount.com"
       end
     end.must_raise ArgumentError
   end
@@ -110,7 +111,7 @@ describe Google::Cloud::Bigquery::Table, :policy, :mock_bigquery do
       _(p.bindings[0].role).wont_be :frozen?
       _(p.bindings[0].members).must_be_kind_of Array
       _(p.bindings[0].members).wont_be :frozen?
-      binding = p.binding_for "roles/bigquery.dataViewer"
+      binding = p.bindings.find { |b| b.role == "roles/bigquery.dataViewer" }
       _(binding).wont_be :frozen?
       members = binding.members
       _(members).must_be_kind_of Array
@@ -118,12 +119,12 @@ describe Google::Cloud::Bigquery::Table, :policy, :mock_bigquery do
       _(members).wont_be :frozen?
       members << "serviceAccount:1234567890@developer.gserviceaccount.com"
       p.set_binding "roles/bigquery.dataOwner", "user:unwanted@example.com"
-      binding_owner = p.binding_for "roles/bigquery.dataOwner"
+      binding_owner = p.bindings.find { |b| b.role == "roles/bigquery.dataOwner" }
       _(binding_owner).wont_be :nil?
       _(binding_owner.members).must_equal ["user:unwanted@example.com"]
       binding_removed = p.remove_binding "roles/bigquery.dataOwner"
       _(binding_removed).must_equal binding_owner
-      _(p.binding_for("roles/bigquery.dataOwner")).must_be :nil?
+      _(p.bindings.find { |b| b.role == "roles/bigquery.dataOwner"}).must_be :nil?
     end
     mock.verify
 
@@ -136,7 +137,7 @@ describe Google::Cloud::Bigquery::Table, :policy, :mock_bigquery do
     _(policy.bindings[0].role).must_be :frozen?
     _(policy.bindings[0].members).must_be_kind_of Array
     _(policy.bindings[0].members).must_be :frozen?
-    binding = policy.binding_for "roles/bigquery.dataViewer"
+    binding = policy.bindings.find { |b| b.role == "roles/bigquery.dataViewer" }
     _(binding).must_equal policy.bindings[0]
     _(binding).must_be :frozen?
     members = binding.members

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_policy_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_policy_test.rb
@@ -83,7 +83,7 @@ describe Google::Cloud::Bigquery::Table, :policy, :mock_bigquery do
     _(policy.bindings[0].role).must_be :frozen?
     _(policy.bindings[0].members).must_be_kind_of Array
     _(policy.bindings[0].members).must_be :frozen?
-    binding = policy.binding "roles/bigquery.dataViewer"
+    binding = policy.binding_for "roles/bigquery.dataViewer"
     _(binding).must_equal policy.bindings[0]
     _(binding).must_be :frozen?
     _(binding.role).must_be :frozen?
@@ -97,7 +97,7 @@ describe Google::Cloud::Bigquery::Table, :policy, :mock_bigquery do
   it "raises if a block is provided to #policy" do
     expect do
       table.policy do |p|
-        p.binding("roles/bigquery.dataViewer").members << "serviceAccount:1234567890@developer.gserviceaccount.com"
+        p.binding_for("roles/bigquery.dataViewer").members << "serviceAccount:1234567890@developer.gserviceaccount.com"
       end
     end.must_raise ArgumentError
   end
@@ -115,7 +115,7 @@ describe Google::Cloud::Bigquery::Table, :policy, :mock_bigquery do
       _(p.bindings[0].role).wont_be :frozen?
       _(p.bindings[0].members).must_be_kind_of Array
       _(p.bindings[0].members).wont_be :frozen?
-      binding = p.binding "roles/bigquery.dataViewer"
+      binding = p.binding_for "roles/bigquery.dataViewer"
       _(binding).wont_be :frozen?
       members = binding.members
       _(members).must_be_kind_of Array
@@ -134,7 +134,7 @@ describe Google::Cloud::Bigquery::Table, :policy, :mock_bigquery do
     _(policy.bindings[0].role).must_be :frozen?
     _(policy.bindings[0].members).must_be_kind_of Array
     _(policy.bindings[0].members).must_be :frozen?
-    binding = policy.binding "roles/bigquery.dataViewer"
+    binding = policy.binding_for "roles/bigquery.dataViewer"
     _(binding).must_equal policy.bindings[0]
     _(binding).must_be :frozen?
     members = binding.members

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_policy_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_policy_test.rb
@@ -77,9 +77,14 @@ describe Google::Cloud::Bigquery::Table, :policy, :mock_bigquery do
     _(policy).must_be :frozen?
     _(policy.etag).must_equal "CAE="
     _(policy.etag).must_be :frozen?
-    # _(policy.roles).must_be_kind_of Hash
-    # _(policy.roles.size).must_equal 1
+    _(policy.bindings).must_be_kind_of Array
+    _(policy.bindings.size).must_equal 1
+    _(policy.bindings[0]).must_be :frozen?
+    _(policy.bindings[0].role).must_be :frozen?
+    _(policy.bindings[0].members).must_be_kind_of Array
+    _(policy.bindings[0].members).must_be :frozen?
     binding = policy.binding "roles/bigquery.dataViewer"
+    _(binding).must_equal policy.bindings[0]
     _(binding).must_be :frozen?
     _(binding.role).must_be :frozen?
     members = binding.members
@@ -104,10 +109,17 @@ describe Google::Cloud::Bigquery::Table, :policy, :mock_bigquery do
 
     bigquery.service.mocked_service = mock
     policy = table.update_policy do |p|
+      _(p.bindings).must_be_kind_of Array
+      _(p.bindings.size).must_equal 1
+      _(p.bindings[0]).wont_be :frozen?
+      _(p.bindings[0].role).wont_be :frozen?
+      _(p.bindings[0].members).must_be_kind_of Array
+      _(p.bindings[0].members).wont_be :frozen?
       binding = p.binding "roles/bigquery.dataViewer"
       _(binding).wont_be :frozen?
       members = binding.members
       _(members).must_be_kind_of Array
+      _(members.size).must_equal 1
       _(members).wont_be :frozen?
       members << "serviceAccount:1234567890@developer.gserviceaccount.com"
     end
@@ -115,9 +127,15 @@ describe Google::Cloud::Bigquery::Table, :policy, :mock_bigquery do
 
     _(policy).must_be_kind_of Google::Cloud::Bigquery::Policy
     _(policy.etag).must_equal "CAF="
-    # _(policy.roles).must_be_kind_of Hash
-    # _(policy.roles.size).must_equal 1
+    _(policy.bindings).must_be_kind_of Array
+    _(policy.bindings).must_be :frozen?
+    _(policy.bindings.size).must_equal 1
+    _(policy.bindings[0]).must_be :frozen?
+    _(policy.bindings[0].role).must_be :frozen?
+    _(policy.bindings[0].members).must_be_kind_of Array
+    _(policy.bindings[0].members).must_be :frozen?
     binding = policy.binding "roles/bigquery.dataViewer"
+    _(binding).must_equal policy.bindings[0]
     _(binding).must_be :frozen?
     members = binding.members
     _(members).must_be_kind_of Array

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_policy_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_policy_test.rb
@@ -122,6 +122,13 @@ describe Google::Cloud::Bigquery::Table, :policy, :mock_bigquery do
       _(members.size).must_equal 1
       _(members).wont_be :frozen?
       members << "serviceAccount:1234567890@developer.gserviceaccount.com"
+      p.set_binding "roles/bigquery.dataOwner", "user:unwanted@example.com"
+      binding_owner = p.binding_for "roles/bigquery.dataOwner"
+      _(binding_owner).wont_be :nil?
+      _(binding_owner.members).must_equal ["user:unwanted@example.com"]
+      binding_removed = p.remove_binding "roles/bigquery.dataOwner"
+      _(binding_removed).must_equal binding_owner
+      _(p.binding_for("roles/bigquery.dataOwner")).must_be :nil?
     end
     mock.verify
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_policy_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_policy_test.rb
@@ -61,9 +61,6 @@ describe Google::Cloud::Bigquery::Table, :policy, :mock_bigquery do
       ]
     )
   }
-  let(:old_policy) { Google::Cloud::BigqueryV2::Policy.from_gapi old_policy_gapi }
-  let(:updated_policy) { Google::Cloud::BigqueryV2::Policy.from_gapi updated_policy_gapi }
-  let(:new_policy) { Google::Cloud::BigqueryV2::Policy.from_gapi new_policy_gapi }
 
   it "gets the policy" do
     mock = Minitest::Mock.new

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_policy_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_policy_test.rb
@@ -78,20 +78,14 @@ describe Google::Cloud::Bigquery::Table, :policy, :mock_bigquery do
     _(policy.etag).must_equal "CAE="
     _(policy.etag).must_be :frozen?
     _(policy.bindings).must_be_kind_of Array
+    _(policy.bindings).must_be :frozen?
     _(policy.bindings.size).must_equal 1
     _(policy.bindings[0]).must_be :frozen?
     _(policy.bindings[0].role).must_be :frozen?
     _(policy.bindings[0].members).must_be_kind_of Array
     _(policy.bindings[0].members).must_be :frozen?
-    binding = policy.binding_for "roles/bigquery.dataViewer"
-    _(binding).must_equal policy.bindings[0]
-    _(binding).must_be :frozen?
-    _(binding.role).must_be :frozen?
-    members = binding.members
-    _(members).must_be_kind_of Array
-    _(members).must_be :frozen?
-    _(members.count).must_equal 1
-    _(members.first).must_equal "user:viewer@example.com"
+    _(policy.bindings[0].members.size).must_equal 1
+    _(policy.bindings[0].members[0]).must_equal "user:viewer@example.com"
   end
 
   it "raises if a block is provided to #policy" do
@@ -110,6 +104,7 @@ describe Google::Cloud::Bigquery::Table, :policy, :mock_bigquery do
     bigquery.service.mocked_service = mock
     policy = table.update_policy do |p|
       _(p.bindings).must_be_kind_of Array
+      _(p.bindings).wont_be :frozen?
       _(p.bindings.size).must_equal 1
       _(p.bindings[0]).wont_be :frozen?
       _(p.bindings[0].role).wont_be :frozen?
@@ -147,7 +142,7 @@ describe Google::Cloud::Bigquery::Table, :policy, :mock_bigquery do
     members = binding.members
     _(members).must_be_kind_of Array
     _(members).must_be :frozen?
-    _(members.count).must_equal 2
+    _(members.size).must_equal 2
     _(members.first).must_equal "user:viewer@example.com"
     _(members.last).must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_policy_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_policy_test.rb
@@ -118,7 +118,7 @@ describe Google::Cloud::Bigquery::Table, :policy, :mock_bigquery do
       _(members.size).must_equal 1
       _(members).wont_be :frozen?
       members << "serviceAccount:1234567890@developer.gserviceaccount.com"
-      p.set_binding "roles/bigquery.dataOwner", "user:unwanted@example.com"
+      p.grant members: "user:unwanted@example.com", role: "roles/bigquery.dataOwner"
       binding_owner = p.bindings.find { |b| b.role == "roles/bigquery.dataOwner" }
       _(binding_owner).wont_be :nil?
       _(binding_owner.members).must_equal ["user:unwanted@example.com"]

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_policy_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_policy_test.rb
@@ -122,7 +122,7 @@ describe Google::Cloud::Bigquery::Table, :policy, :mock_bigquery do
       binding_owner = p.bindings.find { |b| b.role == "roles/bigquery.dataOwner" }
       _(binding_owner).wont_be :nil?
       _(binding_owner.members).must_equal ["user:unwanted@example.com"]
-      binding_removed = p.remove_binding "roles/bigquery.dataOwner"
+      binding_removed = p.revoke role: "roles/bigquery.dataOwner"
       _(binding_removed).must_equal binding_owner
       _(p.bindings.find { |b| b.role == "roles/bigquery.dataOwner"}).must_be :nil?
     end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_policy_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_policy_test.rb
@@ -115,12 +115,13 @@ describe Google::Cloud::Bigquery::Table, :policy, :mock_bigquery do
       _(members.size).must_equal 1
       _(members).wont_be :frozen?
       members << "serviceAccount:1234567890@developer.gserviceaccount.com"
-      p.grant members: "user:unwanted@example.com", role: "roles/bigquery.dataOwner"
+      p.grant role: "roles/bigquery.dataOwner", members: "user:unwanted@example.com"
+      _(p.bindings.size).must_equal 2
       binding_owner = p.bindings.find { |b| b.role == "roles/bigquery.dataOwner" }
       _(binding_owner).wont_be :nil?
       _(binding_owner.members).must_equal ["user:unwanted@example.com"]
-      binding_removed = p.revoke role: "roles/bigquery.dataOwner"
-      _(binding_removed).must_equal binding_owner
+      p.revoke role: "roles/bigquery.dataOwner"
+      _(p.bindings.size).must_equal 1
       _(p.bindings.find { |b| b.role == "roles/bigquery.dataOwner"}).must_be :nil?
     end
     mock.verify

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_policy_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_policy_test.rb
@@ -1,0 +1,148 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+require "helper"
+
+describe Google::Cloud::Bigquery::Table, :policy, :mock_bigquery do
+  let(:dataset_id) { "my_dataset" }
+  let(:table_id) { "my_table" }
+  let(:table_path) { formatted_table_path dataset_id, table_id }
+  let(:table_hash) { random_table_hash dataset_id, table_id }
+  let(:table_gapi) { Google::Apis::BigqueryV2::Table.from_json table_hash.to_json }
+  let(:table) { Google::Cloud::Bigquery::Table.from_gapi table_gapi, bigquery.service }
+  let(:old_policy_gapi) {
+    policy_gapi(
+      bindings: [
+        Google::Apis::BigqueryV2::Binding.new(
+          role: "roles/bigquery.dataViewer",
+          members: [
+            "user:viewer@example.com"
+          ]
+        )
+      ]
+    )
+  }
+  let(:updated_policy_gapi) {
+    policy_gapi(
+      bindings: [
+        Google::Apis::BigqueryV2::Binding.new(
+          role: "roles/bigquery.dataViewer",
+          members: [
+            "user:viewer@example.com",
+            "serviceAccount:1234567890@developer.gserviceaccount.com"
+          ]
+        )
+      ]
+    )
+  }
+  let(:new_policy_gapi) {
+    policy_gapi(
+      etag: "CAF=",
+      bindings: [
+        Google::Apis::BigqueryV2::Binding.new(
+          role: "roles/bigquery.dataViewer",
+          members: [
+            "user:viewer@example.com",
+            "serviceAccount:1234567890@developer.gserviceaccount.com"
+          ]
+        )
+      ]
+    )
+  }
+  let(:old_policy) { Google::Cloud::BigqueryV2::Policy.from_gapi old_policy_gapi }
+  let(:updated_policy) { Google::Cloud::BigqueryV2::Policy.from_gapi updated_policy_gapi }
+  let(:new_policy) { Google::Cloud::BigqueryV2::Policy.from_gapi new_policy_gapi }
+
+  it "gets the policy" do
+    mock = Minitest::Mock.new
+    mock.expect :get_table_iam_policy, old_policy_gapi, [table_path, get_iam_policy_request_gapi]
+
+    bigquery.service.mocked_service = mock
+    policy = table.policy
+    mock.verify
+
+    _(policy).must_be_kind_of Google::Cloud::Bigquery::Policy
+    _(policy.etag).must_equal "CAE="
+    _(policy.roles).must_be_kind_of Hash
+    _(policy.roles.size).must_equal 1
+    _(policy.roles["roles/bigquery.dataViewer"]).must_be_kind_of Array
+    _(policy.roles["roles/bigquery.dataViewer"].count).must_equal 1
+    _(policy.roles["roles/bigquery.dataViewer"].first).must_equal "user:viewer@example.com"
+  end
+
+  it "raises if a block is provided to #policy" do
+    expect do
+      table.policy do |p|
+        p.add "roles/bigquery.dataViewer", "serviceAccount:1234567890@developer.gserviceaccount.com"
+      end
+    end.must_raise ArgumentError
+  end
+
+  it "updates the policy in a block" do
+    mock = Minitest::Mock.new
+    mock.expect :get_table_iam_policy, old_policy_gapi, [table_path, get_iam_policy_request_gapi]
+    mock.expect :set_table_iam_policy, new_policy_gapi, [table_path, set_iam_policy_request_gapi(updated_policy_gapi)]
+
+    bigquery.service.mocked_service = mock
+    policy = table.update_policy do |p|
+      p.add "roles/bigquery.dataViewer", "serviceAccount:1234567890@developer.gserviceaccount.com"
+    end
+    mock.verify
+
+    _(policy).must_be_kind_of Google::Cloud::Bigquery::Policy
+    _(policy.etag).must_equal "CAF="
+    _(policy.roles).must_be_kind_of Hash
+    _(policy.roles.size).must_equal 1
+    _(policy.roles["roles/bigquery.dataViewer"]).must_be_kind_of Array
+    _(policy.roles["roles/bigquery.dataViewer"].count).must_equal 2
+    _(policy.roles["roles/bigquery.dataViewer"].first).must_equal "user:viewer@example.com"
+    _(policy.roles["roles/bigquery.dataViewer"].last).must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+  end
+
+  it "raises if no block is provided to #update_policy" do
+    expect { table.update_policy }.must_raise ArgumentError
+  end
+
+  it "tests the permissions available" do
+    mock = Minitest::Mock.new
+    mock.expect :test_table_iam_permissions,
+                iam_permissions_response_gapi(["bigquery.tables.get"]),
+                [table_path, iam_permissions_request_gapi(["bigquery.tables.get", "bigquery.tables.delete"])]
+
+    bigquery.service.mocked_service = mock
+    permissions = table.test_iam_permissions "bigquery.tables.get", "bigquery.tables.delete"
+    mock.verify
+
+    _(permissions).must_equal ["bigquery.tables.get"]
+  end
+
+  def get_iam_policy_request_gapi
+    Google::Apis::BigqueryV2::GetIamPolicyRequest.new(
+      options: Google::Apis::BigqueryV2::GetPolicyOptions.new(requested_policy_version: 1)
+    )
+  end
+
+  def set_iam_policy_request_gapi policy_gapi
+    Google::Apis::BigqueryV2::SetIamPolicyRequest.new policy: policy_gapi
+  end
+
+  def iam_permissions_request_gapi permissions
+    Google::Apis::BigqueryV2::TestIamPermissionsRequest.new permissions: permissions
+  end
+
+  def iam_permissions_response_gapi permissions
+    Google::Apis::BigqueryV2::TestIamPermissionsResponse.new permissions: permissions
+  end
+end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_policy_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_policy_test.rb
@@ -74,18 +74,25 @@ describe Google::Cloud::Bigquery::Table, :policy, :mock_bigquery do
     mock.verify
 
     _(policy).must_be_kind_of Google::Cloud::Bigquery::Policy
+    _(policy).must_be :frozen?
     _(policy.etag).must_equal "CAE="
-    _(policy.roles).must_be_kind_of Hash
-    _(policy.roles.size).must_equal 1
-    _(policy.roles["roles/bigquery.dataViewer"]).must_be_kind_of Array
-    _(policy.roles["roles/bigquery.dataViewer"].count).must_equal 1
-    _(policy.roles["roles/bigquery.dataViewer"].first).must_equal "user:viewer@example.com"
+    _(policy.etag).must_be :frozen?
+    # _(policy.roles).must_be_kind_of Hash
+    # _(policy.roles.size).must_equal 1
+    binding = policy.binding "roles/bigquery.dataViewer"
+    _(binding).must_be :frozen?
+    _(binding.role).must_be :frozen?
+    members = binding.members
+    _(members).must_be_kind_of Array
+    _(members).must_be :frozen?
+    _(members.count).must_equal 1
+    _(members.first).must_equal "user:viewer@example.com"
   end
 
   it "raises if a block is provided to #policy" do
     expect do
       table.policy do |p|
-        p.add "roles/bigquery.dataViewer", "serviceAccount:1234567890@developer.gserviceaccount.com"
+        p.binding("roles/bigquery.dataViewer").members << "serviceAccount:1234567890@developer.gserviceaccount.com"
       end
     end.must_raise ArgumentError
   end
@@ -97,18 +104,27 @@ describe Google::Cloud::Bigquery::Table, :policy, :mock_bigquery do
 
     bigquery.service.mocked_service = mock
     policy = table.update_policy do |p|
-      p.add "roles/bigquery.dataViewer", "serviceAccount:1234567890@developer.gserviceaccount.com"
+      binding = p.binding "roles/bigquery.dataViewer"
+      _(binding).wont_be :frozen?
+      members = binding.members
+      _(members).must_be_kind_of Array
+      _(members).wont_be :frozen?
+      members << "serviceAccount:1234567890@developer.gserviceaccount.com"
     end
     mock.verify
 
     _(policy).must_be_kind_of Google::Cloud::Bigquery::Policy
     _(policy.etag).must_equal "CAF="
-    _(policy.roles).must_be_kind_of Hash
-    _(policy.roles.size).must_equal 1
-    _(policy.roles["roles/bigquery.dataViewer"]).must_be_kind_of Array
-    _(policy.roles["roles/bigquery.dataViewer"].count).must_equal 2
-    _(policy.roles["roles/bigquery.dataViewer"].first).must_equal "user:viewer@example.com"
-    _(policy.roles["roles/bigquery.dataViewer"].last).must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
+    # _(policy.roles).must_be_kind_of Hash
+    # _(policy.roles.size).must_equal 1
+    binding = policy.binding "roles/bigquery.dataViewer"
+    _(binding).must_be :frozen?
+    members = binding.members
+    _(members).must_be_kind_of Array
+    _(members).must_be :frozen?
+    _(members.count).must_equal 2
+    _(members.first).must_equal "user:viewer@example.com"
+    _(members.last).must_equal "serviceAccount:1234567890@developer.gserviceaccount.com"
   end
 
   it "raises if no block is provided to #update_policy" do

--- a/google-cloud-bigquery/test/helper.rb
+++ b/google-cloud-bigquery/test/helper.rb
@@ -1010,4 +1010,12 @@ class MockBigquery < Minitest::Spec
   def encryption_gapi key_name
     Google::Apis::BigqueryV2::EncryptionConfiguration.new kms_key_name: key_name
   end
+
+  def policy_gapi etag: "CAE=", version: 1, bindings: []
+    Google::Apis::BigqueryV2::Policy.new etag: etag, version: version, bindings: bindings
+  end
+
+  def formatted_table_path dataset_id, table_id
+    "projects/#{project}/datasets/#{dataset_id}/tables/#{table_id}"
+  end
 end


### PR DESCRIPTION
This PR introduces a new design for IAM Policy management that is intended to support (if necessary) a migration to Policy V3. Most notably in comparison with the previous design (see Bigtable [Instance](https://github.com/googleapis/google-cloud-ruby/blob/master/google-cloud-bigtable/lib/google/cloud/bigtable/instance.rb#L790-L864) and [Policy](https://github.com/googleapis/google-cloud-ruby/blob/master/google-cloud-bigtable/lib/google/cloud/bigtable/policy.rb) for an example), the new design exposes `Policy#bindings` and replaces the `role`-oriented helpers with more flexible `grant` and `revoke` methods.

* Add `Bigquery::Policy`
* Add `Table#policy`

closes: #7944