### PR TITLE
feat: Enable server side flow control by default with the option to turn it off

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb
@@ -307,6 +307,17 @@ module Google
         alias inventory_bytesize max_outstanding_bytes
 
         ##
+        # Whether to enforce flow control at the client side only or to enforce it at both the client and
+        # the server.
+        #
+        # @return [Boolean] `true` when only client side flow control is enforced, `false` when both client and
+        # server side flow control are enforced.
+        #
+        def use_legacy_flow_control
+          @inventory[:use_legacy_flow_control]
+        end
+
+        ##
         # The number of seconds that received messages can be held awaiting processing. Default is 3,600 (1 hour).
         #
         # @return [Integer] The maximum number of seconds.
@@ -334,7 +345,8 @@ module Google
             limit:                            @inventory[:max_outstanding_messages].fdiv(@streams).ceil,
             bytesize:                         @inventory[:max_outstanding_bytes].fdiv(@streams).ceil,
             extension:                        @inventory[:max_total_lease_duration],
-            max_duration_per_lease_extension: @inventory[:max_duration_per_lease_extension]
+            max_duration_per_lease_extension: @inventory[:max_duration_per_lease_extension],
+            use_legacy_flow_control:          @inventory[:use_legacy_flow_control]
           }
         end
 

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb
@@ -308,12 +308,12 @@ module Google
 
         ##
         # Whether to enforce flow control at the client side only or to enforce it at both the client and
-        # the server.
+        # the server. For more details about flow control see https://cloud.google.com/pubsub/docs/pull#config.
         #
         # @return [Boolean] `true` when only client side flow control is enforced, `false` when both client and
         # server side flow control are enforced.
         #
-        def use_legacy_flow_control
+        def use_legacy_flow_control?
           @inventory[:use_legacy_flow_control]
         end
 

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb
@@ -389,6 +389,7 @@ module Google
           @inventory[:max_outstanding_bytes] = Integer(@inventory[:max_outstanding_bytes] || 100_000_000)
           @inventory[:max_total_lease_duration] = Integer(@inventory[:max_total_lease_duration] || 3600)
           @inventory[:max_duration_per_lease_extension] = Integer(@inventory[:max_duration_per_lease_extension] || 0)
+          @inventory[:use_legacy_flow_control] = @inventory[:use_legacy_flow_control] || false
         end
 
         def default_error_callbacks

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/inventory.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/inventory.rb
@@ -30,9 +30,11 @@ module Google
 
           include MonitorMixin
 
-          attr_reader :stream, :limit, :bytesize, :extension, :max_duration_per_lease_extension, :use_legacy_flow_control
+          attr_reader :stream, :limit, :bytesize, :extension, :max_duration_per_lease_extension,
+                      :use_legacy_flow_control
 
-          def initialize stream, limit:, bytesize:, extension:, max_duration_per_lease_extension:, use_legacy_flow_control:
+          def initialize stream, limit:, bytesize:, extension:, max_duration_per_lease_extension:,
+                                 use_legacy_flow_control:
             super()
             @stream = stream
             @limit = limit

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/inventory.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/inventory.rb
@@ -34,7 +34,7 @@ module Google
                       :use_legacy_flow_control
 
           def initialize stream, limit:, bytesize:, extension:, max_duration_per_lease_extension:,
-                                 use_legacy_flow_control:
+                         use_legacy_flow_control:
             super()
             @stream = stream
             @limit = limit

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/inventory.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/inventory.rb
@@ -30,15 +30,16 @@ module Google
 
           include MonitorMixin
 
-          attr_reader :stream, :limit, :bytesize, :extension, :max_duration_per_lease_extension
+          attr_reader :stream, :limit, :bytesize, :extension, :max_duration_per_lease_extension, :use_legacy_flow_control
 
-          def initialize stream, limit:, bytesize:, extension:, max_duration_per_lease_extension:
+          def initialize stream, limit:, bytesize:, extension:, max_duration_per_lease_extension:, use_legacy_flow_control:
             super()
             @stream = stream
             @limit = limit
             @bytesize = bytesize
             @extension = extension
             @max_duration_per_lease_extension = max_duration_per_lease_extension
+            @use_legacy_flow_control = use_legacy_flow_control
             @inventory = {}
             @wait_cond = new_cond
           end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
@@ -363,8 +363,8 @@ module Google
               req.modify_deadline_ack_ids += @inventory.ack_ids
               req.modify_deadline_seconds += @inventory.ack_ids.map { @subscriber.deadline }
               req.client_id = @subscriber.service.client_id
