### PR TITLE
feat(firestore): Drop support for Ruby 2.4 and add support for Ruby 3.0

### DIFF
--- a/google-cloud-firestore/.rubocop.yml
+++ b/google-cloud-firestore/.rubocop.yml
@@ -25,7 +25,7 @@ Naming/FileName:
     - "lib/google-cloud-firestore.rb"
 Naming/RescuedExceptionsVariableName:
   Enabled: false
-Naming/UncommunicativeMethodParamName:
+Naming/MethodParameterName:
   Enabled: false
 Style/IfUnlessModifier:
   Enabled: false

--- a/google-cloud-firestore/.rubocop.yml
+++ b/google-cloud-firestore/.rubocop.yml
@@ -11,15 +11,18 @@ AllCops:
     - "conformance/**/*"
     - "test/**/*"
 
-Documentation:
+Style/Documentation:
   Enabled: false
 
+Metrics/AbcSize:
+  Exclude:
+    - "lib/google/cloud/firestore/query.rb"
 Metrics/ClassLength:
   Enabled: false
 Metrics/CyclomaticComplexity:
-  Max: 15
+  Max: 17
 Metrics/PerceivedComplexity:
-  Max: 15
+  Max: 17
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-firestore.rb"

--- a/google-cloud-firestore/Rakefile
+++ b/google-cloud-firestore/Rakefile
@@ -114,7 +114,7 @@ namespace :acceptance do
     puts "Cleaning up Firestore documents and collections."
 
     firestore = Google::Cloud::Firestore.new
-    firestore.cols.all do |col|
+    firestore.cols.each do |col|
       begin
         col.select(firestore.document_id).all_descendants.run.each_slice(500).with_index do |slice, index|
           firestore.batch do |b|

--- a/google-cloud-firestore/acceptance/firestore/batch_test.rb
+++ b/google-cloud-firestore/acceptance/firestore/batch_test.rb
@@ -34,7 +34,7 @@ describe "Batch", :firestore_acceptance do
     doc_ref = rand_batch_col.add foo: "bar"
 
     firestore.batch do |b|
-      b.set doc_ref, foo: "baz"
+      b.set doc_ref, { foo: "baz" }
     end
 
     _(doc_ref.get[:foo]).must_equal "baz"
@@ -45,7 +45,7 @@ describe "Batch", :firestore_acceptance do
     doc_ref = rand_batch_col.add foo: "bar"
 
     firestore.batch do |b|
-      b.update doc_ref, foo: "baz"
+      b.update doc_ref, { foo: "baz" }
     end
 
     _(doc_ref.get[:foo]).must_equal "baz"
@@ -58,7 +58,7 @@ describe "Batch", :firestore_acceptance do
 
     expect do
       firestore.batch do |b|
-        b.update doc_ref, foo: "baz"
+        b.update doc_ref, { foo: "baz" }
       end
     end.must_raise Google::Cloud::NotFoundError
   end

--- a/google-cloud-firestore/acceptance/firestore/document_test.rb
+++ b/google-cloud-firestore/acceptance/firestore/document_test.rb
@@ -101,9 +101,12 @@ describe "Document", :firestore_acceptance do
     timestamp = Time.now
 
     doc_ref = root_col.doc
-    doc_ref.set a: :bar,
-                b: { keep: "bar"},
-                d: firestore.field_server_time
+    data_2 = {
+      a: :bar,
+      b: { keep: "bar"},
+      d: firestore.field_server_time
+    }
+    doc_ref.set data_2
     doc_snp = doc_ref.get
 
     set_timestamp = doc_snp.get "d"
@@ -114,9 +117,13 @@ describe "Document", :firestore_acceptance do
       d: set_timestamp,
     })
 
-    doc_ref.update a: firestore.field_server_time,
-                   b: { c: firestore.field_server_time },
-                   "e.f" => firestore.field_server_time
+    data_3 = {
+      a: firestore.field_server_time,
+      b: { c: firestore.field_server_time },
+      "e.f" => firestore.field_server_time
+    }
+
+    doc_ref.update data_3
     doc_snp = doc_ref.get
 
     update_timestamp = doc_snp[:a]

