### PR TITLE
chore: Replace google-api-client with google-apis-core in google-cloud-errors

### DIFF
--- a/google-cloud-core/Gemfile
+++ b/google-cloud-core/Gemfile
@@ -2,7 +2,6 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "google-api-client", "~> 0.23"
 gem "google-cloud-env", path: "../google-cloud-env"
 gem "google-cloud-errors", path: "../google-cloud-errors"
 gem "google-gax", "~> 1.0"

--- a/google-cloud-errors/Gemfile
+++ b/google-cloud-errors/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "google-api-client", "~> 0.36"
+gem "google-apis-core", "~> 0.2"
 gem "google-gax", "~> 1.8"
 
 gem "rake"


### PR DESCRIPTION
* Remove google-api-client from google-cloud-errors
* Remove google-api-client from google-cloud-core
* Add google-apis-core to google-cloud-errors

It appears that the `google-api-client` dependency was not needed in the `google-cloud-core` `Gemfile`.