### PR TITLE
feat(spanner): support request tagging

### DIFF
--- a/google-cloud-spanner/acceptance/spanner/client/crud_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/crud_test.rb
@@ -159,7 +159,7 @@ describe "Spanner Client", :crud, :spanner do
     _(results.timestamp).wont_be :nil?
   end
 
-   describe "request options" do
+  describe "request options" do
     it "execute CRUD statement with priority options" do
       request_options = { priority: :PRIORITY_MEDIUM }
       results = db.read "accounts", ["account_id"], request_options: request_options
@@ -177,5 +177,27 @@ describe "Spanner Client", :crud, :spanner do
       results = db.read "accounts", ["account_id"]
       _(results.rows.count).must_equal 0
     end
+  end
+
+  it "inserts, updates, upserts, reads, and deletes records with request tagging options" do
+    timestamp = db.insert "accounts", default_account_rows[0],
+                          request_options: { tag: "Tag-CRUD-1" }
+    _(timestamp).wont_be :nil?
+
+    results = db.read "accounts", ["account_id"], single_use: { timestamp: @setup_timestamp },
+                      request_options: { tag: "Tag-CRUD-2" }
+    _(results.timestamp).wont_be :nil?
+
+    timestamp = db.update "accounts", default_account_rows[0],
+                          request_options: { tag: "Tag-CRUD-2" }
+    _(timestamp).wont_be :nil?
+
+    timestamp = db.upsert "accounts", default_account_rows[1],
+                          request_options: { tag: "Tag-CRUD-4" }
+    _(timestamp).wont_be :nil?
+
+    timestamp = db.delete "accounts", [1, 2, 3],
+                          request_options: { tag: "Tag-CRUD-5" }
+    _(timestamp).wont_be :nil?
   end
 end

--- a/google-cloud-spanner/acceptance/spanner/client/pdml_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/pdml_test.rb
@@ -60,4 +60,10 @@ describe "Spanner Client", :pdml, :spanner do
       _(pdml_row_count).must_equal 1
     end
   end
+
+  it "executes a Partitioned DML statement with request tagging option" do
+    pdml_row_count = db.execute_partition_update "UPDATE accounts a SET a.active = TRUE WHERE a.active = FALSE",
+                                                 request_options: { tag: "Tag-P-1" }
+    _(pdml_row_count).must_equal 1
+  end
 end

--- a/google-cloud-spanner/acceptance/spanner/client/read_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/client/read_test.rb
@@ -121,4 +121,9 @@ describe "Spanner Client", :read, :spanner do
     _(db.read(table_name, [:id, :bool], index: table_index, keys: [true]..[true, 11], limit: 2).rows.map(&:to_h)).must_equal [{ id: 3, bool: true }, { id: 5, bool: true }]
     _(db.read(table_name, [:id, :bool], index: table_index, keys: [true]...[true, 11], limit: 2).rows.map(&:to_h)).must_equal [{ id: 3, bool: true }, { id: 5, bool: true }]
   end
+
+  it "reads with request tag option" do
+    request_options = { tag: "Tag-R-1" }
+    _(db.read(table_name, [:id], request_options: request_options).rows.map(&:to_h)).must_equal [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }, { id: 6 }, { id: 7 }, { id: 8 }, { id: 9 }, { id: 10 }, { id: 11 }, { id: 12 }]
+  end
 end

--- a/google-cloud-spanner/lib/google/cloud/spanner/convert.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/convert.rb
@@ -324,6 +324,25 @@ module Google
 
             [input_params, input_param_types]
           end
+
+          ##
+          # Build request options by replacing tag to respecitve statistics
+          # collection tag type.
+          #
+          # @param [Hash] options Common request options.
+          #   * `:tag` (String) A tag used for statistics collection.
+          #
+          # @param [Symbol] tag_type Request tag type.
+          #   Possible values are `request_tag`, `transaction_tag`
+          # @return [Hash, nil]
+          #
+          def to_request_options options, tag_type: nil
+            return unless options
+
+            return options unless options.key? :tag
+
+            options.transform_keys { |k| k == :tag ? tag_type : k }
+          end
         end
 
         # rubocop:enable all

--- a/google-cloud-spanner/lib/google/cloud/spanner/service.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/service.rb
@@ -441,13 +441,18 @@ module Google
           service.rollback request, opts
         end
 
-        def begin_transaction session_name, call_options: nil
+        def begin_transaction session_name, request_options: nil,
+                              call_options: nil
           tx_opts = V1::TransactionOptions.new(
             read_write: V1::TransactionOptions::ReadWrite.new
           )
           opts = default_options session_name: session_name,
                                  call_options: call_options
-          request = { session: session_name, options: tx_opts }
+          request = {
+            session: session_name,
+            options: tx_opts,
+            request_options: request_options
+          }
           service.begin_transaction request, opts
         end
 

--- a/google-cloud-spanner/lib/google/cloud/spanner/session.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/session.rb
@@ -167,6 +167,23 @@ module Google
         #     available optimizer version.
         #   * `:optimizer_statistics_package` (String) Statistics package to
         #     use. Empty to use the database default.
+        # @param [Hash] request_options Common request options.
+        #
+        #   * `:request_tag` (String) A per-request tag which can be applied
+        #     to queries or reads, used for statistics collection. Both
+        #     request_tag and transaction_tag can be specified for a read or
+        #     query that belongs to a transaction. This field is ignored for
+        #     requests where it's not applicable (e.g. CommitRequest).
+        #     `request_tag` must be a valid identifier of the form:
+        #     `[a-zA-Z][a-zA-Z0-9_\-]` between 2 and 64 characters in length.
+        #   * `:transaction_tag` (String) A tag used for statistics collection
+        #     about this transaction. Both request_tag and transaction_tag can
+        #     be specified for a read or query that belongs to a transaction.
+        #     The value of transaction_tag should be the same for all requests
+        #     belonging to the same transaction. If this request doesn't belong
+        #     to any transaction, transaction_tag will be ignored.
+        #     `transaction_tag` must be a valid identifier of the format:
+        #     [a-zA-Z][a-zA-Z0-9_\-]{0,49}
         # @param [Hash] call_options A hash of values to specify the custom
         #   call options, e.g., timeout, retries, etc. Call options are
         #   optional. The following settings can be provided:
@@ -349,6 +366,23 @@ module Google
         #   transactions.
         # @param [Integer] seqno A per-transaction sequence number used to
         #   identify this request.