-              req.max_outstanding_messages = @inventory.limit
-              req.max_outstanding_bytes = @inventory.bytesize
+              req.max_outstanding_messages = @inventory.use_legacy_flow_control ? 0 : @inventory.limit
+              req.max_outstanding_bytes = @inventory.use_legacy_flow_control ? 0 : @inventory.bytesize
             end
           end
 

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -870,6 +870,9 @@ module Google
         #       Default is 1,000. (Note: replaces `:limit`, which is deprecated.)
         #     * `:max_outstanding_bytes` [Integer] The total byte size of received messages to be collected by
         #       subscriber. Default is 100,000,000 (100MB). (Note: replaces `:bytesize`, which is deprecated.)
+        #     * `:use_legacy_flow_control` [Boolean] Disables enforcing flow control settings at the Cloud PubSub
+        #       server and the less accurate method of only enforcing flow control at the client side is used instead.
+        #       Default is false.
         #     * `:max_total_lease_duration` [Integer] The number of seconds that received messages can be held awaiting
         #       processing. Default is 3,600 (1 hour). (Note: replaces `:extension`, which is deprecated.)
         #     * `:max_duration_per_lease_extension` [Integer] The maximum amount of time in seconds for a single lease

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/inventory_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/inventory_test.rb
@@ -167,7 +167,7 @@ describe Google::Cloud::PubSub::Subscriber, :inventory, :mock_pubsub do
 
   it "knows its count limit" do
     subscriber_mock = Minitest::Mock.new
-    inventory = Google::Cloud::PubSub::Subscriber::Inventory.new subscriber_mock, limit: 2, bytesize: 100_000, extension: 3600, max_duration_per_lease_extension: 0
+    inventory = Google::Cloud::PubSub::Subscriber::Inventory.new subscriber_mock, limit: 2, bytesize: 100_000, extension: 3600, max_duration_per_lease_extension: 0, use_legacy_flow_control: false
 
     inventory.add rec_msg1_grpc
     _(inventory).wont_be :full?
@@ -179,7 +179,7 @@ describe Google::Cloud::PubSub::Subscriber, :inventory, :mock_pubsub do
 
   it "knows its bytesize limit" do
     subscriber_mock = Minitest::Mock.new
-    inventory = Google::Cloud::PubSub::Subscriber::Inventory.new subscriber_mock, limit: 1000, bytesize: 100, extension: 3600, max_duration_per_lease_extension: 0
+    inventory = Google::Cloud::PubSub::Subscriber::Inventory.new subscriber_mock, limit: 1000, bytesize: 100, extension: 3600, max_duration_per_lease_extension: 0, use_legacy_flow_control: false
 
     inventory.add rec_msg1_grpc
     _(inventory).wont_be :full?
@@ -191,7 +191,7 @@ describe Google::Cloud::PubSub::Subscriber, :inventory, :mock_pubsub do
 
   it "removes expired items" do
     subscriber_mock = Minitest::Mock.new
-    inventory = Google::Cloud::PubSub::Subscriber::Inventory.new subscriber_mock, limit: 1000, bytesize: 100_000, extension: 3600, max_duration_per_lease_extension: 0
+    inventory = Google::Cloud::PubSub::Subscriber::Inventory.new subscriber_mock, limit: 1000, bytesize: 100_000, extension: 3600, max_duration_per_lease_extension: 0, use_legacy_flow_control: false
 
     expired_time = Time.now - 7200
 
@@ -209,7 +209,7 @@ describe Google::Cloud::PubSub::Subscriber, :inventory, :mock_pubsub do
 
   it "knows its max_duration_per_lease_extension limit" do
     subscriber_mock = Minitest::Mock.new
-    inventory = Google::Cloud::PubSub::Subscriber::Inventory.new subscriber_mock, limit: 1000, bytesize: 100, extension: 3600, max_duration_per_lease_extension: 10
+    inventory = Google::Cloud::PubSub::Subscriber::Inventory.new subscriber_mock, limit: 1000, bytesize: 100, extension: 3600, max_duration_per_lease_extension: 10, use_legacy_flow_control: false
 
     _(inventory.max_duration_per_lease_extension).must_equal 10
   end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber_test.rb
@@ -91,7 +91,7 @@ describe Google::Cloud::PubSub::Subscriber, :mock_pubsub do
       }
     )
     _(subscriber.max_outstanding_messages).must_equal 999
