### PR TITLE
Release google-cloud-data_labeling 0.1.0

### DIFF
--- a/google-cloud-data_labeling/CHANGELOG.md
+++ b/google-cloud-data_labeling/CHANGELOG.md
@@ -1,2 +1,6 @@
 # Release History
 
+### 0.1.0 / 2020-12-08
+
+Initial release.
+

--- a/google-cloud-data_labeling/lib/google/cloud/data_labeling/version.rb
+++ b/google-cloud-data_labeling/lib/google/cloud/data_labeling/version.rb
@@ -20,7 +20,7 @@
 module Google
   module Cloud
     module DataLabeling
-      VERSION = "0.0.1"
+      VERSION = "0.1.0"
     end
   end
 end


### PR DESCRIPTION
Initial release.

<details><summary>Commits since previous release</summary><pre><code></code></pre></details>

This pull request was generated using releasetool.