### PR TITLE
Ignore bundler-related directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,8 @@ _site/*
 
 # Ignore stuff left by synth
 __pycache__
+
+# Ignore bundler directory
+*/.bundle/
+*/vendor/bundle
+*/lib/bundler/man/


### PR DESCRIPTION
Now, bundler-releated directory is ignored by git.
Since there are multiple gems in the top directory,
preceding wild character is required.

c.f. https://github.com/github/gitignore/blob/218a941be92679ce67d0484547e3e142b2f5f6f0/Ruby.gitignore#L41-L44

- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-ruby/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea.
- [x] Follow the instructions in [CONTRIBUTING](CONTRIBUTING.md). Most importantly, ensure the tests and linter pass by running `bundle exec rake ci` in the gem subdirectory.
- [x] Update code documentation if necessary.

closes: #8132