-    _(subscriber.use_legacy_flow_control).must_equal true
+    _(subscriber.use_legacy_flow_control?).must_equal true
     _(subscriber.stream_inventory).must_equal({limit: 500, bytesize: 50000000, max_duration_per_lease_extension: 0, extension: 3600, use_legacy_flow_control: true})
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber_test.rb
@@ -54,7 +54,7 @@ describe Google::Cloud::PubSub::Subscriber, :mock_pubsub do
     _(subscriber.inventory_extension).must_equal 3600 # deprecated Use #max_total_lease_duration.
     _(subscriber.max_total_lease_duration).must_equal 3600
     _(subscriber.max_duration_per_lease_extension).must_equal 0
-    _(subscriber.stream_inventory).must_equal({limit: 500, bytesize: 50000000, max_duration_per_lease_extension: 0, extension: 3600})
+    _(subscriber.stream_inventory).must_equal({limit: 500, bytesize: 50000000, max_duration_per_lease_extension: 0, extension: 3600, use_legacy_flow_control: false})
     _(subscriber.callback_threads).must_equal 8
     _(subscriber.push_threads).must_equal 4
   end
@@ -73,11 +73,25 @@ describe Google::Cloud::PubSub::Subscriber, :mock_pubsub do
     _(subscriber.inventory_extension).must_equal 3600 # deprecated Use #max_total_lease_duration.
     _(subscriber.max_total_lease_duration).must_equal 3600
     _(subscriber.max_duration_per_lease_extension).must_equal 0
-    _(subscriber.stream_inventory).must_equal({limit: 250, bytesize: 12500000, max_duration_per_lease_extension: 0, extension: 3600})
+    _(subscriber.stream_inventory).must_equal({limit: 250, bytesize: 12500000, max_duration_per_lease_extension: 0, extension: 3600, use_legacy_flow_control: false})
     _(subscriber.callback_threads).must_equal callback_threads
     _(subscriber.push_threads).must_equal push_threads
 
     _(subscriber.to_s).must_equal "(subscription: subscription-name-goes-here, streams: [(inventory: 0, status: running, thread: not started), (inventory: 0, status: running, thread: not started), (inventory: 0, status: running, thread: not started), (inventory: 0, status: running, thread: not started), (inventory: 0, status: running, thread: not started), (inventory: 0, status: running, thread: not started), (inventory: 0, status: running, thread: not started), (inventory: 0, status: running, thread: not started)])"
     _(subscriber.stream_pool.first.to_s).must_equal "(inventory: 0, status: running, thread: not started)"
+  end
+
+  it "propagates use_legacy_flow_control" do
+    subscriber = Google::Cloud::PubSub::Subscriber.new(
+      subscription_name,
+      callback,
+      inventory: {
+        max_outstanding_messages: 999,
+        use_legacy_flow_control: true
+      }
+    )
+    _(subscriber.max_outstanding_messages).must_equal 999
+    _(subscriber.use_legacy_flow_control).must_equal true
+    _(subscriber.stream_inventory).must_equal({limit: 500, bytesize: 50000000, max_duration_per_lease_extension: 0, extension: 3600, use_legacy_flow_control: true})
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/listen_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/listen_test.rb
@@ -37,6 +37,7 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     _(subscriber.inventory_extension).must_equal 3600
     _(subscriber.max_total_lease_duration).must_equal 3600
     _(subscriber.max_duration_per_lease_extension).must_equal 0
+    _(subscriber.use_legacy_flow_control).must_equal false
   end
 
   it "will set deadline while creating a Subscriber" do
@@ -55,6 +56,7 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     _(subscriber.inventory_extension).must_equal 3600
     _(subscriber.max_total_lease_duration).must_equal 3600
     _(subscriber.max_duration_per_lease_extension).must_equal 0
+    _(subscriber.use_legacy_flow_control).must_equal false
   end
 
   it "will set deadline while creating a Subscriber" do
@@ -73,6 +75,7 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     _(subscriber.inventory_extension).must_equal 3600
     _(subscriber.max_total_lease_duration).must_equal 3600
     _(subscriber.max_duration_per_lease_extension).must_equal 0
+    _(subscriber.use_legacy_flow_control).must_equal false
   end
 
   it "will set inventory (deprecated) while creating a Subscriber" do
@@ -91,6 +94,7 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     _(subscriber.inventory_extension).must_equal 3600
     _(subscriber.max_total_lease_duration).must_equal 3600
     _(subscriber.max_duration_per_lease_extension).must_equal 0
+    _(subscriber.use_legacy_flow_control).must_equal false
   end
 
   it "will set inventory max_outstanding_messages while creating a Subscriber" do
@@ -109,6 +113,7 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     _(subscriber.inventory_extension).must_equal 3600
     _(subscriber.max_total_lease_duration).must_equal 3600
     _(subscriber.max_duration_per_lease_extension).must_equal 0
