### PR TITLE
feat(debugger): Drop support for Ruby 2.4 and note that Ruby 3.0 is also unsupported

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,31 +1,4 @@
 source "https://rubygems.org"
 
 gem "rake"
-# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
-# See https://github.com/googleapis/google-cloud-ruby/issues/4110
-gem "minitest", "~> 5.11.3"
-gem "minitest-autotest", "~> 1.0"
-gem "minitest-focus", "~> 1.1"
-gem "minitest-rg", "~> 5.2"
-gem "autotest-suffix", "~> 1.1"
-gem "redcarpet", "~> 3.0"
-gem "rubocop", "~> 0.64.0"
-gem "simplecov", "~> 0.16"
-gem "codecov", "~> 0.1", require: false
-gem "yard", "~> 0.9"
-gem "yard-doctest", "~> 0.1.13"
-gem "gems", "~> 0.8"
-gem "actionpack", "~> 5.0"
-gem "railties", "~> 5.0"
-gem "rack", ">= 0.1"
-
-omit_gems = ["gcloud", "google-cloud"]
-
-Dir.glob "*/*.gemspec" do |path|
-  if path =~ %r{([a-z0-9_-]+)/([a-z0-9_-]+)\.gemspec}
-    name = Regexp.last_match 1
-    if name == Regexp.last_match(2) && !omit_gems.include?(name)
-      gem name, path: name
-    end
-  end
-end
+gem "gems", "~> 1.2"

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
 
-gem "rake"
 gem "gems", "~> 1.2"
+gem "rake", "~> 13.0"
+gem "yard", "~> 0.9", ">= 0.9.26"

--- a/Rakefile
+++ b/Rakefile
@@ -539,7 +539,7 @@ end
 def updated_gems
   updated_directories = `git --no-pager diff --name-only HEAD^ HEAD | grep "/" | cut -d/ -f1 | sort | uniq || true`
   updated_directories = updated_directories.split("\n")
-  gems.select { |gem| updated_directories.include? gem }
+  valid_gems.select { |gem| updated_directories.include? gem }
 end
 
 def valid_gems

--- a/Rakefile
+++ b/Rakefile
@@ -2,94 +2,46 @@ require "bundler/setup"
 require "fileutils"
 
 task :bundleupdate do
-  valid_gems.each do |gem|
-    Dir.chdir gem do
-      Bundler.with_clean_env do
-        header "BUNDLE UPDATE FOR #{gem}"
-        sh "bundle update"
-      end
-    end
-  end
+  each_valid_gem bundleupdate: true, name: "BUNDLE UPDATE"
 end
 
 desc "Runs rubocop, jsodoc, and tests for all gems individually."
 task :each, :bundleupdate do |t, args|
-  bundleupdate = args[:bundleupdate]
-  Rake::Task["bundleupdate"].invoke if bundleupdate
-  valid_gems.each do |gem|
-    Dir.chdir gem do
-      Bundler.with_clean_env do
-        header "RUNNING #{gem}"
-        sh "bundle update" if bundleupdate
-        header "#{gem} rubocop", "*"
-        run_task_if_exists "rubocop"
-        header "#{gem} doctest", "*"
-        run_task_if_exists "doctest"
-        header "#{gem} test", "*"
-        run_task_if_exists "test"
-      end
-    end
+  each_valid_gem bundleupdate: args[:bundleupdate] do |gem|
+    header "#{gem} rubocop", "*"
+    run_task_if_exists "rubocop"
+    header "#{gem} doctest", "*"
+    run_task_if_exists "doctest"
+    header "#{gem} test", "*"
+    run_task_if_exists "test"
   end
 end
 
 desc "Runs tests for all gems."
 task :test => :compile do
