### PR TITLE
Release stackdriver 0.20.0

### DIFF
--- a/stackdriver/CHANGELOG.md
+++ b/stackdriver/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release History
 
+### 0.20.0 / 2020-12-02
+
+* BREAKING CHANGE: Removed google-cloud-debugger from the standard suite of stackdriver agents. If you are using the debugger, include the google-cloud-debugger gem explicitly.
+* Update to version 2.x of google-cloud-logging
+* Update to version 0.41 of google-cloud-error_reporting
+* Update to version 0.40 of google-cloud-trace
+
 ### 0.16.1 / 2019-12-18
 
 #### Documentation

--- a/stackdriver/lib/stackdriver/version.rb
+++ b/stackdriver/lib/stackdriver/version.rb
@@ -14,5 +14,5 @@
 
 
 module Stackdriver
-  VERSION = "0.16.1".freeze
+  VERSION = "0.20.0".freeze
 end


### PR DESCRIPTION
* BREAKING CHANGE: Removed google-cloud-debugger from the standard suite of stackdriver agents. If you are using the debugger, include the google-cloud-debugger gem explicitly.
* Update to version 2.x of google-cloud-logging
* Update to version 0.41 of google-cloud-error_reporting
* Update to version 0.40 of google-cloud-trace

<details><summary>Commits since previous release</summary><pre><code>commit bf17920882c3297f66d2249cd023bb2883e707b6
Author: Daniel Azuma <dazuma@google.com>
Date:   Mon Nov 30 13:28:05 2020 -0800

    feat(stackdriver)!: Remove debugger and update other dependencies to post-microgenerator versions

commit 9224cbbfacd25a766ef31cb3be2e1bcb8161a88a
Author: Daniel Azuma <dazuma@google.com>
Date:   Tue Jul 21 16:20:00 2020 -0700

    Release google-cloud-logging 2.0.0 (#7064)
    
    * Update to use the microgenerator-generated low-level client

commit 7d35382342311d90650d622879b8deb700e67550
Author: Daniel Azuma <dazuma@google.com>
Date:   Sun Jun 21 18:06:44 2020 -0700

    chore: Unpin protobuf on Ruby 2.4

commit 703b3425a905bdb2de1a7653229d5fb4af28f65a
Author: Daniel Azuma <dazuma@google.com>
Date:   Tue May 19 09:14:38 2020 -0700

    chore: Pin protobuf for old rubies and always require minitest/focus

commit ea214deaae1d610f98911520e2c2f98c2873b794
Author: Chris Smith <quartzmo@gmail.com>
Date:   Wed Mar 4 15:35:50 2020 -0700

    chore: Update Rake version (remove ~> 12.3)
    
    To prepare Ruby 3 keyword arguments support, there are some other gems also need update. `rake` is one of them.
    
    * Rake 13.0.0 supports Ruby 3 keyword arguments by https://github.com/ruby/rake/pull/326
    * Rake 13 drops Ruby 2.1 or older support by https://github.com/ruby/rake/pull/325
    * Gems under `google-cloud-ruby` repository only supports Ruby 2.4 or higher then dropping Ruby 2.1 support should not be an issue.
    
    refs: #4884
    pr: #4897

commit 828319ec4b794ecfbe352940d5f5347db24d1877
Author: Daniel Azuma <dazuma@google.com>
Date:   Tue Feb 25 14:21:29 2020 -0800

    chore: require the simplecov library explicitly in test helpers

commit 8d7d444e7189735b15961087c598a79882444fd2
Author: David Supplee <dwsupplee@gmail.com>
Date:   Thu Feb 20 11:35:48 2020 -0800

    chore: add documentation links to repo-metadata files

commit 9f6d3fa8ec882f8ca4e4467abd4bdd61bea9a94c
Author: Daniel Azuma <dazuma@google.com>
Date:   Fri Dec 27 11:44:46 2019 -0800

    chore: Split out google-cloud-errors gem (#4537)
</code></pre></details>

This pull request was generated using releasetool.