+    _(subscriber.use_legacy_flow_control).must_equal false
   end
 
   it "will set inventory limit alias while creating a Subscriber" do
@@ -127,6 +132,7 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     _(subscriber.inventory_extension).must_equal 3600
     _(subscriber.max_total_lease_duration).must_equal 3600
     _(subscriber.max_duration_per_lease_extension).must_equal 0
+    _(subscriber.use_legacy_flow_control).must_equal false
   end
 
   it "will set inventory max_outstanding_bytes while creating a Subscriber" do
@@ -145,6 +151,7 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     _(subscriber.inventory_extension).must_equal 3600
     _(subscriber.max_total_lease_duration).must_equal 3600
     _(subscriber.max_duration_per_lease_extension).must_equal 0
+    _(subscriber.use_legacy_flow_control).must_equal false
   end
 
   it "will set inventory bytesize alias while creating a Subscriber" do
@@ -163,6 +170,7 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     _(subscriber.inventory_extension).must_equal 3600
     _(subscriber.max_total_lease_duration).must_equal 3600
     _(subscriber.max_duration_per_lease_extension).must_equal 0
+    _(subscriber.use_legacy_flow_control).must_equal false
   end
 
   it "will set inventory max_total_lease_duration while creating a Subscriber" do
@@ -181,6 +189,7 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     _(subscriber.inventory_extension).must_equal 7200
     _(subscriber.max_total_lease_duration).must_equal 7200
     _(subscriber.max_duration_per_lease_extension).must_equal 0
+    _(subscriber.use_legacy_flow_control).must_equal false
   end
 
   it "will set inventory extension alias while creating a Subscriber" do
@@ -199,6 +208,7 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     _(subscriber.inventory_extension).must_equal 7200
     _(subscriber.max_total_lease_duration).must_equal 7200
     _(subscriber.max_duration_per_lease_extension).must_equal 0
+    _(subscriber.use_legacy_flow_control).must_equal false
   end
 
   it "will set inventory max_duration_per_lease_extension while creating a Subscriber" do
@@ -217,5 +227,25 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     _(subscriber.inventory_extension).must_equal 3600
     _(subscriber.max_total_lease_duration).must_equal 3600
     _(subscriber.max_duration_per_lease_extension).must_equal 10
+    _(subscriber.use_legacy_flow_control).must_equal false
+  end
+
+  it "will set inventory use_legacy_flow_control while creating a Subscriber" do
+    subscriber = subscription.listen inventory: { use_legacy_flow_control: true } do |msg|
+      puts msg.msg_id
+    end
+    _(subscriber).must_be_kind_of Google::Cloud::PubSub::Subscriber
+    _(subscriber.subscription_name).must_equal subscription.name
+    _(subscriber.deadline).must_equal 60
+    _(subscriber.streams).must_equal 2
+    _(subscriber.inventory).must_equal 1000
+    _(subscriber.inventory_limit).must_equal 1000
+    _(subscriber.max_outstanding_messages).must_equal 1000
+    _(subscriber.inventory_bytesize).must_equal 100000000
+    _(subscriber.max_outstanding_bytes).must_equal 100000000
+    _(subscriber.inventory_extension).must_equal 3600
+    _(subscriber.max_total_lease_duration).must_equal 3600
+    _(subscriber.max_duration_per_lease_extension).must_equal 0
+    _(subscriber.use_legacy_flow_control).must_equal true
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/listen_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/listen_test.rb
@@ -37,7 +37,7 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     _(subscriber.inventory_extension).must_equal 3600
     _(subscriber.max_total_lease_duration).must_equal 3600
     _(subscriber.max_duration_per_lease_extension).must_equal 0
-    _(subscriber.use_legacy_flow_control).must_equal false
+    _(subscriber.use_legacy_flow_control?).must_equal false
   end
 
   it "will set deadline while creating a Subscriber" do
@@ -56,7 +56,7 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     _(subscriber.inventory_extension).must_equal 3600
     _(subscriber.max_total_lease_duration).must_equal 3600
     _(subscriber.max_duration_per_lease_extension).must_equal 0
-    _(subscriber.use_legacy_flow_control).must_equal false
+    _(subscriber.use_legacy_flow_control?).must_equal false
   end
 
   it "will set deadline while creating a Subscriber" do
@@ -75,7 +75,7 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     _(subscriber.inventory_extension).must_equal 3600
     _(subscriber.max_total_lease_duration).must_equal 3600
     _(subscriber.max_duration_per_lease_extension).must_equal 0
-    _(subscriber.use_legacy_flow_control).must_equal false
+    _(subscriber.use_legacy_flow_control?).must_equal false
   end
 
   it "will set inventory (deprecated) while creating a Subscriber" do