--- a/google-cloud-firestore/acceptance/firestore/transaction_test.rb
+++ b/google-cloud-firestore/acceptance/firestore/transaction_test.rb
@@ -57,7 +57,7 @@ describe "Transaction", :firestore_acceptance do
     doc_ref = rand_tx_col.doc
 
     resp = firestore.transaction do |tx|
-      tx.set doc_ref, foo: "bar"
+      tx.set doc_ref, { foo: "bar" }
     end
 
     _(resp).must_be :nil?
@@ -70,7 +70,7 @@ describe "Transaction", :firestore_acceptance do
     doc_ref.create foo: "bar"
 
     resp = firestore.transaction do |tx|
-      tx.update doc_ref, foo: "baz"
+      tx.update doc_ref, { foo: "baz" }
     end
 
     _(resp).must_be :nil?
@@ -84,7 +84,7 @@ describe "Transaction", :firestore_acceptance do
 
     expect do
       firestore.transaction do |tx|
-        tx.update doc_ref, foo: "baz"
+        tx.update doc_ref, { foo: "baz" }
       end
     end.must_raise Google::Cloud::NotFoundError
   end
@@ -92,7 +92,7 @@ describe "Transaction", :firestore_acceptance do
   it "has delete method" do
     rand_tx_col = firestore.col "#{root_path}/tx/#{SecureRandom.hex(4)}"
     doc_ref = rand_tx_col.doc
-    doc_ref.create({foo: "bar"})
+    doc_ref.create foo: "bar"
 
     resp = firestore.transaction do |tx|
       tx.delete doc_ref

--- a/google-cloud-firestore/acceptance/firestore/watch_test.rb
+++ b/google-cloud-firestore/acceptance/firestore/watch_test.rb
@@ -16,11 +16,11 @@ require "firestore_helper"
 
 describe "Watch", :firestore_acceptance do
   it "watches a limit query" do
-    watch_col = root_col.doc("watch-limit").col("watch-query")
+    watch_col = root_col.doc("watch-limit-#{SecureRandom.hex(4)}").col("watch-query")
 
-    watch_col.doc("int 5").create(val: 5)
-    watch_col.doc("int 4").create(val: 4)
-    watch_col.doc("int 3").create(val: 3)
+    watch_col.doc("int 5").create val: 5
+    watch_col.doc("int 4").create val: 4
+    watch_col.doc("int 3").create val: 3
 
     snps = []
     listener = watch_col.order(:val).limit(2).listen { |snp| snps << snp }
@@ -28,8 +28,8 @@ describe "Watch", :firestore_acceptance do
     wait_until { snps.count == 1 }
 
     firestore.batch do |b|
-      b.create(watch_col.doc("int 2"), { val: 1 })
-      b.create(watch_col.doc("int 1"), { val: 0 })
+      b.create watch_col.doc("int 2"), { val: 1 }
+      b.create watch_col.doc("int 1"), { val: 0 }
     end
 
     wait_until { snps.count == 2 }
@@ -48,11 +48,11 @@ describe "Watch", :firestore_acceptance do
   end
 
   it "watches a limit_to_last query" do
-    watch_col = root_col.doc("watch-limit_to_last").col("watch-query")
+    watch_col = root_col.doc("watch-limit_to_last-#{SecureRandom.hex(4)}").col("watch-query")
 
-    watch_col.doc("int 3").create(val: 3)
-    watch_col.doc("int 2").create(val: 2)
-    watch_col.doc("int 1").create(val: 1)
+    watch_col.doc("int 3").create val: 3
+    watch_col.doc("int 2").create val: 2
+    watch_col.doc("int 1").create val: 1
 
     snps = []
     listener = watch_col.order(:val).limit_to_last(2).listen { |snp| snps << snp }
@@ -60,8 +60,8 @@ describe "Watch", :firestore_acceptance do
     wait_until { snps.count == 1 }
 
     firestore.batch do |b|
-      b.create(watch_col.doc("int 5"), { val: 5 })
-      b.create(watch_col.doc("int 4"), { val: 4 })
+      b.create watch_col.doc("int 5"), { val: 5 }
+      b.create watch_col.doc("int 4"), { val: 4 }
     end
 
     wait_until { snps.count == 2 }
