### PR TITLE
chore: Add api-spanner-ruby to CODEOWNERS for the google-cloud-spanner directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,3 +15,4 @@
 /google-cloud-datastore/        @googleapis/firestore-dpe @googleapis/yoshi-ruby
 /google-cloud-bigquery*/.       @googleapis/api-bigquery @googleapis/yoshi-ruby
 /google-cloud-pubsub*/.         @googleapis/api-pubsub @googleapis/yoshi-ruby
+/google-cloud-spanner/          @googleapis/api-spanner-ruby @googleapis/yoshi-ruby


### PR DESCRIPTION
/cc @googleapis/api-spanner-ruby 