### PR TITLE
feat(bigquery): Drop support for Ruby 2.4 and add support for Ruby 3.0

### DIFF
--- a/google-cloud-bigquery/.rubocop.yml
+++ b/google-cloud-bigquery/.rubocop.yml
@@ -14,15 +14,22 @@ Style/Documentation:
 Lint/MixedRegexpCaptureTypes:
   Enabled: false
 Metrics/AbcSize:
-  Max: 40
+  Max: 50
 Metrics/BlockLength:
   Exclude:
     - "google-cloud-bigquery.gemspec"
     - "Rakefile"
 Metrics/ClassLength:
   Enabled: false
+Metrics/CyclomaticComplexity:
+  Max: 14
+Metrics/MethodLength:
+  Max: 50
+Metrics/ModuleLength:
+  Exclude:
+    - "lib/google/cloud/bigquery/convert.rb"
 Metrics/PerceivedComplexity:
-  Max: 12
+  Max: 14
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-bigquery.rb"

--- a/google-cloud-bigquery/.rubocop.yml
+++ b/google-cloud-bigquery/.rubocop.yml
@@ -11,12 +11,21 @@ AllCops:
 Style/Documentation:
   Enabled: false
 
+Lint/MixedRegexpCaptureTypes:
+  Enabled: false
+Metrics/AbcSize:
+  Max: 40
 Metrics/BlockLength:
   Exclude:
     - "google-cloud-bigquery.gemspec"
     - "Rakefile"
 Metrics/ClassLength:
   Enabled: false
+Metrics/PerceivedComplexity:
+  Max: 12
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-bigquery.rb"
+Naming/MethodParameterName:
+  Exclude:
+    - "lib/google/cloud/bigquery/external.rb"

--- a/google-cloud-bigquery/.rubocop.yml
+++ b/google-cloud-bigquery/.rubocop.yml
@@ -8,7 +8,7 @@ AllCops:
     - "benchmark/**/*"
     - "test/**/*"
 
-Documentation:
+Style/Documentation:
   Enabled: false
 
 Metrics/BlockLength:
@@ -20,6 +20,3 @@ Metrics/ClassLength:
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-bigquery.rb"
-Naming/UncommunicativeMethodParamName:
-  Exclude:
-    - "lib/google/cloud/bigquery/external.rb"

--- a/google-cloud-bigquery/CONTRIBUTING.md
+++ b/google-cloud-bigquery/CONTRIBUTING.md
@@ -24,7 +24,7 @@ be able to accept your pull requests.
 In order to use the google-cloud-bigquery console and run the project's tests,
 there is a small amount of setup:
 
