### PR TITLE
feat(spanner):  Point In Time Recovery (PITR)

### DIFF
--- a/google-cloud-spanner/acceptance/spanner/database_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/database_test.rb
@@ -113,10 +113,12 @@ describe "Spanner Databases", :spanner do
     job2 = database.update statements: "ALTER DATABASE `#{database_id}` SET OPTIONS (version_retention_period = '#{retention_period}')"
     _(job2).must_be_kind_of Google::Cloud::Spanner::Database::Job
     _(job2).wont_be :done? unless emulator_enabled?
-    job2.wait_until_done!
+    job2_result = job2.wait_until_done!
 
     _(job2).must_be :done?
     _(job2.database).must_be :nil?
+    _(job2_result.metadata).wont_be :nil?
+    _(job2_result.metadata.throttled).must_equal false
 
     database.drop
     _(spanner.database(instance_id, database_id)).must_be :nil?

--- a/google-cloud-spanner/lib/google/cloud/spanner/backup.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/backup.rb
@@ -165,7 +165,7 @@ module Google
         # taken. The version time has microseconds granularity.
         # @return [Time]
         def version_time
-          Convert.timestamp_to_time @grpc.version_time unless @grpc.version_time.nil?
+          Convert.timestamp_to_time @grpc.version_time
         end
 
         ##

--- a/google-cloud-spanner/lib/google/cloud/spanner/backup.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/backup.rb
@@ -161,6 +161,14 @@ module Google
         end
 
         ##
+        # The timestamp when a consistent copy of the database for the backup was
+        # taken. The version time has microseconds granularity.
+        # @return [Time]
+        def version_time
+          Convert.timestamp_to_time @grpc.version_time unless @grpc.version_time.nil?
+        end
+
+        ##
         # Create time is approximately the time when the backup request was
         # received.
         # @return [Time]

--- a/google-cloud-spanner/lib/google/cloud/spanner/database.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/database.rb
@@ -85,6 +85,18 @@ module Google
           @grpc.name.split("/")[5]
         end
 
+        # The version retention period for a database.
+        # @return [String]
+        def version_retention_period
+          @grpc.version_retention_period
+        end
+
+        # The earliest available version time for a database.
+        # @return [Time]
+        def earliest_version_time
+          Convert.timestamp_to_time @grpc.earliest_version_time
+        end
+
         ##
         # The full path for the database resource. Values are of the form
         # `projects/<project_id>/instances/<instance_id>/databases/<database_id>`.

--- a/google-cloud-spanner/lib/google/cloud/spanner/database.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/database.rb
@@ -412,6 +412,11 @@ module Google
         #   366 days from the time the request is received. Required.
         #   Once the `expire_time` has passed, Cloud Spanner will delete the
         #   backup and free the resources used by the backup. Required.
+        # @param [Time] version_time Specifies the time to have an externally 
+        #   consistent copy of the database. If no version time is specified, 
+        #   it will be automatically set to the backup create time. The version
+        #   time can be as far in the past as specified by the database earliest
+        #   version time. Optional.
         # @return [Google::Cloud::Spanner::Backup::Job] The job representing
         #   the long-running, asynchronous processing of a backup create
         #   operation.
@@ -422,7 +427,11 @@ module Google
         #   spanner = Google::Cloud::Spanner.new
         #   database = spanner.database "my-instance", "my-database"
         #
-        #   job = database.create_backup "my-backup", Time.now + 36000
+        #   backup_id = "my-backup"
+        #   expire_time = Time.now + (24 * 60 * 60) # 1 day from now
+        #   version_time = Time.now - (24 * 60 * 60) # 1 day ago (optional)
+        #
+        #   job = database.create_backup backup_id, expire_time, version_time
         #
         #   job.done? #=> false
         #   job.reload! # API call
@@ -434,13 +443,14 @@ module Google
         #     backup = job.backup
         #   end
         #
-        def create_backup backup_id, expire_time
+        def create_backup backup_id, expire_time, version_time = nil
           ensure_service!
           grpc = service.create_backup \
             instance_id,
             database_id,
             backup_id,
-            expire_time
+            expire_time,
+            version_time
           Backup::Job.from_grpc grpc, service
         end
 

--- a/google-cloud-spanner/lib/google/cloud/spanner/database.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/database.rb
@@ -412,8 +412,8 @@ module Google
         #   366 days from the time the request is received. Required.
         #   Once the `expire_time` has passed, Cloud Spanner will delete the
         #   backup and free the resources used by the backup. Required.
