### PR TITLE
Release google-cloud-memcache 1.0.0

### DIFF
--- a/google-cloud-memcache/CHANGELOG.md
+++ b/google-cloud-memcache/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ### 1.0.0 / 2021-02-24
 
-* Connect to the V1 API backend by default
+#### Features
+
+* Include the google-cloud-memcache-v1 client, and connect to the V1 API backend by default
 
 ### 0.1.2 / 2021-02-02
 

--- a/google-cloud-memcache/CHANGELOG.md
+++ b/google-cloud-memcache/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 1.0.0 / 2021-02-24
+
+* Connect to the V1 API backend by default
+
 ### 0.1.2 / 2021-02-02
 
 #### Documentation

--- a/google-cloud-memcache/lib/google/cloud/memcache/version.rb
+++ b/google-cloud-memcache/lib/google/cloud/memcache/version.rb
@@ -20,7 +20,7 @@
 module Google
   module Cloud
     module Memcache
-      VERSION = "0.1.2"
+      VERSION = "1.0.0"
     end
   end
 end


### PR DESCRIPTION
* Connect to the V1 API backend by default

<details><summary>Commits since previous release</summary><pre><code>commit 1b08f1cf2595ceac74d5cd36db9e79566b38a508
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Wed Feb 24 09:01:50 2021 -0800

    chore(memcache): Start tracking obsolete files

commit b2e346ec929aee881edbe50d38e2cd33b7bbfdb3
Author: Daniel Azuma <dazuma@google.com>
Date:   Tue Feb 23 11:33:08 2021 -0800

    feat(memcache)!: Connect to the V1 API backend by default

commit 362e0d6b16fc41d119001b5745c56ae6c95db6a5
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Mon Feb 22 22:58:07 2021 -0800

    chore(memcache): Reformat license and add cloud-rad rake task

commit 332a1a234dbfabd90b81cd79fd0e8643eedfcc57
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Tue Feb 9 13:22:59 2021 -0800

    chore(memcache): Minor update to service description
    
    PiperOrigin-RevId: 356380191
    
    Source-Author: Google APIs <noreply@google.com>
    Source-Date: Mon Feb 8 16:30:59 2021 -0800
    Source-Repo: googleapis/googleapis
    Source-Sha: 84cf54e45ed5970980ae868e0a1e5ad1266a8830
    Source-Link: https://github.com/googleapis/googleapis/commit/84cf54e45ed5970980ae868e0a1e5ad1266a8830
</code></pre></details>

This pull request was generated using releasetool.