### PR TITLE
feat(spanner): add cmek db support

### DIFF
--- a/google-cloud-spanner/lib/google/cloud/spanner/database.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/database.rb
@@ -101,6 +101,14 @@ module Google
           @grpc.state
         end
 
+        # An encryption configuration describing the encryption type and key
+        # resources in Cloud KMS.
+        #
+        # @return [Google::Cloud::Spanner::Admin::Database::V1::EncryptionConfig, nil]
+        def encryption_config
+          @grpc.encryption_config
+        end
+
         ##
         # The database is still being created. Operations on the database may
         # raise with `FAILED_PRECONDITION` in this state.

--- a/google-cloud-spanner/lib/google/cloud/spanner/instance.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/instance.rb
@@ -311,7 +311,8 @@ module Google
         #   following settings can be provided:
         #
         #   * `:kms_key_name` (String) The name of KMS key to use which should
-        #     be the full path, e.g., projects/<your_project>/locations/<your_location>/keyRings/<your_key_ring>/cryptoKeys/<your_key_name>.
+        #     be the full path, e.g., `projects/<project>/locations/<location>\
+        #     /keyRings/<key_ring>/cryptoKeys/<kms_key_name>`
         #
         # @return [Database::Job] The job representing the long-running,
         #   asynchronous processing of a database create operation.

--- a/google-cloud-spanner/lib/google/cloud/spanner/instance.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/instance.rb
@@ -306,6 +306,12 @@ module Google
         #   These statements execute atomically with the creation of the
         #   database: if there is an error in any statement, the database is not
         #   created. Optional.
+        # @param [Hash] encryption_config An encryption configuration describing
+        #   the encryption type and key resources in Cloud KMS. Optional. The
+        #   following settings can be provided:
+        #
+        #   * `:kms_key_name` (String) The name of KMS key to use which should
+        #     be the full path, e.g., projects/<your_project>/locations/<your_location>/keyRings/<your_key_ring>/cryptoKeys/<your_key_name>.
         #
         # @return [Database::Job] The job representing the long-running,
         #   asynchronous processing of a database create operation.
@@ -328,9 +334,10 @@ module Google
         #     database = job.database
         #   end
         #
-        def create_database database_id, statements: []
+        def create_database database_id, statements: [], encryption_config: nil
           grpc = service.create_database instance_id, database_id,
-                                         statements: statements
+                                         statements: statements,
+                                         encryption_config: encryption_config
           Database::Job.from_grpc grpc, service
         end
 

--- a/google-cloud-spanner/lib/google/cloud/spanner/project.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/project.rb
@@ -410,7 +410,7 @@ module Google
         #   end
         #
         def create_database instance_id, database_id, statements: [],
-                                                      encryption_config: nil
+                            encryption_config: nil
           grpc = service.create_database instance_id, database_id,
                                          statements: statements,
                                          encryption_config: encryption_config

--- a/google-cloud-spanner/lib/google/cloud/spanner/project.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/project.rb
@@ -385,7 +385,8 @@ module Google
         #   following settings can be provided:
         #
         #   * `:kms_key_name` (String) The name of KMS key to use which should
-        #     be the full path, e.g., projects/<your_project>/locations/<your_location>/keyRings/<your_key_ring>/cryptoKeys/<your_key_name>.
+        #     be the full path, e.g., `projects/<project>/locations/<location>\
+        #     /keyRings/<key_ring>/cryptoKeys/<kms_key_name>`
         #
         # @return [Database::Job] The job representing the long-running,
         #   asynchronous processing of a database create operation.

--- a/google-cloud-spanner/lib/google/cloud/spanner/project.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/project.rb
@@ -380,6 +380,12 @@ module Google
         #   These statements execute atomically with the creation of the
         #   database: if there is an error in any statement, the database is not
         #   created. Optional.
+        # @param [Hash] encryption_config An encryption configuration describing
+        #   the encryption type and key resources in Cloud KMS. Optional. The
+        #   following settings can be provided:
+        #
+        #   * `:kms_key_name` (String) The name of KMS key to use which should
+        #     be the full path, e.g., projects/<your_project>/locations/<your_location>/keyRings/<your_key_ring>/cryptoKeys/<your_key_name>.
         #
         # @return [Database::Job] The job representing the long-running,
         #   asynchronous processing of a database create operation.
@@ -402,9 +408,11 @@ module Google
         #     database = job.database
         #   end
         #
-        def create_database instance_id, database_id, statements: []
+        def create_database instance_id, database_id, statements: [],
+                                                      encryption_config: nil
           grpc = service.create_database instance_id, database_id,