-  require "active_support/all"
-  valid_gems.each do |gem|
-    $LOAD_PATH.unshift "#{gem}/lib", "#{gem}/test"
-    Dir.glob("#{gem}/test/**/*_test.rb").each { |file| require_relative file }
-    $LOAD_PATH.delete "#{gem}/lib"
-    $LOAD_PATH.delete "#{gem}/test"
-  end
+  Rake::Task["test:each"].invoke
 end
 
 namespace :test do
   desc "Runs tests for all gems individually."
   task :each, :bundleupdate do |t, args|
-    bundleupdate = args[:bundleupdate]
-    Rake::Task["bundleupdate"].invoke if bundleupdate
-    valid_gems.each do |gem|
-      Dir.chdir gem do
-        Bundler.with_clean_env do
-          header "RUNNING TESTS FOR #{gem}"
-          run_task_if_exists "test"
-        end
-      end
+    each_valid_gem bundleupdate: args[:bundleupdate], name: "RUNNING TESTS" do |gem|
+      header "#{gem} test", "*"
+      run_task_if_exists "test"
     end
   end
 
   desc "Runs tests with coverage for all gems."
   task :coverage do
-    FileUtils.remove_dir "coverage", force: true
-    FileUtils.mkdir "coverage"
-
-    require "simplecov"
-    SimpleCov.start do
-      command_name :coverage
-      track_files "lib/**/*.rb"
-      add_filter "test/"
-      valid_gems_with_coverage_filters.each do |gem, filters|
-        filters.each { |filter| add_filter filter }
-        add_group gem, "#{gem}/lib"
-      end
+    each_valid_gem bundleupdate: args[:bundleupdate], name: "RUNNING TESTS" do |gem|
+      header "#{gem} test", "*"
+      run_task_if_exists "test:coverage"
     end
-
-    # Increase the time limit from the default of 0.05 secs because coverage
-    # may run slowly.
-    coverage_timeout = ENV["GCLOUD_TEST_COVERAGE_DEBUGGER_TIMEOUT"] || "0.3"
-    ENV["GCLOUD_TEST_DEBUGGER_TIMEOUT"] = coverage_timeout
-
-    header "Running tests and coverage report"
-    Rake::Task[:test].invoke
   end
 
   desc "Runs codecov report for all gems."
   task :codecov do
-    require "simplecov"
-    require "codecov"
-    SimpleCov.formatter = SimpleCov::Formatter::Codecov
-
-    Rake::Task["test:coverage"].invoke
+    abort "**** Codecov disabled ****"
   end
 end
 
@@ -116,87 +68,52 @@ task :acceptance, [:project, :keyfile, :key] => :compile do |t, args|
   end  # always overwrite when running tests
   ENV["GCLOUD_TEST_KEY"] = key
 
-  valid_gems.each do |gem|
-    $LOAD_PATH.unshift "#{gem}/lib", "#{gem}/acceptance"
-    Dir.glob("#{gem}/acceptance/**/*_test.rb").each { |file| require_relative file }
-    $LOAD_PATH.delete "#{gem}/lib"
-    $LOAD_PATH.delete "#{gem}/acceptance"
+  each_valid_gem name: "RUNNING ACCEPTANCE TESTS" do |gem|
+    header "#{gem} test", "*"
+    run_task_if_exists "acceptance", "#{project},#{keyfile}"
   end
 end
 
 namespace :acceptance do
   desc "Runs acceptance tests for all gems individually."
   task :each, :bundleupdate do |t, args|
-    bundleupdate = args[:bundleupdate]
-    Rake::Task["bundleupdate"].invoke if bundleupdate
-    valid_gems.each do |gem|
-      Dir.chdir gem do
-        Bundler.with_clean_env do
-          header "ACCEPTANCE TESTS FOR #{gem}"
-          run_task_if_exists "acceptance"
-        end
-      end
+    each_valid_gem bundleupdate: args[:bundleupdate], name: "RUNNING ACCEPTANCE TESTS" do |gem|
+      header "#{gem} test", "*"
+      run_task_if_exists "acceptance"
     end
   end
 
   # Runs each gem's acceptance tests without verifying that a test environment
   # is used. May delete production data! Use only with caution!
   task :unsafe, :bundleupdate do |t, args|