+        # @param [Hash] request_options Common request options.
+        #
+        #   * `:request_tag` (String) A per-request tag which can be applied
+        #     to queries or reads, used for statistics collection. Both
+        #     request_tag and transaction_tag can be specified for a read or
+        #     query that belongs to a transaction. This field is ignored for
+        #     requests where it's not applicable (e.g. CommitRequest).
+        #     `request_tag` must be a valid identifier of the form:
+        #     `[a-zA-Z][a-zA-Z0-9_\-]` between 2 and 64 characters in length.
+        #   * `:transaction_tag` (String) A tag used for statistics collection
+        #     about this transaction. Both request_tag and transaction_tag can
+        #     be specified for a read or query that belongs to a transaction.
+        #     The value of transaction_tag should be the same for all requests
+        #     belonging to the same transaction. If this request doesn't belong
+        #     to any transaction, transaction_tag will be ignored.
+        #     `transaction_tag` must be a valid identifier of the format:
+        #     [a-zA-Z][a-zA-Z0-9_\-]{0,49}
         # @param [Hash] call_options A hash of values to specify the custom
         #   call options, e.g., timeout, retries, etc. Call options are
         #   optional. The following settings can be provided:
@@ -413,6 +447,23 @@ module Google
         # @param [Google::Cloud::Spanner::V1::TransactionSelector] transaction The
         #   transaction selector value to send. Only used for single-use
         #   transactions.
+        # @param [Hash] request_options Common request options.
+        #
+        #   * `:request_tag` (String) A per-request tag which can be applied
+        #     to queries or reads, used for statistics collection. Both
+        #     request_tag and transaction_tag can be specified for a read or
+        #     query that belongs to a transaction. This field is ignored for
+        #     requests where it's not applicable (e.g. CommitRequest).
+        #     `request_tag` must be a valid identifier of the form:
+        #     `[a-zA-Z][a-zA-Z0-9_\-]` between 2 and 64 characters in length.
+        #   * `:transaction_tag` (String) A tag used for statistics collection
+        #     about this transaction. Both request_tag and transaction_tag can
+        #     be specified for a read or query that belongs to a transaction.
+        #     The value of transaction_tag should be the same for all requests
+        #     belonging to the same transaction. If this request doesn't belong
+        #     to any transaction, transaction_tag will be ignored.
+        #     `transaction_tag` must be a valid identifier of the format:
+        #     [a-zA-Z][a-zA-Z0-9_\-]{0,49}
         # @param [Hash] call_options A hash of values to specify the custom
         #   call options, e.g., timeout, retries, etc. Call options are
         #   optional. The following settings can be provided:
@@ -506,6 +557,23 @@ module Google
         #     {CommitResponse}. Default value is `false`
         #
         # transaction. Default it is `false`.
+        # @param [Hash] request_options Common request options.
+        #
+        #   * `:request_tag` (String) A per-request tag which can be applied
+        #     to queries or reads, used for statistics collection. Both
+        #     request_tag and transaction_tag can be specified for a read or
+        #     query that belongs to a transaction. This field is ignored for
+        #     requests where it's not applicable (e.g. CommitRequest).
+        #     `request_tag` must be a valid identifier of the form:
+        #     `[a-zA-Z][a-zA-Z0-9_\-]` between 2 and 64 characters in length.
+        #   * `:transaction_tag` (String) A tag used for statistics collection
+        #     about this transaction. Both request_tag and transaction_tag can
+        #     be specified for a read or query that belongs to a transaction.
+        #     The value of transaction_tag should be the same for all requests
+        #     belonging to the same transaction. If this request doesn't belong
+        #     to any transaction, transaction_tag will be ignored.
+        #     `transaction_tag` must be a valid identifier of the format:
+        #     [a-zA-Z][a-zA-Z0-9_\-]{0,49}
         # @param [Hash] call_options A hash of values to specify the custom
         #   call options, e.g., timeout, retries, etc. Call options are
         #   optional. The following settings can be provided:
@@ -605,6 +673,23 @@ module Google
         #     then statistics related to the transaction will be included in
         #     {CommitResponse}. Default value is `false`
         #
+        # @param [Hash] request_options Common request options.
+        #
+        #   * `:request_tag` (String) A per-request tag which can be applied
+        #     to queries or reads, used for statistics collection. Both
+        #     request_tag and transaction_tag can be specified for a read or
+        #     query that belongs to a transaction. This field is ignored for
+        #     requests where it's not applicable (e.g. CommitRequest).
+        #     `request_tag` must be a valid identifier of the form:
+        #     `[a-zA-Z][a-zA-Z0-9_\-]` between 2 and 64 characters in length.
+        #   * `:transaction_tag` (String) A tag used for statistics collection
+        #     about this transaction. Both request_tag and transaction_tag can
+        #     be specified for a read or query that belongs to a transaction.
+        #     The value of transaction_tag should be the same for all requests
+        #     belonging to the same transaction. If this request doesn't belong
+        #     to any transaction, transaction_tag will be ignored.
+        #     `transaction_tag` must be a valid identifier of the format:
+        #     [a-zA-Z][a-zA-Z0-9_\-]{0,49}
         # @param [Hash] call_options A hash of values to specify the custom
         #   call options, e.g., timeout, retries, etc. Call options are
         #   optional. The following settings can be provided:
@@ -696,6 +781,23 @@ module Google
         #     then statistics related to the transaction will be included in
         #     {CommitResponse}. Default value is `false`
         #
+        # @param [Hash] request_options Common request options.
+        #
+        #   * `:request_tag` (String) A per-request tag which can be applied
+        #     to queries or reads, used for statistics collection. Both
+        #     request_tag and transaction_tag can be specified for a read or
+        #     query that belongs to a transaction. This field is ignored for
+        #     requests where it's not applicable (e.g. CommitRequest).
+        #     `request_tag` must be a valid identifier of the form:
+        #     `[a-zA-Z][a-zA-Z0-9_\-]` between 2 and 64 characters in length.
+        #   * `:transaction_tag` (String) A tag used for statistics collection
+        #     about this transaction. Both request_tag and transaction_tag can
+        #     be specified for a read or query that belongs to a transaction.
+        #     The value of transaction_tag should be the same for all requests
+        #     belonging to the same transaction. If this request doesn't belong
+        #     to any transaction, transaction_tag will be ignored.
+        #     `transaction_tag` must be a valid identifier of the format:
+        #     [a-zA-Z][a-zA-Z0-9_\-]{0,49}
         # @param [Hash] call_options A hash of values to specify the custom
         #   call options, e.g., timeout, retries, etc. Call options are
         #   optional. The following settings can be provided:
