### PR TITLE
feat(stackdriver): Update dependencies to post-microgenerator versions

### DIFF
--- a/stackdriver/stackdriver.gemspec
+++ b/stackdriver/stackdriver.gemspec
@@ -18,10 +18,9 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.4"
 
-  gem.add_runtime_dependency "google-cloud-debugger", "~> 0.32"
-  gem.add_runtime_dependency "google-cloud-error_reporting", "~> 0.30"
-  gem.add_runtime_dependency "google-cloud-logging", "~> 2.0"
-  gem.add_runtime_dependency "google-cloud-trace", "~> 0.33"
+  gem.add_runtime_dependency "google-cloud-error_reporting", "~> 0.41"
+  gem.add_runtime_dependency "google-cloud-logging", "~> 2.1"
+  gem.add_runtime_dependency "google-cloud-trace", "~> 0.40"
 
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
   gem.add_development_dependency "google-style", "~> 1.24.0"


### PR DESCRIPTION
* Updates the dependencies for stackdriver to the latest minor releases of logging, trace, and error reporting (notably to post-microgenerator releases).
* Drops debugger from the dependencies. We're mildly deprecating debugger for now for lack of upstream support.
