### PR TITLE
chore(pubsub): Move samples from ruby-docs-samples

### DIFF
--- a/google-cloud-pubsub/.rubocop.yml
+++ b/google-cloud-pubsub/.rubocop.yml
@@ -3,7 +3,7 @@ inherit_gem:
 
 AllCops:
   Exclude:
-    - "acceptance/**/*"
+    - "**/acceptance/**/*"
     - "support/**/*"
     - "test/**/*"
 

--- a/google-cloud-pubsub/Rakefile
+++ b/google-cloud-pubsub/Rakefile
@@ -114,6 +114,40 @@ task :doctest do
   sh "bundle exec yard config load_plugins true && bundle exec yard doctest"
 end
 
+task :samples do
+  Rake::Task["samples:latest"].invoke
+end
+
+namespace :samples do
+  task :latest do
+    if File.directory? "samples"
+      Dir.chdir "samples" do
+        Bundler.with_unbundled_env do
+          ENV["GOOGLE_CLOUD_SAMPLES_TEST"] = "not_master"
+          sh "bundle update"
+          sh "bundle exec rake test"
+        end
+      end
+    else
+      puts "The google-cloud-pubsub gem has no samples to test."
+    end
+  end
+
+  task :master do
+    if File.directory? "samples"
+      Dir.chdir "samples" do
+        Bundler.with_unbundled_env do
+          ENV["GOOGLE_CLOUD_SAMPLES_TEST"] = "master"
+          sh "bundle update"
+          sh "bundle exec rake test"
+        end
+      end
+    else
+      puts "The google-cloud-pubsub gem has no samples to test."
+    end
+  end
+end
+
 desc "Start an interactive shell."
 task :console do
   require "irb"

--- a/google-cloud-pubsub/samples/.rubocop.yml
+++ b/google-cloud-pubsub/samples/.rubocop.yml
@@ -1,0 +1,12 @@
+inherit_gem:
+  google-style: google-style.yml
+
+AllCops:
+  Exclude:
+    - "acceptance/**/*"
+
+Lint/RescueException:
+  Exclude:
+    - "subscriptions.rb"
+Lint/UselessAssignment:
+  Enabled: false

--- a/google-cloud-pubsub/samples/Gemfile
+++ b/google-cloud-pubsub/samples/Gemfile
@@ -1,0 +1,27 @@
+# Copyright 2021 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source "https://rubygems.org"
+
+gem "google-cloud-pubsub", "~> 2.4"
+gem "sinatra"
+
+group :test do
+  gem "google-style", "~> 1.25.1"
+  gem "minitest", "~> 5.14"
+  gem "minitest-focus", "~> 1.1"
+  gem "minitest-hooks", "~> 1.5"
+  gem "rack-test"
+  gem "rake"
+end

