### PR TITLE
chore: Update api name for cloud channel in synth scripts

### DIFF
--- a/google-cloud-channel-v1/synth.py
+++ b/google-cloud-channel-v1/synth.py
@@ -29,7 +29,7 @@ library = gapic.ruby_library(
     ],
     generator_args={
         "ruby-cloud-gem-name": "google-cloud-channel-v1",
-        "ruby-cloud-title": "Channel Services V1",
+        "ruby-cloud-title": "Cloud Channel V1",
         "ruby-cloud-description": "You can use Channel Services to manage your relationships with your partners and your customers. Channel Services include a console and APIs to view and provision links between distributors and resellers, customers and entitlements.",
         "ruby-cloud-env-prefix": "CHANNEL",
         "ruby-cloud-grpc-service-config": "google/cloud/channel/v1/cloudchannel_grpc_service_config.json",

--- a/google-cloud-channel/synth.py
+++ b/google-cloud-channel/synth.py
@@ -26,7 +26,7 @@ library = gapic.ruby_library(
     "channel", "v1",
     generator_args={
         "ruby-cloud-gem-name": "google-cloud-channel",
-        "ruby-cloud-title": "Channel Services",
+        "ruby-cloud-title": "Cloud Channel",
         "ruby-cloud-description": "You can use Channel Services to manage your relationships with your partners and your customers. Channel Services include a console and APIs to view and provision links between distributors and resellers, customers and entitlements.",
         "ruby-cloud-env-prefix": "CHANNEL",
         "ruby-cloud-wrapper-of": "v1:0.0",


### PR DESCRIPTION
The product team asked us to update the API title as shown. This PR just updates synth scripts (hence `chore:`). Will rely on autosynth to regen the docs.