-    bundleupdate = args[:bundleupdate]
-    Rake::Task["bundleupdate"].invoke if bundleupdate
-    valid_gems.each do |gem|
-      Dir.chdir gem do
-        Bundler.with_clean_env do
-          header "UNSAFE ACCEPTANCE TESTS FOR #{gem}"
-          sh "bundle exec rake acceptance:run -v"
-        end
-      end
+    each_valid_gem bundleupdate: args[:bundleupdate], name: "RUNNING UNSAFE ACCEPTANCE TESTS" do |gem|
+      header "UNSAFE ACCEPTANCE TESTS FOR #{gem}"
+      sh "bundle exec rake acceptance:run -v"
     end
   end
 
   desc "Runs acceptance tests with coverage for all gems."
   task :coverage do
-    FileUtils.remove_dir "coverage", force: true
-    FileUtils.mkdir "coverage"
-
-    require "simplecov"
-    SimpleCov.start do
-      command_name :coverage
-      track_files "lib/**/*.rb"
-      add_filter "acceptance/"
-      valid_gems.each { |gem| add_group gem, "#{gem}/lib" }
+    each_valid_gem do |gem|
+      header "#{gem} test", "*"
+      sh "bundle exec rake acceptance:coverage"
     end
-
-    header "Running acceptance tests and coverage report"
-    Rake::Task[:acceptance].invoke
   end
 
   desc "Runs acceptance:cleanup for all gems."
   task :cleanup, :bundleupdate do |t, args|
-    bundleupdate = args[:bundleupdate]
-    Rake::Task["bundleupdate"].invoke if bundleupdate
-    valid_gems.each do |gem|
-      cd gem do
-        Bundler.with_clean_env do
-          run_task_if_exists "acceptance:cleanup"
-        end
-      end
+    each_valid_gem bundleupdate: args[:bundleupdate] do |gem|
+      header "#{gem} cleanup", "*"
+      run_task_if_exists "acceptance:cleanup"
     end
   end
 end
 
 desc "Runs rubocop report for all gems individually."
 task :rubocop, :bundleupdate do |t, args|
-  bundleupdate = args[:bundleupdate]
-  Rake::Task["bundleupdate"].invoke if bundleupdate
-  header "Running rubocop reports"
-  valid_gems.each do |gem|
-    Dir.chdir gem do
-      Bundler.with_clean_env do
-        header "RUBOCOP REPORT FOR #{gem}"
-        run_task_if_exists "rubocop"
-      end
-    end
+  each_valid_gem bundleupdate: args[:bundleupdate] do |gem|
+    header "RUBOCOP REPORT FOR #{gem}"
+    run_task_if_exists "rubocop"
   end
 end
 
@@ -228,16 +145,9 @@ end
 
 desc "Runs yard-doctest example tests for all gems individually."
 task :doctest, :bundleupdate do |t, args|
-  bundleupdate = args[:bundleupdate]
-  Rake::Task["bundleupdate"].invoke if bundleupdate
-  header "Running yard-doctest example code tests"
-  valid_gems.each do |gem|
-    Dir.chdir gem do
-      Bundler.with_clean_env do
-        header "DOCTEST FOR #{gem}"
-        run_task_if_exists "doctest"
-      end
-    end
+  each_valid_gem bundleupdate: args[:bundleupdate] do |gem|
+    header "DOCTEST FOR #{gem}"
+    run_task_if_exists "doctest"
   end
 end
 
@@ -254,27 +164,18 @@ end
 
 desc "Run the CI build for all gems."
 task :ci, :bundleupdate do |t, args|
-  bundleupdate = args[:bundleupdate]
-  valid_gems.each do |gem|
-    Dir.chdir gem do
-      Bundler.with_clean_env do
-        sh "bundle update" if bundleupdate
-        sh "bundle exec rake ci"
-      end
-    end
+  each_valid_gem bundleupdate: args[:bundleupdate] do |gem|
+    header "CI FOR #{gem}"
+    run_task_if_exists "ci"
   end
 end
