### PR TITLE
Release google-cloud-network_connectivity 0.1.0

### DIFF
--- a/google-cloud-network_connectivity/CHANGELOG.md
+++ b/google-cloud-network_connectivity/CHANGELOG.md
@@ -1,2 +1,6 @@
 # Release History
 
+### 0.1.0 / 2021-02-04
+
+Initial release
+

--- a/google-cloud-network_connectivity/lib/google/cloud/network_connectivity/version.rb
+++ b/google-cloud-network_connectivity/lib/google/cloud/network_connectivity/version.rb
@@ -20,7 +20,7 @@
 module Google
   module Cloud
     module NetworkConnectivity
-      VERSION = "0.0.1"
+      VERSION = "0.1.0"
     end
   end
 end


### PR DESCRIPTION
Initial release

<details><summary>Commits since previous release</summary><pre><code></code></pre></details>

This pull request was generated using releasetool.