@@ -786,6 +888,23 @@ module Google
         #     then statistics related to the transaction will be included in
         #     {CommitResponse}. Default value is `false`
         #
+        # @param [Hash] request_options Common request options.
+        #
+        #   * `:request_tag` (String) A per-request tag which can be applied
+        #     to queries or reads, used for statistics collection. Both
+        #     request_tag and transaction_tag can be specified for a read or
+        #     query that belongs to a transaction. This field is ignored for
+        #     requests where it's not applicable (e.g. CommitRequest).
+        #     `request_tag` must be a valid identifier of the form:
+        #     `[a-zA-Z][a-zA-Z0-9_\-]` between 2 and 64 characters in length.
+        #   * `:transaction_tag` (String) A tag used for statistics collection
+        #     about this transaction. Both request_tag and transaction_tag can
+        #     be specified for a read or query that belongs to a transaction.
+        #     The value of transaction_tag should be the same for all requests
+        #     belonging to the same transaction. If this request doesn't belong
+        #     to any transaction, transaction_tag will be ignored.
+        #     `transaction_tag` must be a valid identifier of the format:
+        #     [a-zA-Z][a-zA-Z0-9_\-]{0,49}
         # @param [Hash] call_options A hash of values to specify the custom
         #   call options, e.g., timeout, retries, etc. Call options are
         #   optional. The following settings can be provided:
@@ -878,6 +997,23 @@ module Google
         #     then statistics related to the transaction will be included in
         #     {CommitResponse}. Default value is `false`.
         #
+        # @param [Hash] request_options Common request options.
+        #
+        #   * `:request_tag` (String) A per-request tag which can be applied
+        #     to queries or reads, used for statistics collection. Both
+        #     request_tag and transaction_tag can be specified for a read or
+        #     query that belongs to a transaction. This field is ignored for
+        #     requests where it's not applicable (e.g. CommitRequest).
+        #     `request_tag` must be a valid identifier of the form:
+        #     `[a-zA-Z][a-zA-Z0-9_\-]` between 2 and 64 characters in length.
+        #   * `:transaction_tag` (String) A tag used for statistics collection
+        #     about this transaction. Both request_tag and transaction_tag can
+        #     be specified for a read or query that belongs to a transaction.
+        #     The value of transaction_tag should be the same for all requests
+        #     belonging to the same transaction. If this request doesn't belong
+        #     to any transaction, transaction_tag will be ignored.
+        #     `transaction_tag` must be a valid identifier of the format:
+        #     [a-zA-Z][a-zA-Z0-9_\-]{0,49}
         # @param [Hash] call_options A hash of values to specify the custom
         #   call options, e.g., timeout, retries, etc. Call options are
         #   optional. The following settings can be provided:
@@ -950,6 +1086,23 @@ module Google
         #     then statistics related to the transaction will be included in
         #     {CommitResponse}. Default value is `false`
         #
+        # @param [Hash] request_options Common request options.
+        #
+        #   * `:request_tag` (String) A per-request tag which can be applied
+        #     to queries or reads, used for statistics collection. Both
+        #     request_tag and transaction_tag can be specified for a read or
+        #     query that belongs to a transaction. This field is ignored for
+        #     requests where it's not applicable (e.g. CommitRequest).
+        #     `request_tag` must be a valid identifier of the form:
+        #     `[a-zA-Z][a-zA-Z0-9_\-]` between 2 and 64 characters in length.
+        #   * `:transaction_tag` (String) A tag used for statistics collection
+        #     about this transaction. Both request_tag and transaction_tag can
+        #     be specified for a read or query that belongs to a transaction.
+        #     The value of transaction_tag should be the same for all requests
+        #     belonging to the same transaction. If this request doesn't belong
+        #     to any transaction, transaction_tag will be ignored.
+        #     `transaction_tag` must be a valid identifier of the format:
+        #     [a-zA-Z][a-zA-Z0-9_\-]{0,49}
         # @param [Hash] call_options A hash of values to specify the custom
         #   call options, e.g., timeout, retries, etc. Call options are
         #   optional. The following settings can be provided:

