### PR TITLE
fix(spanner): rubocop failing due to bundler vendor directory

### DIFF
--- a/google-cloud-spanner/.rubocop.yml
+++ b/google-cloud-spanner/.rubocop.yml
@@ -9,6 +9,7 @@ AllCops:
     - "Rakefile"
     - "test/**/*"
     - "benchmark/**/*"
+    - "vendor/**/*"
 
 Documentation:
   Enabled: false


### PR DESCRIPTION
 Add vendor dir to rubocop exclude list

- [X] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-ruby/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea.
- [X] Follow the instructions in [CONTRIBUTING](CONTRIBUTING.md). Most importantly, ensure the tests and linter pass by running `bundle exec rake ci` in the gem subdirectory.

closes: #8417