### PR TITLE
chore: upgrades rubocop to latest version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "minitest-focus", "~> 1.1"
 gem "minitest-rg", "~> 5.2"
 gem "autotest-suffix", "~> 1.1"
 gem "redcarpet", "~> 3.0"
-gem "rubocop", "~> 0.64.0"
+gem "rubocop", "~> 1.8"
 gem "simplecov", "~> 0.16"
 gem "codecov", "~> 0.1", require: false
 gem "yard", "~> 0.9"


### PR DESCRIPTION
Fixes the linux build, that is failing due to rubocop old version (when running with ruby version `3.0.0`).

The linux build is failing with the following error:

```
Running RuboCop...
wrong number of arguments (given 3, expected 2)
/root/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rubocop-0.74.0/lib/rubocop/config_loader_resolver.rb:84:in `merge'
/root/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rubocop-0.74.0/lib/rubocop/config_loader_resolver.rb:76:in `merge_with_default'
/root/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rubocop-0.74.0/lib/rubocop/config_loader.rb:124:in `merge_with_default'
/root/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rubocop-0.74.0/lib/rubocop/config_loader.rb:94:in `configuration_from_file'
/root/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rubocop-0.74.0/lib/rubocop/config_store.rb:44:in `for'
/root/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rubocop-0.74.0/lib/rubocop/cli.rb:242:in `apply_default_formatter'
/root/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rubocop-0.74.0/lib/rubocop/cli.rb:50:in `run'
/root/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rubocop-0.74.0/lib/rubocop/rake_task.rb:44:in `run_cli'
/root/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rubocop-0.74.0/lib/rubocop/rake_task.rb:28:in `block (2 levels) in initialize'
/root/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rake-13.0.3/lib/rake/file_utils_ext.rb:58:in `verbose'
/root/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rubocop-0.74.0/lib/rubocop/rake_task.rb:26:in `block in initialize'
/root/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rake-13.0.3/lib/rake/task.rb:281:in `block in execute'
/root/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rake-13.0.3/lib/rake/task.rb:281:in `each'
/root/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rake-13.0.3/lib/rake/task.rb:281:in `execute'
/root/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rake-13.0.3/lib/rake/task.rb:219:in `block in invoke_with_call_chain'
/root/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rake-13.0.3/lib/rake/task.rb:199:in `synchronize'
/root/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rake-13.0.3/lib/rake/task.rb:199:in `invoke_with_call_chain'
/root/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rake-13.0.3/lib/rake/task.rb:188:in `invoke'
/tmpfs/src/github/google-cloud-ruby/google-cloud-spanner-admin-database-v1/Rakefile:166:in `block in <top (required)>'
/root/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rake-13.0.3/lib/rake/task.rb:281:in `block in execute'
/root/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rake-13.0.3/lib/rake/task.rb:281:in `each'
/root/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rake-13.0.3/lib/rake/task.rb:281:in `execute'
/root/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rake-13.0.3/lib/rake/task.rb:219:in `block in invoke_with_call_chain'
/root/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rake-13.0.3/lib/rake/task.rb:199:in `synchronize'
/root/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rake-13.0.3/lib/rake/task.rb:199:in `invoke_with_call_chain'
/root/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rake-13.0.3/lib/rake/task.rb:188:in `invoke'
/root/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rake-13.0.3/lib/rake/application.rb:160:in `invoke_task'
/root/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rake-13.0.3/lib/rake/application.rb:116:in `block (2 levels) in top_level'
/root/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rake-13.0.3/lib/rake/application.rb:116:in `each'
/root/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rake-13.0.3/lib/rake/application.rb:116:in `block in top_level'
/root/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rake-13.0.3/lib/rake/application.rb:125:in `run_with_threads'
/root/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rake-13.0.3/lib/rake/application.rb:110:in `top_level'
/root/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rake-13.0.3/lib/rake/application.rb:83:in `block in run'
/root/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rake-13.0.3/lib/rake/application.rb:186:in `standard_exception_handling'
/root/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rake-13.0.3/lib/rake/application.rb:80:in `run'
/root/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/rake-13.0.3/exe/rake:27:in `<top (required)>'
/root/.rbenv/versions/3.0.0/bin/rake:23:in `load'
/root/.rbenv/versions/3.0.0/bin/rake:23:in `<top (required)>'
/root/.rbenv/versions/3.0.0/lib/ruby/site_ruby/3.0.0/bundler/cli/exec.rb:63:in `load'
/root/.rbenv/versions/3.0.0/lib/ruby/site_ruby/3.0.0/bundler/cli/exec.rb:63:in `kernel_load'
/root/.rbenv/versions/3.0.0/lib/ruby/site_ruby/3.0.0/bundler/cli/exec.rb:28:in `run'
/root/.rbenv/versions/3.0.0/lib/ruby/site_ruby/3.0.0/bundler/cli.rb:494:in `exec'
/root/.rbenv/versions/3.0.0/lib/ruby/site_ruby/3.0.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/root/.rbenv/versions/3.0.0/lib/ruby/site_ruby/3.0.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
/root/.rbenv/versions/3.0.0/lib/ruby/site_ruby/3.0.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
/root/.rbenv/versions/3.0.0/lib/ruby/site_ruby/3.0.0/bundler/cli.rb:30:in `dispatch'
/root/.rbenv/versions/3.0.0/lib/ruby/site_ruby/3.0.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
/root/.rbenv/versions/3.0.0/lib/ruby/site_ruby/3.0.0/bundler/cli.rb:24:in `start'
/root/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/bundler-2.2.5/exe/bundle:49:in `block in <top (required)>'
/root/.rbenv/versions/3.0.0/lib/ruby/site_ruby/3.0.0/bundler/friendly_errors.rb:130:in `with_friendly_errors'
/root/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/bundler-2.2.5/exe/bundle:37:in `<top (required)>'
/root/.rbenv/versions/3.0.0/bin/bundle:23:in `load'
/root/.rbenv/versions/3.0.0/bin/bundle:23:in `<main>'
RuboCop failed!
```