### PR TITLE
feat(datastore): Drop support for Ruby 2.4 and add support for Ruby 3.0

### DIFF
--- a/google-cloud-datastore/.rubocop.yml
+++ b/google-cloud-datastore/.rubocop.yml
@@ -12,7 +12,7 @@ AllCops:
 Documentation:
   Enabled: false
 
-Layout/AlignHash:
+Layout/HashAlignment:
   Enabled: false
 Metrics/ClassLength:
   Enabled: false
@@ -21,7 +21,7 @@ Naming/FileName:
     - "lib/google-cloud-datastore.rb"
 Naming/RescuedExceptionsVariableName:
   Enabled: false
-Naming/UncommunicativeMethodParamName:
+Naming/MethodParameterName:
   Enabled: false
 Style/ConditionalAssignment:
   Enabled: false

--- a/google-cloud-datastore/.rubocop.yml
+++ b/google-cloud-datastore/.rubocop.yml
@@ -9,25 +9,15 @@ AllCops:
     - "support/**/*"
     - "test/**/*"
 
-Documentation:
+Style/Documentation:
   Enabled: false
 
-Layout/HashAlignment:
-  Enabled: false
 Metrics/ClassLength:
   Enabled: false
+Metrics/CyclomaticComplexity:
+  Max: 15
+Metrics/PerceivedComplexity:
+  Max: 15
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-datastore.rb"
-Naming/RescuedExceptionsVariableName:
-  Enabled: false
-Naming/MethodParameterName:
-  Enabled: false
-Style/ConditionalAssignment:
-  Enabled: false
-Style/IfUnlessModifier:
-  Enabled: false
-Style/NumericPredicate:
-  Enabled: false
-Style/SafeNavigation:
-  Enabled: false

--- a/google-cloud-datastore/.rubocop.yml
+++ b/google-cloud-datastore/.rubocop.yml
@@ -21,3 +21,6 @@ Metrics/PerceivedComplexity:
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-datastore.rb"
+Style/BisectedAttrAccessor:
+  Exclude:
+    - "lib/google/cloud/datastore/dataset/query_results.rb"

--- a/google-cloud-datastore/CONTRIBUTING.md
+++ b/google-cloud-datastore/CONTRIBUTING.md
@@ -24,7 +24,7 @@ be able to accept your pull requests.
 In order to use the google-cloud-datastore console and run the project's tests,
 there is a small amount of setup:
 