-        # @param [Time] version_time Specifies the time to have an externally 
-        #   consistent copy of the database. If no version time is specified, 
+        # @param [Time] version_time Specifies the time to have an externally
+        #   consistent copy of the database. If no version time is specified,
         #   it will be automatically set to the backup create time. The version
         #   time can be as far in the past as specified by the database earliest
         #   version time. Optional.

--- a/google-cloud-spanner/lib/google/cloud/spanner/database.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/database.rb
@@ -431,7 +431,7 @@ module Google
         #   expire_time = Time.now + (24 * 60 * 60) # 1 day from now
         #   version_time = Time.now - (24 * 60 * 60) # 1 day ago (optional)
         #
-        #   job = database.create_backup backup_id, expire_time, version_time
+        #   job = database.create_backup backup_id, expire_time, version_time: version_time
         #
         #   job.done? #=> false
         #   job.reload! # API call
@@ -443,7 +443,7 @@ module Google
         #     backup = job.backup
         #   end
         #
-        def create_backup backup_id, expire_time, version_time = nil
+        def create_backup backup_id, expire_time, version_time: nil
           ensure_service!
           grpc = service.create_backup \
             instance_id,

--- a/google-cloud-spanner/lib/google/cloud/spanner/database/backup_info.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/database/backup_info.rb
@@ -84,12 +84,21 @@ module Google
           end
 
           ##
-          # The backup contains an externally consistent copy of
-          # `source_database` at the timestamp specified by `create_time`.
-          # received.
+          # The timestamp indicating the creation of the backup.
           # @return [Time]
           def create_time
             Convert.timestamp_to_time @grpc.create_time
+          end
+
+          ##
+          # The backup contains an externally consistent copy of
+          # `source_database` at the timestamp specified by
+          # the `version_time` received. If no `version_time` was
+          # given during the creation of the backup, the `version_time`
+          # will be the same as the `create_time`.
+          # @return [Time]
+          def version_time
+            Convert.timestamp_to_time @grpc.version_time unless @grpc.version_time.nil?
           end
 
           ##

--- a/google-cloud-spanner/lib/google/cloud/spanner/database/backup_info.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/database/backup_info.rb
@@ -98,7 +98,7 @@ module Google
           # will be the same as the `create_time`.
           # @return [Time]
           def version_time
-            Convert.timestamp_to_time @grpc.version_time unless @grpc.version_time.nil?
+            Convert.timestamp_to_time @grpc.version_time
           end
 
           ##

--- a/google-cloud-spanner/lib/google/cloud/spanner/service.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/service.rb
@@ -459,11 +459,12 @@ module Google
         end
 
         def create_backup instance_id, database_id, backup_id, expire_time,
-                          call_options: nil
+                          version_time, call_options: nil
           opts = default_options call_options: call_options
           backup = {
             database: database_path(instance_id, database_id),
-            expire_time: expire_time
+            expire_time: expire_time,
+            version_time: version_time
           }
           request = {
             parent:    instance_path(instance_id),

--- a/google-cloud-spanner/test/google/cloud/spanner/backup_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/backup_test.rb
@@ -26,6 +26,7 @@ describe Google::Cloud::Spanner::Backup, :mock_spanner do
         database_id: database_id,
         backup_id: backup_id,
         expire_time: Time.now + 36000,
+        version_time: Time.now - 7200,
         create_time: Time.now,
         size_bytes: 1024
       )
@@ -45,6 +46,7 @@ describe Google::Cloud::Spanner::Backup, :mock_spanner do
     _(backup).wont_be :creating?
 
     _(backup.expire_time).must_be_kind_of Time
+    _(backup.version_time).must_be_kind_of Time
     _(backup.create_time).must_be_kind_of Time
     _(backup.size_in_bytes).must_be :>, 0
   end

--- a/google-cloud-spanner/test/google/cloud/spanner/database/create_backup_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/database/create_backup_test.rb
@@ -73,12 +73,14 @@ describe Google::Cloud::Spanner::Backup, :create_backup, :mock_spanner do
   end
   let(:database) { Google::Cloud::Spanner::Database.from_grpc database_grpc, spanner.service }
   let(:expire_time) { Time.now + 36000 }