@@ -80,27 +80,27 @@ describe "Watch", :firestore_acceptance do
   end
 
   it "watches a query" do
-    watch_col = root_col.doc("watch").col("watch-query")
+    watch_col = root_col.doc("watch-#{SecureRandom.hex(4)}").col("watch-query")
 
-    watch_col.doc("nil").create(val: nil)
-    watch_col.doc("int").create(val: 0)
-    watch_col.doc("true").create(val: true)
-    watch_col.doc("false").create(val: false)
-    watch_col.doc("num").create(val: 0.0)
-    watch_col.doc("str").create(val: "")
-    watch_col.doc("time").create(val: Time.now)
-    watch_col.doc("array").create(val: [])
-    watch_col.doc("hash").create(val: {})
-    watch_col.doc("ref").create(val: root_col.doc("ref"))
-    watch_col.doc("geo").create(val: { longitude: 45, latitude: 45 })
-    watch_col.doc("io").create(val: StringIO.new)
+    watch_col.doc("nil").create val: nil
+    watch_col.doc("int").create val: 0
+    watch_col.doc("true").create val: true
+    watch_col.doc("false").create val: false
+    watch_col.doc("num").create val: 0.0
+    watch_col.doc("str").create val: ""
+    watch_col.doc("time").create val: Time.now
+    watch_col.doc("array").create val: []
+    watch_col.doc("hash").create val: {}
+    watch_col.doc("ref").create val: root_col.doc("ref")
+    watch_col.doc("geo").create val: { longitude: 45, latitude: 45 }
+    watch_col.doc("io").create val: StringIO.new
 
     snps = []
     listener = watch_col.order(:val, :desc).listen { |snp| snps << snp }
 
     wait_until { snps.count == 1 }
 
-    watch_col.doc("added").create(val: false)
+    watch_col.doc("added").create val: false
 
     wait_until { snps.count == 2 }
 
@@ -108,7 +108,7 @@ describe "Watch", :firestore_acceptance do
 
     wait_until { snps.count == 3 }
 
-    watch_col.doc("added").update(val: true)
+    watch_col.doc("added").update({val: true})
 
     wait_until { snps.count == 4 }
 
@@ -143,16 +143,16 @@ describe "Watch", :firestore_acceptance do
   end
 
   it "watches a document" do
-    watch_col = root_col.doc("watch").col("watch-docs")
+    watch_col = root_col.doc("watch-#{SecureRandom.hex(4)}").col("watch-docs")
 
-    watch_col.doc("watch-doc").create(val: true)
+    watch_col.doc("watch-doc").create val: true
 
     snps = []
     listener = watch_col.doc("watch-doc").listen { |snp| snps << snp }
 
     wait_until { snps.count == 1 }
 
-    watch_col.doc("watch-doc").update(val: false)
+    watch_col.doc("watch-doc").update({val: false})
 
     wait_until { snps.count == 2 }
 
@@ -160,7 +160,7 @@ describe "Watch", :firestore_acceptance do
 
     wait_until { snps.count == 3 }
 
-    watch_col.doc("watch-doc").set(val: 1)
+    watch_col.doc("watch-doc").set({val: 1})
 
     wait_until { snps.count == 4 }
 

--- a/google-cloud-firestore/acceptance/firestore_helper.rb
+++ b/google-cloud-firestore/acceptance/firestore_helper.rb
@@ -94,6 +94,7 @@ def clean_up_firestore
           b.delete doc
         end
       end
+      puts "Deleted batch #{index+1} of #{slice.count} documents"
     end
   end
 rescue => e