--- a/google-cloud-spanner/test/google/cloud/spanner/client/commit_transaction_tag_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/commit_transaction_tag_test.rb
@@ -1,0 +1,166 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
+  let(:instance_id) { "my-instance-id" }
+  let(:database_id) { "my-database-id" }
+  let(:session_id) { "session123" }
+  let(:session_grpc) { Google::Cloud::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id) }
+  let(:commit_time) { Time.now }
+  let(:commit_timestamp) { Google::Cloud::Spanner::Convert.time_to_timestamp commit_time }
+  let(:commit_resp) { Google::Cloud::Spanner::V1::CommitResponse.new commit_timestamp: commit_timestamp }
+  let(:tx_opts) { Google::Cloud::Spanner::V1::TransactionOptions.new(read_write: Google::Cloud::Spanner::V1::TransactionOptions::ReadWrite.new) }
+  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:client) { spanner.client instance_id, database_id, pool: { min: 0 } }
+
+  it "commits using a block" do
+    mutations = [
+      Google::Cloud::Spanner::V1::Mutation.new(
+        insert: Google::Cloud::Spanner::V1::Mutation::Write.new(
+          table: "users", columns: %w(id name active),
+          values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([1, "Charlie", false]).list_value]
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [{database: database_path(instance_id, database_id), session: nil}, default_options]
+    mock.expect :commit, commit_resp, [{
+      session: session_grpc.name, mutations: mutations, transaction_id: nil,
+      single_use_transaction: tx_opts, request_options: { transaction_tag: "Tag-1"}
+    }, default_options]
+    spanner.service.mocked_service = mock
+
+    timestamp = client.commit request_options: { tag: "Tag-1"} do |c|
+      c.insert "users", [{ id: 1, name: "Charlie", active: false }]
+    end
+    _(timestamp).must_equal commit_time
+
+    shutdown_client! client
+
+    mock.verify
+  end
+
+  it "updates" do
+    mutations = [
+      Google::Cloud::Spanner::V1::Mutation.new(
+        update: Google::Cloud::Spanner::V1::Mutation::Write.new(
+          table: "users", columns: %w(id name active),
+          values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([1, "Charlie", false]).list_value]
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [{database: database_path(instance_id, database_id), session: nil}, default_options]
+    mock.expect :commit, commit_resp, [{
+      session: session_grpc.name, mutations: mutations, transaction_id: nil,
+      single_use_transaction: tx_opts, request_options: { transaction_tag: "Tag-2" }
+    }, default_options]
+    spanner.service.mocked_service = mock
+
+    timestamp = client.update "users", [{ id: 1, name: "Charlie", active: false }],
+                              request_options: { tag: "Tag-2" }
+    _(timestamp).must_equal commit_time
+
+    shutdown_client! client
+
+    mock.verify
+  end
+
+  it "inserts" do
+    mutations = [
+      Google::Cloud::Spanner::V1::Mutation.new(
+        insert: Google::Cloud::Spanner::V1::Mutation::Write.new(
+          table: "users", columns: %w(id name active),
+          values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([2, "Harvey", true]).list_value]
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [{database: database_path(instance_id, database_id), session: nil}, default_options]
+    mock.expect :commit, commit_resp, [{
+      session: session_grpc.name, mutations: mutations, transaction_id: nil,
+      single_use_transaction: tx_opts, request_options: { transaction_tag: "Tag-3" }
+    }, default_options]
+    spanner.service.mocked_service = mock
+
+    timestamp = client.insert "users", [{ id: 2, name: "Harvey",  active: true }],
+                              request_options: { tag: "Tag-3" }
+    _(timestamp).must_equal commit_time
+
+    shutdown_client! client
+
+    mock.verify
+  end
+
+  it "upserts" do
+    mutations = [
+      Google::Cloud::Spanner::V1::Mutation.new(
+        insert_or_update: Google::Cloud::Spanner::V1::Mutation::Write.new(
+          table: "users", columns: %w(id name active),
+          values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([3, "Marley", false]).list_value]
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [{database: database_path(instance_id, database_id), session: nil}, default_options]
+    mock.expect :commit, commit_resp, [{
+      session: session_grpc.name, mutations: mutations, transaction_id: nil,
+      single_use_transaction: tx_opts, request_options: { transaction_tag: "Tag-4" }
+    }, default_options]
+    spanner.service.mocked_service = mock
+
+    timestamp = client.upsert "users", [{ id: 3, name: "Marley",  active: false }],
+                              request_options: { tag: "Tag-4" }
+    _(timestamp).must_equal commit_time
+
+    shutdown_client! client
+
+    mock.verify
+  end
+
+  it "deletes" do
+    mutations = [
+      Google::Cloud::Spanner::V1::Mutation.new(
+        delete: Google::Cloud::Spanner::V1::Mutation::Delete.new(
+          table: "users", key_set: Google::Cloud::Spanner::V1::KeySet.new(
+            keys: [1, 2].map do |i|
+              Google::Cloud::Spanner::Convert.object_to_grpc_value([i]).list_value
+            end
+          )
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [{database: database_path(instance_id, database_id), session: nil}, default_options]
+    mock.expect :commit, commit_resp, [{
+      session: session_grpc.name, mutations: mutations, transaction_id: nil,
+      single_use_transaction: tx_opts, request_options: { transaction_tag: "Tag-5" }
+    }, default_options]
+    spanner.service.mocked_service = mock
+
+    timestamp = client.delete "users", [1, 2], request_options: { tag: "Tag-5" }
+    _(timestamp).must_equal commit_time
+
+    shutdown_client! client
+
+    mock.verify
+  end
+end

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_query_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_query_test.rb
@@ -408,6 +408,22 @@ describe Google::Cloud::Spanner::Client, :execute_query, :mock_spanner do
     end
   end
 
+  it "can execute a query with request tag" do
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [{ database: database_path(instance_id, database_id), session: nil }, default_options]
+    spanner.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users",
+                                 request_options: { request_tag: "Tag-1" }, options: default_options
+
+    results = client.execute_query "SELECT * FROM users", request_options: { tag: "Tag-1" }
+
+    shutdown_client! client
+
+    mock.verify
+
+    assert_results results
+  end
+
   def assert_results results
     _(results).must_be_kind_of Google::Cloud::Spanner::Results
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_resume_buffer_bound_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_resume_buffer_bound_test.rb
@@ -111,7 +111,7 @@ describe Google::Cloud::Spanner::Client, :read, :resume, :buffer_bound, :mock_sp
       columns: ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"],
       key_set: Google::Cloud::Spanner::V1::KeySet.new(all: true),
       transaction: nil, index: nil, limit: nil, resume_token: nil, partition_token: nil,
-      request_options: nil,
+      request_options: nil
     }, default_options]
     spanner.service.mocked_service = mock
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_test.rb
@@ -322,6 +322,27 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     end
   end
 
+  it "can read with request tag" do
+    mock = Minitest::Mock.new
+    mock.expect :create_session, session_grpc, [{ database: database_path(instance_id, database_id), session: nil }, default_options]
+    mock.expect :streaming_read, results_enum, [{
+      session: session_grpc.name, table: "my-table",
+      columns: ["id"],
+      key_set: Google::Cloud::Spanner::V1::KeySet.new(all: true),
+      transaction: nil, index: nil, limit: nil, resume_token: nil, partition_token: nil,
+      request_options: { request_tag: "Tag-1"}
+     }, default_options]
+    spanner.service.mocked_service = mock
+
+    results = client.read "my-table", [:id], request_options: { tag: "Tag-1" }
+
+    shutdown_client! client
+
+    mock.verify
+
+    assert_results results
+  end
+
   def assert_results results
     _(results).must_be_kind_of Google::Cloud::Spanner::Results
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_retry_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_retry_test.rb
@@ -77,14 +77,20 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
     mock = Minitest::Mock.new
     spanner.service.mocked_service = mock
     mock.expect :create_session, session_grpc, [{ database: database_path(instance_id, database_id), session: nil }, default_options]
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts }, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
     expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
 
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts }, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
     expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
 
     # transaction checkin
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts }, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
 
     def mock.commit *args
       # first time called this will raise
@@ -131,14 +137,20 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
     mock = Minitest::Mock.new
     spanner.service.mocked_service = mock
     mock.expect :create_session, session_grpc, [{ database: database_path(instance_id, database_id), session: nil }, default_options]
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts }, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
     expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
 
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts }, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
     expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
 
     # transaction checkin
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts }, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
 
     def mock.commit *args
       # first time called this will raise
@@ -183,14 +195,20 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
     mock = Minitest::Mock.new
     spanner.service.mocked_service = mock
     mock.expect :create_session, session_grpc, [{ database: database_path(instance_id, database_id), session: nil }, default_options]
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts }, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
     expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
 
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts }, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
     expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
 
     # transaction checkin
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts }, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
 
     def mock.commit *args
       # first time called this will raise
