### PR TITLE
Release google-cloud-service_control 0.1.0

### DIFF
--- a/google-cloud-service_control/CHANGELOG.md
+++ b/google-cloud-service_control/CHANGELOG.md
@@ -1,2 +1,6 @@
 # Release History
 
+### 0.1.0 / 2020-12-08
+
+Initial release.
+

--- a/google-cloud-service_control/lib/google/cloud/service_control/version.rb
+++ b/google-cloud-service_control/lib/google/cloud/service_control/version.rb
@@ -20,7 +20,7 @@
 module Google
   module Cloud
     module ServiceControl
-      VERSION = "0.0.1"
+      VERSION = "0.1.0"
     end
   end
 end


### PR DESCRIPTION
Initial release.

<details><summary>Commits since previous release</summary><pre><code></code></pre></details>

This pull request was generated using releasetool.