### PR TITLE
test(bigtable): Fix unit tests broken by change to #dup in google-protobuf 3.15

### DIFF
--- a/google-cloud-bigtable/test/google/cloud/bigtable/instance/create_table_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/instance/create_table_test.rb
@@ -63,18 +63,25 @@ describe Google::Cloud::Bigtable::Instance, :create_table, :mock_bigtable do
         granularity: :MILLIS
       )
     )
-
     req_table = Google::Cloud::Bigtable::Admin::V2::Table.new(
       column_families: column_families,
       granularity: :MILLIS
     )
-
     mock.expect :create_table, create_res.dup, [
       parent: instance_path(instance_id),
       table_id: table_id,
       table: req_table
     ]
-    mock.expect :get_table, create_res.dup, [
+
+    get_res = Google::Cloud::Bigtable::Admin::V2::Table.new(
+      table_hash(
+        name: table_path(instance_id, table_id),
+        cluster_states: cluster_states.dup,
+        column_families: column_families.dup,
+        granularity: :MILLIS
+      )
+    )
+    mock.expect :get_table, get_res, [
       name: table_path(instance_id, table_id),
       view: :REPLICATION_VIEW
     ]
@@ -114,21 +121,28 @@ describe Google::Cloud::Bigtable::Instance, :create_table, :mock_bigtable do
         granularity: :MILLIS
       )
     )
-
     req_table = Google::Cloud::Bigtable::Admin::V2::Table.new(
       column_families: column_families,
       granularity: :MILLIS
     )
-
     mock.expect :create_table, create_res.dup, [
       parent: instance_path(instance_id),
       table_id: table_id,
       table: req_table
     ]
-    mock.expect :get_table, create_res.dup, [
-                            name: table_path(instance_id, table_id),
-                            view: :REPLICATION_VIEW
-                          ]
+
+    get_res = Google::Cloud::Bigtable::Admin::V2::Table.new(
+      table_hash(
+        name: table_path(instance_id, table_id),
+        cluster_states: cluster_states.dup,
+        column_families: column_families.dup,
+        granularity: :MILLIS
+      )
+    )
+    mock.expect :get_table, get_res, [
+      name: table_path(instance_id, table_id),
+      view: :REPLICATION_VIEW
+    ]
     bigtable.service.mocked_tables = mock
 
     table = instance.create_table(table_id, granularity: :MILLIS) do |cfm|

--- a/google-cloud-bigtable/test/google/cloud/bigtable/project/create_table_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/project/create_table_test.rb
@@ -29,22 +29,29 @@ describe Google::Cloud::Bigtable::Project, :create_table, :mock_bigtable do
       table_hash(
         name: table_path(instance_id, table_id),
         cluster_states: cluster_states,
-        column_families: column_families.to_h,
+        column_families: column_families,
         granularity: :MILLIS
       )
     )
-
     req_table = Google::Cloud::Bigtable::Admin::V2::Table.new(
-      column_families: column_families.to_h,
+      column_families: column_families,
       granularity: :MILLIS
     )
-
     mock.expect :create_table, create_res, [
       parent: instance_path(instance_id),
       table_id: table_id,
       table: req_table
     ]
-    mock.expect :get_table, create_res.dup, [
+
+    get_res = Google::Cloud::Bigtable::Admin::V2::Table.new(
+      table_hash(
+        name: table_path(instance_id, table_id),
+        cluster_states: cluster_states.dup,
+        column_families: column_families.dup,
+        granularity: :MILLIS
+      )
+    )
+    mock.expect :get_table, get_res, [
       name: table_path(instance_id, table_id),
       view: :REPLICATION_VIEW
     ]
@@ -71,6 +78,7 @@ describe Google::Cloud::Bigtable::Project, :create_table, :mock_bigtable do
     table.column_families.each do |name, cf|
       _(cf.gc_rule.to_grpc).must_equal column_families[cf.name].gc_rule
     end
+
     _(table.cluster_states.map(&:cluster_name).sort).must_equal cluster_states.keys
     table.cluster_states.each do |cs|
       _(cs.replication_state).must_equal :READY
@@ -88,25 +96,32 @@ describe Google::Cloud::Bigtable::Project, :create_table, :mock_bigtable do
       table_hash(
         name: table_path(instance_id, table_id),
         cluster_states: cluster_states,
-        column_families: column_families.to_h,
+        column_families: column_families,
         granularity: :MILLIS
       )
     )
-
     req_table = Google::Cloud::Bigtable::Admin::V2::Table.new(
-      column_families: column_families.to_h,
+      column_families: column_families,
       granularity: :MILLIS
     )
-
     mock.expect :create_table, create_res, [
       parent: instance_path(instance_id),
       table_id: table_id,
       table: req_table
     ]
-    mock.expect :get_table, create_res.dup, [
-                            name: table_path(instance_id, table_id),
-                            view: :REPLICATION_VIEW
-                          ]
+
+    get_res = Google::Cloud::Bigtable::Admin::V2::Table.new(
+      table_hash(
+        name: table_path(instance_id, table_id),
+        cluster_states: cluster_states.dup,
+        column_families: column_families.dup,
+        granularity: :MILLIS
+      )
+    )
+    mock.expect :get_table, get_res, [
+      name: table_path(instance_id, table_id),
+      view: :REPLICATION_VIEW
+    ]
     bigtable.service.mocked_tables = mock
 
     table = bigtable.create_table(
@@ -145,23 +160,30 @@ describe Google::Cloud::Bigtable::Project, :create_table, :mock_bigtable do
       table_hash(
         name: table_path(instance_id, table_id),
         cluster_states: cluster_states,
-        column_families: column_families.to_h,
+        column_families: column_families,
         granularity: :MILLIS
       )
     )
-
     req_table = Google::Cloud::Bigtable::Admin::V2::Table.new(
-      column_families: column_families.to_h,
+      column_families: column_families,
       granularity: :MILLIS
     )
-
     mock.expect :create_table, create_res, [
       parent: instance_path(instance_id),
       table_id: table_id,
       table: req_table,
       initial_splits: initial_splits.map { |key| { key: key } }
     ]
-    mock.expect :get_table, create_res.dup, [
+
+    get_res = Google::Cloud::Bigtable::Admin::V2::Table.new(
+      table_hash(
+        name: table_path(instance_id, table_id),
+        cluster_states: cluster_states.dup,
+        column_families: column_families.dup,
+        granularity: :MILLIS
+      )
+    )
+    mock.expect :get_table, get_res, [
       name: table_path(instance_id, table_id),
       view: :REPLICATION_VIEW
     ]


### PR DESCRIPTION
Fix unit tests broken by change to `#dup` in google-protobuf 3.15. In 3.14 the dup does a deep-dup of the map field, whereas in 3.15 the dup is shallow and the two proto objects share the same map field. Since it makes the proto behavior similar to the typical ruby behavior, the new protobuf behavior seems more idiomatic, and we do not consider it a bug.




closes: #10578