@@ -235,17 +253,25 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
     mock = Minitest::Mock.new
     spanner.service.mocked_service = mock
     mock.expect :create_session, session_grpc, [{ database: database_path(instance_id, database_id), session: nil }, default_options]
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts }, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
     expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
 
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts }, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
     expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
 
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts }, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
     expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
 
     # transaction checkin
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts }, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
 
     def mock.commit *args
       # first time called this will raise
@@ -295,23 +321,35 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
     mock = Minitest::Mock.new
     spanner.service.mocked_service = mock
     mock.expect :create_session, session_grpc, [{ database: database_path(instance_id, database_id), session: nil }, default_options]
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts }, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
     expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
 
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts }, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
     expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
 
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts }, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
     expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
 
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts }, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
     expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
 
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts }, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
     expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
 
     # transaction checkin
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts }, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
 
     def mock.commit *args
       raise GRPC::Aborted.new "aborted"

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_rollback_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_rollback_test.rb
@@ -67,11 +67,15 @@ describe Google::Cloud::Spanner::Client, :transaction, :rollback, :mock_spanner 
     mock = Minitest::Mock.new
     spanner.service.mocked_service = mock
     mock.expect :create_session, session_grpc, [{ database: database_path(instance_id, database_id), session: nil }, default_options]
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts}, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
     expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
     mock.expect :rollback, nil, [{ session: session_grpc.name, transaction_id: transaction_id }, default_options]
     # transaction checkin
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts }, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
 
     results = nil
     timestamp = client.transaction do |tx|
@@ -95,11 +99,15 @@ describe Google::Cloud::Spanner::Client, :transaction, :rollback, :mock_spanner 
     mock = Minitest::Mock.new
     spanner.service.mocked_service = mock
     mock.expect :create_session, session_grpc, [{ database: database_path(instance_id, database_id), session: nil }, default_options]
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts }, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
     expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
     mock.expect :rollback, nil, [{ session: session_grpc.name, transaction_id: transaction_id }, default_options]
     # transaction checkin
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts }, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
 
     results = nil
     assert_raises ZeroDivisionError do
@@ -123,10 +131,14 @@ describe Google::Cloud::Spanner::Client, :transaction, :rollback, :mock_spanner 
   it "does not allow nested transactions" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [{ database: database_path(instance_id, database_id), session: nil }, default_options]
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts }, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
     mock.expect :rollback, nil, [{ session: session_grpc.name, transaction_id: transaction_id }, default_options]
     # transaction checkin
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts }, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
     spanner.service.mocked_service = mock
 
     nested_error = assert_raises RuntimeError do

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_test.rb
@@ -60,6 +60,20 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
   end
   let(:results_grpc) { Google::Cloud::Spanner::V1::PartialResultSet.new results_hash }
   let(:results_enum) { Array(results_grpc).to_enum }
+  let(:update_results_grpc) {
+    Google::Cloud::Spanner::V1::PartialResultSet.new(
+      metadata: Google::Cloud::Spanner::V1::ResultSetMetadata.new(
+        row_type: Google::Cloud::Spanner::V1::StructType.new(
+          fields: []
+        )
+      ),
+      values: [],
+      stats: Google::Cloud::Spanner::V1::ResultSetStats.new(
+        row_count_exact: 1
+      )
+    )
+  }
+  let(:update_results_enum) { Array(update_results_grpc).to_enum }
   let(:client) { spanner.client instance_id, database_id, pool: { min: 0 } }
   let(:tx_opts) { Google::Cloud::Spanner::V1::TransactionOptions.new(read_write: Google::Cloud::Spanner::V1::TransactionOptions::ReadWrite.new) }
   let(:commit_time) { Time.now }
@@ -117,14 +131,18 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     mock = Minitest::Mock.new
     spanner.service.mocked_service = mock
     mock.expect :create_session, session_grpc, [{ database: database_path(instance_id, database_id), session: nil }, default_options]
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts}, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
     expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
     mock.expect :commit, commit_resp, [{
       session: session_grpc.name, mutations: [], transaction_id: transaction_id,
       single_use_transaction: nil, request_options: nil
     }, default_options]
     # transaction checkin
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts}, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
 
     results = nil
     timestamp = client.transaction do |tx|
@@ -152,13 +170,17 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [{ database: database_path(instance_id, database_id), session: nil }, default_options]
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts}, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
     mock.expect :commit, commit_resp, [{
       session: session_grpc.name, mutations: mutations, transaction_id: transaction_id,
       single_use_transaction: nil, request_options: nil
     }, default_options]
     # transaction checkin
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts}, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
     spanner.service.mocked_service = mock
 
     timestamp = client.transaction do |tx|
@@ -183,13 +205,17 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [{ database: database_path(instance_id, database_id), session: nil }, default_options]
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts}, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
     mock.expect :commit, commit_resp, [{
       session: session_grpc.name, mutations: mutations, transaction_id: transaction_id,
       single_use_transaction: nil, request_options: nil
     }, default_options]
     # transaction checkin
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts}, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
     spanner.service.mocked_service = mock
 
     timestamp = client.transaction do |tx|
@@ -214,13 +240,17 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [{ database: database_path(instance_id, database_id), session: nil }, default_options]
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts}, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+        session: session_grpc.name, options: tx_opts, request_options: nil
+      }, default_options]
     mock.expect :commit, commit_resp, [{
       session: session_grpc.name, mutations: mutations, transaction_id: transaction_id,
       single_use_transaction: nil, request_options: nil
     }, default_options]
     # transaction checkin
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts}, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
     spanner.service.mocked_service = mock
 
     timestamp = client.transaction do |tx|
@@ -245,13 +275,17 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [{ database: database_path(instance_id, database_id), session: nil }, default_options]
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts}, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
     mock.expect :commit, commit_resp, [{
       session: session_grpc.name, mutations: mutations, transaction_id: transaction_id,
       single_use_transaction: nil, request_options: nil
     }, default_options]
     # transaction checkin
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts}, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
     spanner.service.mocked_service = mock
 
     timestamp = client.transaction do |tx|
@@ -276,13 +310,17 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [{ database: database_path(instance_id, database_id), session: nil }, default_options]
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts}, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
     mock.expect :commit, commit_resp, [{
       session: session_grpc.name, mutations: mutations, transaction_id: transaction_id,
       single_use_transaction: nil, request_options: nil
     }, default_options]
     # transaction checkin
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts}, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
     spanner.service.mocked_service = mock
 
     timestamp = client.transaction do |tx|
