### PR TITLE
chore(storage): Fix public bucket in acceptance tests

### DIFF
--- a/google-cloud-storage/acceptance/storage/filename_test.rb
+++ b/google-cloud-storage/acceptance/storage/filename_test.rb
@@ -15,12 +15,7 @@
 require "storage_helper"
 
 describe Google::Cloud::Storage::File, :storage do
-  let(:bucket_name) {
-    ENV["GCLOUD_TEST_STORAGE_BUCKET"] || "storage-library-test-bucket"
-  }
-  let :bucket do
-    storage.bucket(bucket_name)
-  end
+  let(:bucket) { bucket_public }
 
   # Normalization Form C: a single character for e-acute U+00e9.
   # URL should end with Cafe%CC%81

--- a/google-cloud-storage/acceptance/storage/signed_url_v2_test.rb
+++ b/google-cloud-storage/acceptance/storage/signed_url_v2_test.rb
@@ -23,16 +23,10 @@ describe Google::Cloud::Storage, :signed_url, :v2, :storage do
     safe_gcs_execute { storage.create_bucket(bucket_name) }
   end
   let(:bucket_name) { $bucket_names.first }
-
   let(:files) do
     { logo: { path: "acceptance/data/CloudPlatform_128px_Retina.png" },
       big:  { path: "acceptance/data/three-mb-file.tif" } }
   end
-
-  let(:bucket_public_test_name) {
-    ENV["GCLOUD_TEST_STORAGE_BUCKET"] || "storage-library-test-bucket"
-  }
-  let(:file_public_test_gzip_name) { "gzipped-text.txt" }  # content is "hello world"
 
   before do
     # always create the bucket

--- a/google-cloud-storage/acceptance/storage/signed_url_v4_test.rb
+++ b/google-cloud-storage/acceptance/storage/signed_url_v4_test.rb
@@ -23,16 +23,10 @@ describe Google::Cloud::Storage, :signed_url, :v4, :storage do
     safe_gcs_execute { storage.create_bucket(bucket_name) }
   end
   let(:bucket_name) { $bucket_names.first }
-
   let(:files) do
     { logo: { path: "acceptance/data/CloudPlatform_128px_Retina.png" },
       big:  { path: "acceptance/data/three-mb-file.tif" } }
   end
-
-  let(:bucket_public_test_name) {
-    ENV["GCLOUD_TEST_STORAGE_BUCKET"] || "storage-library-test-bucket"
-  }
-  let(:file_public_test_gzip_name) { "gzipped-text.txt" }  # content is "hello world"
 
   before do
     # always create the bucket

--- a/google-cloud-storage/acceptance/storage_helper.rb
+++ b/google-cloud-storage/acceptance/storage_helper.rb
@@ -123,18 +123,19 @@ end
 require "time"
 require "securerandom"
 t = Time.now.utc.iso8601.gsub ":", "-"
-$bucket_names = 4.times.map { "gcloud-ruby-acceptance-#{t}-#{SecureRandom.hex(4)}".downcase }
+$bucket_names = 3.times.map { "gcloud-ruby-acceptance-#{t}-#{SecureRandom.hex(4)}".downcase }
 $prefix = "gcloud_ruby_acceptance_#{t}_#{SecureRandom.hex(4)}".downcase.gsub "-", "_"
 # bucket names for second project
 $bucket_names_2 = 3.times.map { "gcloud-ruby-acceptance-2-#{t}-#{SecureRandom.hex(4)}".downcase }
+$bucket_name_public = "gcloud-ruby-acceptance-public-read".freeze
 
 def bucket_public
   begin
-    b = storage.bucket $bucket_names[3]
+    b = storage.bucket $bucket_name_public
     return b if b
-    create_bucket_public $bucket_names[3]
+    create_bucket_public $bucket_name_public
   rescue Google::Cloud::PermissionDeniedError
-    create_bucket_public $bucket_names[3]
+    create_bucket_public $bucket_name_public
   end
 end
 


### PR DESCRIPTION
The shared public bucket `storage-library-test-bucket` previously used by the storage acceptance tests is no longer accessible. This PR replaces it with a public bucket fixture scoped to each test suite run.

closes: #8206