### PR TITLE
Release google-cloud-binary_authorization 0.1.0

### DIFF
--- a/google-cloud-binary_authorization/CHANGELOG.md
+++ b/google-cloud-binary_authorization/CHANGELOG.md
@@ -1,2 +1,6 @@
 # Release History
 
+### 0.1.0 / 2020-12-08
+
+Initial release.
+

--- a/google-cloud-binary_authorization/lib/google/cloud/binary_authorization/version.rb
+++ b/google-cloud-binary_authorization/lib/google/cloud/binary_authorization/version.rb
@@ -20,7 +20,7 @@
 module Google
   module Cloud
     module BinaryAuthorization
-      VERSION = "0.0.1"
+      VERSION = "0.1.0"
     end
   end
 end


### PR DESCRIPTION
Initial release.

<details><summary>Commits since previous release</summary><pre><code></code></pre></details>

This pull request was generated using releasetool.