+
 namespace :ci do
   desc "Run the CI build, with acceptance tests, for all gems."
   task :acceptance, :bundleupdate do |t, args|
-    bundleupdate = args[:bundleupdate]
-    valid_gems.each do |gem|
-      Dir.chdir gem do
-        Bundler.with_clean_env do
-          sh "bundle update" if bundleupdate
-          sh "bundle exec rake ci:acceptance"
-        end
-      end
+    each_valid_gem bundleupdate: args[:bundleupdate] do |gem|
+      header "CI ACCEPTANCE FOR #{gem}"
+      run_task_if_exists "ci:acceptance"
     end
   end
   task :a do
@@ -526,14 +427,9 @@ task :compile do
     spec = Gem::Specification::load("#{gem}/#{gem}.gemspec")
     !spec.extensions.empty?
   }
-  gems_with_ext.each do |gem|
-    Dir.chdir gem do
-      Bundler.with_clean_env do
-        header "Compile C extension for #{gem}"
-        sh "bundle update"
-        sh "bundle exec rake compile"
-      end
-    end
+  each_valid_gem bundleupdate: true, gem_list: gems_with_ext do |gem|
+    header "Compile C extension for #{gem}"
+    sh "bundle exec rake compile"
   end
 end
 
@@ -630,13 +526,9 @@ end
 
 desc "Runs python -m synthtool for each gem containing a synth.py file (see https://github.com/googleapis/synthtool)"
 task :synthtool do
-  gapic_gems.each do |gem|
-    Dir.chdir gem do
-      Bundler.with_clean_env do
-        header "Run `python -m synthtool` for #{gem}"
-        sh "python -m synthtool"
-      end
-    end
+  each_valid_gem gem_list: gapic_gems do |gem|
+    header "Run `python -m synthtool` for #{gem}"
+    sh "python -m synthtool"
   end
 end
 
@@ -655,6 +547,23 @@ def valid_gems
     spec = Gem::Specification::load("#{gem}/#{gem}.gemspec")
     spec.required_ruby_version.satisfied_by? Gem::Version.new(RUBY_VERSION)
   }
+end
+
+def each_valid_gem bundleupdate: false, name: "RUNNING", gem_list: nil
+  (gem_list || valid_gems).each do |gem|
+    Dir.chdir gem do
+      block = proc do
+        header "#{name}: #{gem}"
+        sh "bundle update" if bundleupdate
+        yield gem if block_given?
+      end
+      if Bundler.respond_to? :with_unbundled_env
+        Bundler.with_unbundled_env(&block)
+      else
+        Bundler.with_clean_env(&block)
+      end
+    end
+  end
 end
 
 def gapic_gems
@@ -703,7 +612,7 @@ end
 # subdirectories.
 def run_task_if_exists task_name, params = ""
   if `bundle exec rake --tasks #{task_name}` =~ /#{task_name}[^:]/
-    sh "bundle exec rake #{task_name}[#{params}]"
+    sh "bundle exec rake '#{task_name}[#{params}]'"
   end
 end
 

--- a/google-cloud-debugger/.rubocop.yml
+++ b/google-cloud-debugger/.rubocop.yml
@@ -14,10 +14,6 @@ AllCops:
 Documentation:
   Enabled: false
 
-Layout/AlignHash:
-  Enabled: false
-Layout/SpaceInsideStringInterpolation:
-  Enabled: false
 Lint/UnifiedInteger:
   Exclude:
     - "lib/google/cloud/debugger/breakpoint/evaluator.rb"
@@ -32,19 +28,12 @@ Metrics/ClassLength:
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-debugger.rb"
-Style/ConditionalAssignment:
-  Enabled: false
-Style/EmptyMethod:
-  Enabled: false
-Style/IfUnlessModifier:
-  Enabled: false
-Style/NumericLiterals:
-  Enabled: false
-Style/NumericPredicate:
-  Enabled: false
-Style/SafeNavigation:
-  Enabled: false
+Style/IfWithBooleanLiteralBranches:
+  Exclude:
+    - "lib/google/cloud/debugger/breakpoint/variable.rb"
 Style/SymbolArray:
