### PR TITLE
Release google-cloud-domains 0.1.0

### DIFF
--- a/google-cloud-domains/CHANGELOG.md
+++ b/google-cloud-domains/CHANGELOG.md
@@ -1,2 +1,6 @@
 # Release History
 
+### 0.1.0 / 2021-02-23
+
+* Initial release
+

--- a/google-cloud-domains/lib/google/cloud/domains/version.rb
+++ b/google-cloud-domains/lib/google/cloud/domains/version.rb
@@ -20,7 +20,7 @@
 module Google
   module Cloud
     module Domains
-      VERSION = "0.0.1"
+      VERSION = "0.1.0"
     end
   end
 end


### PR DESCRIPTION
* Initial release

<details><summary>Commits since previous release</summary><pre><code></code></pre></details>

This pull request was generated using releasetool.