### PR TITLE
docs(pubsub): Remove EXPERIMENTAL label from RetryPolicy docs

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/retry_policy.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/retry_policy.rb
@@ -31,9 +31,6 @@ module Google
       # Retry Policy is implemented on a best effort basis. At times, the delay between consecutive deliveries may not
       # match the configuration. That is, delay can be more or less than configured backoff.
       #
-      # **EXPERIMENTAL:** This API might be changed in backward-incompatible ways and is not recommended for production
-      # use. It is not subject to any SLA or deprecation policy.
-      #
       # @attr [Numeric] minimum_backoff The minimum delay between consecutive deliveries of a given message. Value
       #   should be between 0 and 600 seconds. The default value is 10 seconds.
       # @attr [Numeric] maximum_backoff The maximum delay between consecutive deliveries of a given message. Value

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -547,9 +547,6 @@ module Google
         # for healthy subscribers. Retry Policy will be triggered on NACKs or acknowledgement deadline exceeded events
         # for a given message.
         #
-        # **EXPERIMENTAL:** This API might be changed in backward-incompatible ways and is not recommended for
-        # production use. It is not subject to any SLA or deprecation policy.
-        #
         # @return [RetryPolicy, nil] The retry policy for the subscription, or `nil`.
         #
         # @example
@@ -575,9 +572,6 @@ module Google
         # default retry policy is applied. This generally implies that messages will be retried as soon as possible
         # for healthy subscribers. Retry Policy will be triggered on NACKs or acknowledgement deadline exceeded events
         # for a given message.
-        #
-        # **EXPERIMENTAL:** This API might be changed in backward-incompatible ways and is not recommended for
-        # production use. It is not subject to any SLA or deprecation policy.
         #
         # @param [RetryPolicy, nil] new_retry_policy A new retry policy for the subscription, or `nil`.
         #

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
@@ -309,9 +309,6 @@ module Google
         #   will be retried as soon as possible for healthy subscribers. Retry Policy will be triggered on NACKs or
         #   acknowledgement deadline exceeded events for a given message.
         #
-        #   **EXPERIMENTAL:** This API might be changed in backward-incompatible ways and is not recommended for
-        #   production use. It is not subject to any SLA or deprecation policy.
-        #
         # @return [Google::Cloud::PubSub::Subscription]
         #
         # @example


### PR DESCRIPTION
closes: #6303