### PR TITLE
Release google-cloud-artifact_registry 0.1.0

### DIFF
--- a/google-cloud-artifact_registry/CHANGELOG.md
+++ b/google-cloud-artifact_registry/CHANGELOG.md
@@ -1,2 +1,6 @@
 # Release History
 
+### 0.1.0 / 2020-12-08
+
+Initial release.
+

--- a/google-cloud-artifact_registry/lib/google/cloud/artifact_registry/version.rb
+++ b/google-cloud-artifact_registry/lib/google/cloud/artifact_registry/version.rb
@@ -20,7 +20,7 @@
 module Google
   module Cloud
     module ArtifactRegistry
-      VERSION = "0.0.1"
+      VERSION = "0.1.0"
     end
   end
 end


### PR DESCRIPTION
Initial release.

<details><summary>Commits since previous release</summary><pre><code></code></pre></details>

This pull request was generated using releasetool.