-  Enabled: false
+  Exclude:
+    - "lib/google/cloud/debugger/breakpoint/evaluator.rb"
 Style/WordArray:
-  Enabled: false
+  Exclude:
+    - "lib/google/cloud/debugger/breakpoint/evaluator.rb"

--- a/google-cloud-debugger/CONTRIBUTING.md
+++ b/google-cloud-debugger/CONTRIBUTING.md
@@ -24,9 +24,9 @@ be able to accept your pull requests.
 In order to use the google-cloud-debugger console and run the project's tests,
 there is a small amount of setup:
 
-1. Install Ruby. google-cloud-debugger requires Ruby 2.4+. You may choose to
-   manage your Ruby and gem installations with [RVM](https://rvm.io/),
-   [rbenv](https://github.com/rbenv/rbenv), or
+1. Install Ruby. google-cloud-debugger requires Ruby 2.5+. It is not currently
+   supported on Ruby 3. You may choose to manage your Ruby and gem installations
+   with [RVM](https://rvm.io/), [rbenv](https://github.com/rbenv/rbenv), or
    [chruby](https://github.com/postmodern/chruby).
 
 2. Install [Bundler](http://bundler.io/).

--- a/google-cloud-debugger/LOGGING.md
+++ b/google-cloud-debugger/LOGGING.md
@@ -3,7 +3,7 @@
 To enable logging for this library, set the logger for the underlying
 [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library. The logger
 that you set may be a Ruby stdlib
-[`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as
+[`Logger`](https://ruby-doc.org/stdlib/libdoc/logger/rdoc/Logger.html) as
 shown below, or a
 [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver

--- a/google-cloud-debugger/README.md
+++ b/google-cloud-debugger/README.md
@@ -246,11 +246,11 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.4+.
+This library is supported on Ruby 2.5+. It is not currently supported on Ruby 3.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or in
-security maintenance, and not end of life. Currently, this means Ruby 2.4 and
+security maintenance, and not end of life. Currently, this means Ruby 2.5 and
 later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-debugger/README.md
+++ b/google-cloud-debugger/README.md
@@ -224,7 +224,7 @@ for a list of possible configuration options.
 
 ## Enabling Logging
 
-To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb) and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
+To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb) and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 
 Configuring a Ruby stdlib logger:
 

--- a/google-cloud-debugger/README.md
+++ b/google-cloud-debugger/README.md
@@ -255,6 +255,12 @@ later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.
 
+The google-cloud-debugger agent has dependencies on libraries that are not
+compatible with Ruby 3, and thus is itself not supported on Ruby 3. There are
+no immediate plans to update it with Ruby 3 support. If you are using the agent
+and require support for Ruby 3, please open an issue at
+https://github.com/googleapis/google-cloud-ruby/issues.
+
 This library follows [Semantic Versioning](http://semver.org/). It is currently
 in major version zero (0.y.z), which means that anything may change at any time
 and the public API should not be considered stable.

--- a/google-cloud-debugger/Rakefile
+++ b/google-cloud-debugger/Rakefile
@@ -31,10 +31,16 @@ end
 
 require "rake/testtask"
 desc "Run tests."
-Rake::TestTask.new test: :compile do |t|
-  t.libs << "test"
-  t.test_files = FileList["test/**/*_test.rb"]
-  t.warning = false
+if RUBY_VERSION.start_with?("3.")
+  task :test => :compile do
+    puts "**** TESTS DISABLED ON RUBY 3 ****"
+  end
+else
+  Rake::TestTask.new test: :compile do |t|
+    t.libs << "test"
+    t.test_files = FileList["test/**/*_test.rb"]
+    t.warning = false
+  end
 end
 
 namespace :test do
@@ -93,10 +99,16 @@ namespace :acceptance do
     Rake::Task[:acceptance].invoke
   end
 
-  Rake::TestTask.new :run do |t|
-    t.libs << "acceptance"
-    t.test_files = FileList["acceptance/**/*_test.rb"]
-    t.warning = false
+  if RUBY_VERSION.start_with?("3.")
+    task :run do
+      puts "**** TESTS DISABLED ON RUBY 3 ****"
+    end
+  else
+    Rake::TestTask.new :run do |t|
+      t.libs << "acceptance"
+      t.test_files = FileList["acceptance/**/*_test.rb"]
+      t.warning = false
+    end
   end
 end
 
@@ -108,9 +120,13 @@ namespace :integration do
 
     ENV["TEST_GOOGLE_CLOUD_PROJECT_URI"] = args[:project_uri]
 
-    $LOAD_PATH.unshift "lib", "integration"
-    Dir.glob("integration/*_test.rb").each { |file| require_relative file }
-    Dir.glob("integration/gae/**/*_test.rb").each { |file| require_relative file }
+    if RUBY_VERSION.start_with?("3.")
+      puts "**** TESTS DISABLED ON RUBY 3 ****"
+    else
+      $LOAD_PATH.unshift "lib", "integration"
+      Dir.glob("integration/*_test.rb").each { |file| require_relative file }
+      Dir.glob("integration/gae/**/*_test.rb").each { |file| require_relative file }
+    end
   end
 
   desc "Run integration tests against GKE"
@@ -120,15 +136,23 @@ namespace :integration do
 
     ENV["TEST_GKE_POD_NAME"] = args[:pod_name]
 
-    $LOAD_PATH.unshift "lib", "integration"
-    Dir.glob("integration/*_test.rb").each { |file| require_relative file }
-    Dir.glob("integration/gke/**/*_test.rb").each { |file| require_relative file }
+    if RUBY_VERSION.start_with?("3.")
+      puts "**** TESTS DISABLED ON RUBY 3 ****"
+    else
+      $LOAD_PATH.unshift "lib", "integration"
+      Dir.glob("integration/*_test.rb").each { |file| require_relative file }
+      Dir.glob("integration/gke/**/*_test.rb").each { |file| require_relative file }
+    end
   end
 end
 
 desc "Run yard-doctest example tests."
 task :doctest do
-  sh "bundle exec yard config load_plugins true && bundle exec yard doctest"
+  if RUBY_VERSION.start_with?("3.")
+    puts "**** TESTS DISABLED ON RUBY 3 ****"
+  else
+    sh "bundle exec yard config load_plugins true && bundle exec yard doctest"
+  end
 end
 
 desc "Start an interactive shell."

--- a/google-cloud-debugger/Rakefile
+++ b/google-cloud-debugger/Rakefile
@@ -83,6 +83,7 @@ task :acceptance, :project, :keyfile do |t, args|
   ENV["LOGGING_PROJECT"] = project
   ENV["LOGGING_KEYFILE_JSON"] = keyfile
 
+  Rake::Task[:compile].invoke
   Rake::Task["acceptance:run"].invoke
 end
 

--- a/google-cloud-debugger/google-cloud-debugger.gemspec
+++ b/google-cloud-debugger/google-cloud-debugger.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
                       ["OVERVIEW.md", "AUTHENTICATION.md", "INSTRUMENTATION.md", "LOGGING.md", "CONTRIBUTING.md", "TROUBLESHOOTING.md", "CHANGELOG.md", "CODE_OF_CONDUCT.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.4"
+  gem.required_ruby_version = "~> 2.5"
 
   gem.extensions << "ext/google/cloud/debugger/debugger_c/extconf.rb"
 
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "stackdriver-core", "~> 1.3"
   gem.add_dependency "concurrent-ruby", "~> 1.1"
 
-  gem.add_development_dependency "google-style", "~> 1.24.0"
+  gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"
   gem.add_development_dependency "minitest-focus", "~> 1.1"

--- a/google-cloud-debugger/lib/google/cloud/debugger/agent.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/agent.rb
@@ -120,7 +120,10 @@ module Google
         # @param [String] app_root Absolute path to the root directory of
         #   the debuggee application. Default to Rack root.
         #
-        def initialize service, logger: nil, service_name:, service_version:,
+        def initialize service,
+                       service_name:,
+                       service_version:,
+                       logger: nil,
                        app_root: nil
           super()
 

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint.rb
@@ -265,7 +265,7 @@ module Google
         def valid?
           Validator.validate self unless complete?
 
-          status && status.is_error ? false : true
+          status&.is_error ? false : true
         end
 
         ##

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/source_location.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/source_location.rb
@@ -37,7 +37,8 @@ module Google
 
           ##
           # @private Create an empty SourceLocation object.
-          def initialize; end
+          def initialize
+          end
 
           ##
           # @private New Google::Cloud::Debugger::Breakpoint::SourceLocation
@@ -53,8 +54,7 @@ module Google
           ##
           # @private Determines if the SourceLocation has any data.
           def empty?
-            path.nil? &&
-              line.nil?
+            path.nil? && line.nil?
           end
 
           ##

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/variable.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/variable.rb
@@ -244,7 +244,7 @@ module Google
 
             # If source is a non-empty Array or Hash, or source has instance
             # variables, evaluate source as a compound variable.
-            if compound_var?(source) && depth > 0
+            if compound_var?(source) && depth.positive?
               from_compound_var source, name: name, depth: depth,
                                         var_table: var_table, limit: limit
             else
@@ -358,9 +358,7 @@ module Google
 
               limit = deduct_limit limit, member_var.total_size
 
-              buffer_full = (limit && limit < 0) ||
-                            i >= MAX_MEMBERS ||
-                            member_var.buffer_full_variable?
+              buffer_full = limit&.negative? || i >= MAX_MEMBERS || member_var.buffer_full_variable?
 
               if buffer_full
                 var.members << Variable.new.tap do |last_var|
@@ -384,8 +382,7 @@ module Google
             new.tap do |var|
               var.name = name if name
 
-              if var_table && var_table.first &&
-                 var_table.first.buffer_full_variable?
+              if var_table&.first&.buffer_full_variable?
                 var.var_table = var_table
                 var.var_table_index = 0
               else

--- a/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/variable_table.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/breakpoint/variable_table.rb
@@ -68,7 +68,7 @@ module Google
           # object_id, return the array index if found.
           def rb_var_index rb_var
             variables.each_with_index do |var, i|
-              return i if var.source_var.object_id == rb_var.object_id
+              return i if var.source_var.equal? rb_var
             end
 
             nil

--- a/google-cloud-debugger/lib/google/cloud/debugger/middleware.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/middleware.rb
@@ -154,7 +154,7 @@ module Google
           @debugger.agent.tracer.disable_traces_for_thread
 
           # Reset quotas after each request finishes.
-          @debugger.agent.quota_manager.reset if @debugger.agent.quota_manager
+          @debugger.agent.quota_manager&.reset
         end
 
         private

--- a/google-cloud-debugger/lib/google/cloud/debugger/rails.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/rails.rb
@@ -151,13 +151,13 @@ module Google
               Debugger::Credentials.new credentials
             end
           rescue StandardError => e
-            STDOUT.puts "Note: Google::Cloud::Debugger is disabled because " \
+            $stdout.puts "Note: Google::Cloud::Debugger is disabled because " \
               "it failed to authorize with the service. (#{e.message})"
             return false
           end
 
           if project_id.to_s.empty?
-            STDOUT.puts "Note: Google::Cloud::Debugger is disabled because " \
+            $stdout.puts "Note: Google::Cloud::Debugger is disabled because " \
               "the project ID could not be determined."
             return false
           end

--- a/google-cloud-debugger/lib/google/cloud/debugger/service.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/service.rb
@@ -25,7 +25,10 @@ module Google
       # @private Represents the gRPC Debugger service, including all the API
       # methods.
       class Service
-        attr_accessor :project, :credentials, :timeout, :host
+        attr_accessor :project
+        attr_accessor :credentials
+        attr_accessor :timeout
+        attr_accessor :host
 
         ##
         # Creates a new Service instance.

--- a/google-cloud-debugger/lib/google/cloud/debugger/snappoint.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/snappoint.rb
@@ -33,11 +33,11 @@ module Google
 
         ##
         # Max size of payload a Snappoint collects
-        MAX_PAYLOAD_SIZE = 32768 # 32KB
+        MAX_PAYLOAD_SIZE = 32_768 # 32KB
 
         ##
         # @private Max size an evaluated expression variable is allowed to be
-        MAX_EXPRESSION_LIMIT = 32768 # 32KB
+        MAX_EXPRESSION_LIMIT = 32_768 # 32KB
 
         ##
         # @private Max size a normal evaluated variable is allowed to be
@@ -56,8 +56,7 @@ module Google
         # variable at index 0. This variable will be shared by other variable
         # evaluations if this Snappoint exceeds size limit.
         def init_var_table
-          return if @variable_table[0] &&
-                    @variable_table[0].buffer_full_variable?
+          return if @variable_table[0]&.buffer_full_variable?
 
           buffer_full_var = Variable.buffer_full_variable
           @variable_table.variables.unshift buffer_full_var
@@ -179,11 +178,9 @@ module Google
             end
           end
 
-          result = variable_table.variables.inject result do |sum, var|
+          variable_table.variables.inject result do |sum, var|
             sum + var.payload_size
           end
-
-          result
         end
 
         ##

--- a/google-cloud-debugger/lib/google/cloud/debugger/transmitter.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/transmitter.rb
@@ -132,7 +132,7 @@ module Google
         # @return [boolean] `true` when started, `false` otherwise.
         #
         def started?
-          @thread_pool.running? if @thread_pool
+          @thread_pool&.running?
         end
 
         ##

--- a/rakelib/kokoro/kokoro.rb
+++ b/rakelib/kokoro/kokoro.rb
@@ -263,7 +263,6 @@ class Kokoro < Command
         puts "#{gem} tests took #{(end_time - start_time).to_i} seconds"
       end
     end
-    verify_in_gemfile gem unless local
   end
 
   def sample_dirs
@@ -280,14 +279,6 @@ class Kokoro < Command
         gem.include? dir
       end
     end
-  end
-
-  def verify_in_gemfile gem = nil
-    gem ||= @gem
-    return if Bundler.environment.gems.map(&:name).include? gem
-    return if ["gcloud", "google-cloud"].include? gem
-    header_2 "#{gem} does not appear in the top-level Gemfile. Please add it."
-    @failed = true
   end
 
   def version gem = nil


### PR DESCRIPTION
This PR also makes some changes to the toplevel Gemfile and Rakefile in this PR, triggered by the fact that we now have a gem that will not run in one of the Ruby versions (3.0.0) in our CI. Specifically:

* The toplevel Gemfile no longer pulls in all gems as dependencies. (Because this would no longer work on Ruby 3.) I also removed the CI check that ensures all gems are listed in the toplevel Gemfile.
* I refactored a bunch of the toplevel rake tasks that operate on all gems. Some of them were running tasks over all gems together (e.g. the test task would just globally load all test files) and this probably now carries too much risk of collisions, especially with different gems that have different dependencies and different Ruby requirements. So now, _all_ toplevel rake tasks that operate on "all" gems, do so by iterating over the gem directories and running each gem-specific rake task separately within its own bundle.
* I cleaned out a whole bunch of other gems as well from the toplevel Gemfile, that are no longer used. For example, minitest is no longer used at the top level because all toplevel test tasks work by running each gem's test task separately. The only gems that remain at the top level are those that are used by the build and release tasks ("rake", "gems", and "yard").
