### PR TITLE
feat(bigtable): Add support for Backup restore to different Instance

### DIFF
--- a/google-cloud-bigtable/.rubocop.yml
+++ b/google-cloud-bigtable/.rubocop.yml
@@ -14,13 +14,7 @@ Documentation:
     - "lib/google-cloud-bigtable.rb"
 
 Metrics/ClassLength:
-  Exclude:
-    - "lib/google/cloud/bigtable/chunk_processor.rb"
-    - "lib/google/cloud/bigtable/column_family_map.rb"
-    - "lib/google/cloud/bigtable/instance.rb"
-    - "lib/google/cloud/bigtable/project.rb"
-    - "lib/google/cloud/bigtable/service.rb"
-    - "lib/google/cloud/bigtable/table.rb"
+  Enabled: false
 Metrics/BlockLength:
   Exclude:
     - "google-cloud-bigtable.gemspec"

--- a/google-cloud-bigtable/acceptance/bigtable_helper.rb
+++ b/google-cloud-bigtable/acceptance/bigtable_helper.rb
@@ -57,16 +57,28 @@ module Acceptance
       super
     end
 
+    def bigtable_instance_id
+      $bigtable_instance_id
+    end
+
+    def bigtable_instance_id_2
+      $bigtable_instance_id_2
+    end
+
     def bigtable_instance
       @instance ||= @bigtable.instance($bigtable_instance_id)
+    end
+
+    def bigtable_instance_2
+      @instance_2 ||= @bigtable.instance($bigtable_instance_id_2)
     end
 
     def bigtable_cluster_id
       $bigtable_cluster_id
     end
 
-    def bigtable_instance_id
-      $bigtable_instance_id
+    def bigtable_cluster_id_2
+      $bigtable_cluster_id
     end
 
     def bigtable_cluster_location
@@ -187,9 +199,11 @@ require "date"
 require "securerandom"
 
 $bigtable_instance_id = "google-cloud-ruby-tests"
+$bigtable_instance_id_2 = "google-cloud-ruby-tests-2"
 $bigtable_cluster_location = "us-east1-b"
 $bigtable_cluster_location_2 = "us-east1-c"
 $bigtable_cluster_id = "#{$bigtable_instance_id}-clstr"
+$bigtable_cluster_id_2 = "#{$bigtable_instance_id}-clstr2"
 $bigtable_read_table_id = "r-#{Date.today.strftime "%y%m%d"}-#{SecureRandom.hex(2)}"
 $bigtable_mutation_table_id = "r-#{Date.today.strftime "%y%m%d"}-#{SecureRandom.hex(2)}"
 
@@ -199,14 +213,26 @@ create_test_instance(
   $bigtable_cluster_location
 )
 
+create_test_instance(
+  $bigtable_instance_id_2,
+  $bigtable_cluster_id_2,
+  $bigtable_cluster_location
+)
+
 create_test_table(
   $bigtable_instance_id,
   $bigtable_read_table_id,
   row_count: 5,
   qualifiers: ["field1", "field2"]
 )
-create_test_table($bigtable_instance_id, $bigtable_mutation_table_id)
+create_test_table(
+  $bigtable_instance_id,
+  $bigtable_mutation_table_id
+)
 
 Minitest.after_run do
-  clean_up_bigtable_objects($bigtable_instance_id, $table_list_for_cleanup)
+  clean_up_bigtable_objects(
+    $bigtable_instance_id,
+    $table_list_for_cleanup
+  )
 end

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/service.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/service.rb
@@ -752,17 +752,20 @@ module Google
         # Create a new table by restoring from a completed backup.
         #
         # @param table_id [String] The table ID for the new table. This table must not yet exist.
-        # @param instance_id [String] The instance ID for the source backup. The table will be created in this instance.
+        # @param instance_id [String] The instance ID for the source backup. The table will be created in this instance
+        #   if table_instance_id is not provided.
         # @param cluster_id [String] The cluster ID for the source backup.
         # @param backup_id [String] The backup ID for the source backup.
+        # @param table_instance_id [String] The instance ID for the table, if different from instance_id. Optional.
         #
         # @return [Gapic::Operation] The {Google::Longrunning::Operation#metadata metadata} field type is
         #   {Google::Cloud::Bigtable::Admin::RestoreTableMetadata RestoreTableMetadata}. The
         #   {Google::Longrunning::Operation#response response} type is
         #   {Google::Cloud::Bigtable::Admin::V2::Table Table}, if successful.
         #
-        def restore_table table_id, instance_id, cluster_id, backup_id
-          tables.restore_table parent:   instance_path(instance_id),
+        def restore_table table_id, instance_id, cluster_id, backup_id, table_instance_id: nil
+          table_instance_id ||= instance_id
+          tables.restore_table parent:   instance_path(table_instance_id),
                                table_id: table_id,
                                backup:   backup_path(instance_id, cluster_id, backup_id)
         end

--- a/google-cloud-bigtable/support/doctest_helper.rb
+++ b/google-cloud-bigtable/support/doctest_helper.rb
@@ -230,6 +230,7 @@ YARD::Doctest.configure do |doctest|
   doctest.before "Google::Cloud::Bigtable::Backup#restore" do
     mock_bigtable do |mock, mocked_instances, mocked_tables, mocked_job|
       mocked_instances.expect :get_instance, instance_resp, [name: "projects/my-project/instances/my-instance"]
+      mocked_instances.expect :get_instance, instance_resp, [name: "projects/my-project/instances/my-other-instance"]
       mocked_instances.expect :get_cluster, cluster_resp, [name: "projects/my-project/instances/my-instance/clusters/my-cluster"]
       mocked_tables.expect :get_backup, backup_resp, [name: "projects/my-project/instances/my-instance/clusters/my-cluster/backups/my-backup"]
       mocked_tables.expect :restore_table, mocked_job, [Hash]


### PR DESCRIPTION
* Add `instance` to `Backup#restore`

closes: #8927