-1. Install Ruby. google-cloud-datastore requires Ruby 2.4+. You may choose to
+1. Install Ruby. google-cloud-datastore requires Ruby 2.5+. You may choose to
    manage your Ruby and gem installations with [RVM](https://rvm.io/),
    [rbenv](https://github.com/rbenv/rbenv), or
    [chruby](https://github.com/postmodern/chruby).

--- a/google-cloud-datastore/LOGGING.md
+++ b/google-cloud-datastore/LOGGING.md
@@ -3,7 +3,7 @@
 To enable logging for this library, set the logger for the underlying
 [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library. The logger
 that you set may be a Ruby stdlib
-[`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as
+[`Logger`](https://ruby-doc.org/stdlib/libdoc/logger/rdoc/Logger.html) as
 shown below, or a
 [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver

--- a/google-cloud-datastore/README.md
+++ b/google-cloud-datastore/README.md
@@ -71,11 +71,11 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.4+.
+This library is supported on Ruby 2.5+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or in
-security maintenance, and not end of life. Currently, this means Ruby 2.4 and
+security maintenance, and not end of life. Currently, this means Ruby 2.5 and
 later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-datastore/README.md
+++ b/google-cloud-datastore/README.md
@@ -49,7 +49,7 @@ tasks = datastore.run query
 
 ## Enabling Logging
 
-To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb) and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
+To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb) and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
 
 Configuring a Ruby stdlib logger:
 

--- a/google-cloud-datastore/Rakefile
+++ b/google-cloud-datastore/Rakefile
@@ -140,7 +140,7 @@ end
 namespace :samples do
   task :latest do
     Dir.chdir "samples" do
-      Bundler.with_clean_env do
+      Bundler.with_unbundled_env do
         ENV["GOOGLE_CLOUD_SAMPLES_TEST"] = "not_master"
         sh "bundle update"
         sh "bundle exec rake test"
@@ -150,7 +150,7 @@ namespace :samples do
 
   task :master do
     Dir.chdir "samples" do
-      Bundler.with_clean_env do
+      Bundler.with_unbundled_env do
         ENV["GOOGLE_CLOUD_SAMPLES_TEST"] = "master"
         sh "bundle update"
         sh "bundle exec rake test"

--- a/google-cloud-datastore/google-cloud-datastore.gemspec
+++ b/google-cloud-datastore/google-cloud-datastore.gemspec
@@ -16,12 +16,12 @@ Gem::Specification.new do |gem|
                       ["OVERVIEW.md", "AUTHENTICATION.md", "EMULATOR.md", "LOGGING.md", "CONTRIBUTING.md", "TROUBLESHOOTING.md", "CHANGELOG.md", "CODE_OF_CONDUCT.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.4"
+  gem.required_ruby_version = ">= 2.5"
 
   gem.add_dependency "google-cloud-core", "~> 1.5"
   gem.add_dependency "google-cloud-datastore-v1", "~> 0.0"
 
-  gem.add_development_dependency "google-style", "~> 1.24.0"
+  gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"
   gem.add_development_dependency "minitest-focus", "~> 1.1"

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset.rb
@@ -535,9 +535,9 @@ module Google
           begin
             yield tx
             tx.commit
-          rescue Google::Cloud::UnavailableError => err
+          rescue Google::Cloud::UnavailableError => e
             # Re-raise if deadline has passed
-            raise err if Time.now - start_time > deadline
+            raise e if Time.now - start_time > deadline
 
             # Sleep with incremental backoff
             sleep backoff *= 1.3
@@ -878,7 +878,7 @@ module Google
 
         def validate_deadline deadline
           return 60 unless deadline.is_a? Numeric
-          return 60 if deadline < 0
+          return 60 if deadline.negative?
           deadline
         end
 

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset/lookup_results.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset/lookup_results.rb
@@ -177,7 +177,7 @@ module Google
               results.each(&block)
               if request_limit
                 request_limit -= 1
-                break if request_limit < 0
+                break if request_limit.negative?
               end
               break unless results.next?
               results = results.next
@@ -187,14 +187,14 @@ module Google
           ##
           # @private New Dataset::LookupResults from a
           # Google::Dataset::V1::LookupResponse object.
-          def self.from_grpc lookup_res, service, consistency = nil, tx = nil
+          def self.from_grpc lookup_res, service, consistency = nil, transaction = nil
             entities = to_gcloud_entities lookup_res.found
             deferred = to_gcloud_keys lookup_res.deferred
             missing  = to_gcloud_entities lookup_res.missing
             new(entities).tap do |lr|
               lr.instance_variable_set :@service,     service
               lr.instance_variable_set :@consistency, consistency
-              lr.instance_variable_set :@transaction, tx
+              lr.instance_variable_set :@transaction, transaction
               lr.instance_variable_set :@deferred,    deferred
               lr.instance_variable_set :@missing,     missing
             end

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset/lookup_results.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset/lookup_results.rb
@@ -167,14 +167,14 @@ module Google
           #     puts "Task #{t.key.id} (#cursor)"
           #   end
           #
-          def all request_limit: nil
+          def all request_limit: nil, &block
             request_limit = request_limit.to_i if request_limit
             unless block_given?
               return enum_for :all, request_limit: request_limit
             end
             results = self
             loop do
-              results.each { |r| yield r }
+              results.each(&block)
               if request_limit
                 request_limit -= 1
                 break if request_limit < 0

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset/query_results.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset/query_results.rb
@@ -58,7 +58,7 @@ module Google
           # The end_cursor of the QueryResults.
           #
           # @return [Google::Cloud::Datastore::Cursor]
-          attr_reader :end_cursor
+          attr_accessor :end_cursor
           alias cursor end_cursor
 
           ##
@@ -70,7 +70,7 @@ module Google
           # * `:MORE_RESULTS_AFTER_LIMIT`
           # * `:MORE_RESULTS_AFTER_CURSOR`
           # * `:NO_MORE_RESULTS`
-          attr_reader :more_results
+          attr_accessor :more_results
 
           ##
           # @private
@@ -78,7 +78,7 @@ module Google
 
           ##
           # @private
-          attr_writer :end_cursor, :more_results
+
 
           ##
           # Convenience method for determining if the `more_results` value
@@ -266,14 +266,14 @@ module Google
           #     puts "Task #{t.key.id} (#cursor)"
           #   end
           #
-          def all request_limit: nil
+          def all request_limit: nil, &block
             request_limit = request_limit.to_i if request_limit
             unless block_given?
               return enum_for :all, request_limit: request_limit
             end
             results = self
             loop do
-              results.each { |r| yield r }
+              results.each(&block)
               if request_limit
                 request_limit -= 1
                 break if request_limit < 0
@@ -335,7 +335,7 @@ module Google
           #     puts "Task #{task.key.id} (#cursor)"
           #   end
           #
-          def all_with_cursor request_limit: nil
+          def all_with_cursor request_limit: nil, &block
             request_limit = request_limit.to_i if request_limit
             unless block_given?
               return enum_for :all_with_cursor, request_limit: request_limit
@@ -343,7 +343,7 @@ module Google
             results = self
 
             loop do
-              results.zip(results.cursors).each { |r, c| yield r, c }
+              results.zip(results.cursors).each(&block)
               if request_limit
                 request_limit -= 1
                 break if request_limit < 0

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset/query_results.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset/query_results.rb
@@ -58,7 +58,7 @@ module Google
           # The end_cursor of the QueryResults.
           #
           # @return [Google::Cloud::Datastore::Cursor]
-          attr_accessor :end_cursor
+          attr_reader :end_cursor
           alias cursor end_cursor
 
           ##
@@ -70,7 +70,7 @@ module Google
           # * `:MORE_RESULTS_AFTER_LIMIT`
           # * `:MORE_RESULTS_AFTER_CURSOR`
           # * `:NO_MORE_RESULTS`
-          attr_accessor :more_results
+          attr_reader :more_results
 
           ##
           # @private
@@ -78,7 +78,7 @@ module Google
 
           ##
           # @private
-
+          attr_writer :end_cursor, :more_results
 
           ##
           # Convenience method for determining if the `more_results` value

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset/query_results.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset/query_results.rb
@@ -276,7 +276,7 @@ module Google
               results.each(&block)
               if request_limit
                 request_limit -= 1
-                break if request_limit < 0
+                break if request_limit.negative?
               end
               break unless results.next?
               results = results.next
@@ -346,7 +346,7 @@ module Google
               results.zip(results.cursors).each(&block)
               if request_limit
                 request_limit -= 1
-                break if request_limit < 0
+                break if request_limit.negative?
               end
               break unless results.next?
               results = results.next

--- a/google-cloud-datastore/lib/google/cloud/datastore/entity.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/entity.rb
@@ -293,7 +293,7 @@ module Google
         #   task.persisted? #=> true
         #
         def persisted?
-          @key && @key.frozen?
+          @key&.frozen?
         end
 
         ##

--- a/google-cloud-datastore/lib/google/cloud/datastore/gql_query.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/gql_query.rb
@@ -157,17 +157,15 @@ module Google
         def named_bindings= new_named_bindings
           @grpc.named_bindings.clear
           new_named_bindings.map do |name, value|
-            if value.is_a? Google::Cloud::Datastore::Cursor
-              @grpc.named_bindings[name.to_s] = \
-                Google::Cloud::Datastore::V1::GqlQueryParameter.new(
-                  cursor: value.to_grpc
-                )
-            else
-              @grpc.named_bindings[name.to_s] = \
-                Google::Cloud::Datastore::V1::GqlQueryParameter.new(
-                  value: Convert.to_value(value)
-                )
-            end
+            @grpc.named_bindings[name.to_s] = if value.is_a? Google::Cloud::Datastore::Cursor
+                                                Google::Cloud::Datastore::V1::GqlQueryParameter.new(
+                                                  cursor: value.to_grpc
+                                                )
+                                              else
+                                                Google::Cloud::Datastore::V1::GqlQueryParameter.new(
+                                                  value: Convert.to_value(value)
+                                                )
+                                              end
           end
         end
 
@@ -208,17 +206,15 @@ module Google
         def positional_bindings= new_positional_bindings
           @grpc.positional_bindings.clear
           new_positional_bindings.map do |value|
-            if value.is_a? Google::Cloud::Datastore::Cursor
-              @grpc.positional_bindings << \
-                Google::Cloud::Datastore::V1::GqlQueryParameter.new(
-                  cursor: value.to_grpc
-                )
-            else
-              @grpc.positional_bindings << \
-                Google::Cloud::Datastore::V1::GqlQueryParameter.new(
-                  value: Convert.to_value(value)
-                )
-            end
+            @grpc.positional_bindings << if value.is_a? Google::Cloud::Datastore::Cursor
+                                           Google::Cloud::Datastore::V1::GqlQueryParameter.new(
+                                             cursor: value.to_grpc
+                                           )
+                                         else
+                                           Google::Cloud::Datastore::V1::GqlQueryParameter.new(
+                                             value: Convert.to_value(value)
+                                           )
+                                         end
           end
         end
 

--- a/google-cloud-datastore/lib/google/cloud/datastore/key.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/key.rb
@@ -272,9 +272,10 @@ module Google
         def to_grpc
           grpc_path = path.map do |pe_kind, pe_id_or_name|
             path_args = { kind: pe_kind }
-            if pe_id_or_name.is_a? Integer
+            case pe_id_or_name
+            when Integer
               path_args[:id] = pe_id_or_name
-            elsif pe_id_or_name.is_a? String
+            when String
               path_args[:name] = pe_id_or_name unless pe_id_or_name.empty?
             end
             Google::Cloud::Datastore::V1::Key::PathElement.new path_args

--- a/google-cloud-datastore/lib/google/cloud/datastore/key.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/key.rb
@@ -306,7 +306,7 @@ module Google
             key.project = key_grpc.partition_id.project_id
             key.namespace = key_grpc.partition_id.namespace_id
           end
-          key.parent = Key.from_grpc key_grpc if key_grpc.path.count > 0
+          key.parent = Key.from_grpc key_grpc if key_grpc.path.count.positive?
           # Freeze the key to make it immutable.
           key.freeze
           key

--- a/google-cloud-datastore/lib/google/cloud/datastore/query.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/query.rb
@@ -340,9 +340,10 @@ module Google
         #   tasks = datastore.run query
         #
         def start cursor
-          if cursor.is_a? Cursor
+          case cursor
+          when Cursor
             @grpc.start_cursor = cursor.to_grpc
-          elsif cursor.is_a? String
+          when String
             @grpc.start_cursor = Convert.decode_bytes cursor
           else
             raise ArgumentError, "Can't set a cursor using a #{cursor.class}."

--- a/google-cloud-datastore/lib/google/cloud/datastore/service.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/service.rb
@@ -25,7 +25,10 @@ module Google
       # @private Represents the GAX Datastore service, including all the API
       # methods.
       class Service
-        attr_accessor :project, :credentials, :host, :timeout
+        attr_accessor :project
+        attr_accessor :credentials
+        attr_accessor :host
+        attr_accessor :timeout
 
         ##
         # Creates a new Service instance.

--- a/google-cloud-datastore/lib/google/cloud/datastore/transaction.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/transaction.rb
@@ -50,7 +50,7 @@ module Google
         # @private Creates a new Transaction instance.
         # Takes a Service instead of project and Credentials.
         def initialize service, previous_transaction: nil
-          @service = service
+          super service
           @previous_transaction = previous_transaction
           reset!
           start

--- a/google-cloud-datastore/samples/.rubocop.yml
+++ b/google-cloud-datastore/samples/.rubocop.yml
@@ -8,3 +8,7 @@ Metrics/BlockLength:
         - "acceptance/*.rb"
 Style/IfUnlessModifier:
     Enabled: false
+Style/RedundantAssignment:
+    Enabled: false
+Style/RedundantBegin:
+    Enabled: false

--- a/google-cloud-datastore/samples/Gemfile
+++ b/google-cloud-datastore/samples/Gemfile
@@ -20,11 +20,9 @@ source "https://rubygems.org"
 if ENV["GOOGLE_CLOUD_SAMPLES_TEST"] == "master"
   gem "google-cloud-datastore", path: "../../google-cloud-datastore"
 else
-  # rubocop:disable Bundler/DuplicatedGem
   # [START datastore_dependencies]
   gem "google-cloud-datastore"
   # [END datastore_dependencies]
-  # rubocop:enable Bundler/DuplicatedGem
 end
 
 group :development, :test do

--- a/google-cloud-datastore/samples/Gemfile
+++ b/google-cloud-datastore/samples/Gemfile
@@ -26,7 +26,7 @@ else
 end
 
 group :development, :test do
-  gem "google-style", "~> 1.24.0"
+  gem "google-style", "~> 1.25.1"
   gem "minitest", "~> 5.14"
   gem "minitest-focus", "~> 1.1"
   gem "minitest-hooks", "~> 1.5"

--- a/google-cloud-datastore/samples/sample.rb
+++ b/google-cloud-datastore/samples/sample.rb
@@ -37,8 +37,10 @@ def key_with_parent task_list_name:, task_name:
   # [START datastore_key_with_parent]
   # task_list_name = "default"
   # task_name = "sampleTask"
-  datastore.key [["TaskList", task_list_name], ["Task", task_name]]
+  task_key = datastore.key [["TaskList", task_list_name], ["Task", task_name]]
   # [END datastore_key_with_parent]
+
+  task_key
 end
 
 def key_with_multilevel_parent user_name:, task_list_name:, task_name:
@@ -48,12 +50,14 @@ def key_with_multilevel_parent user_name:, task_list_name:, task_name:
   # user_name = "alice"
   # task_list_name = "default"
   # task_name = "sampleTask"
-  datastore.key([
-                  ["User", user_name],
-                  ["TaskList", task_list_name],
-                  ["Task", task_name]
-                ])
+  task_key = datastore.key([
+                             ["User", user_name],
+                             ["TaskList", task_list_name],
+                             ["Task", task_name]
+                           ])
   # [END datastore_key_with_multilevel_parent]
+
+  task_key
 end
 
 def entity_with_parent task_list_name:, task_name:
@@ -64,20 +68,22 @@ def entity_with_parent task_list_name:, task_name:
   # task_name = "sampleTask"
   task_key = datastore.key [["TaskList", task_list_name], ["Task", task_name]]
 
-  datastore.entity task_key do |t|
+  task = datastore.entity task_key do |t|
     t["category"] = "Personal"
     t["done"] = false
     t["priority"] = 4
     t["description"] = "Learn Cloud Datastore"
   end
   # [END datastore_entity_with_parent]
+
+  task
 end
 
 def properties
   datastore = Google::Cloud::Datastore.new
 
   # [START datastore_properties]
-  datastore.entity "Task" do |t|
+  task = datastore.entity "Task" do |t|
     t["category"] = "Personal"
     t["created"] = Time.now
     t["done"] = false
@@ -87,6 +93,8 @@ def properties
     t.exclude_from_indexes! "description", true
   end
   # [END datastore_properties]
+
+  task
 end
 
 def array_value task_name:
@@ -105,13 +113,15 @@ def basic_entity
   datastore = Google::Cloud::Datastore.new
 
   # [START datastore_basic_entity]
-  datastore.entity "Task" do |t|
+  task = datastore.entity "Task" do |t|
     t["category"] = "Personal"
     t["done"] = false
     t["priority"] = 4
     t["description"] = "Learn Cloud Datastore"
   end
   # [END datastore_basic_entity]
+
+  task
 end
 
 def upsert task_name:
@@ -156,8 +166,10 @@ def lookup task_name:
   # [START datastore_lookup]
   # task_name = "sampleTask"
   task_key = datastore.key "Task", task_name
-  datastore.find task_key
+  task = datastore.find task_key
   # [END datastore_lookup]
+
+  task
 end
 
 def update task_name:
@@ -503,8 +515,10 @@ def eventual_consistent_query task_list_name:
   query = datastore.query("Task")
                    .ancestor(ancestor_key)
 
-  datastore.run query, consistency: :eventual
+  tasks = datastore.run query, consistency: :eventual
   # [END datastore_eventual_consistent_query]
+
+  tasks
 end
 
 def unindexed_property_query
@@ -543,9 +557,11 @@ end
 def transactional_retry from_key, to_key, amount
   # [START datastore_transactional_retry]
   (1..5).each do |i|
-    return transfer_funds from_key, to_key, amount
-  rescue Google::Cloud::Error => e
-    raise e if i == 5
+    begin
+      return transfer_funds from_key, to_key, amount
+    rescue Google::Cloud::Error => e
+      raise e if i == 5
+    end
   end
   # [END datastore_transactional_retry]
 end

--- a/google-cloud-datastore/samples/sample.rb
+++ b/google-cloud-datastore/samples/sample.rb
@@ -37,10 +37,8 @@ def key_with_parent task_list_name:, task_name:
   # [START datastore_key_with_parent]
   # task_list_name = "default"
   # task_name = "sampleTask"
-  task_key = datastore.key [["TaskList", task_list_name], ["Task", task_name]]
+  datastore.key [["TaskList", task_list_name], ["Task", task_name]]
   # [END datastore_key_with_parent]
-
-  task_key
 end
 
 def key_with_multilevel_parent user_name:, task_list_name:, task_name:
@@ -50,14 +48,12 @@ def key_with_multilevel_parent user_name:, task_list_name:, task_name:
   # user_name = "alice"
   # task_list_name = "default"
   # task_name = "sampleTask"
-  task_key = datastore.key([
-                             ["User", user_name],
-                             ["TaskList", task_list_name],
-                             ["Task", task_name]
-                           ])
+  datastore.key([
+                  ["User", user_name],
+                  ["TaskList", task_list_name],
+                  ["Task", task_name]
+                ])
   # [END datastore_key_with_multilevel_parent]
-
-  task_key
 end
 
 def entity_with_parent task_list_name:, task_name:
@@ -68,22 +64,20 @@ def entity_with_parent task_list_name:, task_name:
   # task_name = "sampleTask"
   task_key = datastore.key [["TaskList", task_list_name], ["Task", task_name]]
 
-  task = datastore.entity task_key do |t|
+  datastore.entity task_key do |t|
     t["category"] = "Personal"
     t["done"] = false
     t["priority"] = 4
     t["description"] = "Learn Cloud Datastore"
   end
   # [END datastore_entity_with_parent]
-
-  task
 end
 
 def properties
   datastore = Google::Cloud::Datastore.new
 
   # [START datastore_properties]
-  task = datastore.entity "Task" do |t|
+  datastore.entity "Task" do |t|
     t["category"] = "Personal"
     t["created"] = Time.now
     t["done"] = false
@@ -93,8 +87,6 @@ def properties
     t.exclude_from_indexes! "description", true
   end
   # [END datastore_properties]
-
-  task
 end
 
 def array_value task_name:
@@ -113,15 +105,13 @@ def basic_entity
   datastore = Google::Cloud::Datastore.new
 
   # [START datastore_basic_entity]
-  task = datastore.entity "Task" do |t|
+  datastore.entity "Task" do |t|
     t["category"] = "Personal"
     t["done"] = false
     t["priority"] = 4
     t["description"] = "Learn Cloud Datastore"
   end
   # [END datastore_basic_entity]
-
-  task
 end
 
 def upsert task_name:
@@ -166,10 +156,8 @@ def lookup task_name:
   # [START datastore_lookup]
   # task_name = "sampleTask"
   task_key = datastore.key "Task", task_name
-  task = datastore.find task_key
+  datastore.find task_key
   # [END datastore_lookup]
-
-  task
 end
 
 def update task_name:
@@ -515,10 +503,8 @@ def eventual_consistent_query task_list_name:
   query = datastore.query("Task")
                    .ancestor(ancestor_key)
 
-  tasks = datastore.run query, consistency: :eventual
+  datastore.run query, consistency: :eventual
   # [END datastore_eventual_consistent_query]
-
-  tasks
 end
 
 def unindexed_property_query
@@ -557,11 +543,9 @@ end
 def transactional_retry from_key, to_key, amount
   # [START datastore_transactional_retry]
   (1..5).each do |i|
-    begin
-      return transfer_funds from_key, to_key, amount
-    rescue Google::Cloud::Error => e
-      raise e if i == 5
-    end
+    return transfer_funds from_key, to_key, amount
+  rescue Google::Cloud::Error => e
+    raise e if i == 5
   end
   # [END datastore_transactional_retry]
 end


### PR DESCRIPTION
`rake ci`, `rake acceptance`, and samples `rubocop` and `rake test` passing locally for Ruby 2.7.2 and 3.0.0.