### PR TITLE
fix(document_ai-v1beta3): Fix version namespace

### DIFF
--- a/google-cloud-document_ai-v1beta3/google-cloud-document_ai-v1beta3.gemspec
+++ b/google-cloud-document_ai-v1beta3/google-cloud-document_ai-v1beta3.gemspec
@@ -5,7 +5,7 @@ require File.expand_path("lib/google/cloud/document_ai/v1beta3/version", __dir__
 
 Gem::Specification.new do |gem|
   gem.name          = "google-cloud-document_ai-v1beta3"
-  gem.version       = Google::Cloud::DocumentAi::V1beta3::VERSION
+  gem.version       = Google::Cloud::DocumentAI::V1beta3::VERSION
 
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"

--- a/google-cloud-document_ai-v1beta3/lib/google/cloud/document_ai/v1beta3/document_processor_service/client.rb
+++ b/google-cloud-document_ai-v1beta3/lib/google/cloud/document_ai/v1beta3/document_processor_service/client.rb
@@ -231,7 +231,7 @@ module Google
               # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= ::Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: ::Google::Cloud::DocumentAi::V1beta3::VERSION
+                gapic_version: ::Google::Cloud::DocumentAI::V1beta3::VERSION
               metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
@@ -302,7 +302,7 @@ module Google
               # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= ::Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: ::Google::Cloud::DocumentAi::V1beta3::VERSION
+                gapic_version: ::Google::Cloud::DocumentAI::V1beta3::VERSION
               metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
@@ -373,7 +373,7 @@ module Google
               # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= ::Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: ::Google::Cloud::DocumentAi::V1beta3::VERSION
+                gapic_version: ::Google::Cloud::DocumentAI::V1beta3::VERSION
               metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {

--- a/google-cloud-document_ai-v1beta3/lib/google/cloud/document_ai/v1beta3/document_processor_service/operations.rb
+++ b/google-cloud-document_ai-v1beta3/lib/google/cloud/document_ai/v1beta3/document_processor_service/operations.rb
@@ -152,7 +152,7 @@ module Google
               # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= ::Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: ::Google::Cloud::DocumentAi::V1beta3::VERSION
+                gapic_version: ::Google::Cloud::DocumentAI::V1beta3::VERSION
               metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
@@ -222,7 +222,7 @@ module Google
               # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= ::Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: ::Google::Cloud::DocumentAi::V1beta3::VERSION
+                gapic_version: ::Google::Cloud::DocumentAI::V1beta3::VERSION
               metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
@@ -292,7 +292,7 @@ module Google
               # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= ::Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: ::Google::Cloud::DocumentAi::V1beta3::VERSION
+                gapic_version: ::Google::Cloud::DocumentAI::V1beta3::VERSION
               metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {
@@ -367,7 +367,7 @@ module Google
               # Set x-goog-api-client and x-goog-user-project headers
               metadata[:"x-goog-api-client"] ||= ::Gapic::Headers.x_goog_api_client \
                 lib_name: @config.lib_name, lib_version: @config.lib_version,
-                gapic_version: ::Google::Cloud::DocumentAi::V1beta3::VERSION
+                gapic_version: ::Google::Cloud::DocumentAI::V1beta3::VERSION
               metadata[:"x-goog-user-project"] = @quota_project_id if @quota_project_id
 
               header_params = {

--- a/google-cloud-document_ai-v1beta3/lib/google/cloud/document_ai/v1beta3/version.rb
+++ b/google-cloud-document_ai-v1beta3/lib/google/cloud/document_ai/v1beta3/version.rb
@@ -19,7 +19,7 @@
 
 module Google
   module Cloud
-    module DocumentAi
+    module DocumentAI
       module V1beta3
         VERSION = "0.0.1"
       end

--- a/google-cloud-document_ai-v1beta3/synth.py
+++ b/google-cloud-document_ai-v1beta3/synth.py
@@ -35,6 +35,7 @@ library = gapic.ruby_library(
         "ruby-cloud-product-url": "https://cloud.google.com/document-ai/",
         "ruby-cloud-api-id": "us-documentai.googleapis.com",
         "ruby-cloud-api-shortname": "documentai",
+        "ruby-cloud-namespace-override": "DocumentAi=DocumentAI",
     }
 )
 


### PR DESCRIPTION
The version constant was in the namespace `DocumentAi` instead of `DocumentAI` because I forgot to include a generator option in the synth script. Fixed.

This is technically a breaking change, but we haven't done any releases of this library yet.