--- a/google-cloud-firestore/google-cloud-firestore.gemspec
+++ b/google-cloud-firestore/google-cloud-firestore.gemspec
@@ -17,14 +17,14 @@ Gem::Specification.new do |gem|
                       ["OVERVIEW.md", "AUTHENTICATION.md", "EMULATOR.md", "LOGGING.md", "CONTRIBUTING.md", "TROUBLESHOOTING.md", "CHANGELOG.md", "CODE_OF_CONDUCT.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.4"
+  gem.required_ruby_version = ">= 2.5"
 
   gem.add_dependency "google-cloud-core", "~> 1.5"
   gem.add_dependency "google-cloud-firestore-v1", "~> 0.0"
   gem.add_dependency "concurrent-ruby", "~> 1.0"
   gem.add_dependency "rbtree", "~> 0.4.2"
 
-  gem.add_development_dependency "google-style", "~> 1.24.0"
+  gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"
   gem.add_development_dependency "minitest-focus", "~> 1.1"

--- a/google-cloud-firestore/lib/google/cloud/firestore/batch.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/batch.rb
@@ -322,8 +322,7 @@ module Google
 
           doc_path = coalesce_doc_path_argument doc
 
-          @writes << Convert.write_for_update(doc_path, data,
-                                              update_time: update_time)
+          @writes << Convert.write_for_update(doc_path, data, update_time: update_time)
 
           nil
         end

--- a/google-cloud-firestore/lib/google/cloud/firestore/client.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/client.rb
@@ -256,7 +256,7 @@ module Google
           ensure_service!
 
           unless block_given?
-            return enum_for :get_all, docs, field_mask: field_mask
+            return enum_for :get_all, *docs, field_mask: field_mask
           end
 
           doc_paths = Array(docs).flatten.map do |doc_path|

--- a/google-cloud-firestore/lib/google/cloud/firestore/client.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/client.rb
@@ -100,11 +100,11 @@ module Google
         #     puts col.collection_id
         #   end
         #
-        def cols
+        def cols &block
           ensure_service!
           grpc = service.list_collections "#{path}/documents"
           cols_enum = CollectionReferenceList.from_grpc(grpc, self, "#{path}/documents").all
-          cols_enum.each { |c| yield c } if block_given?
+          cols_enum.each(&block) if block_given?
           cols_enum
         end
         alias collections cols

--- a/google-cloud-firestore/lib/google/cloud/firestore/collection_reference_list.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/collection_reference_list.rb
@@ -90,14 +90,14 @@ module Google
         #     collection_reference.collection_id
         #   end
         #
-        def all request_limit: nil
+        def all request_limit: nil, &block
           request_limit = request_limit.to_i if request_limit
           unless block_given?
             return enum_for :all, request_limit: request_limit
           end
           results = self
           loop do
-            results.each { |r| yield r }
+            results.each(&block)
             if request_limit
               request_limit -= 1
               break if request_limit < 0

--- a/google-cloud-firestore/lib/google/cloud/firestore/convert.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/convert.rb
@@ -371,12 +371,13 @@ module Google
           def field_value_nested? obj, field_value_type = nil
             return obj if obj.is_a?(FieldValue) && (field_value_type.nil? || obj.type == field_value_type)
 
-            if obj.is_a? Array
+            case obj
+            when Array
               obj.each do |o|
                 val = field_value_nested? o, field_value_type
                 return val if val
               end
-            elsif obj.is_a? Hash
+            when Hash
               obj.each do |_k, v|
                 val = field_value_nested? v, field_value_type
                 return val if val
@@ -564,32 +565,33 @@ module Google
           end
 
           def to_field_transform field_path, field_value
-            if field_value.type == :server_time
+            case field_value.type
+            when :server_time
               Google::Cloud::Firestore::V1::DocumentTransform::FieldTransform.new(
                 field_path:          field_path.formatted_string,
                 set_to_server_value: :REQUEST_TIME
               )
-            elsif field_value.type == :array_union
+            when :array_union
               Google::Cloud::Firestore::V1::DocumentTransform::FieldTransform.new(
                 field_path:              field_path.formatted_string,
                 append_missing_elements: raw_to_value(Array(field_value.value)).array_value
               )
-            elsif field_value.type == :array_delete
+            when :array_delete
               Google::Cloud::Firestore::V1::DocumentTransform::FieldTransform.new(
                 field_path:            field_path.formatted_string,
                 remove_all_from_array: raw_to_value(Array(field_value.value)).array_value
               )
-            elsif field_value.type == :increment
+            when :increment
               Google::Cloud::Firestore::V1::DocumentTransform::FieldTransform.new(
                 field_path: field_path.formatted_string,
                 increment:  raw_to_value(field_value.value)
               )
-            elsif field_value.type == :maximum
+            when :maximum
               Google::Cloud::Firestore::V1::DocumentTransform::FieldTransform.new(
                 field_path: field_path.formatted_string,
                 maximum:    raw_to_value(field_value.value)
               )
-            elsif field_value.type == :minimum
+            when :minimum
               Google::Cloud::Firestore::V1::DocumentTransform::FieldTransform.new(
                 field_path: field_path.formatted_string,
                 minimum:    raw_to_value(field_value.value)

--- a/google-cloud-firestore/lib/google/cloud/firestore/convert.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/convert.rb
@@ -30,7 +30,6 @@ module Google
         # rubocop:disable Metrics/MethodLength
         # rubocop:disable Metrics/ModuleLength
         # rubocop:disable Metrics/PerceivedComplexity
-        # rubocop:disable Style/CaseEquality
         module ClassMethods
           def time_to_timestamp time
             return nil if time.nil?
@@ -263,10 +262,8 @@ module Google
             # Restore delete paths
             field_paths += delete_field_paths_and_values.keys
 
-            if data.empty? && !allow_empty
-              if field_paths_and_values.empty? && delete_field_paths_and_values.empty?
-                raise ArgumentError, "data required for set with merge"
-              end
+            if data.empty? && !allow_empty && (field_paths_and_values.empty? && delete_field_paths_and_values.empty?)
+              raise ArgumentError, "data required for set with merge"
             end
 
             doc = Google::Cloud::Firestore::V1::Document.new(
@@ -531,8 +528,8 @@ module Google
           end
 
           START_FIELD_PATH_CHARS = /\A[a-zA-Z_]/.freeze
-          INVALID_FIELD_PATH_CHARS = %r{[\~\*/\[\]]}.freeze
-          ESCAPED_FIELD_PATH = /\A\`(.*)\`\z/.freeze
+          INVALID_FIELD_PATH_CHARS = %r{[~*/\[\]]}.freeze
+          ESCAPED_FIELD_PATH = /\A`(.*)`\z/.freeze
 
           def build_hash_from_field_paths_and_values pairs
             pairs.each do |field_path, _value|
@@ -611,7 +608,6 @@ module Google
       # rubocop:enable Metrics/MethodLength
       # rubocop:enable Metrics/ModuleLength
       # rubocop:enable Metrics/PerceivedComplexity
-      # rubocop:enable Style/CaseEquality
     end
   end
 end

--- a/google-cloud-firestore/lib/google/cloud/firestore/document_reference.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/document_reference.rb
@@ -90,11 +90,11 @@ module Google
         #     puts col.collection_id
         #   end
         #
-        def cols
+        def cols &block
           ensure_service!
           grpc = service.list_collections path
           cols_enum = CollectionReferenceList.from_grpc(grpc, client, path).all
-          cols_enum.each { |c| yield c } if block_given?
+          cols_enum.each(&block) if block_given?
           cols_enum
         end
         alias collections cols

--- a/google-cloud-firestore/lib/google/cloud/firestore/document_reference/list.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/document_reference/list.rb
@@ -86,8 +86,7 @@ module Google
           def next
             return nil unless next?
             ensure_client!
-            options = { token: token, max: @max }
-            grpc = @client.service.list_documents @parent, @collection_id, options
+            grpc = @client.service.list_documents @parent, @collection_id, token: token, max: @max
             self.class.from_grpc grpc, @client, @parent, @collection_id, @max
           end
 

--- a/google-cloud-firestore/lib/google/cloud/firestore/document_reference/list.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/document_reference/list.rb
@@ -143,14 +143,14 @@ module Google
           #     puts doc_ref.document_id
           #   end
           #
-          def all request_limit: nil
+          def all request_limit: nil, &block
             request_limit = request_limit.to_i if request_limit
             unless block_given?
               return enum_for :all, request_limit: request_limit
             end
             results = self
             loop do
-              results.each { |r| yield r }
+              results.each(&block)
               if request_limit
                 request_limit -= 1
                 break if request_limit < 0

--- a/google-cloud-firestore/lib/google/cloud/firestore/field_path.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/field_path.rb
@@ -210,14 +210,14 @@ module Google
         protected
 
         START_FIELD_PATH_CHARS = /\A[a-zA-Z_]/.freeze
-        INVALID_FIELD_PATH_CHARS = %r{[\~\*\/\[\]]}.freeze
+        INVALID_FIELD_PATH_CHARS = %r{[~*/\[\]]}.freeze
 
         def escape_field_for_path field
           field = String field
 
           if INVALID_FIELD_PATH_CHARS.match(field) ||
              field["."] || field["`"] || field["\\"]
-            escaped_field = field.gsub(/[\`\\]/, "`" => "\\\`", "\\" => "\\\\")
+            escaped_field = field.gsub(/[`\\]/, "`" => "\\\`", "\\" => "\\\\")
             return "`#{escaped_field}`"
           end
 

--- a/google-cloud-firestore/lib/google/cloud/firestore/query.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/query.rb
@@ -1037,9 +1037,10 @@ module Google
           raise ArgumentError, "unknown operator #{op}" if operator.nil?
 
           if value_unary? value
-            operator = if operator == :EQUAL
+            operator = case operator
+                       when :EQUAL
                          value_nan?(value) ? :IS_NAN : :IS_NULL
-                       elsif operator == :NOT_EQUAL
+                       when :NOT_EQUAL
                          value_nan?(value) ? :IS_NOT_NAN : :IS_NOT_NULL
                        else
                          raise ArgumentError, "can only perform '==' and '!=' comparisons on #{value} values"

--- a/google-cloud-firestore/lib/google/cloud/firestore/service.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/service.rb
@@ -26,7 +26,10 @@ module Google
       # @private Represents the gRPC Firestore service, including all the API
       # methods.
       class Service
-        attr_accessor :project, :credentials, :timeout, :host
+        attr_accessor :project
+        attr_accessor :credentials
+        attr_accessor :timeout
+        attr_accessor :host
 
         ##
         # Creates a new Service instance.

--- a/google-cloud-firestore/lib/google/cloud/firestore/transaction.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/transaction.rb
@@ -131,7 +131,7 @@ module Google
           ensure_service!
 
           unless block_given?
-            return enum_for :get_all, docs, field_mask: field_mask
+            return enum_for :get_all, *docs, field_mask: field_mask
           end
 
           doc_paths = Array(docs).flatten.map do |doc_path|

--- a/google-cloud-firestore/lib/google/cloud/firestore/watch/inventory.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/watch/inventory.rb
@@ -33,7 +33,8 @@ module Google
         # make inserting and removing objects much more efficent.
         class Inventory
           attr_accessor :current
-          attr_reader :resume_token, :read_time
+          attr_reader :resume_token
+          attr_reader :read_time
 
           def initialize client, query
             @client = client

--- a/google-cloud-firestore/test/google/cloud/firestore/conformance_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/conformance_test.rb
@@ -208,21 +208,22 @@ class ConformanceDelete < ConformanceTest
   def self.build_test_for description, test, file_path
     define_method("test_#{file_path}: #{description}") do
       doc_ref = doc_ref_from_path test.doc_ref_path
-      opts = {}
+      exists = nil
+      update_time = nil
       if test.precondition && test.precondition.exists
-        opts[:exists] = test.precondition.exists
+        exists = test.precondition.exists
       end
       if test.precondition && test.precondition.update_time
-        opts[:update_time] = Time.at(test.precondition.update_time.seconds)
+        update_time = Time.at(test.precondition.update_time.seconds)
       end
       if test.is_error
         expect do
-          doc_ref.delete opts
+          doc_ref.delete exists: exists, update_time: update_time
         end.must_raise ArgumentError
       else
         firestore_mock.expect :commit, commit_resp, commit_args(database: test.request.database, writes: test.request.writes)
 
-        doc_ref.delete opts
+        doc_ref.delete exists: exists, update_time: update_time
       end
     end
   end


### PR DESCRIPTION
Drop support for Ruby 2.4 and add support for Ruby 3.0 in google-cloud-firestore.

All ci and acceptance passing locally for Ruby 2.7.2 and 3.0.0.