@@ -310,13 +348,17 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [{ database: database_path(instance_id, database_id), session: nil }, default_options]
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts}, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
     mock.expect :commit, commit_resp, [{
       session: session_grpc.name, mutations: mutations, transaction_id: transaction_id,
       single_use_transaction: nil, request_options: nil
     }, default_options]
     # transaction checkin
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts}, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
     spanner.service.mocked_service = mock
 
     timestamp = client.transaction do |tx|
@@ -342,13 +384,17 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [{ database: database_path(instance_id, database_id), session: nil }, default_options]
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts}, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
     mock.expect :commit, commit_resp, [{
       session: session_grpc.name, mutations: mutations, transaction_id: transaction_id,
       single_use_transaction: nil, request_options: nil
     }, default_options]
     # transaction checkin
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts}, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil,
+    }, default_options]
     spanner.service.mocked_service = mock
 
     timestamp = client.transaction do |tx|
@@ -376,13 +422,17 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [{ database: database_path(instance_id, database_id), session: nil }, default_options]
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts}, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+        session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
     mock.expect :commit, commit_resp, [{
       session: session_grpc.name, mutations: mutations, transaction_id: transaction_id,
       single_use_transaction: nil, request_options: nil
     }, default_options]
     # transaction checkin
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts}, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
     spanner.service.mocked_service = mock
 
     timestamp = client.transaction do |tx|
@@ -406,13 +456,17 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
 
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [{ database: database_path(instance_id, database_id), session: nil }, default_options]
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts}, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
     mock.expect :commit, commit_resp, [{
       session: session_grpc.name, mutations: mutations, transaction_id: transaction_id,
       single_use_transaction: nil, request_options: nil
     }, default_options]
     # transaction checkin
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts}, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
     spanner.service.mocked_service = mock
 
     timestamp = client.transaction do |tx|
@@ -428,13 +482,17 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
   it "commits multiple mutations" do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [{ database: database_path(instance_id, database_id), session: nil }, default_options]
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts}, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
     mock.expect :commit, commit_resp, [{
       session: session_grpc.name, mutations: mutations, transaction_id: transaction_id,
       single_use_transaction: nil, request_options: nil
     }, default_options]
     # transaction checkin
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts}, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
     spanner.service.mocked_service = mock
 
     timestamp = client.transaction do |tx|
@@ -465,14 +523,18 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     mock = Minitest::Mock.new
     spanner.service.mocked_service = mock
     mock.expect :create_session, session_grpc, [{ database: database_path(instance_id, database_id), session: nil }, default_options]
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts}, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
     expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, options: default_options
     mock.expect :commit, commit_resp, [{
       session: session_grpc.name, mutations: [], transaction_id: transaction_id,
       single_use_transaction: nil, request_options: nil
     }, expect_options]
     # transaction checkin
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts}, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
 
     results = nil
     timestamp = client.transaction call_options: call_options do |tx|
@@ -496,13 +558,17 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
     it "commits multiple mutations" do
       mock = Minitest::Mock.new
       mock.expect :create_session, session_grpc, [{ database: database_path(instance_id, database_id), session: nil }, default_options]
-      mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts}, default_options]
+      mock.expect :begin_transaction, transaction_grpc, [{
+        session: session_grpc.name, options: tx_opts, request_options: nil
+      }, default_options]
       mock.expect :commit, commit_resp, [{
         session: session_grpc.name, mutations: mutations, transaction_id: transaction_id,
         single_use_transaction: nil, request_options: request_options
       }, default_options]
       # transaction checkin
-      mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts}, default_options]
+      mock.expect :begin_transaction, transaction_grpc, [{
+        session: session_grpc.name, options: tx_opts, request_options: nil
+      }, default_options]
       spanner.service.mocked_service = mock
 
       timestamp = client.transaction request_options: request_options do |tx|
@@ -523,14 +589,18 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
       mock = Minitest::Mock.new
       spanner.service.mocked_service = mock
       mock.expect :create_session, session_grpc, [{ database: database_path(instance_id, database_id), session: nil }, default_options]
-      mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts}, default_options]
+      mock.expect :begin_transaction, transaction_grpc, [{
+        session: session_grpc.name, options: tx_opts, request_options: nil
+      }, default_options]
       expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users", transaction: tx_selector, seqno: 1, request_options: request_options, options: default_options
       mock.expect :commit, commit_resp, [{
         session: session_grpc.name, mutations: [], transaction_id: transaction_id,
         single_use_transaction: nil, request_options: nil
       }, default_options]
       # transaction checkin
-      mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts}, default_options]
+      mock.expect :begin_transaction, transaction_grpc, [{
+        session: session_grpc.name, options: tx_opts, request_options: nil
+      }, default_options]
 
       timestamp = client.transaction do |tx|
         tx.execute_query "SELECT * FROM users", request_options: request_options
@@ -541,6 +611,55 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
 
       mock.verify
     end
