### PR TITLE
chore(security_center): Wrap samples with future prefix

### DIFF
--- a/google-cloud-security_center/samples/notification.rb
+++ b/google-cloud-security_center/samples/notification.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 def create_notification_config org_id:, config_id:, pubsub_topic:
+  # [START securitycenter_create_notification_config]
   # [START scc_create_notification_config]
   require "google/cloud/security_center"
 
@@ -42,10 +43,12 @@ def create_notification_config org_id:, config_id:, pubsub_topic:
     notification_config: notification_config
   )
   puts "Created notification config #{config_id}: #{response}."
-  # [END scc_create_notification_config]
+# [END scc_create_notification_config]
+# [END securitycenter_create_notification_config]
 end
 
 def update_notification_config org_id:, config_id:, description: nil, pubsub_topic: nil, filter: nil
+  # [START securitycenter_update_notification_config]
   # [START scc_update_notification_config]
   require "google/cloud/security_center"
 
@@ -85,10 +88,12 @@ def update_notification_config org_id:, config_id:, description: nil, pubsub_top
     update_mask:         update_mask
   )
   puts response
-  # [END scc_update_notification_config]
+# [END scc_update_notification_config]
+# [END securitycenter_update_notification_config]
 end
 
 def delete_notification_config org_id:, config_id:
+  # [START securitycenter_delete_notification_config]
   # [START scc_delete_notification_config]
   require "google/cloud/security_center"
 
@@ -107,9 +112,11 @@ def delete_notification_config org_id:, config_id:
   response = client.delete_notification_config name: config_path
   puts "Deleted notification config #{config_id} with response: #{response}"
   # [END scc_delete_notification_config]
+  # [END securitycenter_delete_notification_config]
 end
 
 def get_notification_config org_id:, config_id:
+  # [START securitycenter_get_notification_config]
   # [START scc_get_notification_config]
   require "google/cloud/security_center"
 
@@ -127,10 +134,12 @@ def get_notification_config org_id:, config_id:
 
   response = client.get_notification_config name: config_path
   puts "Notification config fetched: #{response}"
-  # [END scc_get_notification_config]
+# [END scc_get_notification_config]
+# [END securitycenter_notification_config]
 end
 
 def list_notification_configs org_id:
+  # [START securitycenter_list_notification_configs]
   # [START scc_list_notification_configs]
   require "google/cloud/security_center"
 
@@ -146,7 +155,8 @@ def list_notification_configs org_id:
       puts element
     end
   end
-  # [END scc_list_notification_configs]
+# [END scc_list_notification_configs]
+# [END securitycenter_list_notification_configs]
 end
 
 if $PROGRAM_NAME == __FILE__

--- a/google-cloud-security_center/samples/notification.rb
+++ b/google-cloud-security_center/samples/notification.rb
@@ -135,7 +135,7 @@ def get_notification_config org_id:, config_id:
   response = client.get_notification_config name: config_path
   puts "Notification config fetched: #{response}"
 # [END scc_get_notification_config]
-# [END securitycenter_notification_config]
+# [END securitycenter_get_notification_config]
 end
 
 def list_notification_configs org_id:

--- a/google-cloud-security_center/samples/notification.rb
+++ b/google-cloud-security_center/samples/notification.rb
@@ -43,8 +43,8 @@ def create_notification_config org_id:, config_id:, pubsub_topic:
     notification_config: notification_config
   )
   puts "Created notification config #{config_id}: #{response}."
-# [END scc_create_notification_config]
-# [END securitycenter_create_notification_config]
+  # [END scc_create_notification_config]
+  # [END securitycenter_create_notification_config]
 end
 
 def update_notification_config org_id:, config_id:, description: nil, pubsub_topic: nil, filter: nil
@@ -88,8 +88,8 @@ def update_notification_config org_id:, config_id:, description: nil, pubsub_top
     update_mask:         update_mask
   )
   puts response
-# [END scc_update_notification_config]
-# [END securitycenter_update_notification_config]
+  # [END scc_update_notification_config]
+  # [END securitycenter_update_notification_config]
 end
 
 def delete_notification_config org_id:, config_id:
@@ -134,8 +134,8 @@ def get_notification_config org_id:, config_id:
 
   response = client.get_notification_config name: config_path
   puts "Notification config fetched: #{response}"
-# [END scc_get_notification_config]
-# [END securitycenter_get_notification_config]
+  # [END scc_get_notification_config]
+  # [END securitycenter_get_notification_config]
 end
 
 def list_notification_configs org_id:
@@ -155,8 +155,8 @@ def list_notification_configs org_id:
       puts element
     end
   end
-# [END scc_list_notification_configs]
-# [END securitycenter_list_notification_configs]
+  # [END scc_list_notification_configs]
+  # [END securitycenter_list_notification_configs]
 end
 
 if $PROGRAM_NAME == __FILE__


### PR DESCRIPTION
Standardizing Security Command Center samples to use 'securitycenter' prefixing. 

- Wrapped existing samples to keep published doclinks unbroken
- Replace region tags that aren't published. 

Once this PR is through, published sample inclusions will be updated to use the new prefix, then I'll come through again and remove the unused block wraps.