@@ -94,7 +94,7 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     _(subscriber.inventory_extension).must_equal 3600
     _(subscriber.max_total_lease_duration).must_equal 3600
     _(subscriber.max_duration_per_lease_extension).must_equal 0
-    _(subscriber.use_legacy_flow_control).must_equal false
+    _(subscriber.use_legacy_flow_control?).must_equal false
   end
 
   it "will set inventory max_outstanding_messages while creating a Subscriber" do
@@ -113,7 +113,7 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     _(subscriber.inventory_extension).must_equal 3600
     _(subscriber.max_total_lease_duration).must_equal 3600
     _(subscriber.max_duration_per_lease_extension).must_equal 0
-    _(subscriber.use_legacy_flow_control).must_equal false
+    _(subscriber.use_legacy_flow_control?).must_equal false
   end
 
   it "will set inventory limit alias while creating a Subscriber" do
@@ -132,7 +132,7 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     _(subscriber.inventory_extension).must_equal 3600
     _(subscriber.max_total_lease_duration).must_equal 3600
     _(subscriber.max_duration_per_lease_extension).must_equal 0
-    _(subscriber.use_legacy_flow_control).must_equal false
+    _(subscriber.use_legacy_flow_control?).must_equal false
   end
 
   it "will set inventory max_outstanding_bytes while creating a Subscriber" do
@@ -151,7 +151,7 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     _(subscriber.inventory_extension).must_equal 3600
     _(subscriber.max_total_lease_duration).must_equal 3600
     _(subscriber.max_duration_per_lease_extension).must_equal 0
-    _(subscriber.use_legacy_flow_control).must_equal false
+    _(subscriber.use_legacy_flow_control?).must_equal false
   end
 
   it "will set inventory bytesize alias while creating a Subscriber" do
@@ -170,7 +170,7 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     _(subscriber.inventory_extension).must_equal 3600
     _(subscriber.max_total_lease_duration).must_equal 3600
     _(subscriber.max_duration_per_lease_extension).must_equal 0
-    _(subscriber.use_legacy_flow_control).must_equal false
+    _(subscriber.use_legacy_flow_control?).must_equal false
   end
 
   it "will set inventory max_total_lease_duration while creating a Subscriber" do
@@ -189,7 +189,7 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     _(subscriber.inventory_extension).must_equal 7200
     _(subscriber.max_total_lease_duration).must_equal 7200
     _(subscriber.max_duration_per_lease_extension).must_equal 0
-    _(subscriber.use_legacy_flow_control).must_equal false
+    _(subscriber.use_legacy_flow_control?).must_equal false
   end
 
   it "will set inventory extension alias while creating a Subscriber" do
@@ -208,7 +208,7 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     _(subscriber.inventory_extension).must_equal 7200
     _(subscriber.max_total_lease_duration).must_equal 7200
     _(subscriber.max_duration_per_lease_extension).must_equal 0
-    _(subscriber.use_legacy_flow_control).must_equal false
+    _(subscriber.use_legacy_flow_control?).must_equal false
   end
 
   it "will set inventory max_duration_per_lease_extension while creating a Subscriber" do
@@ -227,10 +227,10 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     _(subscriber.inventory_extension).must_equal 3600
     _(subscriber.max_total_lease_duration).must_equal 3600
     _(subscriber.max_duration_per_lease_extension).must_equal 10
-    _(subscriber.use_legacy_flow_control).must_equal false
+    _(subscriber.use_legacy_flow_control?).must_equal false
   end
 
-  it "will set inventory use_legacy_flow_control while creating a Subscriber" do
+  it "will use inventory use_legacy_flow_control while creating a Subscriber" do
     subscriber = subscription.listen inventory: { use_legacy_flow_control: true } do |msg|
       puts msg.msg_id
     end
@@ -246,6 +246,6 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     _(subscriber.inventory_extension).must_equal 3600
     _(subscriber.max_total_lease_duration).must_equal 3600
     _(subscriber.max_duration_per_lease_extension).must_equal 0
-    _(subscriber.use_legacy_flow_control).must_equal true
+    _(subscriber.use_legacy_flow_control?).must_equal true
   end
 end


### PR DESCRIPTION
This change enables sending flow control settings automatically to the server.
If inventory.max_outstanding_bytes > 0 or inventory.max_outstanding_bytes > 0, flow control will
be enforced at the server side (in addition to the client side).

This behavior is enabled by default and users who would like to opt-out of this feature --in case
they encounter issues with server side flow control-- can pass in
inventory.use_legacy_flow_control=true in the subscription.listen method.