### PR TITLE
Release google-cloud-retail 0.1.0

### DIFF
--- a/google-cloud-retail/CHANGELOG.md
+++ b/google-cloud-retail/CHANGELOG.md
@@ -1,2 +1,6 @@
 # Release History
 
+### 0.1.0 / 2021-01-12
+
+Initial release.
+

--- a/google-cloud-retail/lib/google/cloud/retail/version.rb
+++ b/google-cloud-retail/lib/google/cloud/retail/version.rb
@@ -20,7 +20,7 @@
 module Google
   module Cloud
     module Retail
-      VERSION = "0.0.1"
+      VERSION = "0.1.0"
     end
   end
 end


### PR DESCRIPTION
Initial release.

<details><summary>Commits since previous release</summary><pre><code></code></pre></details>

This pull request was generated using releasetool.