+  end
+
+  it "can execute a trasaction with transaction and request tag" do
+    mutations = [
+      Google::Cloud::Spanner::V1::Mutation.new(
+        update: Google::Cloud::Spanner::V1::Mutation::Write.new(
+          table: "users", columns: %w(id name active),
+          values: [Google::Cloud::Spanner::Convert.object_to_grpc_value([1, "Charlie", false]).list_value]
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    spanner.service.mocked_service = mock
+    mock.expect :create_session, session_grpc, [{ database: database_path(instance_id, database_id), session: nil }, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
+
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users",
+                                 transaction: tx_selector, seqno: 1,
+                                 request_options: { transaction_tag: "Tag-1", request_tag: "Tag-1-1" },
+                                 options: default_options
+    expect_execute_streaming_sql update_results_enum, session_grpc.name,
+                                 "UPDATE users SET active = true", transaction: tx_selector,
+                                 seqno: 2, request_options: { transaction_tag: "Tag-1", request_tag: "Tag-1-2" },
+                                 options: default_options
+
+    mock.expect :commit, commit_resp, [{
+      session: session_grpc.name, mutations: mutations, transaction_id: transaction_id,
+      single_use_transaction: nil, request_options: { transaction_tag: "Tag-1" }
+    }, default_options]
+
+    # transaction checkin
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
+
+    client.transaction request_options: { tag: "Tag-1" } do |tx|
+      _(tx).must_be_kind_of Google::Cloud::Spanner::Transaction
+
+      tx.execute_query "SELECT * FROM users", request_options: { tag: "Tag-1-1" }
+      tx.execute_update "UPDATE users SET active = true", request_options: { tag: "Tag-1-2" }
+      tx.update "users", [{ id: 1, name: "Charlie", active: false }]
+    end
+
+    shutdown_client! client
+
+    mock.verify
   end
 
   def assert_results results

--- a/google-cloud-spanner/test/google/cloud/spanner/convert/to_request_options_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/convert/to_request_options_test.rb
@@ -1,0 +1,47 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+require "bigdecimal"
+
+describe Google::Cloud::Spanner::Convert, :to_request_options, :mock_spanner do
+  it "returns nil for nil options value" do
+    options = Google::Cloud::Spanner::Convert.to_request_options nil
+    _(options).must_be_nil
+  end
+
+  it "returns same options if tag field not present" do
+    options = Google::Cloud::Spanner::Convert.to_request_options({extra: "123"})
+    _(options).must_equal({ extra: "123" })
+  end
+
+  it "transform tag key to provided tag type" do
+    options = Google::Cloud::Spanner::Convert.to_request_options(
+      { tag: "Tag-1" }, tag_type: :request_tag
+    )
+    _(options).must_equal({ request_tag: "Tag-1"})
+
+    options = Google::Cloud::Spanner::Convert.to_request_options(
+      { tag: "Tag-2" }, tag_type: :transaction_tag
+    )
+    _(options).must_equal({ transaction_tag: "Tag-2"})
+  end
+
+  it "transform tag key to provided tag type and merge with options" do
+    options = Google::Cloud::Spanner::Convert.to_request_options(
+      { extra: "123", transaction_tag: "Tag-1", tag: "Tag-1-1" }, tag_type: :request_tag
+    )
+    _(options).must_equal({ extra: "123", transaction_tag: "Tag-1", request_tag: "Tag-1-1"})
+  end
+end

--- a/google-cloud-spanner/test/google/cloud/spanner/pool/keepalive_or_release_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool/keepalive_or_release_test.rb
@@ -77,7 +77,9 @@ describe Google::Cloud::Spanner::Pool, :keepalive_or_release, :mock_spanner do
     pool.transaction_queue = [transaction]
 
     mock = Minitest::Mock.new
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts }, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
     session.service.mocked_service = mock
 
     pool.keepalive_or_release!

--- a/google-cloud-spanner/test/google/cloud/spanner/pool_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool_test.rb
@@ -128,7 +128,10 @@ describe Google::Cloud::Spanner::Pool, :mock_spanner do
 
     mock = Minitest::Mock.new
     # created when checking in
-    mock.expect :begin_transaction, Google::Cloud::Spanner::V1::Transaction.new(id: "tx-001-02"), [{ session: session_path(instance_id, database_id, session_id), options: tx_opts }, default_options]
+    mock.expect :begin_transaction, Google::Cloud::Spanner::V1::Transaction.new(id: "tx-001-02"), [{
+      session: session_path(instance_id, database_id, session_id), options: tx_opts,
+      request_options: nil
+    }, default_options]
     # reload on session pool checkin
     mock.expect :get_session, session_grpc, [{ name: session_grpc.name }, default_options]
     mock.expect :begin_transaction, Google::Cloud::Spanner::V1::Transaction.new(id: "tx-001-02"), [{session: session_path(instance_id, database_id, session_id), options: tx_opts }, default_options]
@@ -158,7 +161,10 @@ describe Google::Cloud::Spanner::Pool, :mock_spanner do
   it "can create a transaction when checking out and checking in a transaction" do
     mock = Minitest::Mock.new
     # created when checking out
-    mock.expect :begin_transaction, Google::Cloud::Spanner::V1::Transaction.new(id: "tx-001-01"), [{ session: session_path(instance_id, database_id, session_id), options: tx_opts }, default_options]
+    mock.expect :begin_transaction, Google::Cloud::Spanner::V1::Transaction.new(id: "tx-001-01"), [{
+      session: session_path(instance_id, database_id, session_id), options: tx_opts,
+      request_options: nil
+    }, default_options]
     # created when checking in
     mock.expect :begin_transaction, Google::Cloud::Spanner::V1::Transaction.new(id: "tx-001-02"), [{ session: session_path(instance_id, database_id, session_id), options: tx_opts }, default_options]
     spanner.service.mocked_service = mock
@@ -186,8 +192,14 @@ describe Google::Cloud::Spanner::Pool, :mock_spanner do
     mock = Minitest::Mock.new
     mock.expect :create_session, session_grpc, [{ database: database_path(instance_id, database_id), session: nil }, default_options]
     # created when checking out
-    mock.expect :begin_transaction, Google::Cloud::Spanner::V1::Transaction.new(id: "tx-001-01"), [{ session: session_path(instance_id, database_id, session_id), options: tx_opts }, default_options]
-    mock.expect :begin_transaction, Google::Cloud::Spanner::V1::Transaction.new(id: "tx-002-01"), [{ session: session_path(instance_id, database_id, session_id), options: tx_opts }, default_options]
+    mock.expect :begin_transaction, Google::Cloud::Spanner::V1::Transaction.new(id: "tx-001-01"), [{
+      session: session_path(instance_id, database_id, session_id), options: tx_opts,
+      request_options: nil
+    }, default_options]
+    mock.expect :begin_transaction, Google::Cloud::Spanner::V1::Transaction.new(id: "tx-002-01"), [{
+      session: session_path(instance_id, database_id, session_id), options: tx_opts,
+      request_options: nil
+    }, default_options]
     spanner.service.mocked_service = mock
 
     _(pool.all_sessions.size).must_equal 1
@@ -217,11 +229,23 @@ describe Google::Cloud::Spanner::Pool, :mock_spanner do
     mock = Minitest::Mock.new
    mock.expect :create_session, session_grpc, [{ database: database_path(instance_id, database_id), session: nil }, default_options]
     # created when checking out
-    mock.expect :begin_transaction, Google::Cloud::Spanner::V1::Transaction.new(id: "tx-001-01"), [{ session: session_path(instance_id, database_id, session_id), options: tx_opts}, default_options]
-    mock.expect :begin_transaction, Google::Cloud::Spanner::V1::Transaction.new(id: "tx-002-01"), [{ session: session_path(instance_id, database_id, session_id), options: tx_opts}, default_options]
+    mock.expect :begin_transaction, Google::Cloud::Spanner::V1::Transaction.new(id: "tx-001-01"), [{
+      session: session_path(instance_id, database_id, session_id), options: tx_opts,
+      request_options: nil
+    }, default_options]
+    mock.expect :begin_transaction, Google::Cloud::Spanner::V1::Transaction.new(id: "tx-002-01"), [{
+      session: session_path(instance_id, database_id, session_id), options: tx_opts,
+      request_options: nil
+    }, default_options]
     # created when checking in
-    mock.expect :begin_transaction, Google::Cloud::Spanner::V1::Transaction.new(id: "tx-001-02"), [{ session: session_path(instance_id, database_id, session_id), options: tx_opts}, default_options]
-    mock.expect :begin_transaction, Google::Cloud::Spanner::V1::Transaction.new(id: "tx-002-02"), [{ session: session_path(instance_id, database_id, session_id), options: tx_opts}, default_options]
+    mock.expect :begin_transaction, Google::Cloud::Spanner::V1::Transaction.new(id: "tx-001-02"), [{
+      session: session_path(instance_id, database_id, session_id), options: tx_opts,
+      request_options: nil
+    }, default_options]
+    mock.expect :begin_transaction, Google::Cloud::Spanner::V1::Transaction.new(id: "tx-002-02"), [{
+      session: session_path(instance_id, database_id, session_id), options: tx_opts,
+      request_options: nil
+    }, default_options]
     spanner.service.mocked_service = mock
 
     _(pool.all_sessions.size).must_equal 1
@@ -251,10 +275,22 @@ describe Google::Cloud::Spanner::Pool, :mock_spanner do
     mock.expect :create_session, session_grpc, [{ database: database_path(instance_id, database_id), session: nil }, default_options]
     mock.expect :create_session, session_grpc, [{ database: database_path(instance_id, database_id), session: nil }, default_options]
     # created when checking out
-    mock.expect :begin_transaction, Google::Cloud::Spanner::V1::Transaction.new(id: "tx-001-01"), [{ session: session_path(instance_id, database_id, session_id), options: tx_opts }, default_options]
-    mock.expect :begin_transaction, Google::Cloud::Spanner::V1::Transaction.new(id: "tx-002-01"), [{ session: session_path(instance_id, database_id, session_id), options: tx_opts }, default_options]
-    mock.expect :begin_transaction, Google::Cloud::Spanner::V1::Transaction.new(id: "tx-003-01"), [{ session: session_path(instance_id, database_id, session_id), options: tx_opts }, default_options]
-    mock.expect :begin_transaction, Google::Cloud::Spanner::V1::Transaction.new(id: "tx-004-01"), [{ session: session_path(instance_id, database_id, session_id), options: tx_opts }, default_options]
+    mock.expect :begin_transaction, Google::Cloud::Spanner::V1::Transaction.new(id: "tx-001-01"), [{
+      session: session_path(instance_id, database_id, session_id), options: tx_opts,
+      request_options: nil
+    }, default_options]
+    mock.expect :begin_transaction, Google::Cloud::Spanner::V1::Transaction.new(id: "tx-002-01"), [{
+      session: session_path(instance_id, database_id, session_id), options: tx_opts,
+      request_options: nil
+    }, default_options]
+    mock.expect :begin_transaction, Google::Cloud::Spanner::V1::Transaction.new(id: "tx-003-01"), [{
+      session: session_path(instance_id, database_id, session_id), options: tx_opts,
+      request_options: nil
+    }, default_options]
+    mock.expect :begin_transaction, Google::Cloud::Spanner::V1::Transaction.new(id: "tx-004-01"), [{
+      session: session_path(instance_id, database_id, session_id), options: tx_opts,
+      request_options: nil
+    }, default_options]
     spanner.service.mocked_service = mock
 
     _(pool.all_sessions.size).must_equal 1

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/batch_update_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/batch_update_test.rb
@@ -180,6 +180,29 @@ describe Google::Cloud::Spanner::Transaction, :batch_update, :mock_spanner do
     end
   end
 
+  it "can execute a barch DML with transaction and request tag" do
+    transaction = Google::Cloud::Spanner::Transaction.from_grpc transaction_grpc, session
+    transaction.transaction_tag = "Tag-1"
+
+    mock = Minitest::Mock.new
+    mock.expect :execute_batch_dml, batch_response_grpc, [{
+      session: session_grpc.name, transaction: tx_selector,
+      statements: [statement_grpc("UPDATE users SET active = true")], seqno: 1,
+      request_options: { transaction_tag: "Tag-1", request_tag: "Tag-1-1" }
+    }, default_options]
+    session.service.mocked_service = mock
+
+    request_options = { tag: "Tag-1-1" }
+    row_counts = transaction.batch_update request_options: request_options do |b|
+      b.batch_update "UPDATE users SET active = true"
+    end
+
+    mock.verify
+
+    _(row_counts.count).must_equal 1
+    _(row_counts.first).must_equal 1
+  end
+
   def statement_grpc sql, params: nil, param_types: {}
     Google::Cloud::Spanner::V1::ExecuteBatchDmlRequest::Statement.new \
       sql: sql, params: params, param_types: param_types

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/execute_query_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/execute_query_test.rb
@@ -283,6 +283,24 @@ describe Google::Cloud::Spanner::Transaction, :execute_query, :mock_spanner do
     assert_results results
   end
 
+  it "execute query with transaction and request tag" do
+    transaction = Google::Cloud::Spanner::Transaction.from_grpc transaction_grpc, session
+    transaction.transaction_tag = "Tag-1"
+    mock = Minitest::Mock.new
+    session.service.mocked_service = mock
+
+    mock = Minitest::Mock.new
+    session.service.mocked_service = mock
+    expect_execute_streaming_sql results_enum, session_grpc.name, "SELECT * FROM users",
+                                 transaction: tx_selector, seqno: 1,
+                                 request_options: { transaction_tag: "Tag-1", request_tag: "Tag-1-1"},
+                                 options: default_options
+
+    transaction.execute_query "SELECT * FROM users",
+                              request_options: { tag: "Tag-1-1"}
+    mock.verify
+  end
+
   def assert_results results
     _(results).must_be_kind_of Google::Cloud::Spanner::Results
 

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/keepalive_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/keepalive_test.rb
@@ -28,7 +28,9 @@ describe Google::Cloud::Spanner::Session, :keepalive, :mock_spanner do
 
   it "creates new transaction when calling keepalive" do
     mock = Minitest::Mock.new
-    mock.expect :begin_transaction, transaction_grpc, [{ session: session_grpc.name, options: tx_opts }, default_options]
+    mock.expect :begin_transaction, transaction_grpc, [{
+      session: session_grpc.name, options: tx_opts, request_options: nil
+    }, default_options]
     spanner.service.mocked_service = mock
 
     transaction.keepalive!


### PR DESCRIPTION
Adds support for request options with request and transaction tags.

closes: #8162 