### PR TITLE
test(pubsub): Fix protobuf Duration initialization

### DIFF
--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/update_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/update_test.rb
@@ -281,7 +281,7 @@ describe Google::Cloud::PubSub::Subscription, :update, :mock_pubsub do
   end
 
   it "updates retry_minimum_backoff" do
-    retry_policy = Google::Cloud::PubSub::V1::RetryPolicy.new minimum_backoff: new_retry_minimum_backoff, maximum_backoff: retry_maximum_backoff
+    retry_policy = retry_policy_grpc new_retry_minimum_backoff, retry_maximum_backoff
     update_sub = Google::Cloud::PubSub::V1::Subscription.new name: sub_path, retry_policy: retry_policy
     update_mask = Google::Protobuf::FieldMask.new paths: ["retry_policy"]
     mock = Minitest::Mock.new
@@ -297,7 +297,7 @@ describe Google::Cloud::PubSub::Subscription, :update, :mock_pubsub do
   end
 
   it "updates retry_maximum_backoff" do
-    retry_policy = Google::Cloud::PubSub::V1::RetryPolicy.new minimum_backoff: retry_minimum_backoff, maximum_backoff: new_retry_maximum_backoff
+    retry_policy = retry_policy_grpc retry_minimum_backoff, new_retry_maximum_backoff
     update_sub = Google::Cloud::PubSub::V1::Subscription.new name: sub_path, retry_policy: retry_policy
     update_mask = Google::Protobuf::FieldMask.new paths: ["retry_policy"]
     mock = Minitest::Mock.new
@@ -407,7 +407,7 @@ describe Google::Cloud::PubSub::Subscription, :update, :mock_pubsub do
       _(subscription).must_be :reference?
       _(subscription).wont_be :resource?
       _(subscription.name).must_equal sub_path
-      retry_policy = Google::Cloud::PubSub::V1::RetryPolicy.new minimum_backoff: new_retry_minimum_backoff, maximum_backoff: retry_maximum_backoff
+      retry_policy = retry_policy_grpc new_retry_minimum_backoff, retry_maximum_backoff
       update_sub = Google::Cloud::PubSub::V1::Subscription.new name: sub_path, retry_policy: retry_policy
       update_mask = Google::Protobuf::FieldMask.new paths: ["retry_policy"]
       mock = Minitest::Mock.new
@@ -427,7 +427,7 @@ describe Google::Cloud::PubSub::Subscription, :update, :mock_pubsub do
     it "updates retry_maximum_backoff" do
       _(subscription).must_be :reference?
       _(subscription).wont_be :resource?
-      retry_policy = Google::Cloud::PubSub::V1::RetryPolicy.new minimum_backoff: retry_minimum_backoff, maximum_backoff: new_retry_maximum_backoff
+      retry_policy = retry_policy_grpc retry_minimum_backoff, new_retry_maximum_backoff
       update_sub = Google::Cloud::PubSub::V1::Subscription.new name: sub_path, retry_policy: retry_policy
       update_mask = Google::Protobuf::FieldMask.new paths: ["retry_policy"]
       mock = Minitest::Mock.new

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic_test.rb
@@ -267,9 +267,8 @@ describe Google::Cloud::PubSub::Topic, :mock_pubsub do
   it "creates a subscription with retry_minimum_backoff and retry_maximum_backoff" do
     new_sub_name = "new-sub-#{Time.now.to_i}"
     create_res = Google::Cloud::PubSub::V1::Subscription.new subscription_hash(topic_name, new_sub_name, retry_minimum_backoff: retry_minimum_backoff, retry_maximum_backoff: retry_maximum_backoff)
-    retry_policy_grpc = Google::Cloud::PubSub::V1::RetryPolicy.new minimum_backoff: retry_minimum_backoff, maximum_backoff: retry_maximum_backoff
     mock = Minitest::Mock.new
-    mock.expect :create_subscription, create_res, create_subscription_args(new_sub_name, topic_name, retry_policy: retry_policy_grpc)
+    mock.expect :create_subscription, create_res, create_subscription_args(new_sub_name, topic_name, retry_policy: retry_policy_grpc(retry_minimum_backoff, retry_maximum_backoff))
     topic.service.mocked_subscriber = mock
 
     sub = topic.subscribe new_sub_name, retry_policy: retry_policy


### PR DESCRIPTION
* Workaround for 3.15 regression: Floating point issue when
  auto-converting float to google.protobuf.Duration.

refs: protocolbuffers/protobuf#8314