-                                         statements: statements
+                                         statements: statements,
+                                         encryption_config: encryption_config
           Database::Job.from_grpc grpc, service
         end
 

--- a/google-cloud-spanner/lib/google/cloud/spanner/service.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/service.rb
@@ -210,12 +210,13 @@ module Google
         end
 
         def create_database instance_id, database_id, statements: [],
-                            call_options: nil
+                            call_options: nil, encryption_config: nil
           opts = default_options call_options: call_options
           request = {
             parent: instance_path(instance_id),
             create_statement: "CREATE DATABASE `#{database_id}`",
-            extra_statements: Array(statements)
+            extra_statements: Array(statements),
+            encryption_config: encryption_config
           }
           databases.create_database request, opts
         end

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/create_database_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/create_database_test.rb
@@ -66,7 +66,7 @@ describe Google::Cloud::Spanner::Instance, :create_database, :mock_spanner do
         result_type: Google::Cloud::Spanner::Admin::Database::V1::Database,
         metadata_type: Google::Cloud::Spanner::Admin::Database::V1::CreateDatabaseMetadata
       )
-    mock.expect :create_database, create_res, [{ parent: instance_path(instance_id), create_statement: "CREATE DATABASE `#{database_id}`", extra_statements: [] }, nil]
+    mock.expect :create_database, create_res, [{ parent: instance_path(instance_id), create_statement: "CREATE DATABASE `#{database_id}`", extra_statements: [], encryption_config: nil }, nil]
     mock.expect :get_operation, operation_done, [{ name: "1234567890" }, Gapic::CallOptions]
     instance.service.mocked_databases = mock
 
@@ -98,13 +98,37 @@ describe Google::Cloud::Spanner::Instance, :create_database, :mock_spanner do
         metadata_type: Google::Cloud::Spanner::Admin::Database::V1::CreateDatabaseMetadata
       )
     mock = Minitest::Mock.new
-    mock.expect :create_database, create_res, [{ parent: instance_path(instance_id), create_statement: "CREATE DATABASE `#{database_id}`", extra_statements: ["CREATE TABLE table1;", "CREATE TABLE table2;"] }, nil]
+    mock.expect :create_database, create_res, [{ parent: instance_path(instance_id), create_statement: "CREATE DATABASE `#{database_id}`", extra_statements: ["CREATE TABLE table1;", "CREATE TABLE table2;"], encryption_config: nil }, nil]
     instance.service.mocked_databases = mock
 
     job = instance.create_database database_id, statements: [
       "CREATE TABLE table1;",
       "CREATE TABLE table2;"
     ]
+
+    mock.verify
+
+    _(job).must_be_kind_of Google::Cloud::Spanner::Database::Job
+    _(job).wont_be :done?
+  end
+
+  it "creates a database with cmek config" do
+    instance_id = "my-instance-id"
+    database_id = "new-database"
+
+    kms_key_name = "projects/<your_project>/locations/<your_location>/keyRings/<your_key_ring>/cryptoKeys/<your_key_name>"
+
+    create_res = \
+      Gapic::Operation.new(
+        job_grpc, Object.new,
+        result_type: Google::Cloud::Spanner::Admin::Database::V1::Database,
+        metadata_type: Google::Cloud::Spanner::Admin::Database::V1::CreateDatabaseMetadata
+      )
+    mock = Minitest::Mock.new
+    mock.expect :create_database, create_res, [{ parent: instance_path(instance_id), create_statement: "CREATE DATABASE `#{database_id}`", extra_statements: [], encryption_config: { kms_key_name: kms_key_name } }, nil]
+    instance.service.mocked_databases = mock
+
+    job = instance.create_database database_id, encryption_config: { kms_key_name: kms_key_name }
 
     mock.verify
 

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/create_database_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/create_database_test.rb
@@ -116,7 +116,7 @@ describe Google::Cloud::Spanner::Instance, :create_database, :mock_spanner do
     instance_id = "my-instance-id"
     database_id = "new-database"
 
