### PR TITLE
chore(asset): Update synth to remove v1beta1 dep, and remove rubocop config hack

### DIFF
--- a/google-cloud-asset/.rubocop.yml
+++ b/google-cloud-asset/.rubocop.yml
@@ -17,10 +17,6 @@ Metrics/BlockLength:
   Exclude:
     - "samples/**/acceptance/*.rb"
 
-Metrics/MethodLength:
-  Exclude:
-    - "samples/quickstart.rb"
-
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-asset.rb"

--- a/google-cloud-asset/samples/quickstart.rb
+++ b/google-cloud-asset/samples/quickstart.rb
@@ -157,17 +157,16 @@ def analyze_iam_policy scope: "", full_resource_name: ""
   # scope = 'SCOPE_OF_THE_QUERY'
   # full_resource_name = 'QUERY_RESOURCE'
   asset_service = Google::Cloud::Asset.asset_service
-  resource_selector = {
-    full_resource_name: full_resource_name
-  }
-  options = {
-    expand_groups:      true,
-    output_group_edges: true
-  }
+
   query = {
     scope:             scope,
-    resource_selector: resource_selector,
-    options:           options
+    resource_selector: {
+      full_resource_name: full_resource_name
+    },
+    options:           {
+      expand_groups:      true,
+      output_group_edges: true
+    }
   }
 
   response = asset_service.analyze_iam_policy analysis_query: query
@@ -184,17 +183,16 @@ def analyze_iam_policy_longrunning_gcs scope: "", full_resource_name: "", uri: "
   # full_resource_name = 'QUERY_RESOURCE'
   # uri = 'OUTPUT_GCS_URI'
   asset_service = Google::Cloud::Asset.asset_service
-  resource_selector = {
-    full_resource_name: full_resource_name
-  }
-  options = {
-    expand_groups:      true,
-    output_group_edges: true
-  }
+
   query = {
     scope:             scope,
-    resource_selector: resource_selector,
-    options:           options
+    resource_selector: {
+      full_resource_name: full_resource_name
+    },
+    options:           {
+      expand_groups:      true,
+      output_group_edges: true
+    }
   }
   output_config = {
     gcs_destination: {
@@ -223,17 +221,16 @@ def analyze_iam_policy_longrunning_bigquery scope: "", full_resource_name: "", d
   # dataset = 'BIGQUERY_DATASET'
   # table_prefix = 'BIGQUERY_TABLE_PREFIX'
   asset_service = Google::Cloud::Asset.asset_service
-  resource_selector = {
-    full_resource_name: full_resource_name
-  }
-  options = {
-    expand_groups:      true,
-    output_group_edges: true
-  }
+
   query = {
     scope:             scope,
-    resource_selector: resource_selector,
-    options:           options
+    resource_selector: {
+      full_resource_name: full_resource_name
+    },
+    options:           {
+      expand_groups:      true,
+      output_group_edges: true
+    }
   }
   output_config = {
     bigquery_destination: {

--- a/google-cloud-asset/synth.py
+++ b/google-cloud-asset/synth.py
@@ -40,7 +40,7 @@ library = gapic.ruby_library(
         "ruby-cloud-title": "Cloud Asset",
         "ruby-cloud-description": "A metadata inventory service that allows you to view, monitor, and analyze all your GCP and Anthos assets across projects and services.",
         "ruby-cloud-env-prefix": "ASSET",
-        "ruby-cloud-wrapper-of": "v1:0.0;v1beta1:0.0",
+        "ruby-cloud-wrapper-of": "v1:0.0",
         "ruby-cloud-product-url": "https://cloud.google.com/asset-inventory/",
         "ruby-cloud-api-id": "cloudasset.googleapis.com",
         "ruby-cloud-api-shortname": "cloudasset",


### PR DESCRIPTION
Two chore-level cleanup items:

* Update the synth script to remove the obsolete version v1beta1 from the dependencies list. This will cause the generator to remove it from the library's gemspec and documentation in the next synth run.
* Consolidate some input hashes in the quickstart sample, bringing the methods under Rubocop's threshold. This will remove the need for a rubocop config hack that was introduced by #8188 (and which the generator keeps trying to remove—see #9292.)