### PR TITLE
make column family cf1 name consistent in the documentation

### DIFF
--- a/google-cloud-bigtable/OVERVIEW.md
+++ b/google-cloud-bigtable/OVERVIEW.md
@@ -194,8 +194,8 @@ table = bigtable.table("my-instance", "my-table")
 
 entry = table.new_mutation_entry("user-1")
 entry.set_cell(
-  "cf-1",
-  "field-1",
+  "cf1",
+  "field1",
   "XYZ",
   timestamp: (Time.now.to_f * 1000000).round(-3) # microseconds
 ).delete_cells("cf2", "field02")
@@ -245,8 +245,8 @@ table = bigtable.table("my-instance", "my-table")
 predicate_filter = Google::Cloud::Bigtable::RowFilter.key("user-10")
 on_match_mutations = Google::Cloud::Bigtable::MutationEntry.new
 on_match_mutations.set_cell(
-  "cf-1",
-  "field-1",
+  "cf1",
+  "field1",
   "XYZ",
   timestamp: (Time.now.to_f * 1000000).round(-3) # microseconds
 ).delete_cells("cf2", "field02")

--- a/google-cloud-bigtable/README.md
+++ b/google-cloud-bigtable/README.md
@@ -45,8 +45,8 @@ table = bigtable.table("my-instance", "my-table")
 
 entry = table.new_mutation_entry("user-1")
 entry.set_cell(
-  "cf-1",
-  "field-1",
+  "cf1",
+  "field1",
   "XYZ",
   timestamp: Time.now.to_i * 1000 # Time stamp in milli seconds.
 ).delete_cells("cf2", "field02")

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/instance.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/instance.rb
@@ -509,8 +509,8 @@ module Google
         #
         #   entry = table.new_mutation_entry("user-1")
         #   entry.set_cell(
-        #     "cf-1",
-        #     "field-1",
+        #     "cf1",
+        #     "field1",
         #     "XYZ",
         #     timestamp: (Time.now.to_f * 1000000).round(-3) # microseconds
         #   ).delete_cells("cf2", "field02")

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/mutation_entry.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/mutation_entry.rb
@@ -104,8 +104,8 @@ module Google
         # @example With timestamp.
         #   entry = Google::Cloud::Bigtable::MutationEntry.new("user-1")
         #   entry.set_cell(
-        #     "cf-1",
-        #     "field-1",
+        #     "cf1",
+        #     "field1",
         #     "XYZ",
         #     timestamp: (Time.now.to_f * 1000000).round(-3) # microseconds
         #   )
@@ -156,14 +156,14 @@ module Google
         #
         # @example Without timestamp range.
         #   entry = Google::Cloud::Bigtable::MutationEntry.new("user-1")
-        #   entry.delete_cells("cf-1", "field-1")
+        #   entry.delete_cells("cf1", "field1")
         #
         # @example With timestamp range.
         #   entry = Google::Cloud::Bigtable::MutationEntry.new("user-1")
         #   timestamp_micros = (Time.now.to_f * 1000000).round(-3)
         #   entry.delete_cells(
         #     "cf1",
-        #     "field-1",
+        #     "field1",
         #     timestamp_from: timestamp_micros - 5000000,
         #     timestamp_to: timestamp_micros
         #   )
@@ -172,7 +172,7 @@ module Google
         #   timestamp_micros = (Time.now.to_f * 1000000).round(-3)
         #   entry.delete_cells(
         #     "cf1",
-        #     "field-1",
+        #     "field1",
         #     timestamp_from: timestamp_micros - 5000000
         #   )
         #
@@ -201,7 +201,7 @@ module Google
         #
         # @example
         #   entry = Google::Cloud::Bigtable::MutationEntry.new("user-1")
-        #   entry.delete_from_family("cf-1")
+        #   entry.delete_from_family("cf1")
         #
         def delete_from_family family
           @mutations << Google::Cloud::Bigtable::V2::Mutation.new(delete_from_family: { family_name: family })

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/mutation_operations.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/mutation_operations.rb
@@ -65,8 +65,8 @@ module Google
         #
         #   entry = table.new_mutation_entry("user-1")
         #   entry.set_cell(
-        #     "cf-1",
-        #     "field-1",
+        #     "cf1",
+        #     "field1",
         #     "XYZ",
         #     timestamp: (Time.now.to_f * 1000000).round(-3) # microseconds
         #   ).delete_cells("cf2", "field02")
@@ -219,8 +219,8 @@ module Google
         #   predicate_filter = Google::Cloud::Bigtable::RowFilter.key("user-10")
         #   on_match_mutations = Google::Cloud::Bigtable::MutationEntry.new
         #   on_match_mutations.set_cell(
-        #     "cf-1",
-        #     "field-1",
+        #     "cf1",
+        #     "field1",
         #     "XYZ",
         #     timestamp: (Time.now.to_f * 1000000).round(-3) # microseconds
         #   ).delete_cells("cf2", "field02")


### PR DESCRIPTION
Small fix documentation.

[big talbe column description](https://github.com/googleapis/google-cloud-ruby/issues/8407)

closes: #8407