+  let(:version_time) { Time.now }
 
   it "create a database backup" do
     mock = Minitest::Mock.new
     create_req = {
       database: database_path(instance_id, database_id),
-      expire_time: expire_time
+      expire_time: expire_time,
+      version_time: version_time
     }
     create_res = Gapic::Operation.new(
       job_grpc, mock,
@@ -98,7 +100,7 @@ describe Google::Cloud::Spanner::Backup, :create_backup, :mock_spanner do
     mock.expect :get_operation, operation_done, [{ name: "1234567890" }, Gapic::CallOptions]
     spanner.service.mocked_databases = mock
 
-    job = database.create_backup backup_id, expire_time
+    job = database.create_backup backup_id, expire_time, version_time
 
     _(job).must_be_kind_of Google::Cloud::Spanner::Backup::Job
     _(job).wont_be :done?
@@ -125,7 +127,8 @@ describe Google::Cloud::Spanner::Backup, :create_backup, :mock_spanner do
     mock = Minitest::Mock.new
     create_req = {
       database: database_path(instance_id, database_id),
-      expire_time: expire_time
+      expire_time: expire_time,
+      version_time: nil
     }
     create_res = Gapic::Operation.new(
       job_grpc, mock,

--- a/google-cloud-spanner/test/google/cloud/spanner/database/create_backup_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/database/create_backup_test.rb
@@ -100,7 +100,7 @@ describe Google::Cloud::Spanner::Backup, :create_backup, :mock_spanner do
     mock.expect :get_operation, operation_done, [{ name: "1234567890" }, Gapic::CallOptions]
     spanner.service.mocked_databases = mock
 
-    job = database.create_backup backup_id, expire_time, version_time
+    job = database.create_backup backup_id, expire_time, version_time: version_time
 
     _(job).must_be_kind_of Google::Cloud::Spanner::Backup::Job
     _(job).wont_be :done?

--- a/google-cloud-spanner/test/google/cloud/spanner/database_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/database_test.rb
@@ -27,9 +27,11 @@ describe Google::Cloud::Spanner::Instance, :mock_spanner do
       source_database_id: source_database_id
     )
   end
+  let(:version_retention_period) { "1d" }
+  let(:earliest_version_time) { Time.now }
   let(:database_grpc) do
     Google::Cloud::Spanner::Admin::Database::V1::Database.new \
-      database_hash(instance_id: instance_id, database_id: database_id, restore_info: restore_info)
+      database_hash(instance_id: instance_id, database_id: database_id, restore_info: restore_info, version_retention_period: version_retention_period, earliest_version_time: earliest_version_time)
   end
   let(:database) { Google::Cloud::Spanner::Database.from_grpc database_grpc, spanner.service }
 
@@ -42,6 +44,9 @@ describe Google::Cloud::Spanner::Instance, :mock_spanner do
     _(database.state).must_equal :READY
     _(database).must_be :ready?
     _(database).wont_be :creating?
+
+    _(database.version_retention_period).must_equal version_retention_period
+    _(database.earliest_version_time).must_equal earliest_version_time
 
     restore_info = database.restore_info
     _(restore_info).must_be_kind_of Google::Cloud::Spanner::Database::RestoreInfo

--- a/google-cloud-spanner/test/helper.rb
+++ b/google-cloud-spanner/test/helper.rb
@@ -91,11 +91,13 @@ class MockSpanner < Minitest::Spec
   end
 
   def database_hash instance_id: "my-instance-id", database_id: "database-#{rand(9999)}",
-                    state: "READY", restore_info: {}
+                    state: "READY", restore_info: {}, version_retention_period: "", earliest_version_time: nil
     {
       name: "projects/#{project}/instances/#{instance_id}/databases/#{database_id}",
       state: state,
-      restore_info: restore_info
+      restore_info: restore_info,
+      version_retention_period: version_retention_period,
+      earliest_version_time: earliest_version_time
     }
   end
 

--- a/google-cloud-spanner/test/helper.rb
+++ b/google-cloud-spanner/test/helper.rb
@@ -119,12 +119,14 @@ class MockSpanner < Minitest::Spec
 
   def backup_hash instance_id: "my-instance-id", database_id: "database-#{rand(9999)}",
                   backup_id: "backup-#{rand(9999)}", state: "READY", expire_time: Time.now + 36000,
-                  create_time: Time.now, size_bytes: 1024, referencing_databases: ["db1"]
+                  version_time: Time.now - 3600, create_time: Time.now, size_bytes: 1024, 
+                  referencing_databases: ["db1"]
     {
       name: "projects/#{project}/instances/#{instance_id}/backups/#{backup_id}",
       database: "projects/#{project}/instances/#{instance_id}/databases/#{database_id}",
       state: state,
       expire_time: expire_time,
+      version_time: version_time,
       create_time: create_time,
       size_bytes: size_bytes,
       referencing_databases: referencing_databases.map do |database|


### PR DESCRIPTION
Implements the PITR-lite support.

With this functionality users will be able to set the retention period for their databases (through the version_retention_period database field).

Users will also be able to create a backup from a consistent timestamp of the database within its version_retention_period.