### PR TITLE
feat(bigquery): Replace google-api-client with google-apis-bigquery_v2

### DIFF
--- a/google-cloud-bigquery/google-cloud-bigquery.gemspec
+++ b/google-cloud-bigquery/google-cloud-bigquery.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.4"
 
   gem.add_dependency "concurrent-ruby", "~> 1.0"
-  gem.add_dependency "google-api-client", "~> 0.47"
+  gem.add_dependency "google-apis-bigquery_v2", "~> 0.1"
   gem.add_dependency "google-cloud-core", "~> 1.2"
   gem.add_dependency "googleauth", "~> 0.9"
   gem.add_dependency "mini_mime", "~> 1.0"


### PR DESCRIPTION
The acceptance tests are currently failing for me locally with this gem. The failures are unaffected by this PR.