### PR TITLE
fix(stackdriver): Remove debugger references completely

### DIFF
--- a/stackdriver/Gemfile
+++ b/stackdriver/Gemfile
@@ -3,7 +3,6 @@ source "https://rubygems.org"
 gemspec
 
 gem "google-cloud-core", path: "../google-cloud-core"
-gem "google-cloud-debugger", path: "../google-cloud-debugger"
 gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-error_reporting", path: "../google-cloud-error_reporting"
 gem "google-cloud-errors", path: "../google-cloud-errors"

--- a/stackdriver/Rakefile
+++ b/stackdriver/Rakefile
@@ -87,8 +87,6 @@ end
 
 desc "Run the CI build"
 task :ci do
-  header "BUILDING stackdriver"
-  Rake::Task[:debugger_c].invoke
   header "stackdriver rubocop", "*"
   Rake::Task[:rubocop].invoke
   header "stackdriver yard", "*"
@@ -112,18 +110,6 @@ namespace :ci do
 end
 
 task default: :test
-
-desc "Compiles c extension for google-cloud-debugger"
-task :debugger_c do
-  header "compiling google-cloud-debugger", "*"
-  debugger_directory = File.join File.dirname(Dir.getwd), "google-cloud-debugger"
-  Dir.chdir debugger_directory do
-    Bundler.with_clean_env do
-      sh "bundle update"
-      sh "bundle exec rake compile"
-    end
-  end
-end
 
 def header str, token = "#"
   line_length = str.length + 8

--- a/stackdriver/lib/stackdriver.rb
+++ b/stackdriver/lib/stackdriver.rb
@@ -13,18 +13,15 @@
 # limitations under the License.
 
 
-gem "google-cloud-debugger"
 gem "google-cloud-error_reporting"
 gem "google-cloud-logging"
 gem "google-cloud-trace"
 
-require "google/cloud/debugger"
 require "google/cloud/error_reporting"
 require "google/cloud/logging"
 require "google/cloud/trace"
 
 if defined? ::Rails::Railtie
-  require "google/cloud/debugger/rails"
   require "google/cloud/error_reporting/rails"
   require "google/cloud/logging/rails"
   require "google/cloud/trace/rails"

--- a/stackdriver/test/stackdriver_test.rb
+++ b/stackdriver/test/stackdriver_test.rb
@@ -24,10 +24,6 @@ describe Stackdriver do
     defined?(Google::Cloud::Logging).wont_be_nil
   end
 
-  it "requires google-cloud-debugger rails module" do
-    defined?(Google::Cloud::Debugger::Railtie).wont_be_nil
-  end
-
   it "requires google-cloud-error_reporting rails module" do
     defined?(Google::Cloud::ErrorReporting::Railtie).wont_be_nil
   end


### PR DESCRIPTION
Previously I removed debugger from the stackdriver gem's dependency list, but failed to remove the require statements etc. And the tests didn't catch it because I also failed to remove debugger from the Gemfile. 😫

Fixed.