-    kms_key_name = "projects/<your_project>/locations/<your_location>/keyRings/<your_key_ring>/cryptoKeys/<your_key_name>"
+    kms_key_name = "projects/<project>/locations/<location>/keyRings/<key_ring>/cryptoKeys/<kms_key_name>"
 
     create_res = \
       Gapic::Operation.new(

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/database_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/database_test.rb
@@ -22,7 +22,11 @@ describe Google::Cloud::Spanner::Instance, :database, :mock_spanner do
   it "gets an database" do
     database_id = "found-database"
 
-    get_res = Google::Cloud::Spanner::Admin::Database::V1::Database.new database_hash(instance_id: instance_id, database_id: database_id)
+    kms_key_name = "projects/<project>/locations/<location>/keyRings/<key_ring>/cryptoKeys/<kms_key_name>"
+    encryption_config = Google::Cloud::Spanner::Admin::Database::V1::EncryptionConfig.new kms_key_name: kms_key_name
+
+    get_res = Google::Cloud::Spanner::Admin::Database::V1::Database.new database_hash(instance_id: instance_id, database_id: database_id, encryption_config: encryption_config)
+    puts get_res
     mock = Minitest::Mock.new
     mock.expect :get_database, get_res, [{ name: database_path(instance_id, database_id) }, nil]
     instance.service.mocked_databases = mock
@@ -34,6 +38,7 @@ describe Google::Cloud::Spanner::Instance, :database, :mock_spanner do
     _(database.project_id).must_equal project
     _(database.instance_id).must_equal instance_id
     _(database.database_id).must_equal database_id
+    _(database.encryption_config).must_equal encryption_config
 
     _(database.path).must_equal database_path(instance_id, database_id)
 

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/database_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/database_test.rb
@@ -26,7 +26,6 @@ describe Google::Cloud::Spanner::Instance, :database, :mock_spanner do
     encryption_config = Google::Cloud::Spanner::Admin::Database::V1::EncryptionConfig.new kms_key_name: kms_key_name
 
     get_res = Google::Cloud::Spanner::Admin::Database::V1::Database.new database_hash(instance_id: instance_id, database_id: database_id, encryption_config: encryption_config)
-    puts get_res
     mock = Minitest::Mock.new
     mock.expect :get_database, get_res, [{ name: database_path(instance_id, database_id) }, nil]
     instance.service.mocked_databases = mock

--- a/google-cloud-spanner/test/google/cloud/spanner/project/create_database_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project/create_database_test.rb
@@ -78,7 +78,7 @@ describe Google::Cloud::Spanner::Project, :create_database, :mock_spanner do
     instance_id = "my-instance-id"
     database_id = "new-database"
 
-    kms_key_name = "projects/<your_project>/locations/<your_location>/keyRings/<your_key_ring>/cryptoKeys/<your_key_name>"
+    kms_key_name = "projects/<project>/locations/<location>/keyRings/<key_ring>/cryptoKeys/<kms_key_name>"
 
     create_res = \
       Gapic::Operation.new(

--- a/google-cloud-spanner/test/google/cloud/spanner/project/database_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project/database_test.rb
@@ -20,7 +20,10 @@ describe Google::Cloud::Spanner::Project, :database, :mock_spanner do
   it "gets an database" do
     database_id = "found-database"
 
-    get_res = Google::Cloud::Spanner::Admin::Database::V1::Database.new database_hash(instance_id: instance_id, database_id: database_id)
+    kms_key_name = "projects/<project>/locations/<location>/keyRings/<key_ring>/cryptoKeys/<kms_key_name>"
+    encryption_config = Google::Cloud::Spanner::Admin::Database::V1::EncryptionConfig.new kms_key_name: kms_key_name
+
+    get_res = Google::Cloud::Spanner::Admin::Database::V1::Database.new database_hash(instance_id: instance_id, database_id: database_id, encryption_config: encryption_config)
     mock = Minitest::Mock.new
     mock.expect :get_database, get_res, [{ name: database_path(instance_id, database_id) }, nil]
     spanner.service.mocked_databases = mock
@@ -32,6 +35,7 @@ describe Google::Cloud::Spanner::Project, :database, :mock_spanner do
     _(database.project_id).must_equal project
     _(database.instance_id).must_equal instance_id
     _(database.database_id).must_equal database_id
+    _(database.encryption_config).must_equal encryption_config
 
     _(database.path).must_equal database_path(instance_id, database_id)
 

--- a/google-cloud-spanner/test/helper.rb
+++ b/google-cloud-spanner/test/helper.rb
@@ -91,11 +91,12 @@ class MockSpanner < Minitest::Spec
   end
 
   def database_hash instance_id: "my-instance-id", database_id: "database-#{rand(9999)}",
-                    state: "READY", restore_info: {}
+                    state: "READY", restore_info: {}, encryption_config: {}
     {
       name: "projects/#{project}/instances/#{instance_id}/databases/#{database_id}",
       state: state,
-      restore_info: restore_info
+      restore_info: restore_info,
+      encryption_config: encryption_config
     }
   end
 


### PR DESCRIPTION
This PR only includes the db support (for `create_database` and `get_database`) and I will create another PR for backup support. This way (smaller PR) would be easier for code review. 