--- a/google-cloud-pubsub/samples/README.md
+++ b/google-cloud-pubsub/samples/README.md
@@ -1,0 +1,129 @@
+<img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
+
+# Google Cloud Pub/Sub Ruby Samples
+
+[Google Cloud Pub/Sub][language_docs] is a simple, reliable, scalable foundation for stream analytics 
+and event-driven computing systems.
+
+[language_docs]: https://cloud.google.com/pubsub/docs/
+
+## Setup
+
+### Authentication
+
+Authentication is typically done through [Application Default Credentials](https://cloud.google.com/docs/authentication#getting_credentials_for_server-centric_flow)
+, which means you do not have to change the code to authenticate as long as your
+environment has credentials. You have a few options for setting up
+authentication:
+
+1. When running locally, use the [Google Cloud SDK](https://cloud.google.com/sdk/)
+
+       gcloud auth application-default login
+
+1. When running on App Engine or Compute Engine, credentials are already set-up.
+However, you may need to configure your Compute Engine instance with
+[additional scopes](https://cloud.google.com/compute/docs/authentication#using).
+
+1. You can create a [Service Account key file](https://cloud.google.com/docs/authentication#service_accounts)
+. This file can be used to authenticate to Google Cloud Platform services from
+any environment. To use the file, set the `GOOGLE_APPLICATION_CREDENTIALS`
+environment variable to the path to the key file, for example:
+
+       export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service_account.json
+
+### Set Project ID
+
+Next, set the `GOOGLE_CLOUD_PROJECT` environment variable to the project name
+set in the
+[Google Cloud Platform Developer Console](https://console.cloud.google.com):
+
+    export GOOGLE_CLOUD_PROJECT="YOUR-PROJECT-ID"
+
+### Install Dependencies
+
+1. Install the [Bundler](http://bundler.io/) gem.
+
+1. Install dependencies using:
+
+       bundle install
+
+## Run samples
+
+If using the `topics.rb create_push_subscription` command (see below), first deploy the push listener
+App Engine app defined in `listener.rb` and configured in `app.yaml`. The `endpoint` argument to
+`create_push_subscription` should look like `https://my-project.appspot.com/push`. You can see messages
+pushed to the listener in [Google Cloud Logging](https://cloud.google.com/logging/docs/), or simply
+run `tail` on the logs as shown below.
+
+    gcloud app deploy --promote
+    gcloud app logs tail -s default
+
+Run the quickstart sample to create a topic:
+
+    bundle exec ruby quickstart.rb <topic_id>
+
+Run the sample for using topics:
+
+    bundle exec ruby topics.rb
+
+Usage:
+
+    bundle exec ruby topics.rb [command] [arguments]
+
+    Commands:
+    create_topic                                    <project_id> <topic_id>                              Create a topic
+    list_topics                                     <project_id>                                         List topics in a project
+    list_topic_subscriptions                        <project_id> <topic_id>                              List subscriptions in a topic
+    delete_topic                                    <project_id> <topic_id>                              Delete topic policies
+    get_topic_policy                                <project_id> <topic_id>                              Get topic policies
+    set_topic_policy                                <project_id> <topic_id>                              Set topic policies
+    test_topic_permissions                          <project_id> <topic_id>                              Test topic permissions
+    create_pull_subscription                        <project_id> <topic_id> <subscription_id>            Create a pull subscription
+    create_push_subscription                        <project_id> <topic_id> <subscription_id> <endpoint> Create a push subscription
+    publish_message                                 <project_id> <topic_id>                              Publish message
+    publish_message_async                           <project_id> <topic_id>                              Publish messages asynchronously
+    publish_messages_async_with_batch_settings      <project_id> <topic_id>                              Publish messages asynchronously in batch
+    publish_message_async_with_custom_attributes    <project_id> <topic_id>                              Publish messages asynchronously with custom attributes
+    publish_messages_async_with_concurrency_control <project_id> <topic_id>                              Publish messages asynchronously with concurrency control
+
+Example:
+
+    bundle exec ruby topics.rb create_topic my-new-topic
+
+    Topic my-new-topic created.
+
+Run the sample for using subscriptions:
+
+    bundle exec ruby subscriptions.rb
+
+Usage:
+
+    bundle exec ruby subscriptions.rb [command] [arguments]
+
+    Commands:
+    update_push_configuration                    <project_id> <subscription_id> <endpoint> Update the endpoint of a push subscription
+    list_subscriptions                           <project_id>                              List subscriptions of a project
+    delete_subscription                          <project_id> <subscription_id>            Delete a subscription
+    get_subscription_policy                      <project_id> <subscription_id>            Get policies of a subscription
+    set_subscription_policy                      <project_id> <subscription_id>            Set policies of a subscription
+    test_subscription_policy                     <project_id> <subscription_id>            Test policies of a subscription
+    listen_for_messages                          <project_id> <subscription_id>            Listen for messages
+    listen_for_messages_with_custom_attributes   <project_id> <subscription_id>            Listen for messages with custom attributes
+    pull_messages                                <project_id> <subscription_id>            Pull messages
+    listen_for_messages_with_error_handler       <project_id> <subscription_id>            Listen for messages with an error handler
+    listen_for_messages_with_flow_control        <project_id> <subscription_id>            Listen for messages with flow control
+    listen_for_messages_with_concurrency_control <project_id> <subscription_id>            Listen for messages with concurrency control
+
+Example:
+
+    bundle exec ruby subscriptions.rb list_subscriptions
+
+    Subscriptions:
+    YOUR-SUBSCRIPTION
+
+
+## Test samples
+
+Test the samples using the Project ID configured above:
+
+    bundle exec rake test

--- a/google-cloud-pubsub/samples/Rakefile
+++ b/google-cloud-pubsub/samples/Rakefile
@@ -1,0 +1,23 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "rake/testtask"
+require "rubocop/rake_task"
+
+Rake::TestTask.new "test" do |t|
+  t.test_files = FileList["**/*_test.rb"]
+  t.warning = false
+end
+
+RuboCop::RakeTask.new

--- a/google-cloud-pubsub/samples/acceptance/helper.rb
+++ b/google-cloud-pubsub/samples/acceptance/helper.rb
@@ -1,0 +1,27 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "minitest/autorun"
+require "minitest/focus"
+require "minitest/hooks/default"
+require "google/cloud/pubsub"
+require "securerandom"
+
+def random_topic_id
+  "ruby-pubsub-samples-test-topic-#{SecureRandom.hex 4}"
+end
+
+def random_subscription_id
+  "ruby-pubsub-samples-test-subscription-#{SecureRandom.hex 4}"
+end

--- a/google-cloud-pubsub/samples/acceptance/quickstart_test.rb
+++ b/google-cloud-pubsub/samples/acceptance/quickstart_test.rb
@@ -1,0 +1,32 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "helper"
+require_relative "../quickstart.rb"
+
+describe "quickstart" do
+  let(:pubsub) { Google::Cloud::Pubsub.new }
+  let(:topic_id) { random_topic_id }
+
+  it "supports quickstart_create_topic" do
+    assert_output "Topic projects/#{pubsub.project}/topics/#{topic_id} created.\n" do
+      quickstart topic_id: topic_id
+    end
+
+    topic = pubsub.topic topic_id
+    assert topic
+    # cleanup
+    topic.delete
+  end
+end

--- a/google-cloud-pubsub/samples/acceptance/subscriptions_test.rb
+++ b/google-cloud-pubsub/samples/acceptance/subscriptions_test.rb
@@ -1,0 +1,182 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "helper"
+require_relative "../subscriptions.rb"
+
+describe "subscriptions" do
+  let(:pubsub) { Google::Cloud::Pubsub.new }
+  let(:endpoint) { "https://#{pubsub.project}.appspot.com/push" }
+  let(:role) { "roles/pubsub.subscriber" }
+  let(:service_account_email) { "serviceAccount:kokoro@#{pubsub.project}.iam.gserviceaccount.com" }
+
+  before :all do
+    @topic = pubsub.create_topic random_topic_id
+  end
+
+  after :all do
+    @topic.delete
+  end
+
+  before do
+    @subscription = @topic.subscribe random_subscription_id
+  end
+
+  after do
+    @subscription.delete if @subscription
+    @subscription = nil
+  end
+
+  it "supports pubsub_update_push_configuration, pubsub_list_subscriptions, pubsub_set_subscription_policy, pubsub_get_subscription_policy, " \
+     "pubsub_test_subscription_permissions, pubsub_detach_subscription, pubsub_delete_subscription" do
+    # pubsub_update_push_configuration
+    assert_output "Push endpoint updated.\n" do
+      update_push_configuration subscription_id: @subscription.name, new_endpoint: endpoint
+    end
+    @subscription = @topic.subscription @subscription.name
+    assert @subscription
+    assert_equal endpoint, @subscription.endpoint
+    assert @subscription.push_config
+    assert_equal endpoint, @subscription.push_config.endpoint
+
+    # pubsub_list_subscriptions
+    out, _err = capture_io do
+      list_subscriptions
+    end
+    assert_includes out, "Subscriptions:"
+    assert_includes out, "projects/#{pubsub.project}/subscriptions/"
+
+    # pubsub_set_subscription_policy
+    set_subscription_policy subscription_id: @subscription.name, role: role, service_account_email: service_account_email
+    @subscription.reload!
+    assert_equal [service_account_email], @subscription.policy.roles[role]
+
+    # pubsub_get_subscription_policy
+    assert_output "Subscription policy:\n#{@subscription.policy.roles}\n" do
+      get_subscription_policy subscription_id: @subscription.name
+    end
+
+    # pubsub_test_subscription_permissions
+    assert_output "Permission to consume\nPermission to update\n" do
+      test_subscription_permissions subscription_id: @subscription.name
+    end
+
+    # pubsub_detach_subscription
+    assert_output "Subscription is detached.\n" do
+      detach_subscription subscription_id: @subscription.name
+    end
+
+    # pubsub_delete_subscription
+    assert_output "Subscription #{@subscription.name} deleted.\n" do
+      delete_subscription subscription_id: @subscription.name
+    end
+    @subscription = @topic.subscription @subscription.name
+    refute @subscription
+  end
+
+  it "supports pubsub_subscriber_sync_pull" do
+    @topic.publish "This is a test message."
+    sleep 5
+
+    # pubsub_subscriber_sync_pull
+    expect_with_retry "pubsub_subscriber_sync_pull" do
+      assert_output "Message pulled: This is a test message.\n" do
+        pull_messages subscription_id: @subscription.name
+      end
+    end
+  end
+
+  it "supports pubsub_subscriber_async_pull, pubsub_quickstart_subscriber" do
+    @topic.publish "This is a test message."
+    sleep 5
+
+    # pubsub_subscriber_async_pull
+    # pubsub_quickstart_subscriber
+    expect_with_retry "pubsub_subscriber_async_pull" do
+      assert_output "Received message: This is a test message.\n" do
+        listen_for_messages subscription_id: @subscription.name
+      end
+    end
+  end
+
+  it "supports pubsub_subscriber_async_pull_custom_attributes" do
+    @topic.publish "This is a test message.", origin: "ruby-sample"
+    sleep 5
+
+    # pubsub_subscriber_async_pull_custom_attributes
+    expect_with_retry "pubsub_subscriber_async_pull_custom_attributes" do
+      out, _err = capture_io do
+        listen_for_messages_with_custom_attributes subscription_id: @subscription.name
+      end
+      assert_includes out, "Received message: This is a test message."
+      assert_includes out, "Attributes:"
+      assert_includes out, "origin: ruby-sample"
+    end
+  end
+
+  it "supports pubsub_subscriber_flow_settings" do
+    @topic.publish "This is a test message."
+    sleep 5
+
+    # pubsub_subscriber_flow_settings
+    expect_with_retry "pubsub_subscriber_flow_settings" do
+      assert_output "Received message: This is a test message.\n" do
+        listen_for_messages_with_flow_control subscription_id: @subscription.name
+      end
+    end
+  end
+
+  it "supports pubsub_subscriber_concurrency_control" do
+    @topic.publish "This is a test message."
+    sleep 5
+
+    # pubsub_subscriber_concurrency_control
+    expect_with_retry "pubsub_subscriber_concurrency_control" do
+      assert_output "Received message: This is a test message.\n" do
+        listen_for_messages_with_concurrency_control subscription_id: @subscription.name
+      end
+    end
+  end
+
+  it "supports pubsub_subscriber_sync_pull_with_lease" do
+    @topic.publish "This is a test message."
+    sleep 5
+
+    # # pubsub_subscriber_sync_pull_with_lease
+    expect_with_retry "pubsub_subscriber_sync_pull_with_lease" do
+      out, _err = capture_io do
+        subscriber_sync_pull_with_lease subscription_id: @subscription.name
+        sleep 10 # Allow enough time for output from non-blocking worker to be captured.
+      end
+      assert_includes out, "Reset ack deadline for \"This is a test message.\" for 30 seconds."
+      assert_includes out, "Finished processing \"This is a test message.\"."
+      assert_includes out, "Done."
+    end
+  end
+
+  # Pub/Sub calls may not respond immediately.
+  # Wrap expectations that may require multiple attempts with this method.
+  def expect_with_retry sample_name, attempts: 5
+    @attempt_number ||= 0
+    yield
+    @attempt_number = nil
+  rescue Minitest::Assertion => e
+    @attempt_number += 1
+    puts "failed attempt #{@attempt_number} for #{sample_name}"
+    sleep @attempt_number*@attempt_number
+    retry if @attempt_number < attempts
+    @attempt_number = nil
+    raise e
+  end
+end

--- a/google-cloud-pubsub/samples/acceptance/topics_test.rb
+++ b/google-cloud-pubsub/samples/acceptance/topics_test.rb
@@ -1,0 +1,355 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "helper"
+require_relative "../topics.rb"
+require_relative "../subscriptions.rb"
+
+describe "topics" do
+  let(:pubsub) { Google::Cloud::Pubsub.new }
+  let(:role) { "roles/pubsub.publisher" }
+  let(:service_account_email) { "serviceAccount:kokoro@#{pubsub.project}.iam.gserviceaccount.com" }
+  let(:topic_id) { random_topic_id }
+  let(:subscription_id) { random_subscription_id }
+  let(:dead_letter_topic_id) { random_topic_id }
+
+  after do
+    @subscription.delete if @subscription
+    @topic.delete if @topic
+  end
+
+  it "supports pubsub_create_topic, pubsub_list_topics, pubsub_set_topic_policy, pubsub_get_topic_policy, pubsub_test_topic_permissions, pubsub_delete_topic" do
+    # pubsub_create_topic
+    assert_output "Topic projects/#{pubsub.project}/topics/#{topic_id} created.\n" do
+      create_topic topic_id: topic_id
+    end
+    topic = pubsub.topic topic_id
+    assert topic
+    assert_equal "projects/#{pubsub.project}/topics/#{topic_id}", topic.name
+
+    # pubsub_list_topics
+    out, _err = capture_io do
+      list_topics
+    end
+    assert_includes out, "Topics in project:"
+    assert_includes out, "projects/#{pubsub.project}/topics/"
+
+    # pubsub_set_topic_policy
+    set_topic_policy topic_id: topic.name, role: role, service_account_email: service_account_email
+    topic.reload!
+    assert_equal [service_account_email], topic.policy.roles[role]
+
+    # pubsub_get_topic_policy
+    assert_output "Topic policy:\n#{topic.policy.roles}\n" do
+      get_topic_policy topic_id: topic_id
+    end
+
+    # pubsub_test_topic_permissions
+    assert_output "Permission to attach subscription\nPermission to publish\nPermission to update\n" do
+      test_topic_permissions topic_id: topic_id
+    end
+
+    # pubsub_delete_topic
+    assert_output "Topic #{topic_id} deleted.\n" do
+      delete_topic topic_id: topic_id
+    end
+    topic = pubsub.topic topic_id
+    refute topic
+  end
+
+  it "supports pubsub_create_pull_subscription, pubsub_list_topic_subscriptions, pubsub_quickstart_publisher, pubsub_subscriber_sync_pull" do
+    #setup
+    @topic = pubsub.create_topic topic_id
+
+    # pubsub_create_pull_subscription
+    assert_output "Pull subscription #{subscription_id} created.\n" do
+      create_pull_subscription topic_id: topic_id, subscription_id: subscription_id
+    end
+    @subscription = @topic.subscription subscription_id
+    assert @subscription
+    assert_equal "projects/#{pubsub.project}/subscriptions/#{subscription_id}", @subscription.name
+
+    # pubsub_list_topic_subscriptions
+    assert_output "Subscriptions in topic #{@topic.name}:\n#{@subscription.name}\n" do
+      list_topic_subscriptions topic_id: topic_id
+    end
+
+    # pubsub_quickstart_publisher
+    assert_output "Message published.\n" do
+      publish_message topic_id: topic_id
+    end
+
+    # pubsub_subscriber_sync_pull
+    expect_with_retry "pubsub_subscriber_sync_pull" do
+      assert_output "Message pulled: This is a test message.\n" do
+        pull_messages subscription_id: subscription_id
+      end
+    end
+  end
+
+  it "supports pubsub_enable_subscription_ordering, pubsub_publish_with_ordering_keys, pubsub_resume_publish_with_ordering_keys" do
+    #setup
+    @topic = pubsub.create_topic topic_id
+
+    # pubsub_enable_subscription_ordering
+    assert_output "Pull subscription #{subscription_id} created with message ordering.\n" do
+      create_ordered_pull_subscription topic_id: topic_id, subscription_id: subscription_id
+    end
+    @subscription = @topic.subscription subscription_id
+    assert @subscription
+    assert_equal "projects/#{pubsub.project}/subscriptions/#{subscription_id}", @subscription.name
+    assert @subscription.message_ordering?
+
+    # pubsub_publish_with_ordering_keys
+    assert_output "Messages published with ordering key.\n" do
+      publish_ordered_messages topic_id: topic_id
+    end
+
+    messages = []
+    expect_with_retry "pubsub_publish_with_ordering_keys" do
+      @subscription.pull(max: 20).each do |message|
+        messages << message
+        message.acknowledge!
+      end
+      assert_equal 10, messages.length
+    end
+    received_time_counter = Hash.new 0
+    messages.each_with_index do |message, i|
+      assert_equal "ordering-key", message.ordering_key
+      assert_equal "This is message \##{i}.", message.data
+      received_time_counter[message.publish_time] += 1
+    end
+    assert_equal 1, received_time_counter.length
+
+    # pubsub_resume_publish_with_ordering_keys
+    out, _err = capture_io do
+      publish_resume_publish topic_id: topic_id
+    end
+    assert_includes out, "Message \#0 successfully published."
+    assert_includes out, "Message \#9 successfully published."
+
+    messages = []
+    expect_with_retry "pubsub_resume_publish_with_ordering_keys" do
+      @subscription.pull(max: 20).each do |message|
+        messages << message
+        message.acknowledge!
+      end
+      assert_equal 10, messages.length
+    end
+    received_time_counter = Hash.new 0
+    messages.each_with_index do |message, i|
+      assert_equal "ordering-key", message.ordering_key
+      assert_equal "This is message \##{i}.", message.data
+      received_time_counter[message.publish_time] += 1
+    end
+    assert_equal 1, received_time_counter.length
+  end
+
+  it "supports pubsub_create_push_subscription" do
+    #setup
+    @topic = pubsub.create_topic topic_id
+    endpoint = "https://#{pubsub.project}.appspot.com/push"
+
+    # pubsub_create_pull_subscription
+    assert_output "Push subscription #{subscription_id} created.\n" do
+      create_push_subscription topic_id: topic_id, subscription_id: subscription_id, endpoint: endpoint
+    end
+    @subscription = @topic.subscription subscription_id
+    assert @subscription
+    assert_equal "projects/#{pubsub.project}/subscriptions/#{subscription_id}", @subscription.name
+    assert_equal endpoint, @subscription.endpoint
+    assert @subscription.push_config
+    assert_equal endpoint, @subscription.push_config.endpoint
+  end
+
+  it "supports pubsub_dead_letter_create_subscription, pubsub_dead_letter_update_subscription, pubsub_dead_letter_delivery_attempt" do
+    #setup
+    @topic = pubsub.create_topic topic_id
+    @dead_letter_topic = pubsub.create_topic dead_letter_topic_id
+    
+    begin
+      # pubsub_dead_letter_create_subscription
+      out, _err = capture_io do
+        dead_letter_create_subscription topic_id: topic_id,
+                                        subscription_id: subscription_id,
+                                        dead_letter_topic_id: dead_letter_topic_id
+      end
+      assert_includes out, "Created subscription #{subscription_id} with dead letter topic #{dead_letter_topic_id}."
+
+      @subscription = @topic.subscription subscription_id
+      assert @subscription
+      assert_equal "projects/#{pubsub.project}/subscriptions/#{subscription_id}", @subscription.name
+      assert @subscription.dead_letter_topic
+      assert_equal "projects/#{pubsub.project}/topics/#{dead_letter_topic_id}", @subscription.dead_letter_topic.name
+      assert_equal 10, @subscription.dead_letter_max_delivery_attempts
+
+      # pubsub_dead_letter_update_subscription
+      assert_output "Max delivery attempts is now 20.\n" do
+        dead_letter_update_subscription subscription_id: subscription_id
+      end
+      @subscription.reload!
+      assert @subscription.dead_letter_topic
+      assert_equal "projects/#{pubsub.project}/topics/#{dead_letter_topic_id}", @subscription.dead_letter_topic.name
+      assert_equal 20, @subscription.dead_letter_max_delivery_attempts
+
+      @topic.publish "This is a dead letter topic test message."
+      # pubsub_dead_letter_delivery_attempt
+      expect_with_retry "pubsub_dead_letter_delivery_attempt" do
+        out, _err = capture_io do
+          dead_letter_delivery_attempt subscription_id: subscription_id
+        end
+        assert_includes out, "Received message: This is a dead letter topic test message."
+        assert_includes out, "Delivery Attempt: 1"
+      end
+
+      # pubsub_dead_letter_remove
+      assert_output "Removed dead letter topic from #{subscription_id} subscription.\n" do
+        dead_letter_remove subscription_id: subscription_id
+      end
+      @subscription.reload!
+      refute @subscription.dead_letter_topic
+      refute @subscription.dead_letter_max_delivery_attempts
+
+    ensure
+      @dead_letter_topic.delete
+    end
+  end
+
+  it "supports pubsub_publish" do
+    #setup
+    @topic = pubsub.create_topic topic_id
+    @subscription = @topic.subscribe random_subscription_id
+
+    # pubsub_publish
+    assert_output "Message published asynchronously.\n" do
+      publish_message_async topic_id: topic_id
+    end
+
+    messages = []
+    expect_with_retry "pubsub_publish" do
+      @subscription.pull(max: 1).each do |message|
+        messages << message
+        message.acknowledge!
+      end
+      assert_equal 1, messages.length
+      assert_equal "This is a test message.", messages[0].data
+    end
+  end
+
+  it "supports pubsub_publish_custom_attributes" do
+    #setup
+    @topic = pubsub.create_topic topic_id
+    @subscription = @topic.subscribe random_subscription_id
+
+    # pubsub_publish_custom_attributes
+    assert_output "Message with custom attributes published asynchronously.\n" do
+      publish_message_async_with_custom_attributes topic_id: topic_id
+    end
+
+    messages = []
+    expect_with_retry "pubsub_publish_custom_attributes" do
+      @subscription.pull(max: 1).each do |message|
+        messages << message
+        message.acknowledge!
+      end
+      assert_equal 1, messages.length
+      assert_equal "This is a test message.", messages[0].data
+      assert_equal 2, messages[0].attributes.size
+      assert_equal "ruby-sample", messages[0].attributes["origin"]
+      assert_equal "gcp", messages[0].attributes["username"]
+    end
+  end
+
+  it "supports pubsub_publisher_batch_settings" do
+    #setup
+    @topic = pubsub.create_topic topic_id
+    @subscription = @topic.subscribe random_subscription_id
+
+    # pubsub_publisher_batch_settings
+    assert_output "Messages published asynchronously in batch.\n" do
+      publish_messages_async_with_batch_settings topic_id: topic_id
+    end
+
+    messages = []
+    expect_with_retry "pubsub_publisher_batch_settings" do
+      @subscription.pull(max: 20).each do |message|
+        messages << message
+        message.acknowledge!
+      end
+      assert_equal 10, messages.length
+    end
+    received_time_counter = Hash.new 0
+    messages.each do |message|
+      received_time_counter[message.publish_time] += 1
+    end
+    assert_equal 1, received_time_counter.length
+  end
+
+  it "supports pubsub_publisher_concurrency_control" do
+    #setup
+    @topic = pubsub.create_topic topic_id
+    @subscription = @topic.subscribe random_subscription_id
+
+    # pubsub_publisher_concurrency_control
+    assert_output "Message published asynchronously.\n" do
+      publish_messages_async_with_concurrency_control topic_id: topic_id
+    end
+
+    messages = []
+    expect_with_retry "pubsub_publisher_concurrency_control" do
+      @subscription.pull(max: 1).each do |message|
+        messages << message
+        message.acknowledge!
+      end
+      assert_equal 1, messages.length
+      assert_equal "This is a test message.", messages[0].data
+    end
+  end
+
+  it "supports publish_with_error_handler" do
+    #setup
+    @topic = pubsub.create_topic topic_id
+    @subscription = @topic.subscribe random_subscription_id
+
+    # publish_with_error_handler
+    assert_output "Message published asynchronously.\n" do
+      publish_message_async topic_id: topic_id
+    end
+
+    messages = []
+    expect_with_retry "pubsub_publish" do
+      @subscription.pull(max: 1).each do |message|
+        messages << message
+        message.acknowledge!
+      end
+      assert_equal 1, messages.length
+      assert_equal "This is a test message.", messages[0].data
+    end
+  end
+
+  # Pub/Sub calls may not respond immediately.
+  # Wrap expectations that may require multiple attempts with this method.
+  def expect_with_retry sample_name, attempts: 5
+    @attempt_number ||= 0
+    yield
+    @attempt_number = nil
+  rescue Minitest::Assertion => e
+    @attempt_number += 1
+    puts "failed attempt #{@attempt_number} for #{sample_name}"
+    sleep @attempt_number*@attempt_number
+    retry if @attempt_number < attempts
+    @attempt_number = nil
+    raise e
+  end
+end

--- a/google-cloud-pubsub/samples/app.yaml
+++ b/google-cloud-pubsub/samples/app.yaml
@@ -1,0 +1,16 @@
+# Copyright 2021 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+runtime: ruby27
+entrypoint: bundle exec ruby listener.rb

--- a/google-cloud-pubsub/samples/listener.rb
+++ b/google-cloud-pubsub/samples/listener.rb
@@ -1,0 +1,26 @@
+# Copyright 2021 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "sinatra"
+require "json"
+require "base64"
+
+post "/push" do
+  message = JSON.parse request.body.read
+  data = Base64.decode64 message["message"]["data"]
+  logger.info "Pushed Message: #{data}"
+  response.status = 204
+end
+
+set :port, 8080

--- a/google-cloud-pubsub/samples/quickstart.rb
+++ b/google-cloud-pubsub/samples/quickstart.rb
@@ -1,0 +1,35 @@
+# Copyright 2021 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def quickstart topic_id:
+  # [START pubsub_quickstart_create_topic]
+  # [START require_library]
+  # Imports the Google Cloud client library
+  require "google/cloud/pubsub"
+  # [END require_library]
+
+  # Instantiates a client
+  pubsub = Google::Cloud::Pubsub.new
+
+  # The name for the new topic
+  # topic_id = "your-topic-id"
+
+  # Creates the new topic
+  topic = pubsub.create_topic topic_id
+
+  puts "Topic #{topic.name} created."
+  # [END pubsub_quickstart_create_topic]
+end
+
+quickstart topic_id: ARGV.shift if $PROGRAM_NAME == __FILE__

--- a/google-cloud-pubsub/samples/subscriptions.rb
+++ b/google-cloud-pubsub/samples/subscriptions.rb
@@ -1,0 +1,417 @@
+# Copyright 2021 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "google/cloud/pubsub"
+
+def update_push_configuration subscription_id:, new_endpoint:
+  # [START pubsub_update_push_configuration]
+  # subscription_id   = "your-subscription-id"
+  # new_endpoint      = "Endpoint where your app receives messages""
+  require "google/cloud/pubsub"
+
+  pubsub = Google::Cloud::Pubsub.new
+
+  subscription          = pubsub.subscription subscription_id
+  subscription.endpoint = new_endpoint
+
+  puts "Push endpoint updated."
+  # [END pubsub_update_push_configuration]
+end
+
+def list_subscriptions
+  # [START pubsub_list_subscriptions]
+  require "google/cloud/pubsub"
+
+  pubsub = Google::Cloud::Pubsub.new
+
+  subscriptions = pubsub.list_subscriptions
+
+  puts "Subscriptions:"
+  subscriptions.each do |subscription|
+    puts subscription.name
+  end
+  # [END pubsub_list_subscriptions]
+end
+
+def detach_subscription subscription_id:
+  # [START pubsub_detach_subscription]
+  # subscription_id = "your-subscription-id"
+  require "google/cloud/pubsub"
+
+  pubsub = Google::Cloud::Pubsub.new
+
+  subscription = pubsub.subscription subscription_id
+  subscription.detach
+
+  sleep 120
+  subscription.reload!
+  if subscription.detached?
+    puts "Subscription is detached."
+  else
+    puts "Subscription is NOT detached."
+  end
+  # [END pubsub_detach_subscription]
+end
+
+def delete_subscription subscription_id:
+  # [START pubsub_delete_subscription]
+  # subscription_id = "your-subscription-id"
+  require "google/cloud/pubsub"
+
+  pubsub = Google::Cloud::Pubsub.new
+
+  subscription = pubsub.subscription subscription_id
+  subscription.delete
+
+  puts "Subscription #{subscription_id} deleted."
+  # [END pubsub_delete_subscription]
+end
+
+def get_subscription_policy subscription_id:
+  # [START pubsub_get_subscription_policy]
+  # subscription_id = "your-subscription-id"
+  require "google/cloud/pubsub"
+
+  pubsub = Google::Cloud::Pubsub.new
+
+  subscription = pubsub.subscription subscription_id
+  policy       = subscription.policy
+
+  puts "Subscription policy:"
+  puts policy.roles
+  # [END pubsub_get_subscription_policy]
+end
+
+def set_subscription_policy subscription_id:, role:, service_account_email:
+  # [START pubsub_set_subscription_policy]
+  # subscription_id       = "your-subscription-id"
+  # role                  = "roles/pubsub.publisher"
+  # service_account_email = "serviceAccount:account_name@project_name.iam.gserviceaccount.com"
+  require "google/cloud/pubsub"
+
+  pubsub = Google::Cloud::Pubsub.new
+
+  subscription = pubsub.subscription subscription_id
+  subscription.policy do |policy|
+    policy.add role, service_account_email
+  end
+  # [END pubsub_set_subscription_policy]
+end
+
+def test_subscription_permissions subscription_id:
+  # [START pubsub_test_subscription_permissions]
+  # subscription_id = "your-subscription-id"
+  require "google/cloud/pubsub"
+
+  pubsub = Google::Cloud::Pubsub.new
+
+  subscription = pubsub.subscription subscription_id
+  permissions  = subscription.test_permissions "pubsub.subscriptions.consume",
+                                               "pubsub.subscriptions.update"
+
+  puts "Permission to consume" if permissions.include? "pubsub.subscriptions.consume"
+  puts "Permission to update" if permissions.include? "pubsub.subscriptions.update"
+  # [END pubsub_test_subscription_permissions]
+end
+
+def dead_letter_update_subscription subscription_id:
+  # [START pubsub_dead_letter_update_subscription]
+  # subscription_id       = "your-subscription-id"
+  # role                  = "roles/pubsub.publisher"
+  # service_account_email = "serviceAccount:account_name@project_name.iam.gserviceaccount.com"
+  require "google/cloud/pubsub"
+
+  pubsub = Google::Cloud::Pubsub.new
+
+  subscription = pubsub.subscription subscription_id
+  subscription.dead_letter_max_delivery_attempts = 20
+  puts "Max delivery attempts is now #{subscription.dead_letter_max_delivery_attempts}."
+  # [END pubsub_dead_letter_update_subscription]
+end
+
+def dead_letter_remove subscription_id:
+  # [START pubsub_dead_letter_remove]
+  # subscription_id = "your-subscription-id"
+  require "google/cloud/pubsub"
+
+  pubsub = Google::Cloud::Pubsub.new
+
+  subscription = pubsub.subscription subscription_id
+  subscription.remove_dead_letter_policy
+  puts "Removed dead letter topic from #{subscription_id} subscription."
+  # [END pubsub_dead_letter_remove]
+end
+
+def listen_for_messages subscription_id:
+  # [START pubsub_subscriber_async_pull]
+  # [START pubsub_quickstart_subscriber]
+  # subscription_id = "your-subscription-id"
+  require "google/cloud/pubsub"
+
+  pubsub = Google::Cloud::Pubsub.new
+
+  subscription = pubsub.subscription subscription_id
+  subscriber   = subscription.listen do |received_message|
+    puts "Received message: #{received_message.data}"
+    received_message.acknowledge!
+  end
+
+  subscriber.start
+  # Let the main thread sleep for 60 seconds so the thread for listening
+  # messages does not quit
+  sleep 60
+  subscriber.stop.wait!
+  # [END pubsub_subscriber_async_pull]
+  # [END pubsub_quickstart_subscriber]
+end
+
+def listen_for_messages_with_custom_attributes subscription_id:
+  # [START pubsub_subscriber_async_pull_custom_attributes]
+  # subscription_id = "your-subscription-id"
+  require "google/cloud/pubsub"
+
+  pubsub = Google::Cloud::Pubsub.new
+
+  subscription = pubsub.subscription subscription_id
+  subscriber   = subscription.listen do |received_message|
+    puts "Received message: #{received_message.data}"
+    unless received_message.attributes.empty?
+      puts "Attributes:"
+      received_message.attributes.each do |key, value|
+        puts "#{key}: #{value}"
+      end
+    end
+    received_message.acknowledge!
+  end
+
+  subscriber.start
+  # Let the main thread sleep for 60 seconds so the thread for listening
+  # messages does not quit
+  sleep 60
+  subscriber.stop.wait!
+  # [END pubsub_subscriber_async_pull_custom_attributes]
+end
+
+def pull_messages subscription_id:
+  # [START pubsub_subscriber_sync_pull]
+  # subscription_id = "your-subscription-id"
+  require "google/cloud/pubsub"
+
+  pubsub = Google::Cloud::Pubsub.new
+
+  subscription = pubsub.subscription subscription_id
+  subscription.pull.each do |message|
+    puts "Message pulled: #{message.data}"
+    message.acknowledge!
+  end
+  # [END pubsub_subscriber_sync_pull]
+end
+
+def listen_for_messages_with_error_handler subscription_id:
+  # [START pubsub_subscriber_error_listener]
+  # subscription_id = "your-subscription-id"
+  require "google/cloud/pubsub"
+
+  pubsub = Google::Cloud::Pubsub.new
+
+  subscription = pubsub.subscription subscription_id
+  subscriber   = subscription.listen do |received_message|
+    puts "Received message: #{received_message.data}"
+    received_message.acknowledge!
+  end
+  # Propagate expection from child threads to the main thread as soon as it is
+  # raised. Exceptions happened in the callback thread are collected in the
+  # callback thread pool and do not propagate to the main thread
+  Thread.abort_on_exception = true
+
+  begin
+    subscriber.start
+    # Let the main thread sleep for 60 seconds so the thread for listening
+    # messages does not quit
+    sleep 60
+    subscriber.stop.wait!
+  rescue Exception => e
+    puts "Exception #{e.inspect}: #{e.message}"
+    raise "Stopped listening for messages."
+  end
+  # [END pubsub_subscriber_error_listener]
+end
+
+def listen_for_messages_with_flow_control subscription_id:
+  # [START pubsub_subscriber_flow_settings]
+  # subscription_id = "your-subscription-id"
+  require "google/cloud/pubsub"
+
+  pubsub = Google::Cloud::Pubsub.new
+
+  subscription = pubsub.subscription subscription_id
+  subscriber   = subscription.listen inventory: 10 do |received_message|
+    puts "Received message: #{received_message.data}"
+    received_message.acknowledge!
+  end
+
+  subscriber.start
+  # Let the main thread sleep for 60 seconds so the thread for listening
+  # messages does not quit
+  sleep 60
+  subscriber.stop.wait!
+  # [END pubsub_subscriber_flow_settings]
+end
+
+def listen_for_messages_with_concurrency_control subscription_id:
+  # [START pubsub_subscriber_concurrency_control]
+  # subscription_id = "your-subscription-id"
+  require "google/cloud/pubsub"
+
+  pubsub = Google::Cloud::Pubsub.new
+
+  subscription = pubsub.subscription subscription_id
+  # Use 2 threads for streaming, 4 threads for executing callbacks and 2 threads
+  # for sending acknowledgements and/or delays
+  subscriber   = subscription.listen streams: 2, threads: {
+    callback: 4,
+    push:     2
+  } do |received_message|
+    puts "Received message: #{received_message.data}"
+    received_message.acknowledge!
+  end
+
+  subscriber.start
+  # Let the main thread sleep for 60 seconds so the thread for listening
+  # messages does not quit
+  sleep 60
+  subscriber.stop.wait!
+  # [END pubsub_subscriber_concurrency_control]
+end
+
+def dead_letter_delivery_attempt subscription_id:
+  # [START pubsub_dead_letter_delivery_attempt]
+  # subscription_id = "your-subscription-id"
+  require "google/cloud/pubsub"
+
+  pubsub = Google::Cloud::Pubsub.new
+
+  subscription = pubsub.subscription subscription_id
+  subscription.pull.each do |message|
+    puts "Received message: #{message.data}"
+    puts "Delivery Attempt: #{message.delivery_attempt}"
+    message.acknowledge!
+  end
+  # [END pubsub_dead_letter_delivery_attempt]
+end
+
+def subscriber_sync_pull_with_lease subscription_id:
+  # [START pubsub_subscriber_sync_pull_with_lease]
+  # subscription_id = "your-subscription-id"
+  require "google/cloud/pubsub"
+
+  pubsub = Google::Cloud::Pubsub.new
+
+  subscription = pubsub.subscription subscription_id
+  new_ack_deadline = 30
+  processed = false
+
+  # The subscriber pulls a specified number of messages.
+  received_messages = subscription.pull max: 1
+
+  # Obtain the first message.
+  message = received_messages.first
+
+  # Send the message to a non-blocking worker that starts a long-running process, such as writing
+  # the message to a table, which may take longer than the default 10-sec acknowledge deadline.
+  Thread.new do
+    sleep 15
+    processed = true
+    puts "Finished processing \"#{message.data}\"."
+  end
+
+  loop do
+    sleep 1
+    if processed
+      # If the message has been processed, acknowledge the message.
+      message.acknowledge!
+      puts "Done."
+      # Exit after the message is acknowledged.
+      break
+    else
+      # If the message has not yet been processed, reset its ack deadline.
+      message.modify_ack_deadline! new_ack_deadline
+      puts "Reset ack deadline for \"#{message.data}\" for #{new_ack_deadline} seconds."
+    end
+  end
+  # [END pubsub_subscriber_sync_pull_with_lease]
+end
+
+if $PROGRAM_NAME == __FILE__
+  case ARGV.shift
+  when "update_push_configuration"
+    update_push_configuration subscription_id: ARGV.shift,
+                              new_endpoint:    ARGV.shift
+  when "list_subscriptions"
+    list_subscriptions
+  when "detach_subscription"
+    detach_subscription subscription_id: ARGV.shift
+  when "delete_subscription"
+    delete_subscription subscription_id: ARGV.shift
+  when "get_subscription_policy"
+    get_subscription_policy psubscription_id: ARGV.shift
+  when "set_subscription_policy"
+    set_subscription_policy subscription_id: ARGV.shift
+  when "test_subscription_permissions"
+    test_subscription_permissions subscription_id: ARGV.shift
+  when "dead_letter_update_subscription"
+    dead_letter_update_subscription subscription_id: ARGV.shift
+  when "dead_letter_remove"
+    dead_letter_remove subscription_id: ARGV.shift
+  when "listen_for_messages"
+    listen_for_messages subscription_id: ARGV.shift
+  when "listen_for_messages_with_custom_attributes"
+    listen_for_messages_with_custom_attributes subscription_id: ARGV.shift
+  when "pull_messages"
+    pull_messages subscription_id: ARGV.shift
+  when "listen_for_messages_with_error_handler"
+    listen_for_messages_with_error_handler subscription_id: ARGV.shift
+  when "listen_for_messages_with_flow_control"
+    listen_for_messages_with_flow_control subscription_id: ARGV.shift
+  when "listen_for_messages_with_concurrency_control"
+    listen_for_messages_with_concurrency_control subscription_id: ARGV.shift
+  when "dead_letter_delivery_attempt"
+    dead_letter_delivery_attempt subscription_id: ARGV.shift
+  when "subscriber_sync_pull_with_lease"
+    subscriber_sync_pull_with_lease subscription_id: ARGV.shift
+  else
+    puts <<~USAGE
+      Usage: bundle exec ruby subscriptions.rb [command] [arguments]
+
+      Commands:
+        update_push_configuration                    <subscription_id> <endpoint> Update the endpoint of a push subscription
+        list_subscriptions                                                        List subscriptions of a project
+        detach_subscription                          <subscription_id>            Detach a subscription
+        delete_subscription                          <subscription_id>            Delete a subscription
+        get_subscription_policy                      <subscription_id>            Get policies of a subscription
+        set_subscription_policy                      <subscription_id>            Set policies of a subscription
+        test_subscription_permissions                <subscription_id>            Test policies of a subscription
+        dead_letter_update_subscription              <subscription_id>            Update a subscription's dead letter policy
+        dead_letter_remove                           <subscription_id>            Delete a subscription's dead letter policy
+        listen_for_messages                          <subscription_id>            Listen for messages
+        listen_for_messages_with_custom_attributes   <subscription_id>            Listen for messages with custom attributes
+        pull_messages                                <subscription_id>            Pull messages
+        listen_for_messages_with_error_handler       <subscription_id>            Listen for messages with an error handler
+        listen_for_messages_with_flow_control        <subscription_id>            Listen for messages with flow control
+        listen_for_messages_with_concurrency_control <subscription_id>            Listen for messages with concurrency control
+        dead_letter_delivery_attempt                 <subscription_id>            Pull messages that have a delivery attempts field
+        subscriber_sync_pull_with_lease              <subscription_id>            Pull messages and reset their acknowledgement deadlines
+    USAGE
+  end
+end

--- a/google-cloud-pubsub/samples/topics.rb
+++ b/google-cloud-pubsub/samples/topics.rb
@@ -1,0 +1,446 @@
+# Copyright 2021 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "google/cloud/pubsub"
+
+def create_topic topic_id:
+  # [START pubsub_create_topic]
+  # topic_id = "your-topic-id"
+  require "google/cloud/pubsub"
+
+  pubsub = Google::Cloud::Pubsub.new
+
+  topic = pubsub.create_topic topic_id
+
+  puts "Topic #{topic.name} created."
+  # [END pubsub_create_topic]
+end
+
+def list_topics
+  # [START pubsub_list_topics]
+  require "google/cloud/pubsub"
+
+  pubsub = Google::Cloud::Pubsub.new
+
+  topics = pubsub.topics
+
+  puts "Topics in project:"
+  topics.each do |topic|
+    puts topic.name
+  end
+  # [END pubsub_list_topics]
+end
+
+def list_topic_subscriptions topic_id:
+  # [START pubsub_list_topic_subscriptions]
+  # topic_id = "your-topic-id"
+  require "google/cloud/pubsub"
+
+  pubsub = Google::Cloud::Pubsub.new
+
+  topic         = pubsub.topic topic_id
+  subscriptions = topic.subscriptions
+
+  puts "Subscriptions in topic #{topic.name}:"
+  subscriptions.each do |subscription|
+    puts subscription.name
+  end
+  # [END pubsub_list_topic_subscriptions]
+end
+
+def delete_topic topic_id:
+  # [START pubsub_delete_topic]
+  # topic_id = "your-topic-id"
+  require "google/cloud/pubsub"
+
+  pubsub = Google::Cloud::Pubsub.new
+
+  topic = pubsub.topic topic_id
+  topic.delete
+
+  puts "Topic #{topic_id} deleted."
+  # [END pubsub_delete_topic]
+end
+
+def get_topic_policy topic_id:
+  # [START pubsub_get_topic_policy]
+  # topic_id = "your-topic-id"
+  require "google/cloud/pubsub"
+
+  pubsub = Google::Cloud::Pubsub.new
+
+  topic  = pubsub.topic topic_id
+  policy = topic.policy
+
+  puts "Topic policy:"
+  puts policy.roles
+  # [END pubsub_get_topic_policy]
+end
+
+def set_topic_policy topic_id:, role:, service_account_email:
+  # [START pubsub_set_topic_policy]
+  # topic_id              = "your-topic-id"
+  # role                  = "roles/pubsub.publisher"
+  # service_account_email = "serviceAccount:account_name@project_name.iam.gserviceaccount.com"
+  require "google/cloud/pubsub"
+
+  pubsub = Google::Cloud::Pubsub.new
+
+  topic = pubsub.topic topic_id
+  topic.policy do |policy|
+    policy.add role, service_account_email
+  end
+  # [END pubsub_set_topic_policy]
+end
+
+def test_topic_permissions topic_id:
+  # [START pubsub_test_topic_permissions]
+  # topic_id = "your-topic-id"
+  require "google/cloud/pubsub"
+
+  pubsub = Google::Cloud::Pubsub.new
+
+  topic       = pubsub.topic topic_id
+  permissions = topic.test_permissions "pubsub.topics.attachSubscription",
+                                       "pubsub.topics.publish", "pubsub.topics.update"
+
+  puts "Permission to attach subscription" if permissions.include? "pubsub.topics.attachSubscription"
+  puts "Permission to publish" if permissions.include? "pubsub.topics.publish"
+  puts "Permission to update" if permissions.include? "pubsub.topics.update"
+  # [END pubsub_test_topic_permissions]
+end
+
+def create_pull_subscription topic_id:, subscription_id:
+  # [START pubsub_create_pull_subscription]
+  # topic_id        = "your-topic-id"
+  # subscription_id = "your-subscription-id"
+  require "google/cloud/pubsub"
+
+  pubsub = Google::Cloud::Pubsub.new
+
+  topic        = pubsub.topic topic_id
+  subscription = topic.subscribe subscription_id
+
+  puts "Pull subscription #{subscription_id} created."
+  # [END pubsub_create_pull_subscription]
+end
+
+def create_ordered_pull_subscription topic_id:, subscription_id:
+  # [START pubsub_enable_subscription_ordering]
+  # topic_id        = "your-topic-id"
+  # subscription_id = "your-subscription-id"
+  require "google/cloud/pubsub"
+
+  pubsub = Google::Cloud::Pubsub.new
+
+  topic        = pubsub.topic topic_id
+  subscription = topic.subscribe subscription_id,
+                                 message_ordering: true
+
+  puts "Pull subscription #{subscription_id} created with message ordering."
+  # [END pubsub_enable_subscription_ordering]
+end
+
+def create_push_subscription topic_id:, subscription_id:, endpoint:
+  # [START pubsub_create_push_subscription]
+  # topic_id          = "your-topic-id"
+  # subscription_id   = "your-subscription-id"
+  # endpoint          = "https://your-test-project.appspot.com/push"
+  require "google/cloud/pubsub"
+
+  pubsub = Google::Cloud::Pubsub.new
+
+  topic        = pubsub.topic topic_id
+  subscription = topic.subscribe subscription_id,
+                                 endpoint: endpoint
+
+  puts "Push subscription #{subscription_id} created."
+  # [END pubsub_create_push_subscription]
+end
+
+def dead_letter_create_subscription topic_id:, subscription_id:, dead_letter_topic_id:
+  # [START pubsub_dead_letter_create_subscription]
+  # topic_id             = "your-topic-id"
+  # subscription_id      = "your-subscription-id"
+  # dead_letter_topic_id = "your-dead-letter-topic-id"
+  require "google/cloud/pubsub"
+
+  pubsub = Google::Cloud::Pubsub.new
+
+  topic             = pubsub.topic topic_id
+  dead_letter_topic = pubsub.topic dead_letter_topic_id
+  subscription      = topic.subscribe subscription_id,
+                                      dead_letter_topic:                 dead_letter_topic,
+                                      dead_letter_max_delivery_attempts: 10
+
+  puts "Created subscription #{subscription_id} with dead letter topic #{dead_letter_topic_id}."
+  puts "To process dead letter messages, remember to add a subscription to your dead letter topic."
+  # [END pubsub_dead_letter_create_subscription]
+end
+
+def publish_message topic_id:
+  # [START pubsub_quickstart_publisher]
+  # topic_id = "your-topic-id"
+  require "google/cloud/pubsub"
+
+  pubsub = Google::Cloud::Pubsub.new
+
+  topic = pubsub.topic topic_id
+  topic.publish "This is a test message."
+
+  puts "Message published."
+  # [END pubsub_quickstart_publisher]
+end
+
+def publish_message_async topic_id:
+  # [START pubsub_publish]
+  # topic_id = "your-topic-id"
+  require "google/cloud/pubsub"
+
+  pubsub = Google::Cloud::Pubsub.new
+
+  topic = pubsub.topic topic_id
+  topic.publish_async "This is a test message." do |result|
+    raise "Failed to publish the message." unless result.succeeded?
+    puts "Message published asynchronously."
+  end
+
+  # Stop the async_publisher to send all queued messages immediately.
+  topic.async_publisher.stop.wait!
+  # [END pubsub_publish]
+end
+
+def publish_message_async_with_custom_attributes topic_id:
+  # [START pubsub_publish_custom_attributes]
+  # topic_id = "your-topic-id"
+  require "google/cloud/pubsub"
+
+  pubsub = Google::Cloud::Pubsub.new
+
+  topic = pubsub.topic topic_id
+  # Add two attributes, origin and username, to the message
+  topic.publish_async "This is a test message.",
+                      origin:   "ruby-sample",
+                      username: "gcp" do |result|
+    raise "Failed to publish the message." unless result.succeeded?
+    puts "Message with custom attributes published asynchronously."
+  end
+
+  # Stop the async_publisher to send all queued messages immediately.
+  topic.async_publisher.stop.wait!
+  # [END pubsub_publish_custom_attributes]
+end
+
+def publish_messages_async_with_batch_settings topic_id:
+  # [START pubsub_publisher_batch_settings]
+  # topic_id = "your-topic-id"
+  require "google/cloud/pubsub"
+
+  pubsub = Google::Cloud::Pubsub.new
+
+  # Start sending messages in one request once the size of all queued messages
+  # reaches 1 MB or the number of queued messages reaches 20
+  topic = pubsub.topic topic_id, async: {
+    max_bytes:    1_000_000,
+    max_messages: 20
+  }
+  10.times do |i|
+    topic.publish_async "This is message \##{i}."
+  end
+
+  # Stop the async_publisher to send all queued messages immediately.
+  topic.async_publisher.stop.wait!
+  puts "Messages published asynchronously in batch."
+  # [END pubsub_publisher_batch_settings]
+end
+
+def publish_messages_async_with_concurrency_control topic_id:
+  # [START pubsub_publisher_concurrency_control]
+  # topic_id = "your-topic-id"
+  require "google/cloud/pubsub"
+
+  pubsub = Google::Cloud::Pubsub.new
+
+  topic = pubsub.topic topic_id, async: {
+    threads: {
+      # Use exactly one thread for publishing message and exactly one thread
+      # for executing callbacks
+      publish:  1,
+      callback: 1
+    }
+  }
+  topic.publish_async "This is a test message." do |result|
+    raise "Failed to publish the message." unless result.succeeded?
+    puts "Message published asynchronously."
+  end
+
+  # Stop the async_publisher to send all queued messages immediately.
+  topic.async_publisher.stop.wait!
+  # [END pubsub_publisher_concurrency_control]
+end
+
+def publish_with_error_handler topic_id:
+  # [START pubsub_publish_with_error_handler]
+  # topic_id = "your-topic-id"
+  require "google/cloud/pubsub"
+
+  pubsub = Google::Cloud::Pubsub.new
+
+  topic = pubsub.topic topic_id
+
+  begin
+    topic.publish_async "This is a test message." do |result|
+      raise "Failed to publish the message." unless result.succeeded?
+      puts "Message published asynchronously."
+    end
+
+    # Stop the async_publisher to send all queued messages immediately.
+    topic.async_publisher.stop.wait!
+  rescue StandardError => e
+    puts "Received error while publishing: #{e.message}"
+  end
+  # [END pubsub_publish_with_error_handler]
+end
+
+def publish_ordered_messages topic_id:
+  # [START pubsub_publish_with_ordering_keys]
+  # topic_id = "your-topic-id"
+  require "google/cloud/pubsub"
+
+  pubsub = Google::Cloud::Pubsub.new
+
+  # Start sending messages in one request once the size of all queued messages
+  # reaches 1 MB or the number of queued messages reaches 20
+  topic = pubsub.topic topic_id, async: {
+    max_bytes:    1_000_000,
+    max_messages: 20
+  }
+  topic.enable_message_ordering!
+  10.times do |i|
+    topic.publish_async "This is message \##{i}.",
+                        ordering_key: "ordering-key"
+  end
+
+  # Stop the async_publisher to send all queued messages immediately.
+  topic.async_publisher.stop!
+  puts "Messages published with ordering key."
+  # [END pubsub_publish_with_ordering_keys]
+end
+
+def publish_resume_publish topic_id:
+  # [START pubsub_resume_publish_with_ordering_keys]
+  # topic_id = "your-topic-id"
+  require "google/cloud/pubsub"
+
+  pubsub = Google::Cloud::Pubsub.new
+
+  # Start sending messages in one request once the size of all queued messages
+  # reaches 1 MB or the number of queued messages reaches 20
+  topic = pubsub.topic topic_id, async: {
+    max_bytes:    1_000_000,
+    max_messages: 20
+  }
+  topic.enable_message_ordering!
+  10.times do |i|
+    topic.publish_async "This is message \##{i}.",
+                        ordering_key: "ordering-key" do |result|
+      if result.succeeded?
+        puts "Message \##{i} successfully published."
+      else
+        puts "Message \##{i} failed to publish"
+        # Allow publishing to continue on "ordering-key" after processing the
+        # failure.
+        topic.resume_publish "ordering-key"
+      end
+    end
+  end
+
+  # Stop the async_publisher to send all queued messages immediately.
+  topic.async_publisher.stop!
+  # [END pubsub_resume_publish_with_ordering_keys]
+end
+
+if $PROGRAM_NAME == __FILE__
+  case ARGV.shift
+  when "create_topic"
+    create_topic topic_id: ARGV.shift
+  when "list_topics"
+    list_topics
+  when "list_topic_subscriptions"
+    list_topic_subscriptions topic_id: ARGV.shift
+  when "delete_topic"
+    delete_topic topic_id: ARGV.shift
+  when "get_topic_policy"
+    get_topic_policy topic_id: ARGV.shift
+  when "set_topic_policy"
+    set_topic_policy topic_id: ARGV.shift, role: ARGV.shift, service_account_email: ARGV.shift
+  when "test_topic_permissions"
+    test_topic_permissions topic_id: ARGV.shift
+  when "create_pull_subscription"
+    create_pull_subscription topic_id:        ARGV.shift,
+                             subscription_id: ARGV.shift
+  when "create_ordered_pull_subscription"
+    create_ordered_pull_subscription topic_id:        ARGV.shift,
+                                     subscription_id: ARGV.shift
+  when "create_push_subscription"
+    create_push_subscription topic_id:        ARGV.shift,
+                             subscription_id: ARGV.shift,
+                             endpoint:        ARGV.shift
+  when "dead_letter_create_subscription"
+    dead_letter_create_subscription topic_id:             ARGV.shift,
+                                    subscription_id:      ARGV.shift,
+                                    dead_letter_topic_id: ARGV.shift
+  when "publish_message"
+    publish_message topic_id: ARGV.shift
+  when "publish_message_async"
+    publish_message_async topic_id: ARGV.shift
+  when "publish_message_async_with_custom_attributes"
+    publish_message_async_with_custom_attributes topic_id: ARGV.shift
+  when "publish_messages_async_with_batch_settings"
+    publish_messages_with_batch_settings topic_id: ARGV.shift
+  when "publish_messages_async_with_concurrency_control"
+    publish_messages_async_with_concurrency_control topic_id: ARGV.shift
+  when "publish_with_error_handler"
+    publish_with_error_handler topic_id: ARGV.shift
+  when "publish_ordered_messages"
+    publish_ordered_messages topic_id: ARGV.shift
+  when "publish_resume_publish"
+    publish_resume_publish topic_id: ARGV.shift
+  else
+    puts <<~USAGE
+      Usage: bundle exec ruby topics.rb [command] [arguments]
+
+      Commands:
+        create_topic                                    <topic_id>                                          Create a topic
+        list_topics                                                                                         List topics in a project
+        list_topic_subscriptions                        <topic_id>                                          List subscriptions in a topic
+        delete_topic                                    <topic_id>                                          Delete topic policies
+        get_topic_policy                                <topic_id>                                          Get topic policies
+        set_topic_policy                                <topic_id> <role> <service_account_email>           Set topic policies
+        test_topic_permissions                          <topic_id>                                          Test topic permissions
+        create_pull_subscription                        <topic_id> <subscription_id>                        Create a pull subscription
+        create_ordered_pull_subscription                <topic_id> <subscription_id>                        Create a pull subscription with ordering enabled
+        create_push_subscription                        <topic_id> <subscription_id> <endpoint>             Create a push subscription
+        dead_letter_create_subscription                 <topic_id> <subscription_id> <dead_letter_topic_id> Create a subscription with a dead letter topic
+        publish_message                                 <topic_id>                                          Publish message
+        publish_message_async                           <topic_id>                                          Publish messages asynchronously
+        publish_message_async_with_custom_attributes    <topic_id>                                          Publish messages asynchronously with custom attributes
+        publish_messages_async_with_batch_settings      <topic_id>                                          Publish messages asynchronously in batch
+        publish_messages_async_with_concurrency_control <topic_id>                                          Publish messages asynchronously with concurrency control
+        publish_with_error_handler                      <topic_id>                                          Publish messages asynchronously with error handling
+        publish_ordered_messages                        <topic_id>                                          Publish messages asynchronously with ordering keys
+        publish_resume_publish                          <topic_id>                                          Publish messages asynchronously with ordering keys and resume on failure
+    USAGE
+  end
+end


### PR DESCRIPTION
This PR moves the samples without changes. It updates `Gemfile` and `Rakefile` and adds `.rubocop.yml`. Tests and rubocop are passing on Ruby 2.7.2 and 3.0.0.