### PR TITLE
feat(spanner): optionalize `credentials` when using cloud spanner emulator host

### DIFF
--- a/google-cloud-spanner/lib/google/cloud/spanner.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner.rb
@@ -105,7 +105,7 @@ module Google
         if emulator_host
           credentials = :this_channel_is_insecure
         else
-          credentials ||= default_credentials(scope: scope)
+          credentials ||= default_credentials scope: scope
           unless credentials.is_a? Google::Auth::Credentials
             credentials = Spanner::Credentials.new credentials, scope: scope
           end

--- a/google-cloud-spanner/lib/google/cloud/spanner.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner.rb
@@ -91,19 +91,19 @@ module Google
       def self.new project_id: nil, credentials: nil, scope: nil, timeout: nil,
                    endpoint: nil, project: nil, keyfile: nil,
                    emulator_host: nil, lib_name: nil, lib_version: nil
-        project_id    ||= (project || default_project_id)
+        project_id    ||= project || default_project_id
         scope         ||= configure.scope
         timeout       ||= configure.timeout
-        endpoint      ||= configure.endpoint
-        credentials   ||= (keyfile || default_credentials(scope: scope))
         emulator_host ||= configure.emulator_host
+        endpoint      ||= emulator_host || configure.endpoint
+        credentials   ||= keyfile
         lib_name      ||= configure.lib_name
         lib_version   ||= configure.lib_version
 
         if emulator_host
           credentials = :this_channel_is_insecure
-          endpoint = emulator_host
         else
+          credentials ||= default_credentials(scope: scope)
           unless credentials.is_a? Google::Auth::Credentials
             credentials = Spanner::Credentials.new credentials, scope: scope
           end

--- a/google-cloud-spanner/lib/google/cloud/spanner.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner.rb
@@ -49,6 +49,8 @@ module Google
       # @param [String, Hash, Google::Auth::Credentials] credentials The path to
       #   the keyfile as a String, the contents of the keyfile as a Hash, or a
       #   Google::Auth::Credentials object. (See {Spanner::Credentials})
+      #   If `emulator_host` is present, this becomes optional and the value is
+      #   internally overriden with `:this_channel_is_insecure`.
       # @param [String, Array<String>] scope The OAuth 2.0 scopes controlling
       #   the set of resources and operations that the connection can access.
       #   See [Using OAuth 2.0 to Access Google
@@ -60,7 +62,7 @@ module Google
       #   * `https://www.googleapis.com/auth/spanner.data`
       # @param [Integer] timeout Default timeout to use in requests. Optional.
       # @param [String] endpoint Override of the endpoint host name. Optional.
-      #   If the param is nil, uses the default endpoint.
+      #   If the param is nil, uses `emulator_host` or the default endpoint.
       # @param [String] project Alias for the `project_id` argument. Deprecated.
       # @param [String] keyfile Alias for the `credentials` argument.
       #   Deprecated.

--- a/google-cloud-spanner/test/google/cloud/spanner_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner_test.rb
@@ -370,13 +370,11 @@ describe Google::Cloud do
       ENV.stub :[], nil do
         # Get project_id from Google Compute Engine
         Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
-          Google::Cloud::Spanner::Credentials.stub :default, default_credentials do
-            spanner = Google::Cloud::Spanner.new emulator_host: emulator_host
-            _(spanner).must_be_kind_of Google::Cloud::Spanner::Project
-            _(spanner.project).must_equal "project-id"
-            _(spanner.service.credentials).must_equal :this_channel_is_insecure
-            _(spanner.service.host).must_equal emulator_host
-          end
+          spanner = Google::Cloud::Spanner.new emulator_host: emulator_host
+          _(spanner).must_be_kind_of Google::Cloud::Spanner::Project
+          _(spanner.project).must_equal "project-id"
+          _(spanner.service.credentials).must_equal :this_channel_is_insecure
+          _(spanner.service.host).must_equal emulator_host
         end
       end
     end

--- a/google-cloud-spanner/test/google/cloud/spanner_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner_test.rb
@@ -364,7 +364,7 @@ describe Google::Cloud do
       end
     end
 
-    it "allows emulator_host to be set" do
+    it "allows emulator_host to be set with emulator_host and implicit default_project_id" do
       emulator_host = "localhost:4567"
       # Clear all environment variables
       ENV.stub :[], nil do
@@ -376,6 +376,18 @@ describe Google::Cloud do
           _(spanner.service.credentials).must_equal :this_channel_is_insecure
           _(spanner.service.host).must_equal emulator_host
         end
+      end
+    end
+
+    it 'allows emulator_host to be set with emulator_host and project_id' do
+      emulator_host = "localhost:4567"
+      project_id = "arbitrary-string"
+      ENV.stub :[], nil do
+        spanner = Google::Cloud::Spanner.new project_id: project_id, emulator_host: emulator_host
+        _(spanner).must_be_kind_of Google::Cloud::Spanner::Project
+        _(spanner.project).must_equal project_id
+        _(spanner.service.credentials).must_equal :this_channel_is_insecure
+        _(spanner.service.host).must_equal emulator_host
       end
     end
 


### PR DESCRIPTION
With Cloud Spanner Emulator, we must specify `emulator_host`
when calling `Google::Cloud::Spanner.new`.

The `credentials` argument, which was previously required but
not-so meaningful, now becomes optional when `emulator_host`
is specified.

`:this_channel_is_insecure` is assigned as before.

Now you can just call:
`Google::Cloud::Spanner.new(project_id: 'arbitrary-string', emulator_host: 'localhost:9010')`

-----

- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-ruby/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea.
- [x] Follow the instructions in [CONTRIBUTING](CONTRIBUTING.md). Most importantly, ensure the tests and linter pass by running `bundle exec rake ci` in the gem subdirectory.
- [x] Update code documentation if necessary.

Regarding the second checkbox, I confirmed that the `bundle exec rake ci` has its own RuboCop problem and I will send another patch to fix the issue. (It did not work on master branch.) I have confirmed that `bundle exec rake test` and `bundle exec rake doctest` pass in my local environment.

-----

closes: #8134 