-1. Install Ruby. google-cloud-bigquery requires Ruby 2.4+. You may choose to
+1. Install Ruby. google-cloud-bigquery requires Ruby 2.5+. You may choose to
    manage your Ruby and gem installations with [RVM](https://rvm.io/),
    [rbenv](https://github.com/rbenv/rbenv), or
    [chruby](https://github.com/postmodern/chruby).

--- a/google-cloud-bigquery/LOGGING.md
+++ b/google-cloud-bigquery/LOGGING.md
@@ -4,7 +4,7 @@ To enable logging for this library, set the logger for the underlying [Google
 API
 Client](https://github.com/google/google-api-ruby-client/blob/master/README.md#logging)
 library. The logger that you set may be a Ruby stdlib
-[`Logger`](https://ruby-doc.org/stdlib-2.4.0/libdoc/logger/rdoc/Logger.html) as
+[`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as
 shown below, or a
 [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver

--- a/google-cloud-bigquery/LOGGING.md
+++ b/google-cloud-bigquery/LOGGING.md
@@ -4,7 +4,7 @@ To enable logging for this library, set the logger for the underlying [Google
 API
 Client](https://github.com/google/google-api-ruby-client/blob/master/README.md#logging)
 library. The logger that you set may be a Ruby stdlib
-[`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as
+[`Logger`](https://ruby-doc.org/stdlib/libdoc/logger/rdoc/Logger.html) as
 shown below, or a
 [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
 that will write logs to [Stackdriver

--- a/google-cloud-bigquery/README.md
+++ b/google-cloud-bigquery/README.md
@@ -52,7 +52,7 @@ data = data.next if data.next?
 
 ## Enabling Logging
 
-To enable logging for this library, set the logger for the underlying [Google API Client](https://github.com/google/google-api-ruby-client/blob/master/README.md#logging) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.4.0/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/).
+To enable logging for this library, set the logger for the underlying [Google API Client](https://github.com/google/google-api-ruby-client/blob/master/README.md#logging) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/).
 
 If you do not set the logger explicitly and your application is running in a Rails environment, it will default to `Rails.logger`. Otherwise, if you do not set the logger and you are not using Rails, logging is disabled by default.
 
@@ -70,11 +70,11 @@ Google::Apis.logger = my_logger
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.4+.
+This library is supported on Ruby 2.5+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or in
-security maintenance, and not end of life. Currently, this means Ruby 2.4 and
+security maintenance, and not end of life. Currently, this means Ruby 2.5 and
 later. Older versions of Ruby _may_ still work, but are unsupported and not
 recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
 about the Ruby support schedule.

--- a/google-cloud-bigquery/README.md
+++ b/google-cloud-bigquery/README.md
@@ -52,7 +52,7 @@ data = data.next if data.next?
 
 ## Enabling Logging
 
-To enable logging for this library, set the logger for the underlying [Google API Client](https://github.com/google/google-api-ruby-client/blob/master/README.md#logging) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/).
+To enable logging for this library, set the logger for the underlying [Google API Client](https://github.com/google/google-api-ruby-client/blob/master/README.md#logging) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/stdlib/libdoc/logger/rdoc/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/).
 
 If you do not set the logger explicitly and your application is running in a Rails environment, it will default to `Rails.logger`. Otherwise, if you do not set the logger and you are not using Rails, logging is disabled by default.
 

--- a/google-cloud-bigquery/Rakefile
+++ b/google-cloud-bigquery/Rakefile
@@ -104,12 +104,10 @@ namespace :acceptance do
     require "google/cloud/bigquery"
     puts "Cleaning up BigQuery datasets and tables"
     Google::Cloud.bigquery.datasets.all do |ds|
-      begin
-        ds.tables.all(&:delete)
-        ds.delete force: true
-      rescue Google::Cloud::Error => e
-        puts e.message
-      end
+      ds.tables.all(&:delete)
+      ds.delete force: true
+    rescue Google::Cloud::Error => e
+      puts e.message
     end
   end
 

--- a/google-cloud-bigquery/google-cloud-bigquery.gemspec
+++ b/google-cloud-bigquery/google-cloud-bigquery.gemspec
@@ -16,16 +16,16 @@ Gem::Specification.new do |gem|
                        "CHANGELOG.md", "CODE_OF_CONDUCT.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.4"
+  gem.required_ruby_version = ">= 2.5"
 
   gem.add_dependency "concurrent-ruby", "~> 1.0"
   gem.add_dependency "google-apis-bigquery_v2", "~> 0.1"
-  gem.add_dependency "google-cloud-core", "~> 1.2"
   gem.add_dependency "googleauth", "~> 0.9"
+  gem.add_dependency "google-cloud-core", "~> 1.2"
   gem.add_dependency "mini_mime", "~> 1.0"
 
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
-  gem.add_development_dependency "google-style", "~> 1.24.0"
+  gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"
   gem.add_development_dependency "minitest-focus", "~> 1.1"

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
@@ -23,8 +23,6 @@ require "date"
 module Google
   module Cloud
     module Bigquery
-      # rubocop:disable Metrics/ModuleLength
-
       ##
       # @private
       #
@@ -378,8 +376,6 @@ module Google
           (time_obj.to_i * 1000) + (time_obj.nsec / 1_000_000)
         end
       end
-
-      # rubocop:enable Metrics/ModuleLength
     end
   end
 end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/copy_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/copy_job.rb
@@ -144,6 +144,7 @@ module Google
           ##
           # @private Create an Updater object.
           def initialize gapi
+            super()
             @gapi = gapi
           end
 

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/data.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/data.rb
@@ -482,14 +482,14 @@ module Google
         #     puts row[:word]
         #   end
         #
-        def all request_limit: nil
+        def all request_limit: nil, &block
           request_limit = request_limit.to_i if request_limit
 
           return enum_for :all, request_limit: request_limit unless block_given?
 
           results = self
           loop do
-            results.each { |r| yield r }
+            results.each(&block)
             if request_limit
               request_limit -= 1
               break if request_limit.negative?

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -705,7 +705,7 @@ module Google
               user_defined_function_resources: udfs_gapi(udfs)
             )
           }.delete_if { |_, v| v.nil? }
-          new_view = Google::Apis::BigqueryV2::Table.new new_view_opts
+          new_view = Google::Apis::BigqueryV2::Table.new(**new_view_opts)
 
           gapi = service.insert_table dataset_id, new_view
           Table.from_gapi gapi, service
@@ -779,7 +779,7 @@ module Google
               refresh_interval_ms: refresh_interval_ms
             )
           }.delete_if { |_, v| v.nil? }
-          new_view = Google::Apis::BigqueryV2::Table.new new_view_opts
+          new_view = Google::Apis::BigqueryV2::Table.new(**new_view_opts)
 
           gapi = service.insert_table dataset_id, new_view
           Table.from_gapi gapi, service
@@ -2629,7 +2629,7 @@ module Google
           return if attributes.empty?
           ensure_service!
           patch_args = Hash[attributes.map { |attr| [attr, @gapi.send(attr)] }]
-          patch_gapi = Google::Apis::BigqueryV2::Dataset.new patch_args
+          patch_gapi = Google::Apis::BigqueryV2::Dataset.new(**patch_args)
           patch_gapi.etag = etag if etag
           @gapi = service.patch_dataset dataset_id, patch_gapi
         end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -2573,6 +2573,8 @@ module Google
 
         protected
 
+        # rubocop:disable Lint/SuppressedException
+
         def insert_data_with_autocreate table_id, rows, skip_invalid: nil, ignore_unknown: nil, insert_ids: nil
           insert_data table_id, rows, skip_invalid: skip_invalid, ignore_unknown: ignore_unknown, insert_ids: insert_ids
         rescue Google::Cloud::NotFoundError
@@ -2586,6 +2588,8 @@ module Google
           sleep 60
           retry
         end
+
+        # rubocop:enable Lint/SuppressedException
 
         def insert_data table_id, rows, skip_invalid: nil, ignore_unknown: nil, insert_ids: nil
           rows = [rows] if rows.is_a? Hash
@@ -2798,6 +2802,7 @@ module Google
           ##
           # @private Create an Updater object.
           def initialize gapi
+            super()
             @updates = []
             @gapi = gapi
           end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -2573,8 +2573,6 @@ module Google
 
         protected
 
-        # rubocop:disable Lint/SuppressedException
-
         def insert_data_with_autocreate table_id, rows, skip_invalid: nil, ignore_unknown: nil, insert_ids: nil
           insert_data table_id, rows, skip_invalid: skip_invalid, ignore_unknown: ignore_unknown, insert_ids: insert_ids
         rescue Google::Cloud::NotFoundError
@@ -2584,12 +2582,11 @@ module Google
               yield tbl_updater if block_given?
             end
           rescue Google::Cloud::AlreadyExistsError
+            # Do nothing if it already exists
           end
           sleep 60
           retry
         end
-
-        # rubocop:enable Lint/SuppressedException
 
         def insert_data table_id, rows, skip_invalid: nil, ignore_unknown: nil, insert_ids: nil
           rows = [rows] if rows.is_a? Hash

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -2581,11 +2581,8 @@ module Google
             create_table table_id do |tbl_updater|
               yield tbl_updater if block_given?
             end
-          # rubocop:disable Lint/HandleExceptions
           rescue Google::Cloud::AlreadyExistsError
           end
-          # rubocop:enable Lint/HandleExceptions
-
           sleep 60
           retry
         end
@@ -2757,12 +2754,11 @@ module Google
 
         def load_local_or_uri file, updater
           job_gapi = updater.to_gapi
-          job = if local_file? file
-                  load_local file, job_gapi
-                else
-                  load_storage file, job_gapi
-                end
-          job
+          if local_file? file
+            load_local file, job_gapi
+          else
+            load_storage file, job_gapi
+          end
         end
 
         def storage_url? files

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset/access.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset/access.rb
@@ -1194,7 +1194,7 @@ module Google
             @rules.reject!(&find_by_scope_and_value(scope, value))
             # Add new rule for this role, scope, and value
             opts = { role: role, scope => value }
-            @rules << Google::Apis::BigqueryV2::Dataset::Access.new(opts)
+            @rules << Google::Apis::BigqueryV2::Dataset::Access.new(**opts)
           end
 
           # @private
@@ -1204,7 +1204,7 @@ module Google
             @rules.reject!(&find_by_scope_and_resource_ref(:routine, value))
             # Add new rule for this role, scope, and value
             opts = { routine: value }
-            @rules << Google::Apis::BigqueryV2::Dataset::Access.new(opts)
+            @rules << Google::Apis::BigqueryV2::Dataset::Access.new(**opts)
           end
 
           # @private
@@ -1215,7 +1215,7 @@ module Google
             @rules.reject!(&find_by_scope_and_resource_ref(:view, value))
             # Add new rule for this role, scope, and value
             opts = { view: value }
-            @rules << Google::Apis::BigqueryV2::Dataset::Access.new(opts)
+            @rules << Google::Apis::BigqueryV2::Dataset::Access.new(**opts)
           end
 
           # @private

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset/list.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset/list.rb
@@ -120,12 +120,12 @@ module Google
           #     puts dataset.name
           #   end
           #
-          def all request_limit: nil
+          def all request_limit: nil, &block
             request_limit = request_limit.to_i if request_limit
             return enum_for :all, request_limit: request_limit unless block_given?
             results = self
             loop do
-              results.each { |r| yield r }
+              results.each(&block)
               if request_limit
                 request_limit -= 1
                 break if request_limit.negative?

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/extract_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/extract_job.rb
@@ -263,9 +263,10 @@ module Google
             extract_config = Google::Apis::BigqueryV2::JobConfigurationExtract.new(
               destination_uris: Array(storage_urls)
             )
-            if source.is_a? Google::Apis::BigqueryV2::TableReference
+            case source
+            when Google::Apis::BigqueryV2::TableReference
               extract_config.source_table = source
-            elsif source.is_a? Google::Apis::BigqueryV2::ModelReference
+            when Google::Apis::BigqueryV2::ModelReference
               extract_config.source_model = source
             end
             job = Google::Apis::BigqueryV2::Job.new(

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/extract_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/extract_job.rb
@@ -246,6 +246,7 @@ module Google
           ##
           # @private Create an Updater object.
           def initialize gapi
+            super()
             @gapi = gapi
           end
 

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/job.rb
@@ -507,7 +507,8 @@ module Google
         # @attr_reader [Fixnum] slot_ms The slot-milliseconds the job spent in the given reservation.
         #
         class ReservationUsage
-          attr_reader :name, :slot_ms
+          attr_reader :name
+          attr_reader :slot_ms
 
           ##
           # @private Creates a new ReservationUsage instance.
@@ -571,7 +572,8 @@ module Google
         #   end
         #
         class ScriptStatistics
-          attr_reader :evaluation_kind, :stack_frames
+          attr_reader :evaluation_kind
+          attr_reader :stack_frames
 
           ##
           # @private Creates a new ScriptStatistics instance.
@@ -636,7 +638,11 @@ module Google
         #   end
         #
         class ScriptStackFrame
-          attr_reader :start_line, :start_column, :end_line, :end_column, :text
+          attr_reader :start_line
+          attr_reader :start_column
+          attr_reader :end_line
+          attr_reader :end_column
+          attr_reader :text
 
           ##
           # @private Creates a new ScriptStackFrame instance.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/job/list.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/job/list.rb
@@ -72,8 +72,8 @@ module Google
             return nil unless next?
             ensure_service!
             next_kwargs = @kwargs.merge token: token
-            next_gapi = @service.list_jobs next_kwargs
-            self.class.from_gapi next_gapi, @service, next_kwargs
+            next_gapi = @service.list_jobs(**next_kwargs)
+            self.class.from_gapi next_gapi, @service, **next_kwargs
           end
 
           ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/job/list.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/job/list.rb
@@ -121,12 +121,12 @@ module Google
           #     puts job.state
           #   end
           #
-          def all request_limit: nil
+          def all request_limit: nil, &block
             request_limit = request_limit.to_i if request_limit
             return enum_for :all, request_limit: request_limit unless block_given?
             results = self
             loop do
-              results.each { |r| yield r }
+              results.each(&block)
               if request_limit
                 request_limit -= 1
                 break if request_limit.negative?

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
@@ -606,6 +606,7 @@ module Google
           ##
           # @private Create an Updater object.
           def initialize gapi
+            super()
             @updates = []
             @gapi = gapi
             @schema = nil

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/model/list.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/model/list.rb
@@ -124,12 +124,12 @@ module Google
           #     puts model.model_id
           #   end
           #
-          def all request_limit: nil
+          def all request_limit: nil, &block
             request_limit = request_limit.to_i if request_limit
             return enum_for :all, request_limit: request_limit unless block_given?
             results = self
             loop do
-              results.each { |r| yield r }
+              results.each(&block)
               if request_limit
                 request_limit -= 1
                 break if request_limit.negative?

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/policy.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/policy.rb
@@ -96,7 +96,8 @@ module Google
       #   end
       #
       class Policy
-        attr_reader :etag, :bindings
+        attr_reader :etag
+        attr_reader :bindings
 
         # @private
         def initialize etag, bindings

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -56,7 +56,8 @@ module Google
         # @private The Service object.
         attr_accessor :service
 
-        attr_reader :name, :numeric_id
+        attr_reader :name
+        attr_reader :numeric_id
 
         ##
         # Creates a new Service instance.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project/list.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project/list.rb
@@ -121,12 +121,12 @@ module Google
           #     puts project.name
           #   end
           #
-          def all request_limit: nil
+          def all request_limit: nil, &block
             request_limit = request_limit.to_i if request_limit
             return enum_for :all, request_limit: request_limit unless block_given?
             results = self
             loop do
-              results.each { |r| yield r }
+              results.each(&block)
               if request_limit
                 request_limit -= 1
                 break if request_limit.negative?

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
@@ -935,13 +935,13 @@ module Google
             raise ArgumentError, "types must use the same format as params" if types.class != params.class
 
             case params
-            when Array then
+            when Array
               @gapi.configuration.query.use_legacy_sql = false
               @gapi.configuration.query.parameter_mode = "POSITIONAL"
               @gapi.configuration.query.query_parameters = params.zip(types).map do |param, type|
                 Convert.to_query_param param, type
               end
-            when Hash then
+            when Hash
               @gapi.configuration.query.use_legacy_sql = false
               @gapi.configuration.query.parameter_mode = "NAMED"
               @gapi.configuration.query.query_parameters = params.map do |name, param|
@@ -1592,9 +1592,20 @@ module Google
         #   end
         #
         class Stage
-          attr_reader :compute_ratio_avg, :compute_ratio_max, :id, :name, :read_ratio_avg, :read_ratio_max,
-                      :records_read, :records_written, :status, :steps, :wait_ratio_avg, :wait_ratio_max,
-                      :write_ratio_avg, :write_ratio_max
+          attr_reader :compute_ratio_avg
+          attr_reader :compute_ratio_max
+          attr_reader :id
+          attr_reader :name
+          attr_reader :read_ratio_avg
+          attr_reader :read_ratio_max
+          attr_reader :records_read
+          attr_reader :records_written
+          attr_reader :status
+          attr_reader :steps
+          attr_reader :wait_ratio_avg
+          attr_reader :wait_ratio_max
+          attr_reader :write_ratio_avg
+          attr_reader :write_ratio_max
 
           ##
           # @private Creates a new Stage instance.
@@ -1657,7 +1668,8 @@ module Google
         #   end
         #
         class Step
-          attr_reader :kind, :substeps
+          attr_reader :kind
+          attr_reader :substeps
 
           ##
           # @private Creates a new Stage instance.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
@@ -692,8 +692,11 @@ module Google
           end
           ensure_schema!
 
-          options = { token: token, max: max, start: start }
-          data_hash = service.list_tabledata destination_table_dataset_id, destination_table_table_id, options
+          data_hash = service.list_tabledata destination_table_dataset_id,
+                                             destination_table_table_id,
+                                             token: token,
+                                             max: max,
+                                             start: start
           Data.from_gapi_json data_hash, destination_table_gapi, @gapi, service
         end
         alias query_results data

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
@@ -704,6 +704,7 @@ module Google
           ##
           # @private Create an Updater object.
           def initialize service, gapi
+            super()
             @service = service
             @gapi = gapi
           end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
@@ -712,8 +712,6 @@ module Google
             @gapi = gapi
           end
 
-          # rubocop:disable all
-
           ##
           # @private Create an Updater from an options hash.
           #
@@ -751,8 +749,6 @@ module Google
             updater.udfs = options[:udfs]
             updater
           end
-
-          # rubocop:enable all
 
           ##
           # Sets the geographic location where the job should run. Required

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/routine.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/routine.rb
@@ -1006,6 +1006,7 @@ module Google
           ##
           # @private Create an Updater object.
           def initialize gapi
+            super()
             @original_gapi = gapi
             @gapi = gapi.dup
           end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/routine.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/routine.rb
@@ -1210,14 +1210,10 @@ module Google
           end
           alias refresh! reload!
 
-          # rubocop:disable Style/CaseEquality
-
           # @private
           def updates?
             !(@gapi === @original_gapi)
           end
-
-          # rubocop:enable Style/CaseEquality
 
           # @private
           def to_gapi

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/routine/list.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/routine/list.rb
@@ -124,12 +124,12 @@ module Google
           #     puts routine.routine_id
           #   end
           #
-          def all request_limit: nil
+          def all request_limit: nil, &block
             request_limit = request_limit.to_i if request_limit
             return enum_for :all, request_limit: request_limit unless block_given?
             results = self
             loop do
-              results.each { |r| yield r }
+              results.each(&block)
               if request_limit
                 request_limit -= 1
                 break if request_limit.negative?

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -483,7 +483,7 @@ module Google
             table_id:   m["tbl"]
           }.delete_if { |_, v| v.nil? }
           str_table_ref_hash = default_ref.to_h.merge str_table_ref_hash
-          ref = Google::Apis::BigqueryV2::TableReference.new str_table_ref_hash
+          ref = Google::Apis::BigqueryV2::TableReference.new(**str_table_ref_hash)
           validate_table_ref ref
           ref
         end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -602,7 +602,7 @@ module Google
           protected
 
           def retry? result, current_retries #:nodoc:
-            if current_retries < (@retries) && (retry_error_reason? result)
+            if current_retries < @retries && retry_error_reason?(result)
               return true
             end
             false

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -554,9 +554,9 @@ module Google
           nil
         end
 
-        def execute backoff: nil
+        def execute backoff: nil, &block
           if backoff
-            Backoff.new(retries: retries).execute { yield }
+            Backoff.new(retries: retries).execute(&block)
           else
             yield
           end
@@ -590,22 +590,20 @@ module Google
           def execute
             current_retries = 0
             loop do
-              begin
-                return yield
-              rescue Google::Apis::Error => e
-                raise e unless retry? e.body, current_retries
+              return yield
+            rescue Google::Apis::Error => e
+              raise e unless retry? e.body, current_retries
 
-                @backoff.call current_retries
-                current_retries += 1
-              end
+              @backoff.call current_retries
+              current_retries += 1
             end
           end
 
           protected
 
           def retry? result, current_retries #:nodoc:
-            if current_retries < @retries
-              return true if retry_error_reason? result
+            if current_retries < (@retries) && (retry_error_reason? result)
+              return true
             end
             false
           end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/standard_sql.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/standard_sql.rb
@@ -401,11 +401,12 @@ module Google
           # @private New Google::Apis::BigqueryV2::StandardSqlDataType from a String or StandardSql::DataType object.
           def self.gapi_from_string_or_data_type data_type
             return if data_type.nil?
-            if data_type.is_a? StandardSql::DataType
+            case data_type
+            when StandardSql::DataType
               data_type.to_gapi
-            elsif data_type.is_a? Hash
+            when Hash
               data_type
-            elsif data_type.is_a?(String) || data_type.is_a?(Symbol)
+            when String, Symbol
               Google::Apis::BigqueryV2::StandardSqlDataType.new type_kind: data_type.to_s.upcase
             else
               raise ArgumentError, "Unable to convert #{data_type} to Google::Apis::BigqueryV2::StandardSqlDataType"

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -2374,8 +2374,12 @@ module Google
           end
 
           ensure_service!
-          options = { skip_invalid: skip_invalid, ignore_unknown: ignore_unknown, insert_ids: insert_ids }
-          gapi = service.insert_tabledata dataset_id, table_id, rows, options
+          gapi = service.insert_tabledata dataset_id,
+                                          table_id,
+                                          rows,
+                                          skip_invalid: skip_invalid,
+                                          ignore_unknown: ignore_unknown,
+                                          insert_ids: insert_ids
           InsertResponse.from_gapi rows, gapi
         end
 
@@ -2674,7 +2678,7 @@ module Google
           return if attributes.empty?
           ensure_service!
           patch_args = Hash[attributes.map { |attr| [attr, @gapi.send(attr)] }]
-          patch_gapi = Google::Apis::BigqueryV2::Table.new patch_args
+          patch_gapi = Google::Apis::BigqueryV2::Table.new(**patch_args)
           patch_gapi.etag = etag if etag
           @gapi = service.patch_table dataset_id, table_id, patch_gapi
 

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -2800,12 +2800,11 @@ module Google
 
         def load_local_or_uri file, updater
           job_gapi = updater.to_gapi
-          job = if local_file? file
-                  load_local file, job_gapi
-                else
-                  load_storage file, job_gapi
-                end
-          job
+          if local_file? file
+            load_local file, job_gapi
+          else
+            load_storage file, job_gapi
+          end
         end
 
         def storage_url? files

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -2857,6 +2857,7 @@ module Google
           ##
           # @private Create an Updater object.
           def initialize gapi
+            super()
             @updates = []
             @gapi = gapi
             @schema = nil

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table/async_inserter.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table/async_inserter.rb
@@ -64,7 +64,10 @@ module Google
         class AsyncInserter
           include MonitorMixin
 
-          attr_reader :max_bytes, :max_rows, :interval, :threads
+          attr_reader :max_bytes
+          attr_reader :max_rows
+          attr_reader :interval
+          attr_reader :threads
           ##
           # @private Implementation accessors
           attr_reader :table, :batch
@@ -265,18 +268,16 @@ module Google
             json_rows = @batch.json_rows
             insert_ids = @batch.insert_ids
             Concurrent::Future.new executor: @thread_pool do
-              begin
-                raise ArgumentError, "No rows provided" if json_rows.empty?
-                options = { skip_invalid: @skip_invalid, ignore_unknown: @ignore_unknown, insert_ids: insert_ids }
-                insert_resp = @table.service.insert_tabledata_json_rows(
-                  @table.dataset_id, @table.table_id, json_rows, options
-                )
-                result = Result.new InsertResponse.from_gapi(orig_rows, insert_resp)
-              rescue StandardError => e
-                result = Result.new nil, e
-              ensure
-                @callback&.call result
-              end
+              raise ArgumentError, "No rows provided" if json_rows.empty?
+              options = { skip_invalid: @skip_invalid, ignore_unknown: @ignore_unknown, insert_ids: insert_ids }
+              insert_resp = @table.service.insert_tabledata_json_rows(
+                @table.dataset_id, @table.table_id, json_rows, options
+              )
+              result = Result.new InsertResponse.from_gapi(orig_rows, insert_resp)
+            rescue StandardError => e
+              result = Result.new nil, e
+            ensure
+              @callback&.call result
             end.execute
 
             @batch = nil
@@ -286,7 +287,11 @@ module Google
           ##
           # @private
           class Batch
-            attr_reader :max_bytes, :max_rows, :rows, :json_rows, :insert_ids
+            attr_reader :max_bytes
+            attr_reader :max_rows
+            attr_reader :rows
+            attr_reader :json_rows
+            attr_reader :insert_ids
 
             def initialize max_bytes: 10_000_000, max_rows: 500
               @max_bytes = max_bytes
@@ -395,7 +400,8 @@ module Google
               @error = error
             end
 
-            attr_reader :insert_response, :error
+            attr_reader :insert_response
+            attr_reader :error
 
             ##
             # Checks if an error is present, meaning that the insert operation

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table/async_inserter.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table/async_inserter.rb
@@ -269,10 +269,13 @@ module Google
             insert_ids = @batch.insert_ids
             Concurrent::Future.new executor: @thread_pool do
               raise ArgumentError, "No rows provided" if json_rows.empty?
-              options = { skip_invalid: @skip_invalid, ignore_unknown: @ignore_unknown, insert_ids: insert_ids }
-              insert_resp = @table.service.insert_tabledata_json_rows(
-                @table.dataset_id, @table.table_id, json_rows, options
-              )
+              insert_resp = @table.service.insert_tabledata_json_rows @table.dataset_id,
+                                                                      @table.table_id,
+                                                                      json_rows,
+                                                                      skip_invalid: @skip_invalid,
+                                                                      ignore_unknown: @ignore_unknown,
+                                                                      insert_ids: insert_ids
+
               result = Result.new InsertResponse.from_gapi(orig_rows, insert_resp)
             rescue StandardError => e
               result = Result.new nil, e

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table/list.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table/list.rb
@@ -130,12 +130,12 @@ module Google
           #     puts table.name
           #   end
           #
-          def all request_limit: nil
+          def all request_limit: nil, &block
             request_limit = request_limit.to_i if request_limit
             return enum_for :all, request_limit: request_limit unless block_given?
             results = self
             loop do
-              results.each { |r| yield r }
+              results.each(&block)
               if request_limit
                 request_limit -= 1
                 break if request_limit.negative?

--- a/google-cloud-bigquery/samples/simple_app/Gemfile
+++ b/google-cloud-bigquery/samples/simple_app/Gemfile
@@ -26,7 +26,7 @@ else
 end
 
 group :test do
-  gem "google-style", "~> 1.24.0"
+  gem "google-style", "~> 1.25.1"
   gem "minitest", "~> 5.14"
   gem "rake"
 end

--- a/google-cloud-bigquery/samples/simple_app/Gemfile
+++ b/google-cloud-bigquery/samples/simple_app/Gemfile
@@ -20,11 +20,9 @@ source "https://rubygems.org"
 if ENV["GOOGLE_CLOUD_SAMPLES_TEST"] == "master"
   gem "google-cloud-bigquery", path: "../../../google-cloud-bigquery"
 else
-  # rubocop:disable Bundler/DuplicatedGem
   # [START bigquery_dependencies]
   gem "google-cloud-bigquery"
   # [END bigquery_dependencies]
-  # rubocop:enable Bundler/DuplicatedGem
 end
 
 group :test do

--- a/google-cloud-bigquery/samples/snippets/Gemfile
+++ b/google-cloud-bigquery/samples/snippets/Gemfile
@@ -20,11 +20,9 @@ source "https://rubygems.org"
 if ENV["GOOGLE_CLOUD_SAMPLES_TEST"] == "master"
   gem "google-cloud-bigquery", path: "../../../google-cloud-bigquery"
 else
-  # rubocop:disable Bundler/DuplicatedGem
   # [START bigquery_dependencies]
   gem "google-cloud-bigquery"
   # [END bigquery_dependencies]
-  # rubocop:enable Bundler/DuplicatedGem
 end
 
 group :test do

--- a/google-cloud-bigquery/samples/snippets/Gemfile
+++ b/google-cloud-bigquery/samples/snippets/Gemfile
@@ -27,8 +27,8 @@ end
 
 group :test do
   gem "google-cloud-storage"
-  gem "google-style", "~> 1.24.0"
-  gem "minitest", "~> 5.13"
+  gem "google-style", "~> 1.25.1"
+  gem "minitest", "~> 5.14"
   gem "minitest-focus", "~> 1.1"
   gem "rake"
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/policy_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/policy_test.rb
@@ -202,13 +202,13 @@ describe Google::Cloud::Bigquery::Policy, :mock_bigquery do
     it "raises when grant would change the bindings" do
       expect do
         policy.grant role: role_editor, members: member_editor
-      end.must_raise RuntimeError # TODO replace with FrozenError when Ruby > 2.4
+      end.must_raise FrozenError
     end
 
     it "raises when revoke would change the bindings" do
       expect do
         policy.revoke role: role_viewer
-      end.must_raise RuntimeError # TODO replace with FrozenError when Ruby > 2.4
+      end.must_raise FrozenError
     end
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_async_inserter_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_async_inserter_test.rb
@@ -52,7 +52,9 @@ describe Google::Cloud::Bigquery::Table::AsyncInserter, :mock_bigquery do
       [table.project_id, table.dataset_id, table.table_id, insert_req, options: { skip_serialization: true }]
     table.service.mocked_service = mock
 
-    inserter = table.insert_async
+    inserter = table.insert_async do |result|
+      puts "table.insert_async: #{result.error.inspect}" if result.error
+    end
 
     SecureRandom.stub :uuid, insert_id do
       inserter.insert rows.first
@@ -84,7 +86,9 @@ describe Google::Cloud::Bigquery::Table::AsyncInserter, :mock_bigquery do
       [table.project_id, table.dataset_id, table.table_id, insert_req, options: { skip_serialization: true }]
     table.service.mocked_service = mock
 
-    inserter = table.insert_async
+    inserter = table.insert_async do |result|
+      puts "table.insert_async: #{result.error.inspect}" if result.error
+    end
 
     SecureRandom.stub :uuid, insert_id do
       inserter.insert rows
@@ -116,7 +120,9 @@ describe Google::Cloud::Bigquery::Table::AsyncInserter, :mock_bigquery do
       [table.project_id, table.dataset_id, table.table_id, insert_req, options: { skip_serialization: true }]
     table.service.mocked_service = mock
 
-    inserter = table.insert_async
+    inserter = table.insert_async do |result|
+      puts "table.insert_async: #{result.error.inspect}" if result.error
+    end
 
     SecureRandom.stub :uuid, insert_id do
       rows.each do |row|
@@ -154,6 +160,7 @@ describe Google::Cloud::Bigquery::Table::AsyncInserter, :mock_bigquery do
     insert_result = nil
 
     inserter = table.insert_async do |result|
+      puts "table.insert_async: #{result.error.inspect}" if result.error
       insert_result = result
       callback_called = true
     end
@@ -252,6 +259,7 @@ describe Google::Cloud::Bigquery::Table::AsyncInserter, :mock_bigquery do
     callbacks = 0
 
     inserter = table.insert_async max_bytes: 150 do |response|
+      puts "table.insert_async: #{result.error.inspect}" if result.error
       callbacks += 1
     end
 
@@ -290,6 +298,7 @@ describe Google::Cloud::Bigquery::Table::AsyncInserter, :mock_bigquery do
     callbacks = 0
 
     inserter = table.insert_async max_rows: 2 do |response|
+      puts "table.insert_async: #{result.error.inspect}" if result.error
       callbacks += 1
     end
 
@@ -324,7 +333,9 @@ describe Google::Cloud::Bigquery::Table::AsyncInserter, :mock_bigquery do
                 [table.project_id, table.dataset_id, table.table_id, insert_req, options: { skip_serialization: true }]
     table.service.mocked_service = mock
 
-    inserter = table.insert_async
+    inserter = table.insert_async do |result|
+      puts "table.insert_async: #{result.error.inspect}" if result.error
+    end
 
     inserter.insert rows, insert_ids: insert_ids
 
@@ -354,7 +365,9 @@ describe Google::Cloud::Bigquery::Table::AsyncInserter, :mock_bigquery do
                 [table.project_id, table.dataset_id, table.table_id, insert_req, options: { skip_serialization: true }]
     table.service.mocked_service = mock
 
-    inserter = table.insert_async
+    inserter = table.insert_async do |result|
+      puts "table.insert_async: #{result.error.inspect}" if result.error
+    end
 
     rows.zip(insert_ids).each do |row, insert_id|
       inserter.insert row, insert_ids: insert_id
@@ -380,7 +393,9 @@ describe Google::Cloud::Bigquery::Table::AsyncInserter, :mock_bigquery do
   it "raises if the insert_ids option is provided but size does not match rows" do
     insert_ids.pop # Remove one of the insert_ids to cause error.
 
-    inserter = table.insert_async
+    inserter = table.insert_async do |result|
+      puts "table.insert_async: #{result.error.inspect}" if result.error
+    end
 
     expect { inserter.insert rows, insert_ids: insert_ids }.must_raise ArgumentError
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_reference_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_reference_test.rb
@@ -332,7 +332,9 @@ describe Google::Cloud::Bigquery::Table, :reference, :mock_bigquery do
       [table.project_id, table.dataset_id, table.table_id, insert_req, options: { skip_serialization: true }]
     table.service.mocked_service = mock
 
-    inserter = table.insert_async
+    inserter = table.insert_async do |result|
+      puts "table.insert_async: #{result.error.inspect}" if result.error
+    end
 
     SecureRandom.stub :uuid, insert_id do
       rows.each do |row|


### PR DESCRIPTION
Drop support for Ruby 2.4 and add support for Ruby 3.0 in google-cloud-bigquery.

All ci and acceptance passing locally for Ruby 2.7.2 and 3.0.0.