### PR TITLE
feat(bigquery): Add support for BIGNUMERIC data type

### DIFF
--- a/google-cloud-bigquery/.rubocop.yml
+++ b/google-cloud-bigquery/.rubocop.yml
@@ -29,7 +29,7 @@ Metrics/ModuleLength:
   Exclude:
     - "lib/google/cloud/bigquery/convert.rb"
 Metrics/PerceivedComplexity:
-  Max: 14
+  Max: 16
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-bigquery.rb"

--- a/google-cloud-bigquery/OVERVIEW.md
+++ b/google-cloud-bigquery/OVERVIEW.md
@@ -160,8 +160,8 @@ The BigQuery data types are converted to and from Ruby types as follows:
 | `BOOL`       | `true`/`false`                       |                                                              |
 | `INT64`      | `Integer`                            |                                                              |
 | `FLOAT64`    | `Float`                              |                                                              |
-| `NUMERIC`    | `BigDecimal`                         | `BigDecimal` args will be rounded to scale 9.                |
-| `BIGNUMERIC` | to `BigDecimal`, from `String`       | To avoid rounding `BigDecimal` args to scale 9, pass string. |
+| `NUMERIC`    | `BigDecimal`                         | `BigDecimal` values will be rounded to scale 9.              |
+| `BIGNUMERIC` | converted to `BigDecimal`            | Pass data as `String` and map query param values in `types`. |
 | `STRING`     | `String`                             |                                                              |
 | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.                       |
 | `DATE`       | `Date`                               |                                                              |

--- a/google-cloud-bigquery/OVERVIEW.md
+++ b/google-cloud-bigquery/OVERVIEW.md
@@ -160,8 +160,8 @@ The BigQuery data types are converted to and from Ruby types as follows:
 | `BOOL`       | `true`/`false`                       | |
 | `INT64`      | `Integer`                            | |
 | `FLOAT64`    | `Float`                              | |
-| `NUMERIC`    | `BigDecimal`                         | Up to precision 38, scale 9 |
-| `BIGNUMERIC` | `BigDecimal`                         | Up to precision 76+, scale 38 |
+| `NUMERIC`    | `BigDecimal`                         | Conversions to NUMERIC will be rounded to scale 9. |
+| `BIGNUMERIC` | `BigDecimal`                         | Conversions must be specified using `types` param. |
 | `STRING`     | `String`                             | |
 | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone. |
 | `DATE`       | `Date`                               | |

--- a/google-cloud-bigquery/OVERVIEW.md
+++ b/google-cloud-bigquery/OVERVIEW.md
@@ -155,21 +155,21 @@ more complex types such as `ARRAY` and `STRUCT`.
 
 The BigQuery data types are converted to and from Ruby types as follows:
 
-| BigQuery     | Ruby                                 | Notes |
-|------------- |--------------------------------------|-------|
-| `BOOL`       | `true`/`false`                       | |
-| `INT64`      | `Integer`                            | |
-| `FLOAT64`    | `Float`                              | |
-| `NUMERIC`    | `BigDecimal`                         | BigDecimal inputs rounded to scale 9. |
+| BigQuery     | Ruby                                 | Notes                                                        |
+|------------- |--------------------------------------|--------------------------------------------------------------|
+| `BOOL`       | `true`/`false`                       |                                                              |
+| `INT64`      | `Integer`                            |                                                              |
+| `FLOAT64`    | `Float`                              |                                                              |
+| `NUMERIC`    | `BigDecimal`                         | BigDecimal args will be rounded to scale 9.                  |
 | `BIGNUMERIC` | to `BigDecimal`, from `String`       | To avoid rounding BigDecimal args to scale 9, pass `String`. |
-| `STRING`     | `String`                             | |
-| `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone. |
-| `DATE`       | `Date`                               | |
-| `TIMESTAMP`  | `Time`                               | |
-| `TIME`       | `Google::Cloud::BigQuery::Time`      | |
-| `BYTES`      | `File`, `IO`, `StringIO`, or similar | |
-| `ARRAY`      | `Array`                              | Nested arrays, `nil` values are not supported. |
-| `STRUCT`     | `Hash`                               | Hash keys may be strings or symbols. |
+| `STRING`     | `String`                             |                                                              |
+| `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.                       |
+| `DATE`       | `Date`                               |                                                              |
+| `TIMESTAMP`  | `Time`                               |                                                              |
+| `TIME`       | `Google::Cloud::BigQuery::Time`      |                                                              |
+| `BYTES`      | `File`, `IO`, `StringIO`, or similar |                                                              |
+| `ARRAY`      | `Array`                              | Nested arrays, `nil` values are not supported.               |
+| `STRUCT`     | `Hash`                               | Hash keys may be strings or symbols.                         |
 
 See [Data
 Types](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types)

--- a/google-cloud-bigquery/OVERVIEW.md
+++ b/google-cloud-bigquery/OVERVIEW.md
@@ -160,8 +160,8 @@ The BigQuery data types are converted to and from Ruby types as follows:
 | `BOOL`       | `true`/`false`                       |                                                              |
 | `INT64`      | `Integer`                            |                                                              |
 | `FLOAT64`    | `Float`                              |                                                              |
-| `NUMERIC`    | `BigDecimal`                         | BigDecimal args will be rounded to scale 9.                  |
-| `BIGNUMERIC` | to `BigDecimal`, from `String`       | To avoid rounding BigDecimal args to scale 9, pass `String`. |
+| `NUMERIC`    | `BigDecimal`                         | `BigDecimal` args will be rounded to scale 9.                |
+| `BIGNUMERIC` | to `BigDecimal`, from `String`       | To avoid rounding `BigDecimal` args to scale 9, pass string. |
 | `STRING`     | `String`                             |                                                              |
 | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.                       |
 | `DATE`       | `Date`                               |                                                              |

--- a/google-cloud-bigquery/OVERVIEW.md
+++ b/google-cloud-bigquery/OVERVIEW.md
@@ -155,20 +155,21 @@ more complex types such as `ARRAY` and `STRUCT`.
 
 The BigQuery data types are converted to and from Ruby types as follows:
 
-| BigQuery    | Ruby           | Notes  |
-|-------------|----------------|---|
-| `BOOL`      | `true`/`false` | |
-| `INT64`     | `Integer`      | |
-| `FLOAT64`   | `Float`        | |
-| `NUMERIC`   | `BigDecimal`   | Will be rounded to 9 decimal places |
-| `STRING`    | `String`       | |
-| `DATETIME`  | `DateTime`     | `DATETIME` does not support time zone. |
-| `DATE`      | `Date`         | |
-| `TIMESTAMP` | `Time`         | |
-| `TIME`      | `Google::Cloud::BigQuery::Time` | |
-| `BYTES`     | `File`, `IO`, `StringIO`, or similar | |
-| `ARRAY`     | `Array` | Nested arrays and `nil` values are not supported. |
-| `STRUCT`    | `Hash`         | Hash keys may be strings or symbols. |
+| BigQuery     | Ruby                                 | Notes |
+|------------- |--------------------------------------|-------|
+| `BOOL`       | `true`/`false`                       | |
+| `INT64`      | `Integer`                            | |
+| `FLOAT64`    | `Float`                              | |
+| `NUMERIC`    | `BigDecimal`                         | Up to precision 38, scale 9 |
+| `BIGNUMERIC` | `BigDecimal`                         | Up to precision 76+, scale 38 |
+| `STRING`     | `String`                             | |
+| `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone. |
+| `DATE`       | `Date`                               | |
+| `TIMESTAMP`  | `Time`                               | |
+| `TIME`       | `Google::Cloud::BigQuery::Time`      | |
+| `BYTES`      | `File`, `IO`, `StringIO`, or similar | |
+| `ARRAY`      | `Array`                              | Nested arrays, `nil` values are not supported. |
+| `STRUCT`     | `Hash`                               | Hash keys may be strings or symbols. |
 
 See [Data
 Types](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types)

--- a/google-cloud-bigquery/OVERVIEW.md
+++ b/google-cloud-bigquery/OVERVIEW.md
@@ -160,8 +160,8 @@ The BigQuery data types are converted to and from Ruby types as follows:
 | `BOOL`       | `true`/`false`                       | |
 | `INT64`      | `Integer`                            | |
 | `FLOAT64`    | `Float`                              | |
-| `NUMERIC`    | `BigDecimal`                         | Conversions to NUMERIC will be rounded to scale 9. |
-| `BIGNUMERIC` | `BigDecimal`                         | Conversions must be specified using `types` param. |
+| `NUMERIC`    | `BigDecimal`                         | BigDecimal inputs rounded to scale 9. |
+| `BIGNUMERIC` | to `BigDecimal`, from `String`       | To avoid rounding BigDecimal args to scale 9, pass `String`. |
 | `STRING`     | `String`                             | |
 | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone. |
 | `DATE`       | `Date`                               | |

--- a/google-cloud-bigquery/acceptance/bigquery/advanced_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/advanced_test.rb
@@ -20,8 +20,8 @@ describe Google::Cloud::Bigquery, :advanced, :bigquery do
   let(:table_id) { "examples_table" }
   let(:table) { @table }
 
-  let(:bigdecimal_numeric) { BigDecimal("0.123456789") }
-  let(:bigdecimal_bignumeric) { BigDecimal("0.12345678901234567890123456789012345678") }
+  let(:string_numeric) { "0.123456789" }
+  let(:string_bignumeric) { "0.12345678901234567890123456789012345678" }
 
   before do
     @table = get_or_create_example_table dataset, table_id
@@ -177,10 +177,10 @@ describe Google::Cloud::Bigquery, :advanced, :bigquery do
 
     _(rows.count).must_equal 1
     _(rows[0][:my_numeric]).must_be_kind_of BigDecimal
-    _(rows[0][:my_numeric]).must_equal bigdecimal_numeric
-    # TODO: add BIGNUMERIC -> BigDecimal conversion to data
-    # _(rows[0][:my_numeric]).must_be_kind_of BigDecimal
-    # _(rows[0][:my_numeric]).must_equal bigdecimal_bignumeric
+    _(rows[0][:my_numeric]).must_equal BigDecimal(string_numeric)
+
+    _(rows[0][:my_bignumeric]).must_be_kind_of BigDecimal
+    _(rows[0][:my_bignumeric]).must_equal BigDecimal(string_bignumeric)
   end
 
   def assert_rows_equal returned_row, example_row
@@ -240,8 +240,8 @@ describe Google::Cloud::Bigquery, :advanced, :bigquery do
         name: "Bilbo",
         age: 111,
         weight: 67.2,
-        my_numeric: bigdecimal_numeric,
-        my_bignumeric: bigdecimal_bignumeric,
+        my_numeric: BigDecimal(string_numeric),
+        my_bignumeric: string_bignumeric, # BigDecimal would be rounded, use String instead!
         is_magic: false,
         scores: [],
         spells: [],

--- a/google-cloud-bigquery/acceptance/bigquery/advanced_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/advanced_test.rb
@@ -20,6 +20,9 @@ describe Google::Cloud::Bigquery, :advanced, :bigquery do
   let(:table_id) { "examples_table" }
   let(:table) { @table }
 
+  let(:bigdecimal_numeric) { BigDecimal("0.123456789") }
+  let(:bigdecimal_bignumeric) { BigDecimal("0.12345678901234567890123456789012345678") }
+
   before do
     @table = get_or_create_example_table dataset, table_id
   end
@@ -169,6 +172,17 @@ describe Google::Cloud::Bigquery, :advanced, :bigquery do
     _(child_jobs[1].script_statistics.stack_frames[0].text.length).must_be :>, 0
   end
 
+  it "queries max scale numeric and bignumeric values" do
+    rows = bigquery.query "SELECT my_numeric, my_bignumeric FROM #{dataset_id}.#{table_id} WHERE id = 1"
+
+    _(rows.count).must_equal 1
+    _(rows[0][:my_numeric]).must_be_kind_of BigDecimal
+    _(rows[0][:my_numeric]).must_equal bigdecimal_numeric
+    # TODO: add BIGNUMERIC -> BigDecimal conversion to data
+    # _(rows[0][:my_numeric]).must_be_kind_of BigDecimal
+    # _(rows[0][:my_numeric]).must_equal bigdecimal_bignumeric
+  end
+
   def assert_rows_equal returned_row, example_row
     _(returned_row[:id]).must_equal example_row[:id]
     _(returned_row[:name]).must_equal example_row[:name]
@@ -197,6 +211,8 @@ describe Google::Cloud::Bigquery, :advanced, :bigquery do
         schema.string "name", mode: :nullable
         schema.integer "age", mode: :nullable
         schema.float "weight", mode: :nullable
+        schema.numeric "my_numeric", mode: :nullable
+        schema.bignumeric "my_bignumeric", mode: :nullable
         schema.boolean "is_magic", mode: :nullable
         schema.float "scores", mode: :repeated
         schema.record "spells", mode: :repeated do |spells|
@@ -224,6 +240,8 @@ describe Google::Cloud::Bigquery, :advanced, :bigquery do
         name: "Bilbo",
         age: 111,
         weight: 67.2,
+        my_numeric: bigdecimal_numeric,
+        my_bignumeric: bigdecimal_bignumeric,
         is_magic: false,
         scores: [],
         spells: [],

--- a/google-cloud-bigquery/acceptance/bigquery/dataset_reference_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/dataset_reference_test.rb
@@ -207,7 +207,7 @@ describe Google::Cloud::Bigquery::Dataset, :reference, :bigquery do
   end
 
   it "inserts rows directly and gets its data" do
-    insert_response = table.insert rows
+    insert_response = dataset.insert table_id, rows
     _(insert_response).must_be :success?
     _(insert_response.insert_count).must_equal 3
     _(insert_response.insert_errors).must_be :empty?

--- a/google-cloud-bigquery/acceptance/bigquery/legacy_query_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/legacy_query_test.rb
@@ -39,7 +39,7 @@ describe Google::Cloud::Bigquery, :legacy_query_types, :bigquery do
     _(rows.count).must_equal 1
     _(rows.first[:value]).must_equal 12.0
   end
-focus
+
   it "queries a numeric value" do
     rows = bigquery.query "SELECT CAST('123456789.123456789' AS NUMERIC) AS value", legacy_sql: true
 
@@ -47,7 +47,7 @@ focus
     _(rows.count).must_equal 1
     _(rows.first[:value]).must_equal BigDecimal("123456789.123456789")
   end
-focus
+
   it "queries a rounded numeric value" do
     rows = bigquery.query "SELECT CAST('123456789.1234567891' AS NUMERIC) AS value", legacy_sql: true
 
@@ -55,7 +55,7 @@ focus
     _(rows.count).must_equal 1
     _(rows.first[:value]).must_equal BigDecimal("123456789.123456789")
   end
-focus
+
   it "queries a bignumeric value" do
     rows = bigquery.query "SELECT CAST('123456789.1234567891' AS BIGNUMERIC) AS value", legacy_sql: true
 

--- a/google-cloud-bigquery/acceptance/bigquery/legacy_query_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/legacy_query_test.rb
@@ -39,13 +39,29 @@ describe Google::Cloud::Bigquery, :legacy_query_types, :bigquery do
     _(rows.count).must_equal 1
     _(rows.first[:value]).must_equal 12.0
   end
-
+focus
   it "queries a numeric value" do
     rows = bigquery.query "SELECT CAST('123456789.123456789' AS NUMERIC) AS value", legacy_sql: true
 
     _(rows.class).must_equal Google::Cloud::Bigquery::Data
     _(rows.count).must_equal 1
     _(rows.first[:value]).must_equal BigDecimal("123456789.123456789")
+  end
+focus
+  it "queries a rounded numeric value" do
+    rows = bigquery.query "SELECT CAST('123456789.1234567891' AS NUMERIC) AS value", legacy_sql: true
+
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal BigDecimal("123456789.123456789")
+  end
+focus
+  it "queries a bignumeric value" do
+    rows = bigquery.query "SELECT CAST('123456789.1234567891' AS BIGNUMERIC) AS value", legacy_sql: true
+
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal BigDecimal("123456789.1234567891")
   end
 
   it "queries a boolean value" do

--- a/google-cloud-bigquery/acceptance/bigquery/named_params_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/named_params_test.rb
@@ -91,7 +91,7 @@ describe Google::Cloud::Bigquery, :named_params, :bigquery do
     _(rows.count).must_equal 1
     _(rows.first[:value]).must_equal BigDecimal("123456789.123456789")
   end
-focus
+
   it "queries the data with a rounded numeric parameter" do
     rows = bigquery.query "SELECT @value AS value", params: { value: BigDecimal("123456789.1234567891") }
 
@@ -113,7 +113,7 @@ focus
     _(rows.count).must_equal 1
     _(rows.first[:value]).must_be_nil
   end
-focus
+
   it "queries the data with a bignumeric parameter and bignumeric type" do
     rows = bigquery.query "SELECT @value AS value", 
                           params: { value: BigDecimal("123456789.1234567891") },

--- a/google-cloud-bigquery/acceptance/bigquery/named_params_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/named_params_test.rb
@@ -323,6 +323,17 @@ describe Google::Cloud::Bigquery, :named_params, :bigquery do
     _(rows.first[:value]).must_equal []
   end
 
+  it "queries the data with a converted string to integer in an array parameter" do
+    rows = bigquery.query "SELECT @value AS value", params: { value: ["1"] }, types: { value: [:INT64] }
+
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :repeated?
+    _(rows.fields.first).must_be :integer?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal [1]
+  end
+
   it "queries the data with a struct parameter" do
     rows = bigquery.query "SELECT @value AS value", params: { value: { message: "hello", repeat: 1 } }
 
@@ -370,5 +381,37 @@ describe Google::Cloud::Bigquery, :named_params, :bigquery do
     _(rows.fields.first.fields.last).must_be :integer?
     _(rows.count).must_equal 1
     _(rows.first[:value]).must_be_nil
+  end
+
+  it "queries the data with nested nil in a struct parameter" do
+    rows = bigquery.query "SELECT @value AS value", params: { value: { message: nil, repeat: 1 } }, types: { value: { message: :STRING, repeat: :INT64 } }
+
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :record?
+    _(rows.fields.first.fields.count).must_equal 2
+    _(rows.fields.first.fields.first.name).must_equal "message"
+    _(rows.fields.first.fields.first).must_be :string?
+    _(rows.fields.first.fields.last.name).must_equal "repeat"
+    _(rows.fields.first.fields.last).must_be :integer?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal({ message: nil, repeat: 1 })
+  end
+
+  it "queries the data with a converted string to integer in a struct parameter" do
+    rows = bigquery.query "SELECT @value AS value", params: { value: { message: "hello", repeat: "1" } }, types: { value: { message: :STRING, repeat: :INT64 } }
+
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :record?
+    _(rows.fields.first.fields.count).must_equal 2
+    _(rows.fields.first.fields.first.name).must_equal "message"
+    _(rows.fields.first.fields.first).must_be :string?
+    _(rows.fields.first.fields.last.name).must_equal "repeat"
+    _(rows.fields.first.fields.last).must_be :integer?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal({ message: "hello", repeat: 1 })
   end
 end

--- a/google-cloud-bigquery/acceptance/bigquery/named_params_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/named_params_test.rb
@@ -91,6 +91,17 @@ describe Google::Cloud::Bigquery, :named_params, :bigquery do
     _(rows.count).must_equal 1
     _(rows.first[:value]).must_equal BigDecimal("123456789.123456789")
   end
+focus
+  it "queries the data with a rounded numeric parameter" do
+    rows = bigquery.query "SELECT @value AS value", params: { value: BigDecimal("123456789.1234567891") }
+
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :numeric?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal BigDecimal("123456789.123456789")
+  end
 
   it "queries the data with a nil parameter and numeric type" do
     rows = bigquery.query "SELECT @value AS value", params: { value: nil }, types: { value: :NUMERIC }
@@ -99,6 +110,30 @@ describe Google::Cloud::Bigquery, :named_params, :bigquery do
     _(rows.fields.count).must_equal 1
     _(rows.fields.first.name).must_equal "value"
     _(rows.fields.first).must_be :numeric?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_be_nil
+  end
+focus
+  it "queries the data with a bignumeric parameter and bignumeric type" do
+    rows = bigquery.query "SELECT @value AS value", 
+                          params: { value: BigDecimal("123456789.1234567891") },
+                          types: { value: :BIGNUMERIC }
+
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :bignumeric?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal BigDecimal("123456789.1234567891")
+  end
+
+  it "queries the data with a nil parameter and bignumeric type" do
+    rows = bigquery.query "SELECT @value AS value", params: { value: nil }, types: { value: :BIGNUMERIC }
+
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :bignumeric?
     _(rows.count).must_equal 1
     _(rows.first[:value]).must_be_nil
   end

--- a/google-cloud-bigquery/acceptance/bigquery/positional_params_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/positional_params_test.rb
@@ -80,7 +80,7 @@ describe Google::Cloud::Bigquery, :positional_params, :bigquery do
     _(rows.count).must_equal 1
     _(rows.first[:value]).must_be_nil
   end
-
+focus
   it "queries the data with a numeric parameter" do
     rows = bigquery.query "SELECT ? AS value", params: [BigDecimal("123456789.123456789")]
 
@@ -91,7 +91,18 @@ describe Google::Cloud::Bigquery, :positional_params, :bigquery do
     _(rows.count).must_equal 1
     _(rows.first[:value]).must_equal BigDecimal("123456789.123456789")
   end
+focus
+  it "queries the data with a rounded numeric parameter" do
+    rows = bigquery.query "SELECT ? AS value", params: [BigDecimal("123456789.1234567891")]
 
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :numeric?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal BigDecimal("123456789.123456789")
+  end
+focus
   it "queries the data with a nil parameter and numeric type" do
     rows = bigquery.query "SELECT ? AS value", params: [nil], types: [:NUMERIC]
 
@@ -99,6 +110,28 @@ describe Google::Cloud::Bigquery, :positional_params, :bigquery do
     _(rows.fields.count).must_equal 1
     _(rows.fields.first.name).must_equal "value"
     _(rows.fields.first).must_be :numeric?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_be_nil
+  end
+focus
+  it "queries the data with a bignumeric parameter and bignumeric type" do
+    rows = bigquery.query "SELECT ? AS value", params: [BigDecimal("123456789.1234567891")], types: [:BIGNUMERIC]
+
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :bignumeric?
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal BigDecimal("123456789.1234567891")
+  end
+focus
+  it "queries the data with a nil parameter and bignumeric type" do
+    rows = bigquery.query "SELECT ? AS value", params: [nil], types: [:BIGNUMERIC]
+
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.fields.count).must_equal 1
+    _(rows.fields.first.name).must_equal "value"
+    _(rows.fields.first).must_be :bignumeric?
     _(rows.count).must_equal 1
     _(rows.first[:value]).must_be_nil
   end

--- a/google-cloud-bigquery/acceptance/bigquery/positional_params_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/positional_params_test.rb
@@ -80,7 +80,7 @@ describe Google::Cloud::Bigquery, :positional_params, :bigquery do
     _(rows.count).must_equal 1
     _(rows.first[:value]).must_be_nil
   end
-focus
+
   it "queries the data with a numeric parameter" do
     rows = bigquery.query "SELECT ? AS value", params: [BigDecimal("123456789.123456789")]
 
@@ -91,7 +91,7 @@ focus
     _(rows.count).must_equal 1
     _(rows.first[:value]).must_equal BigDecimal("123456789.123456789")
   end
-focus
+
   it "queries the data with a rounded numeric parameter" do
     rows = bigquery.query "SELECT ? AS value", params: [BigDecimal("123456789.1234567891")]
 
@@ -102,7 +102,7 @@ focus
     _(rows.count).must_equal 1
     _(rows.first[:value]).must_equal BigDecimal("123456789.123456789")
   end
-focus
+
   it "queries the data with a nil parameter and numeric type" do
     rows = bigquery.query "SELECT ? AS value", params: [nil], types: [:NUMERIC]
 
@@ -113,7 +113,7 @@ focus
     _(rows.count).must_equal 1
     _(rows.first[:value]).must_be_nil
   end
-focus
+
   it "queries the data with a bignumeric parameter and bignumeric type" do
     rows = bigquery.query "SELECT ? AS value", params: [BigDecimal("123456789.1234567891")], types: [:BIGNUMERIC]
 
@@ -124,7 +124,7 @@ focus
     _(rows.count).must_equal 1
     _(rows.first[:value]).must_equal BigDecimal("123456789.1234567891")
   end
-focus
+
   it "queries the data with a nil parameter and bignumeric type" do
     rows = bigquery.query "SELECT ? AS value", params: [nil], types: [:BIGNUMERIC]
 

--- a/google-cloud-bigquery/acceptance/bigquery/positional_params_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/positional_params_test.rb
@@ -296,6 +296,17 @@ describe Google::Cloud::Bigquery, :positional_params, :bigquery do
     _(rows.first[:value]).must_equal ["foo", "bar", "baz"]
   end
 
+  it "queries the data with an array of bignumeric parameters" do
+    param_1 = BigDecimal("123456789.1234567891")
+    param_2 = BigDecimal("123456789.1234567892")
+    param_3 = BigDecimal("123456789.1234567893")
+    rows = bigquery.query "SELECT ? AS value", params: [[param_1, param_2, param_3]], types: [[:BIGNUMERIC]]
+
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal [param_1, param_2, param_3]
+  end
+
   it "queries the data with an empty array of integers and type" do
     rows = bigquery.query "SELECT ? AS value", params: [[]], types: [[:INT64]]
 

--- a/google-cloud-bigquery/acceptance/bigquery/standard_query_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/standard_query_test.rb
@@ -39,13 +39,21 @@ describe Google::Cloud::Bigquery, :standard_query_types, :bigquery do
     _(rows.count).must_equal 1
     _(rows.first[:value]).must_equal 12.0
   end
-
+focus
   it "queries a numeric value" do
     rows = bigquery.query "SELECT NUMERIC '123456789.123456789' AS value", standard_sql: true
 
     _(rows.class).must_equal Google::Cloud::Bigquery::Data
     _(rows.count).must_equal 1
     _(rows.first[:value]).must_equal BigDecimal("123456789.123456789")
+  end
+focus
+  it "queries a bignumeric value" do
+    rows = bigquery.query "SELECT BIGNUMERIC '123456789.1234567891' AS value", standard_sql: true
+
+    _(rows.class).must_equal Google::Cloud::Bigquery::Data
+    _(rows.count).must_equal 1
+    _(rows.first[:value]).must_equal BigDecimal("123456789.1234567891")
   end
 
   it "queries a boolean value" do

--- a/google-cloud-bigquery/acceptance/bigquery/standard_query_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/standard_query_test.rb
@@ -39,7 +39,7 @@ describe Google::Cloud::Bigquery, :standard_query_types, :bigquery do
     _(rows.count).must_equal 1
     _(rows.first[:value]).must_equal 12.0
   end
-focus
+
   it "queries a numeric value" do
     rows = bigquery.query "SELECT NUMERIC '123456789.123456789' AS value", standard_sql: true
 
@@ -47,7 +47,7 @@ focus
     _(rows.count).must_equal 1
     _(rows.first[:value]).must_equal BigDecimal("123456789.123456789")
   end
-focus
+
   it "queries a bignumeric value" do
     rows = bigquery.query "SELECT BIGNUMERIC '123456789.1234567891' AS value", standard_sql: true
 

--- a/google-cloud-bigquery/acceptance/bigquery_helper.rb
+++ b/google-cloud-bigquery/acceptance/bigquery_helper.rb
@@ -150,16 +150,16 @@ module Acceptance
       addl.include? :bigquery
     end
 
-    # def self.run_one_method klass, method_name, reporter
-    #   result = nil
-    #   reporter.prerecord klass, method_name
-    #   (1..3).each do |try|
-    #     result = Minitest.run_one_method(klass, method_name)
-    #     break if (result.passed? || result.skipped?)
-    #     puts "Retrying #{klass}##{method_name} (#{try})"
-    #   end
-    #   reporter.record result
-    # end
+    def self.run_one_method klass, method_name, reporter
+      result = nil
+      reporter.prerecord klass, method_name
+      (1..3).each do |try|
+        result = Minitest.run_one_method(klass, method_name)
+        break if (result.passed? || result.skipped?)
+        puts "Retrying #{klass}##{method_name} (#{try})"
+      end
+      reporter.record result
+    end
   end
 end
 

--- a/google-cloud-bigquery/acceptance/bigquery_helper.rb
+++ b/google-cloud-bigquery/acceptance/bigquery_helper.rb
@@ -150,16 +150,16 @@ module Acceptance
       addl.include? :bigquery
     end
 
-    def self.run_one_method klass, method_name, reporter
-      result = nil
-      reporter.prerecord klass, method_name
-      (1..3).each do |try|
-        result = Minitest.run_one_method(klass, method_name)
-        break if (result.passed? || result.skipped?)
-        puts "Retrying #{klass}##{method_name} (#{try})"
-      end
-      reporter.record result
-    end
+    # def self.run_one_method klass, method_name, reporter
+    #   result = nil
+    #   reporter.prerecord klass, method_name
+    #   (1..3).each do |try|
+    #     result = Minitest.run_one_method(klass, method_name)
+    #     break if (result.passed? || result.skipped?)
+    #     puts "Retrying #{klass}##{method_name} (#{try})"
+    #   end
+    #   reporter.record result
+    # end
   end
 end
 

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
@@ -266,7 +266,7 @@ module Google
         ##
         # @private
         def self.to_json_row row
-          Hash[row.map { |k, v| [k.to_s, to_json_value(v)] }] # TODO: support type
+          Hash[row.map { |k, v| [k.to_s, to_json_value(v)] }]
         end
 
         def self.resolve_legacy_sql standard_sql, legacy_sql

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
@@ -28,21 +28,21 @@ module Google
       #
       # Internal conversion of raw data values to/from Bigquery values
       #
-      # | BigQuery     | Ruby                                 | Notes |
-      # |------------- |--------------------------------------|-------|
-      # | `BOOL`       | `true`/`false`                       | |
-      # | `INT64`      | `Integer`                            | |
-      # | `FLOAT64`    | `Float`                              | |
-      # | `NUMERIC`    | `BigDecimal`                         | Up to precision 38, scale 9 |
-      # | `BIGNUMERIC` | `BigDecimal`                         | Up to precision 76+, scale 38 |
-      # | `STRING`     | `String`                             | |
-      # | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone. |
-      # | `DATE`       | `Date`                               | |
-      # | `TIMESTAMP`  | `Time`                               | |
-      # | `TIME`       | `Google::Cloud::BigQuery::Time`      | |
-      # | `BYTES`      | `File`, `IO`, `StringIO`, or similar | |
-      # | `ARRAY`      | `Array`                              | Nested arrays, `nil` values are not supported. |
-      # | `STRUCT`     | `Hash`                               | Hash keys may be strings or symbols. |
+      #   | BigQuery     | Ruby                                 | Notes                                              |
+      #   |--------------|--------------------------------------|----------------------------------------------------|
+      #   | `BOOL`       | `true`/`false`                       |                                                    |
+      #   | `INT64`      | `Integer`                            |                                                    |
+      #   | `FLOAT64`    | `Float`                              |                                                    |
+      #   | `NUMERIC`    | `BigDecimal`                         | Conversions to NUMERIC will be rounded to scale 9. |
+      #   | `BIGNUMERIC` | `BigDecimal`                         | Conversions must be specified using `types` param. |
+      #   | `STRING`     | `String`                             |                                                    |
+      #   | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.             |
+      #   | `DATE`       | `Date`                               |                                                    |
+      #   | `TIMESTAMP`  | `Time`                               |                                                    |
+      #   | `TIME`       | `Google::Cloud::BigQuery::Time`      |                                                    |
+      #   | `BYTES`      | `File`, `IO`, `StringIO`, or similar |                                                    |
+      #   | `ARRAY`      | `Array`                              | Nested arrays, `nil` values are not supported.     |
+      #   | `STRUCT`     | `Hash`                               | Hash keys may be strings or symbols.               |
       #
       module Convert
         ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
@@ -33,8 +33,8 @@ module Google
       #   | `BOOL`       | `true`/`false`                       |                                                    |
       #   | `INT64`      | `Integer`                            |                                                    |
       #   | `FLOAT64`    | `Float`                              |                                                    |
-      #   | `NUMERIC`    | `BigDecimal`                         | Conversions to NUMERIC will be rounded to scale 9. |
-      #   | `BIGNUMERIC` | `BigDecimal`                         | Conversions must be specified using `types` param. |
+      #   | `NUMERIC`    | `BigDecimal`                         | BigDecimal args will be rounded to scale 9.        |
+      #   | `BIGNUMERIC` | to `BigDecimal`, from `String`       | To avoid rounding BigDecimal args, pass `String`.  |
       #   | `STRING`     | `String`                             |                                                    |
       #   | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.             |
       #   | `DATE`       | `Date`                               |                                                    |

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
@@ -26,15 +26,15 @@ module Google
       ##
       # @private
       #
-      # Internal conversion of raw data values to/from Bigquery values
+      # Internal conversion of raw data values to/from BigQuery values
       #
       #   | BigQuery     | Ruby                                 | Notes                                              |
       #   |--------------|--------------------------------------|----------------------------------------------------|
       #   | `BOOL`       | `true`/`false`                       |                                                    |
       #   | `INT64`      | `Integer`                            |                                                    |
       #   | `FLOAT64`    | `Float`                              |                                                    |
-      #   | `NUMERIC`    | `BigDecimal`                         | BigDecimal args will be rounded to scale 9.        |
-      #   | `BIGNUMERIC` | to `BigDecimal`, from `String`       | To avoid rounding BigDecimal args, pass `String`.  |
+      #   | `NUMERIC`    | `BigDecimal`                         | `BigDecimal` values will be rounded to scale 9.    |
+      #   | `BIGNUMERIC` | converted to `BigDecimal`            | Pass data as `String`; map query params in `types`.|
       #   | `STRING`     | `String`                             |                                                    |
       #   | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.             |
       #   | `DATE`       | `Date`                               |                                                    |

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
@@ -28,20 +28,22 @@ module Google
       #
       # Internal conversion of raw data values to/from Bigquery values
       #
-      # | BigQuery    | Ruby           | Notes  |
-      # |-------------|----------------|---|
-      # | `BOOL`      | `true`/`false` | |
-      # | `INT64`     | `Integer`      | |
-      # | `FLOAT64`   | `Float`        | |
-      # | `NUMERIC`   | `BigDecimal`   | Will be rounded to 9 decimal places |
-      # | `STRING`    | `String`       | |
-      # | `DATETIME`  | `DateTime`  | `DATETIME` does not support time zone. |
-      # | `DATE`      | `Date`         | |
-      # | `TIMESTAMP` | `Time`         | |
-      # | `TIME`      | `Google::Cloud::BigQuery::Time` | |
-      # | `BYTES`     | `File`, `IO`, `StringIO`, or similar | |
-      # | `ARRAY` | `Array` | Nested arrays, `nil` values are not supported. |
-      # | `STRUCT`    | `Hash`        | Hash keys may be strings or symbols. |
+      # | BigQuery     | Ruby                                 | Notes |
+      # |------------- |--------------------------------------|-------|
+      # | `BOOL`       | `true`/`false`                       | |
+      # | `INT64`      | `Integer`                            | |
+      # | `FLOAT64`    | `Float`                              | |
+      # | `NUMERIC`    | `BigDecimal`                         | Up to precision 38, scale 9 |
+      # | `BIGNUMERIC` | `BigDecimal`                         | Up to precision 76+, scale 38 |
+      # | `STRING`     | `String`                             | |
+      # | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone. |
+      # | `DATE`       | `Date`                               | |
+      # | `TIMESTAMP`  | `Time`                               | |
+      # | `TIME`       | `Google::Cloud::BigQuery::Time`      | |
+      # | `BYTES`      | `File`, `IO`, `StringIO`, or similar | |
+      # | `ARRAY`      | `Array`                              | Nested arrays, `nil` values are not supported. |
+      # | `STRUCT`     | `Hash`                               | Hash keys may be strings or symbols. |
+      #
       module Convert
         ##
         # @private

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
@@ -223,7 +223,7 @@ module Google
             value.value
           elsif BigDecimal === value
             if value.finite?
-              # Round to precision of 9 unless explicit BIGNUMERIC
+              # Round to precision of 9 unless explicit `BIGNUMERIC`
               bigdecimal = type == :BIGNUMERIC ? value : value.round(9)
               bigdecimal.to_s "F"
             else

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
@@ -265,12 +265,6 @@ module Google
 
         ##
         # @private
-        def self.to_json_rows rows
-          rows.map { |row| to_json_row row }
-        end
-
-        ##
-        # @private
         def self.to_json_row row
           Hash[row.map { |k, v| [k.to_s, to_json_value(v)] }] # TODO: support type
         end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -1145,8 +1145,8 @@ module Google
         #   | `BOOL`       | `true`/`false`                       |                                                    |
         #   | `INT64`      | `Integer`                            |                                                    |
         #   | `FLOAT64`    | `Float`                              |                                                    |
-        #   | `NUMERIC`    | `BigDecimal`                         | Conversions to NUMERIC will be rounded to scale 9. |
-        #   | `BIGNUMERIC` | `BigDecimal`                         | Conversions must be specified using `types` param. |
+        #   | `NUMERIC`    | `BigDecimal`                         | BigDecimal args will be rounded to scale 9.        |
+        #   | `BIGNUMERIC` | to `BigDecimal`, from `String`       | To avoid rounding BigDecimal args, pass `String`.  |
         #   | `STRING`     | `String`                             |                                                    |
         #   | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.             |
         #   | `DATE`       | `Date`                               |                                                    |
@@ -1488,8 +1488,8 @@ module Google
         #   | `BOOL`       | `true`/`false`                       |                                                    |
         #   | `INT64`      | `Integer`                            |                                                    |
         #   | `FLOAT64`    | `Float`                              |                                                    |
-        #   | `NUMERIC`    | `BigDecimal`                         | Conversions to NUMERIC will be rounded to scale 9. |
-        #   | `BIGNUMERIC` | `BigDecimal`                         | Conversions must be specified using `types` param. |
+        #   | `NUMERIC`    | `BigDecimal`                         | BigDecimal args will be rounded to scale 9.        |
+        #   | `BIGNUMERIC` | to `BigDecimal`, from `String`       | To avoid rounding BigDecimal args, pass `String`.  |
         #   | `STRING`     | `String`                             |                                                    |
         #   | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.             |
         #   | `DATE`       | `Date`                               |                                                    |

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -1140,20 +1140,21 @@ module Google
         #
         #   Ruby types are mapped to BigQuery types as follows:
         #
-        #   | BigQuery    | Ruby                                 | Notes                                          |
-        #   |-------------|--------------------------------------|------------------------------------------------|
-        #   | `BOOL`      | `true`/`false`                       |                                                |
-        #   | `INT64`     | `Integer`                            |                                                |
-        #   | `FLOAT64`   | `Float`                              |                                                |
-        #   | `NUMERIC`   | `BigDecimal`                         | Will be rounded to 9 decimal places            |
-        #   | `STRING`    | `String`                             |                                                |
-        #   | `DATETIME`  | `DateTime`                           | `DATETIME` does not support time zone.         |
-        #   | `DATE`      | `Date`                               |                                                |
-        #   | `TIMESTAMP` | `Time`                               |                                                |
-        #   | `TIME`      | `Google::Cloud::BigQuery::Time`      |                                                |
-        #   | `BYTES`     | `File`, `IO`, `StringIO`, or similar |                                                |
-        #   | `ARRAY`     | `Array`                              | Nested arrays, `nil` values are not supported. |
-        #   | `STRUCT`    | `Hash`                               | Hash keys may be strings or symbols.           |
+        #   | BigQuery     | Ruby                                 | Notes                                          |
+        #   |--------------|--------------------------------------|------------------------------------------------|
+        #   | `BOOL`       | `true`/`false`                       |                                                |
+        #   | `INT64`      | `Integer`                            |                                                |
+        #   | `FLOAT64`    | `Float`                              |                                                |
+        #   | `NUMERIC`    | `BigDecimal`                         | Up to precision 38, scale 9                    |
+        #   | `BIGNUMERIC` | `BigDecimal`                         | Up to precision 76+, scale 38                  |
+        #   | `STRING`     | `String`                             |                                                |
+        #   | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.         |
+        #   | `DATE`       | `Date`                               |                                                |
+        #   | `TIMESTAMP`  | `Time`                               |                                                |
+        #   | `TIME`       | `Google::Cloud::BigQuery::Time`      |                                                |
+        #   | `BYTES`      | `File`, `IO`, `StringIO`, or similar |                                                |
+        #   | `ARRAY`      | `Array`                              | Nested arrays, `nil` values are not supported. |
+        #   | `STRUCT`     | `Hash`                               | Hash keys may be strings or symbols.           |
         #
         #   See [Data Types](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types) for an overview
         #   of each BigQuery data type, including allowed values.
@@ -1169,6 +1170,7 @@ module Google
         #   * `:INT64`
         #   * `:FLOAT64`
         #   * `:NUMERIC`
+        #   * `:BIGNUMERIC`
         #   * `:STRING`
         #   * `:DATETIME`
         #   * `:DATE`
@@ -1481,20 +1483,21 @@ module Google
         #
         #   Ruby types are mapped to BigQuery types as follows:
         #
-        #   | BigQuery    | Ruby                                 | Notes                                          |
-        #   |-------------|--------------------------------------|------------------------------------------------|
-        #   | `BOOL`      | `true`/`false`                       |                                                |
-        #   | `INT64`     | `Integer`                            |                                                |
-        #   | `FLOAT64`   | `Float`                              |                                                |
-        #   | `NUMERIC`   | `BigDecimal`                         | Will be rounded to 9 decimal places            |
-        #   | `STRING`    | `String`                             |                                                |
-        #   | `DATETIME`  | `DateTime`                           | `DATETIME` does not support time zone.         |
-        #   | `DATE`      | `Date`                               |                                                |
-        #   | `TIMESTAMP` | `Time`                               |                                                |
-        #   | `TIME`      | `Google::Cloud::BigQuery::Time`      |                                                |
-        #   | `BYTES`     | `File`, `IO`, `StringIO`, or similar |                                                |
-        #   | `ARRAY`     | `Array`                              | Nested arrays, `nil` values are not supported. |
-        #   | `STRUCT`    | `Hash`                               | Hash keys may be strings or symbols.           |
+        #   | BigQuery     | Ruby                                 | Notes                                          |
+        #   |--------------|--------------------------------------|------------------------------------------------|
+        #   | `BOOL`       | `true`/`false`                       |                                                |
+        #   | `INT64`      | `Integer`                            |                                                |
+        #   | `FLOAT64`    | `Float`                              |                                                |
+        #   | `NUMERIC`    | `BigDecimal`                         | Up to precision 38, scale 9                    |
+        #   | `BIGNUMERIC` | `BigDecimal`                         | Up to precision 76+, scale 38                  |
+        #   | `STRING`     | `String`                             |                                                |
+        #   | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.         |
+        #   | `DATE`       | `Date`                               |                                                |
+        #   | `TIMESTAMP`  | `Time`                               |                                                |
+        #   | `TIME`       | `Google::Cloud::BigQuery::Time`      |                                                |
+        #   | `BYTES`      | `File`, `IO`, `StringIO`, or similar |                                                |
+        #   | `ARRAY`      | `Array`                              | Nested arrays, `nil` values are not supported. |
+        #   | `STRUCT`     | `Hash`                               | Hash keys may be strings or symbols.           |
         #
         #   See [Data Types](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types) for an overview
         #   of each BigQuery data type, including allowed values.
@@ -1510,6 +1513,7 @@ module Google
         #   * `:INT64`
         #   * `:FLOAT64`
         #   * `:NUMERIC`
+        #   * `:BIGNUMERIC`
         #   * `:STRING`
         #   * `:DATETIME`
         #   * `:DATE`

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -1145,8 +1145,8 @@ module Google
         #   | `BOOL`       | `true`/`false`                       |                                                    |
         #   | `INT64`      | `Integer`                            |                                                    |
         #   | `FLOAT64`    | `Float`                              |                                                    |
-        #   | `NUMERIC`    | `BigDecimal`                         | `BigDecimal` args will be rounded to scale 9.      |
-        #   | `BIGNUMERIC` | to `BigDecimal`, from `String`       | To avoid rounding `BigDecimal` args, pass `String`.|
+        #   | `NUMERIC`    | `BigDecimal`                         | `BigDecimal` values will be rounded to scale 9.    |
+        #   | `BIGNUMERIC` |                                      | Query param values must be mapped in `types`.      |
         #   | `STRING`     | `String`                             |                                                    |
         #   | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.             |
         #   | `DATE`       | `Date`                               |                                                    |
@@ -1488,8 +1488,8 @@ module Google
         #   | `BOOL`       | `true`/`false`                       |                                                    |
         #   | `INT64`      | `Integer`                            |                                                    |
         #   | `FLOAT64`    | `Float`                              |                                                    |
-        #   | `NUMERIC`    | `BigDecimal`                         | `BigDecimal` args will be rounded to scale 9.      |
-        #   | `BIGNUMERIC` | to `BigDecimal`, from `String`       | To avoid rounding `BigDecimal` args, pass `String`.|
+        #   | `NUMERIC`    | `BigDecimal`                         | `BigDecimal` values will be rounded to scale 9.    |
+        #   | `BIGNUMERIC` |                                      | Query param values must be mapped in `types`.      |
         #   | `STRING`     | `String`                             |                                                    |
         #   | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.             |
         #   | `DATE`       | `Date`                               |                                                    |

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -1140,21 +1140,21 @@ module Google
         #
         #   Ruby types are mapped to BigQuery types as follows:
         #
-        #   | BigQuery     | Ruby                                 | Notes                                          |
-        #   |--------------|--------------------------------------|------------------------------------------------|
-        #   | `BOOL`       | `true`/`false`                       |                                                |
-        #   | `INT64`      | `Integer`                            |                                                |
-        #   | `FLOAT64`    | `Float`                              |                                                |
-        #   | `NUMERIC`    | `BigDecimal`                         | Up to precision 38, scale 9                    |
-        #   | `BIGNUMERIC` | `BigDecimal`                         | Up to precision 76+, scale 38                  |
-        #   | `STRING`     | `String`                             |                                                |
-        #   | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.         |
-        #   | `DATE`       | `Date`                               |                                                |
-        #   | `TIMESTAMP`  | `Time`                               |                                                |
-        #   | `TIME`       | `Google::Cloud::BigQuery::Time`      |                                                |
-        #   | `BYTES`      | `File`, `IO`, `StringIO`, or similar |                                                |
-        #   | `ARRAY`      | `Array`                              | Nested arrays, `nil` values are not supported. |
-        #   | `STRUCT`     | `Hash`                               | Hash keys may be strings or symbols.           |
+        #   | BigQuery     | Ruby                                 | Notes                                              |
+        #   |--------------|--------------------------------------|----------------------------------------------------|
+        #   | `BOOL`       | `true`/`false`                       |                                                    |
+        #   | `INT64`      | `Integer`                            |                                                    |
+        #   | `FLOAT64`    | `Float`                              |                                                    |
+        #   | `NUMERIC`    | `BigDecimal`                         | Conversions to NUMERIC will be rounded to scale 9. |
+        #   | `BIGNUMERIC` | `BigDecimal`                         | Conversions must be specified using `types` param. |
+        #   | `STRING`     | `String`                             |                                                    |
+        #   | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.             |
+        #   | `DATE`       | `Date`                               |                                                    |
+        #   | `TIMESTAMP`  | `Time`                               |                                                    |
+        #   | `TIME`       | `Google::Cloud::BigQuery::Time`      |                                                    |
+        #   | `BYTES`      | `File`, `IO`, `StringIO`, or similar |                                                    |
+        #   | `ARRAY`      | `Array`                              | Nested arrays, `nil` values are not supported.     |
+        #   | `STRUCT`     | `Hash`                               | Hash keys may be strings or symbols.               |
         #
         #   See [Data Types](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types) for an overview
         #   of each BigQuery data type, including allowed values.
@@ -1483,21 +1483,21 @@ module Google
         #
         #   Ruby types are mapped to BigQuery types as follows:
         #
-        #   | BigQuery     | Ruby                                 | Notes                                          |
-        #   |--------------|--------------------------------------|------------------------------------------------|
-        #   | `BOOL`       | `true`/`false`                       |                                                |
-        #   | `INT64`      | `Integer`                            |                                                |
-        #   | `FLOAT64`    | `Float`                              |                                                |
-        #   | `NUMERIC`    | `BigDecimal`                         | Up to precision 38, scale 9                    |
-        #   | `BIGNUMERIC` | `BigDecimal`                         | Up to precision 76+, scale 38                  |
-        #   | `STRING`     | `String`                             |                                                |
-        #   | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.         |
-        #   | `DATE`       | `Date`                               |                                                |
-        #   | `TIMESTAMP`  | `Time`                               |                                                |
-        #   | `TIME`       | `Google::Cloud::BigQuery::Time`      |                                                |
-        #   | `BYTES`      | `File`, `IO`, `StringIO`, or similar |                                                |
-        #   | `ARRAY`      | `Array`                              | Nested arrays, `nil` values are not supported. |
-        #   | `STRUCT`     | `Hash`                               | Hash keys may be strings or symbols.           |
+        #   | BigQuery     | Ruby                                 | Notes                                              |
+        #   |--------------|--------------------------------------|----------------------------------------------------|
+        #   | `BOOL`       | `true`/`false`                       |                                                    |
+        #   | `INT64`      | `Integer`                            |                                                    |
+        #   | `FLOAT64`    | `Float`                              |                                                    |
+        #   | `NUMERIC`    | `BigDecimal`                         | Conversions to NUMERIC will be rounded to scale 9. |
+        #   | `BIGNUMERIC` | `BigDecimal`                         | Conversions must be specified using `types` param. |
+        #   | `STRING`     | `String`                             |                                                    |
+        #   | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.             |
+        #   | `DATE`       | `Date`                               |                                                    |
+        #   | `TIMESTAMP`  | `Time`                               |                                                    |
+        #   | `TIME`       | `Google::Cloud::BigQuery::Time`      |                                                    |
+        #   | `BYTES`      | `File`, `IO`, `StringIO`, or similar |                                                    |
+        #   | `ARRAY`      | `Array`                              | Nested arrays, `nil` values are not supported.     |
+        #   | `STRUCT`     | `Hash`                               | Hash keys may be strings or symbols.               |
         #
         #   See [Data Types](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types) for an overview
         #   of each BigQuery data type, including allowed values.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -1158,13 +1158,13 @@ module Google
         #
         #   See [Data Types](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types) for an overview
         #   of each BigQuery data type, including allowed values.
-        # @param [Array, Hash] types Standard SQL only. Types of the SQL parameters in `params`. It is not always to
-        #   infer the right SQL type from a value in `params`. In these cases, `types` must be used to specify the SQL
-        #   type for these values.
+        # @param [Array, Hash] types Standard SQL only. Types of the SQL parameters in `params`. It is not always
+        #   possible to infer the right SQL type from a value in `params`. In these cases, `types` must be used to
+        #   specify the SQL type for these values.
         #
-        #   Must match the value type passed to `params`. This must be an `Array` when the query uses positional query
-        #   parameters. This must be an `Hash` when the query uses named query parameters. The values should be BigQuery
-        #   type codes from the following list:
+        #   Arguments must match the value type passed to `params`. This must be an `Array` when the query uses
+        #   positional query parameters. This must be an `Hash` when the query uses named query parameters. The values
+        #   should be BigQuery type codes from the following list:
         #
         #   * `:BOOL`
         #   * `:INT64`
@@ -1501,13 +1501,13 @@ module Google
         #
         #   See [Data Types](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types) for an overview
         #   of each BigQuery data type, including allowed values.
-        # @param [Array, Hash] types Standard SQL only. Types of the SQL parameters in `params`. It is not always to
-        #   infer the right SQL type from a value in `params`. In these cases, `types` must be used to specify the SQL
-        #   type for these values.
+        # @param [Array, Hash] types Standard SQL only. Types of the SQL parameters in `params`. It is not always
+        #   possible to infer the right SQL type from a value in `params`. In these cases, `types` must be used to
+        #   specify the SQL type for these values.
         #
-        #   Must match the value type passed to `params`. This must be an `Array` when the query uses positional query
-        #   parameters. This must be an `Hash` when the query uses named query parameters. The values should be BigQuery
-        #   type codes from the following list:
+        #   Arguments must match the value type passed to `params`. This must be an `Array` when the query uses
+        #   positional query parameters. This must be an `Hash` when the query uses named query parameters. The values
+        #   should be BigQuery type codes from the following list:
         #
         #   * `:BOOL`
         #   * `:INT64`
@@ -2411,6 +2411,21 @@ module Google
         # Inserts data into the given table for near-immediate querying, without
         # the need to complete a load operation before the data can appear in
         # query results.
+        #
+        # Simple Ruby types are generally accepted per JSON rules, along with the following support for BigQuery's more
+        # complex types:
+        #
+        # | BigQuery     | Ruby                                 | Notes                                              |
+        # |--------------|--------------------------------------|----------------------------------------------------|
+        # | `NUMERIC`    | `BigDecimal`                         | `BigDecimal` values will be rounded to scale 9.    |
+        # | `BIGNUMERIC` | `String`                             | Pass as `String` to avoid rounding to scale 9.     |
+        # | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.             |
+        # | `DATE`       | `Date`                               |                                                    |
+        # | `TIMESTAMP`  | `Time`                               |                                                    |
+        # | `TIME`       | `Google::Cloud::BigQuery::Time`      |                                                    |
+        # | `BYTES`      | `File`, `IO`, `StringIO`, or similar |                                                    |
+        # | `ARRAY`      | `Array`                              | Nested arrays, `nil` values are not supported.     |
+        # | `STRUCT`     | `Hash`                               | Hash keys may be strings or symbols.               |
         #
         # Because BigQuery's streaming API is designed for high insertion rates,
         # modifications to the underlying table metadata are eventually

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -1145,8 +1145,8 @@ module Google
         #   | `BOOL`       | `true`/`false`                       |                                                    |
         #   | `INT64`      | `Integer`                            |                                                    |
         #   | `FLOAT64`    | `Float`                              |                                                    |
-        #   | `NUMERIC`    | `BigDecimal`                         | BigDecimal args will be rounded to scale 9.        |
-        #   | `BIGNUMERIC` | to `BigDecimal`, from `String`       | To avoid rounding BigDecimal args, pass `String`.  |
+        #   | `NUMERIC`    | `BigDecimal`                         | `BigDecimal` args will be rounded to scale 9.      |
+        #   | `BIGNUMERIC` | to `BigDecimal`, from `String`       | To avoid rounding `BigDecimal` args, pass `String`.|
         #   | `STRING`     | `String`                             |                                                    |
         #   | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.             |
         #   | `DATE`       | `Date`                               |                                                    |
@@ -1488,8 +1488,8 @@ module Google
         #   | `BOOL`       | `true`/`false`                       |                                                    |
         #   | `INT64`      | `Integer`                            |                                                    |
         #   | `FLOAT64`    | `Float`                              |                                                    |
-        #   | `NUMERIC`    | `BigDecimal`                         | BigDecimal args will be rounded to scale 9.        |
-        #   | `BIGNUMERIC` | to `BigDecimal`, from `String`       | To avoid rounding BigDecimal args, pass `String`.  |
+        #   | `NUMERIC`    | `BigDecimal`                         | `BigDecimal` args will be rounded to scale 9.      |
+        #   | `BIGNUMERIC` | to `BigDecimal`, from `String`       | To avoid rounding `BigDecimal` args, pass `String`.|
         #   | `STRING`     | `String`                             |                                                    |
         #   | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.             |
         #   | `DATE`       | `Date`                               |                                                    |
@@ -2426,10 +2426,10 @@ module Google
         #
         # @param [String] table_id The ID of the destination table.
         # @param [Hash, Array<Hash>] rows A hash object or array of hash objects
-        #   containing the data. Required. BigDecimal values will be rounded to
-        #   scale 9 to conform with the BigQuery NUMERIC data type. To avoid
-        #   rounding BIGNUMERIC type values with scale greater than 9, use String
-        #   instead of BigDecimal.
+        #   containing the data. Required. `BigDecimal` values will be rounded to
+        #   scale 9 to conform with the BigQuery `NUMERIC` data type. To avoid
+        #   rounding `BIGNUMERIC` type values with scale greater than 9, use `String`
+        #   instead of `BigDecimal`.
         # @param [Array<String|Symbol>, Symbol] insert_ids A unique ID for each row. BigQuery uses this property to
         #   detect duplicate insertion requests on a best-effort basis. For more information, see [data
         #   consistency](https://cloud.google.com/bigquery/streaming-data-into-bigquery#dataconsistency). Optional. If
@@ -2496,7 +2496,7 @@ module Google
         #     t.schema.integer "age", mode: :required
         #   end
         #
-        # @example Provide BIGNUMERIC values as a String to avoid rounding to scale 9 in the conversion from BigDecimal:
+        # @example Pass `BIGNUMERIC` value as a string to avoid rounding to scale 9 in the conversion from `BigDecimal`:
         #   require "google/cloud/bigquery"
         #
         #   bigquery = Google::Cloud::Bigquery.new

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -2426,7 +2426,10 @@ module Google
         #
         # @param [String] table_id The ID of the destination table.
         # @param [Hash, Array<Hash>] rows A hash object or array of hash objects
-        #   containing the data. Required.
+        #   containing the data. Required. BigDecimal values will be rounded to
+        #   scale 9 to conform with the BigQuery NUMERIC data type. To avoid
+        #   rounding BIGNUMERIC type values with scale greater than 9, use String
+        #   instead of BigDecimal.
         # @param [Array<String|Symbol>, Symbol] insert_ids A unique ID for each row. BigQuery uses this property to
         #   detect duplicate insertion requests on a best-effort basis. For more information, see [data
         #   consistency](https://cloud.google.com/bigquery/streaming-data-into-bigquery#dataconsistency). Optional. If
@@ -2492,6 +2495,18 @@ module Google
         #     t.schema.string "first_name", mode: :required
         #     t.schema.integer "age", mode: :required
         #   end
+        #
+        # @example Provide BIGNUMERIC values as a String to avoid rounding to scale 9 in the conversion from BigDecimal:
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #
+        #   row = {
+        #     "my_numeric" => BigDecimal("123456798.987654321"),
+        #     "my_bignumeric" => "123456798.98765432100001" # BigDecimal would be rounded, use String instead!
+        #   }
+        #   dataset.insert "my_table", row
         #
         # @!group Data
         #

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
@@ -773,9 +773,18 @@ module Google
           end
 
           ##
-          # Adds a numeric number field to the schema. Numeric is a
-          # fixed-precision numeric type with 38 decimal digits, 9 that follow
-          # the decimal point.
+          # Adds a numeric number field to the schema. `NUMERIC` is a decimal
+          # type with fixed precision and scale. Precision is the number of
+          # digits that the number contains. Scale is how many of these
+          # digits appear after the decimal point. It supports:
+          #
+          # Precision: 38
+          # Scale: 9
+          # Min: -9.9999999999999999999999999999999999999E+28
+          # Max: 9.9999999999999999999999999999999999999E+28
+          #
+          # This type can represent decimal fractions exactly, and is suitable
+          # for financial calculations.
           #
           # See {Schema#numeric}
           #
@@ -800,6 +809,45 @@ module Google
           # @!group Schema
           def numeric name, description: nil, mode: :nullable
             schema.numeric name, description: description, mode: mode
+          end
+
+          ##
+          # Adds a bignumeric number field to the schema. `BIGNUMERIC` is a
+          # decimal type with fixed precision and scale. Precision is the
+          # number of digits that the number contains. Scale is how many of
+          # these digits appear after the decimal point. It supports:
+          #
+          # Precision: 76.76 (the 77th digit is partial)
+          # Scale: 38
+          # Min: -5.7896044618658097711785492504343953926634992332820282019728792003956564819968E+38
+          # Max: 5.7896044618658097711785492504343953926634992332820282019728792003956564819967E+38
+          #
+          # This type can represent decimal fractions exactly, and is suitable
+          # for financial calculations.
+          #
+          # See {Schema#bignumeric}
+          #
+          # @param [String] name The field name. The name must contain only
+          #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+          #   start with a letter or underscore. The maximum length is 128
+          #   characters.
+          # @param [String] description A description of the field.
+          # @param [Symbol] mode The field's mode. The possible values are
+          #   `:nullable`, `:required`, and `:repeated`. The default value is
+          #   `:nullable`.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #   job = dataset.load_job "my_table", "gs://abc/file" do |schema|
+          #     schema.bignumeric "total_cost", mode: :required
+          #   end
+          #
+          # @!group Schema
+          def bignumeric name, description: nil, mode: :nullable
+            schema.bignumeric name, description: description, mode: mode
           end
 
           ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -293,20 +293,21 @@ module Google
         #
         #   Ruby types are mapped to BigQuery types as follows:
         #
-        #   | BigQuery    | Ruby                                 | Notes                                          |
-        #   |-------------|--------------------------------------|------------------------------------------------|
-        #   | `BOOL`      | `true`/`false`                       |                                                |
-        #   | `INT64`     | `Integer`                            |                                                |
-        #   | `FLOAT64`   | `Float`                              |                                                |
-        #   | `NUMERIC`   | `BigDecimal`                         | Will be rounded to 9 decimal places            |
-        #   | `STRING`    | `String`                             |                                                |
-        #   | `DATETIME`  | `DateTime`                           | `DATETIME` does not support time zone.         |
-        #   | `DATE`      | `Date`                               |                                                |
-        #   | `TIMESTAMP` | `Time`                               |                                                |
-        #   | `TIME`      | `Google::Cloud::BigQuery::Time`      |                                                |
-        #   | `BYTES`     | `File`, `IO`, `StringIO`, or similar |                                                |
-        #   | `ARRAY`     | `Array`                              | Nested arrays, `nil` values are not supported. |
-        #   | `STRUCT`    | `Hash`                               | Hash keys may be strings or symbols.           |
+        #   | BigQuery     | Ruby                                 | Notes                                          |
+        #   |--------------|--------------------------------------|------------------------------------------------|
+        #   | `BOOL`       | `true`/`false`                       |                                                |
+        #   | `INT64`      | `Integer`                            |                                                |
+        #   | `FLOAT64`    | `Float`                              |                                                |
+        #   | `NUMERIC`    | `BigDecimal`                         | Up to precision 38, scale 9                    |
+        #   | `BIGNUMERIC` | `BigDecimal`                         | Up to precision 76+, scale 38                  |
+        #   | `STRING`     | `String`                             |                                                |
+        #   | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.         |
+        #   | `DATE`       | `Date`                               |                                                |
+        #   | `TIMESTAMP`  | `Time`                               |                                                |
+        #   | `TIME`       | `Google::Cloud::BigQuery::Time`      |                                                |
+        #   | `BYTES`      | `File`, `IO`, `StringIO`, or similar |                                                |
+        #   | `ARRAY`      | `Array`                              | Nested arrays, `nil` values are not supported. |
+        #   | `STRUCT`     | `Hash`                               | Hash keys may be strings or symbols.           |
         #
         #   See [Data Types](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types) for an overview
         #   of each BigQuery data type, including allowed values.
@@ -322,6 +323,7 @@ module Google
         #   * `:INT64`
         #   * `:FLOAT64`
         #   * `:NUMERIC`
+        #   * `:BIGNUMERIC`
         #   * `:STRING`
         #   * `:DATETIME`
         #   * `:DATE`
@@ -638,20 +640,21 @@ module Google
         #
         #   Ruby types are mapped to BigQuery types as follows:
         #
-        #   | BigQuery    | Ruby                                 | Notes                                          |
-        #   |-------------|--------------------------------------|------------------------------------------------|
-        #   | `BOOL`      | `true`/`false`                       |                                                |
-        #   | `INT64`     | `Integer`                            |                                                |
-        #   | `FLOAT64`   | `Float`                              |                                                |
-        #   | `NUMERIC`   | `BigDecimal`                         | Will be rounded to 9 decimal places            |
-        #   | `STRING`    | `String`                             |                                                |
-        #   | `DATETIME`  | `DateTime`                           | `DATETIME` does not support time zone.         |
-        #   | `DATE`      | `Date`                               |                                                |
-        #   | `TIMESTAMP` | `Time`                               |                                                |
-        #   | `TIME`      | `Google::Cloud::BigQuery::Time`      |                                                |
-        #   | `BYTES`     | `File`, `IO`, `StringIO`, or similar |                                                |
-        #   | `ARRAY`     | `Array`                              | Nested arrays, `nil` values are not supported. |
-        #   | `STRUCT`    | `Hash`                               | Hash keys may be strings or symbols.           |
+        #   | BigQuery     | Ruby                                 | Notes                                          |
+        #   |--------------|--------------------------------------|------------------------------------------------|
+        #   | `BOOL`       | `true`/`false`                       |                                                |
+        #   | `INT64`      | `Integer`                            |                                                |
+        #   | `FLOAT64`    | `Float`                              |                                                |
+        #   | `NUMERIC`    | `BigDecimal`                         | Up to precision 38, scale 9                    |
+        #   | `BIGNUMERIC` | `BigDecimal`                         | Up to precision 76+, scale 38                  |
+        #   | `STRING`     | `String`                             |                                                |
+        #   | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.         |
+        #   | `DATE`       | `Date`                               |                                                |
+        #   | `TIMESTAMP`  | `Time`                               |                                                |
+        #   | `TIME`       | `Google::Cloud::BigQuery::Time`      |                                                |
+        #   | `BYTES`      | `File`, `IO`, `StringIO`, or similar |                                                |
+        #   | `ARRAY`      | `Array`                              | Nested arrays, `nil` values are not supported. |
+        #   | `STRUCT`     | `Hash`                               | Hash keys may be strings or symbols.           |
         #
         #   See [Data Types](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types) for an overview
         #   of each BigQuery data type, including allowed values.
@@ -667,6 +670,7 @@ module Google
         #   * `:INT64`
         #   * `:FLOAT64`
         #   * `:NUMERIC`
+        #   * `:BIGNUMERIC`
         #   * `:STRING`
         #   * `:DATETIME`
         #   * `:DATE`

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -311,13 +311,13 @@ module Google
         #
         #   See [Data Types](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types) for an overview
         #   of each BigQuery data type, including allowed values.
-        # @param [Array, Hash] types Standard SQL only. Types of the SQL parameters in `params`. It is not always to
-        #   infer the right SQL type from a value in `params`. In these cases, `types` must be used to specify the SQL
-        #   type for these values.
+        # @param [Array, Hash] types Standard SQL only. Types of the SQL parameters in `params`. It is not always
+        #   possible to infer the right SQL type from a value in `params`. In these cases, `types` must be used to
+        #   specify the SQL type for these values.
         #
-        #   Must match the value type passed to `params`. This must be an `Array` when the query uses positional query
-        #   parameters. This must be an `Hash` when the query uses named query parameters. The values should be BigQuery
-        #   type codes from the following list:
+        #   Arguments must match the value type passed to `params`. This must be an `Array` when the query uses
+        #   positional query parameters. This must be an `Hash` when the query uses named query parameters. The values
+        #   should be BigQuery type codes from the following list:
         #
         #   * `:BOOL`
         #   * `:INT64`
@@ -658,13 +658,13 @@ module Google
         #
         #   See [Data Types](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types) for an overview
         #   of each BigQuery data type, including allowed values.
-        # @param [Array, Hash] types Standard SQL only. Types of the SQL parameters in `params`. It is not always to
-        #   infer the right SQL type from a value in `params`. In these cases, `types` must be used to specify the SQL
-        #   type for these values.
+        # @param [Array, Hash] types Standard SQL only. Types of the SQL parameters in `params`. It is not always
+        #   possible to infer the right SQL type from a value in `params`. In these cases, `types` must be used to
+        #   specify the SQL type for these values.
         #
-        #   Must match the value type passed to `params`. This must be an `Array` when the query uses positional query
-        #   parameters. This must be an `Hash` when the query uses named query parameters. The values should be BigQuery
-        #   type codes from the following list:
+        #   Arguments must match the value type passed to `params`. This must be an `Array` when the query uses
+        #   positional query parameters. This must be an `Hash` when the query uses named query parameters. The values
+        #   should be BigQuery type codes from the following list:
         #
         #   * `:BOOL`
         #   * `:INT64`

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -298,8 +298,8 @@ module Google
         #   | `BOOL`       | `true`/`false`                       |                                                    |
         #   | `INT64`      | `Integer`                            |                                                    |
         #   | `FLOAT64`    | `Float`                              |                                                    |
-        #   | `NUMERIC`    | `BigDecimal`                         | Conversions to NUMERIC will be rounded to scale 9. |
-        #   | `BIGNUMERIC` | `BigDecimal`                         | Conversions must be specified using `types` param. |
+        #   | `NUMERIC`    | `BigDecimal`                         | BigDecimal args will be rounded to scale 9.        |
+        #   | `BIGNUMERIC` | to `BigDecimal`, from `String`       | To avoid rounding BigDecimal args, pass `String`.  |
         #   | `STRING`     | `String`                             |                                                    |
         #   | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.             |
         #   | `DATE`       | `Date`                               |                                                    |
@@ -645,8 +645,8 @@ module Google
         #   | `BOOL`       | `true`/`false`                       |                                                    |
         #   | `INT64`      | `Integer`                            |                                                    |
         #   | `FLOAT64`    | `Float`                              |                                                    |
-        #   | `NUMERIC`    | `BigDecimal`                         | Conversions to NUMERIC will be rounded to scale 9. |
-        #   | `BIGNUMERIC` | `BigDecimal`                         | Conversions must be specified using `types` param. |
+        #   | `NUMERIC`    | `BigDecimal`                         | BigDecimal args will be rounded to scale 9.        |
+        #   | `BIGNUMERIC` | to `BigDecimal`, from `String`       | To avoid rounding BigDecimal args, pass `String`.  |
         #   | `STRING`     | `String`                             |                                                    |
         #   | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.             |
         #   | `DATE`       | `Date`                               |                                                    |

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -298,8 +298,8 @@ module Google
         #   | `BOOL`       | `true`/`false`                       |                                                    |
         #   | `INT64`      | `Integer`                            |                                                    |
         #   | `FLOAT64`    | `Float`                              |                                                    |
-        #   | `NUMERIC`    | `BigDecimal`                         | BigDecimal args will be rounded to scale 9.        |
-        #   | `BIGNUMERIC` | to `BigDecimal`, from `String`       | To avoid rounding BigDecimal args, pass `String`.  |
+        #   | `NUMERIC`    | `BigDecimal`                         | `BigDecimal` args will be rounded to scale 9.      |
+        #   | `BIGNUMERIC` | to `BigDecimal`, from `String`       | To avoid rounding `BigDecimal` args, pass `String`.|
         #   | `STRING`     | `String`                             |                                                    |
         #   | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.             |
         #   | `DATE`       | `Date`                               |                                                    |
@@ -645,8 +645,8 @@ module Google
         #   | `BOOL`       | `true`/`false`                       |                                                    |
         #   | `INT64`      | `Integer`                            |                                                    |
         #   | `FLOAT64`    | `Float`                              |                                                    |
-        #   | `NUMERIC`    | `BigDecimal`                         | BigDecimal args will be rounded to scale 9.        |
-        #   | `BIGNUMERIC` | to `BigDecimal`, from `String`       | To avoid rounding BigDecimal args, pass `String`.  |
+        #   | `NUMERIC`    | `BigDecimal`                         | `BigDecimal` args will be rounded to scale 9.      |
+        #   | `BIGNUMERIC` | to `BigDecimal`, from `String`       | To avoid rounding `BigDecimal` args, pass `String`.|
         #   | `STRING`     | `String`                             |                                                    |
         #   | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.             |
         #   | `DATE`       | `Date`                               |                                                    |

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -298,8 +298,8 @@ module Google
         #   | `BOOL`       | `true`/`false`                       |                                                    |
         #   | `INT64`      | `Integer`                            |                                                    |
         #   | `FLOAT64`    | `Float`                              |                                                    |
-        #   | `NUMERIC`    | `BigDecimal`                         | `BigDecimal` args will be rounded to scale 9.      |
-        #   | `BIGNUMERIC` | to `BigDecimal`, from `String`       | To avoid rounding `BigDecimal` args, pass `String`.|
+        #   | `NUMERIC`    | `BigDecimal`                         | `BigDecimal` values will be rounded to scale 9.    |
+        #   | `BIGNUMERIC` |                                      | Query param values must be mapped in `types`.      |
         #   | `STRING`     | `String`                             |                                                    |
         #   | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.             |
         #   | `DATE`       | `Date`                               |                                                    |
@@ -645,8 +645,8 @@ module Google
         #   | `BOOL`       | `true`/`false`                       |                                                    |
         #   | `INT64`      | `Integer`                            |                                                    |
         #   | `FLOAT64`    | `Float`                              |                                                    |
-        #   | `NUMERIC`    | `BigDecimal`                         | `BigDecimal` args will be rounded to scale 9.      |
-        #   | `BIGNUMERIC` | to `BigDecimal`, from `String`       | To avoid rounding `BigDecimal` args, pass `String`.|
+        #   | `NUMERIC`    | `BigDecimal`                         | `BigDecimal` values will be rounded to scale 9.    |
+        #   | `BIGNUMERIC` |                                      | Query param values must be mapped in `types`.      |
         #   | `STRING`     | `String`                             |                                                    |
         #   | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.             |
         #   | `DATE`       | `Date`                               |                                                    |

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -293,21 +293,21 @@ module Google
         #
         #   Ruby types are mapped to BigQuery types as follows:
         #
-        #   | BigQuery     | Ruby                                 | Notes                                          |
-        #   |--------------|--------------------------------------|------------------------------------------------|
-        #   | `BOOL`       | `true`/`false`                       |                                                |
-        #   | `INT64`      | `Integer`                            |                                                |
-        #   | `FLOAT64`    | `Float`                              |                                                |
-        #   | `NUMERIC`    | `BigDecimal`                         | Up to precision 38, scale 9                    |
-        #   | `BIGNUMERIC` | `BigDecimal`                         | Up to precision 76+, scale 38                  |
-        #   | `STRING`     | `String`                             |                                                |
-        #   | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.         |
-        #   | `DATE`       | `Date`                               |                                                |
-        #   | `TIMESTAMP`  | `Time`                               |                                                |
-        #   | `TIME`       | `Google::Cloud::BigQuery::Time`      |                                                |
-        #   | `BYTES`      | `File`, `IO`, `StringIO`, or similar |                                                |
-        #   | `ARRAY`      | `Array`                              | Nested arrays, `nil` values are not supported. |
-        #   | `STRUCT`     | `Hash`                               | Hash keys may be strings or symbols.           |
+        #   | BigQuery     | Ruby                                 | Notes                                              |
+        #   |--------------|--------------------------------------|----------------------------------------------------|
+        #   | `BOOL`       | `true`/`false`                       |                                                    |
+        #   | `INT64`      | `Integer`                            |                                                    |
+        #   | `FLOAT64`    | `Float`                              |                                                    |
+        #   | `NUMERIC`    | `BigDecimal`                         | Conversions to NUMERIC will be rounded to scale 9. |
+        #   | `BIGNUMERIC` | `BigDecimal`                         | Conversions must be specified using `types` param. |
+        #   | `STRING`     | `String`                             |                                                    |
+        #   | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.             |
+        #   | `DATE`       | `Date`                               |                                                    |
+        #   | `TIMESTAMP`  | `Time`                               |                                                    |
+        #   | `TIME`       | `Google::Cloud::BigQuery::Time`      |                                                    |
+        #   | `BYTES`      | `File`, `IO`, `StringIO`, or similar |                                                    |
+        #   | `ARRAY`      | `Array`                              | Nested arrays, `nil` values are not supported.     |
+        #   | `STRUCT`     | `Hash`                               | Hash keys may be strings or symbols.               |
         #
         #   See [Data Types](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types) for an overview
         #   of each BigQuery data type, including allowed values.
@@ -640,21 +640,21 @@ module Google
         #
         #   Ruby types are mapped to BigQuery types as follows:
         #
-        #   | BigQuery     | Ruby                                 | Notes                                          |
-        #   |--------------|--------------------------------------|------------------------------------------------|
-        #   | `BOOL`       | `true`/`false`                       |                                                |
-        #   | `INT64`      | `Integer`                            |                                                |
-        #   | `FLOAT64`    | `Float`                              |                                                |
-        #   | `NUMERIC`    | `BigDecimal`                         | Up to precision 38, scale 9                    |
-        #   | `BIGNUMERIC` | `BigDecimal`                         | Up to precision 76+, scale 38                  |
-        #   | `STRING`     | `String`                             |                                                |
-        #   | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.         |
-        #   | `DATE`       | `Date`                               |                                                |
-        #   | `TIMESTAMP`  | `Time`                               |                                                |
-        #   | `TIME`       | `Google::Cloud::BigQuery::Time`      |                                                |
-        #   | `BYTES`      | `File`, `IO`, `StringIO`, or similar |                                                |
-        #   | `ARRAY`      | `Array`                              | Nested arrays, `nil` values are not supported. |
-        #   | `STRUCT`     | `Hash`                               | Hash keys may be strings or symbols.           |
+        #   | BigQuery     | Ruby                                 | Notes                                              |
+        #   |--------------|--------------------------------------|----------------------------------------------------|
+        #   | `BOOL`       | `true`/`false`                       |                                                    |
+        #   | `INT64`      | `Integer`                            |                                                    |
+        #   | `FLOAT64`    | `Float`                              |                                                    |
+        #   | `NUMERIC`    | `BigDecimal`                         | Conversions to NUMERIC will be rounded to scale 9. |
+        #   | `BIGNUMERIC` | `BigDecimal`                         | Conversions must be specified using `types` param. |
+        #   | `STRING`     | `String`                             |                                                    |
+        #   | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.             |
+        #   | `DATE`       | `Date`                               |                                                    |
+        #   | `TIMESTAMP`  | `Time`                               |                                                    |
+        #   | `TIME`       | `Google::Cloud::BigQuery::Time`      |                                                    |
+        #   | `BYTES`      | `File`, `IO`, `StringIO`, or similar |                                                    |
+        #   | `ARRAY`      | `Array`                              | Nested arrays, `nil` values are not supported.     |
+        #   | `STRUCT`     | `Hash`                               | Hash keys may be strings or symbols.               |
         #
         #   See [Data Types](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types) for an overview
         #   of each BigQuery data type, including allowed values.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
@@ -853,20 +853,21 @@ module Google
           #
           #   Ruby types are mapped to BigQuery types as follows:
           #
-          #   | BigQuery    | Ruby                                 | Notes                                          |
-          #   |-------------|--------------------------------------|------------------------------------------------|
-          #   | `BOOL`      | `true`/`false`                       |                                                |
-          #   | `INT64`     | `Integer`                            |                                                |
-          #   | `FLOAT64`   | `Float`                              |                                                |
-          #   | `NUMERIC`   | `BigDecimal`                         | Will be rounded to 9 decimal places            |
-          #   | `STRING`    | `String`                             |                                                |
-          #   | `DATETIME`  | `DateTime`                           | `DATETIME` does not support time zone.         |
-          #   | `DATE`      | `Date`                               |                                                |
-          #   | `TIMESTAMP` | `Time`                               |                                                |
-          #   | `TIME`      | `Google::Cloud::BigQuery::Time`      |                                                |
-          #   | `BYTES`     | `File`, `IO`, `StringIO`, or similar |                                                |
-          #   | `ARRAY`     | `Array`                              | Nested arrays, `nil` values are not supported. |
-          #   | `STRUCT`    | `Hash`                               | Hash keys may be strings or symbols.           |
+          #   | BigQuery     | Ruby                                 | Notes                                          |
+          #   |--------------|--------------------------------------|------------------------------------------------|
+          #   | `BOOL`       | `true`/`false`                       |                                                |
+          #   | `INT64`      | `Integer`                            |                                                |
+          #   | `FLOAT64`    | `Float`                              |                                                |
+          #   | `NUMERIC`    | `BigDecimal`                         | Up to precision 38, scale 9                    |
+          #   | `BIGNUMERIC` | `BigDecimal`                         | Up to precision 76+, scale 38                  |
+          #   | `STRING`     | `String`                             |                                                |
+          #   | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.         |
+          #   | `DATE`       | `Date`                               |                                                |
+          #   | `TIMESTAMP`  | `Time`                               |                                                |
+          #   | `TIME`       | `Google::Cloud::BigQuery::Time`      |                                                |
+          #   | `BYTES`      | `File`, `IO`, `StringIO`, or similar |                                                |
+          #   | `ARRAY`      | `Array`                              | Nested arrays, `nil` values are not supported. |
+          #   | `STRUCT`     | `Hash`                               | Hash keys may be strings or symbols.           |
           #
           #   See [Data Types](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types) for an overview
           #   of each BigQuery data type, including allowed values.
@@ -887,20 +888,21 @@ module Google
           #
           #   Ruby types are mapped to BigQuery types as follows:
           #
-          #   | BigQuery    | Ruby                                 | Notes                                          |
-          #   |-------------|--------------------------------------|------------------------------------------------|
-          #   | `BOOL`      | `true`/`false`                       |                                                |
-          #   | `INT64`     | `Integer`                            |                                                |
-          #   | `FLOAT64`   | `Float`                              |                                                |
-          #   | `NUMERIC`   | `BigDecimal`                         | Will be rounded to 9 decimal places            |
-          #   | `STRING`    | `String`                             |                                                |
-          #   | `DATETIME`  | `DateTime`                           | `DATETIME` does not support time zone.         |
-          #   | `DATE`      | `Date`                               |                                                |
-          #   | `TIMESTAMP` | `Time`                               |                                                |
-          #   | `TIME`      | `Google::Cloud::BigQuery::Time`      |                                                |
-          #   | `BYTES`     | `File`, `IO`, `StringIO`, or similar |                                                |
-          #   | `ARRAY`     | `Array`                              | Nested arrays, `nil` values are not supported. |
-          #   | `STRUCT`    | `Hash`                               | Hash keys may be strings or symbols.           |
+          #   | BigQuery     | Ruby                                 | Notes                                          |
+          #   |--------------|--------------------------------------|------------------------------------------------|
+          #   | `BOOL`       | `true`/`false`                       |                                                |
+          #   | `INT64`      | `Integer`                            |                                                |
+          #   | `FLOAT64`    | `Float`                              |                                                |
+          #   | `NUMERIC`    | `BigDecimal`                         | Up to precision 38, scale 9                    |
+          #   | `BIGNUMERIC` | `BigDecimal`                         | Up to precision 76+, scale 38                  |
+          #   | `STRING`     | `String`                             |                                                |
+          #   | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.         |
+          #   | `DATE`       | `Date`                               |                                                |
+          #   | `TIMESTAMP`  | `Time`                               |                                                |
+          #   | `TIME`       | `Google::Cloud::BigQuery::Time`      |                                                |
+          #   | `BYTES`      | `File`, `IO`, `StringIO`, or similar |                                                |
+          #   | `ARRAY`      | `Array`                              | Nested arrays, `nil` values are not supported. |
+          #   | `STRUCT`     | `Hash`                               | Hash keys may be strings or symbols.           |
           #
           #   See [Data Types](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types) for an overview
           #   of each BigQuery data type, including allowed values.
@@ -916,6 +918,7 @@ module Google
           #   * `:INT64`
           #   * `:FLOAT64`
           #   * `:NUMERIC`
+          #   * `:BIGNUMERIC`
           #   * `:STRING`
           #   * `:DATETIME`
           #   * `:DATE`

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
@@ -858,8 +858,8 @@ module Google
           #   | `BOOL`       | `true`/`false`                       |                                                  |
           #   | `INT64`      | `Integer`                            |                                                  |
           #   | `FLOAT64`    | `Float`                              |                                                  |
-          #   | `NUMERIC`    | `BigDecimal`                         | BigDecimal args will be rounded to scale 9.      |
-          #   | `BIGNUMERIC` | to `BigDecimal`, from `String`       | To avoid rounding BigDecimal args, pass `String`.|
+          #   | `NUMERIC`    | `BigDecimal`                         | `BigDecimal` args will be rounded to scale 9.    |
+          #   | `BIGNUMERIC` | to `BigDecimal`, from `String`       | To avoid rounding `BigDecimal` args, pass string.|
           #   | `STRING`     | `String`                             |                                                  |
           #   | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.           |
           #   | `DATE`       | `Date`                               |                                                  |
@@ -893,8 +893,8 @@ module Google
           #   | `BOOL`       | `true`/`false`                       |                                                  |
           #   | `INT64`      | `Integer`                            |                                                  |
           #   | `FLOAT64`    | `Float`                              |                                                  |
-          #   | `NUMERIC`    | `BigDecimal`                         | BigDecimal args will be rounded to scale 9.      |
-          #   | `BIGNUMERIC` | to `BigDecimal`, from `String`       | To avoid rounding BigDecimal args, pass `String`.|
+          #   | `NUMERIC`    | `BigDecimal`                         | `BigDecimal` args will be rounded to scale 9.    |
+          #   | `BIGNUMERIC` | to `BigDecimal`, from `String`       | To avoid rounding `BigDecimal` args, pass string.|
           #   | `STRING`     | `String`                             |                                                  |
           #   | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.           |
           #   | `DATE`       | `Date`                               |                                                  |

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
@@ -906,13 +906,13 @@ module Google
           #
           #   See [Data Types](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types) for an overview
           #   of each BigQuery data type, including allowed values.
-          # @param [Array, Hash] types Standard SQL only. Types of the SQL parameters in `params`. It is not always to
-          #   infer the right SQL type from a value in `params`. In these cases, `types` must be used to specify the SQL
-          #   type for these values.
+          # @param [Array, Hash] types Standard SQL only. Types of the SQL parameters in `params`. It is not always
+          #   possible to infer the right SQL type from a value in `params`. In these cases, `types` must be used to
+          #   specify the SQL type for these values.
           #
-          #   Must match the value type passed to `params`. This must be an `Array` when the query uses positional query
-          #   parameters. This must be an `Hash` when the query uses named query parameters. The values should be
-          #   BigQuery type codes from the following list:
+          #   Arguments must match the value type passed to `params`. This must be an `Array` when the query uses
+          #   positional query parameters. This must be an `Hash` when the query uses named query parameters. The values
+          #   should be BigQuery type codes from the following list:
           #
           #   * `:BOOL`
           #   * `:INT64`

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
@@ -858,8 +858,8 @@ module Google
           #   | `BOOL`       | `true`/`false`                       |                                                  |
           #   | `INT64`      | `Integer`                            |                                                  |
           #   | `FLOAT64`    | `Float`                              |                                                  |
-          #   | `NUMERIC`    | `BigDecimal`                         | Conversions to NUMERIC rounded to scale 9.       |
-          #   | `BIGNUMERIC` | `BigDecimal`                         | Conversions must be specified via `types` param. |
+          #   | `NUMERIC`    | `BigDecimal`                         | BigDecimal args will be rounded to scale 9.      |
+          #   | `BIGNUMERIC` | to `BigDecimal`, from `String`       | To avoid rounding BigDecimal args, pass `String`.|
           #   | `STRING`     | `String`                             |                                                  |
           #   | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.           |
           #   | `DATE`       | `Date`                               |                                                  |
@@ -893,8 +893,8 @@ module Google
           #   | `BOOL`       | `true`/`false`                       |                                                  |
           #   | `INT64`      | `Integer`                            |                                                  |
           #   | `FLOAT64`    | `Float`                              |                                                  |
-          #   | `NUMERIC`    | `BigDecimal`                         | Conversions to NUMERIC rounded to scale 9.       |
-          #   | `BIGNUMERIC` | `BigDecimal`                         | Conversions must be specified via `types` param. |
+          #   | `NUMERIC`    | `BigDecimal`                         | BigDecimal args will be rounded to scale 9.      |
+          #   | `BIGNUMERIC` | to `BigDecimal`, from `String`       | To avoid rounding BigDecimal args, pass `String`.|
           #   | `STRING`     | `String`                             |                                                  |
           #   | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.           |
           #   | `DATE`       | `Date`                               |                                                  |

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
@@ -853,21 +853,21 @@ module Google
           #
           #   Ruby types are mapped to BigQuery types as follows:
           #
-          #   | BigQuery     | Ruby                                 | Notes                                          |
-          #   |--------------|--------------------------------------|------------------------------------------------|
-          #   | `BOOL`       | `true`/`false`                       |                                                |
-          #   | `INT64`      | `Integer`                            |                                                |
-          #   | `FLOAT64`    | `Float`                              |                                                |
-          #   | `NUMERIC`    | `BigDecimal`                         | Up to precision 38, scale 9                    |
-          #   | `BIGNUMERIC` | `BigDecimal`                         | Up to precision 76+, scale 38                  |
-          #   | `STRING`     | `String`                             |                                                |
-          #   | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.         |
-          #   | `DATE`       | `Date`                               |                                                |
-          #   | `TIMESTAMP`  | `Time`                               |                                                |
-          #   | `TIME`       | `Google::Cloud::BigQuery::Time`      |                                                |
-          #   | `BYTES`      | `File`, `IO`, `StringIO`, or similar |                                                |
-          #   | `ARRAY`      | `Array`                              | Nested arrays, `nil` values are not supported. |
-          #   | `STRUCT`     | `Hash`                               | Hash keys may be strings or symbols.           |
+          #   | BigQuery     | Ruby                                 | Notes                                            |
+          #   |--------------|--------------------------------------|--------------------------------------------------|
+          #   | `BOOL`       | `true`/`false`                       |                                                  |
+          #   | `INT64`      | `Integer`                            |                                                  |
+          #   | `FLOAT64`    | `Float`                              |                                                  |
+          #   | `NUMERIC`    | `BigDecimal`                         | Conversions to NUMERIC rounded to scale 9.       |
+          #   | `BIGNUMERIC` | `BigDecimal`                         | Conversions must be specified via `types` param. |
+          #   | `STRING`     | `String`                             |                                                  |
+          #   | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.           |
+          #   | `DATE`       | `Date`                               |                                                  |
+          #   | `TIMESTAMP`  | `Time`                               |                                                  |
+          #   | `TIME`       | `Google::Cloud::BigQuery::Time`      |                                                  |
+          #   | `BYTES`      | `File`, `IO`, `StringIO`, or similar |                                                  |
+          #   | `ARRAY`      | `Array`                              | Nested arrays, `nil` values are not supported.   |
+          #   | `STRUCT`     | `Hash`                               | Hash keys may be strings or symbols.             |
           #
           #   See [Data Types](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types) for an overview
           #   of each BigQuery data type, including allowed values.
@@ -888,21 +888,21 @@ module Google
           #
           #   Ruby types are mapped to BigQuery types as follows:
           #
-          #   | BigQuery     | Ruby                                 | Notes                                          |
-          #   |--------------|--------------------------------------|------------------------------------------------|
-          #   | `BOOL`       | `true`/`false`                       |                                                |
-          #   | `INT64`      | `Integer`                            |                                                |
-          #   | `FLOAT64`    | `Float`                              |                                                |
-          #   | `NUMERIC`    | `BigDecimal`                         | Up to precision 38, scale 9                    |
-          #   | `BIGNUMERIC` | `BigDecimal`                         | Up to precision 76+, scale 38                  |
-          #   | `STRING`     | `String`                             |                                                |
-          #   | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.         |
-          #   | `DATE`       | `Date`                               |                                                |
-          #   | `TIMESTAMP`  | `Time`                               |                                                |
-          #   | `TIME`       | `Google::Cloud::BigQuery::Time`      |                                                |
-          #   | `BYTES`      | `File`, `IO`, `StringIO`, or similar |                                                |
-          #   | `ARRAY`      | `Array`                              | Nested arrays, `nil` values are not supported. |
-          #   | `STRUCT`     | `Hash`                               | Hash keys may be strings or symbols.           |
+          #   | BigQuery     | Ruby                                 | Notes                                            |
+          #   |--------------|--------------------------------------|--------------------------------------------------|
+          #   | `BOOL`       | `true`/`false`                       |                                                  |
+          #   | `INT64`      | `Integer`                            |                                                  |
+          #   | `FLOAT64`    | `Float`                              |                                                  |
+          #   | `NUMERIC`    | `BigDecimal`                         | Conversions to NUMERIC rounded to scale 9.       |
+          #   | `BIGNUMERIC` | `BigDecimal`                         | Conversions must be specified via `types` param. |
+          #   | `STRING`     | `String`                             |                                                  |
+          #   | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.           |
+          #   | `DATE`       | `Date`                               |                                                  |
+          #   | `TIMESTAMP`  | `Time`                               |                                                  |
+          #   | `TIME`       | `Google::Cloud::BigQuery::Time`      |                                                  |
+          #   | `BYTES`      | `File`, `IO`, `StringIO`, or similar |                                                  |
+          #   | `ARRAY`      | `Array`                              | Nested arrays, `nil` values are not supported.   |
+          #   | `STRUCT`     | `Hash`                               | Hash keys may be strings or symbols.             |
           #
           #   See [Data Types](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types) for an overview
           #   of each BigQuery data type, including allowed values.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
@@ -858,8 +858,8 @@ module Google
           #   | `BOOL`       | `true`/`false`                       |                                                  |
           #   | `INT64`      | `Integer`                            |                                                  |
           #   | `FLOAT64`    | `Float`                              |                                                  |
-          #   | `NUMERIC`    | `BigDecimal`                         | `BigDecimal` args will be rounded to scale 9.    |
-          #   | `BIGNUMERIC` | to `BigDecimal`, from `String`       | To avoid rounding `BigDecimal` args, pass string.|
+          #   | `NUMERIC`    | `BigDecimal`                         | `BigDecimal` values will be rounded to scale 9.  |
+          #   | `BIGNUMERIC` |                                      | Query param values must be mapped in `types`.    |
           #   | `STRING`     | `String`                             |                                                  |
           #   | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.           |
           #   | `DATE`       | `Date`                               |                                                  |
@@ -893,8 +893,8 @@ module Google
           #   | `BOOL`       | `true`/`false`                       |                                                  |
           #   | `INT64`      | `Integer`                            |                                                  |
           #   | `FLOAT64`    | `Float`                              |                                                  |
-          #   | `NUMERIC`    | `BigDecimal`                         | `BigDecimal` args will be rounded to scale 9.    |
-          #   | `BIGNUMERIC` | to `BigDecimal`, from `String`       | To avoid rounding `BigDecimal` args, pass string.|
+          #   | `NUMERIC`    | `BigDecimal`                         | `BigDecimal` values will be rounded to scale 9.  |
+          #   | `BIGNUMERIC` |                                      | Query param values must be mapped in `types`.    |
           #   | `STRING`     | `String`                             |                                                  |
           #   | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.           |
           #   | `DATE`       | `Date`                               |                                                  |

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
@@ -332,9 +332,18 @@ module Google
         end
 
         ##
-        # Adds a numeric number field to the schema. Numeric is a
-        # fixed-precision numeric type with 38 decimal digits, 9 that follow the
-        # decimal point.
+        # Adds a numeric number field to the schema. `NUMERIC` is a decimal
+        # type with fixed precision and scale. Precision is the number of
+        # digits that the number contains. Scale is how many of these
+        # digits appear after the decimal point. It supports:
+        #
+        # Precision: 38
+        # Scale: 9
+        # Min: -9.9999999999999999999999999999999999999E+28
+        # Max: 9.9999999999999999999999999999999999999E+28
+        #
+        # This type can represent decimal fractions exactly, and is suitable
+        # for financial calculations.
         #
         # @param [String] name The field name. The name must contain only
         #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
@@ -347,6 +356,33 @@ module Google
         #
         def numeric name, description: nil, mode: :nullable
           add_field name, :numeric, description: description, mode: mode
+        end
+
+        ##
+        # Adds a bignumeric number field to the schema. `BIGNUMERIC` is a
+        # decimal type with fixed precision and scale. Precision is the
+        # number of digits that the number contains. Scale is how many of
+        # these digits appear after the decimal point. It supports:
+        #
+        # Precision: 76.76 (the 77th digit is partial)
+        # Scale: 38
+        # Min: -5.7896044618658097711785492504343953926634992332820282019728792003956564819968E+38
+        # Max: 5.7896044618658097711785492504343953926634992332820282019728792003956564819967E+38
+        #
+        # This type can represent decimal fractions exactly, and is suitable
+        # for financial calculations.
+        #
+        # @param [String] name The field name. The name must contain only
+        #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+        #   start with a letter or underscore. The maximum length is 128
+        #   characters.
+        # @param [String] description A description of the field.
+        # @param [Symbol] mode The field's mode. The possible values are
+        #   `:nullable`, `:required`, and `:repeated`. The default value is
+        #   `:nullable`.
+        #
+        def bignumeric name, description: nil, mode: :nullable
+          add_field name, :bignumeric, description: description, mode: mode
         end
 
         ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
@@ -404,9 +404,18 @@ module Google
           end
 
           ##
-          # Adds a numeric number field to the schema. Numeric is a
-          # fixed-precision numeric type with 38 decimal digits, 9 that follow
-          # the decimal point.
+          # Adds a numeric number field to the schema. `NUMERIC` is a decimal
+          # type with fixed precision and scale. Precision is the number of
+          # digits that the number contains. Scale is how many of these
+          # digits appear after the decimal point. It supports:
+          #
+          # Precision: 38
+          # Scale: 9
+          # Min: -9.9999999999999999999999999999999999999E+28
+          # Max: 9.9999999999999999999999999999999999999E+28
+          #
+          # This type can represent decimal fractions exactly, and is suitable
+          # for financial calculations.
           #
           # This can only be called on fields that are of type `RECORD`.
           #
@@ -423,6 +432,37 @@ module Google
             record_check!
 
             add_field name, :numeric, description: description, mode: mode
+          end
+
+          ##
+          # Adds a bignumeric number field to the schema. `BIGNUMERIC` is a
+          # decimal type with fixed precision and scale. Precision is the
+          # number of digits that the number contains. Scale is how many of
+          # these digits appear after the decimal point. It supports:
+          #
+          # Precision: 76.76 (the 77th digit is partial)
+          # Scale: 38
+          # Min: -5.7896044618658097711785492504343953926634992332820282019728792003956564819968E+38
+          # Max: 5.7896044618658097711785492504343953926634992332820282019728792003956564819967E+38
+          #
+          # This type can represent decimal fractions exactly, and is suitable
+          # for financial calculations.
+          #
+          # This can only be called on fields that are of type `RECORD`.
+          #
+          # @param [String] name The field name. The name must contain only
+          #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+          #   start with a letter or underscore. The maximum length is 128
+          #   characters.
+          # @param [String] description A description of the field.
+          # @param [Symbol] mode The field's mode. The possible values are
+          #   `:nullable`, `:required`, and `:repeated`. The default value is
+          #   `:nullable`.
+          #
+          def bignumeric name, description: nil, mode: :nullable
+            record_check!
+
+            add_field name, :bignumeric, description: description, mode: mode
           end
 
           ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
@@ -40,8 +40,8 @@ module Google
           MODES = ["NULLABLE", "REQUIRED", "REPEATED"].freeze
 
           # @private
-          TYPES = ["STRING", "INTEGER", "INT64", "FLOAT", "FLOAT64", "NUMERIC", "BOOLEAN", "BOOL", "BYTES", "TIMESTAMP",
-                   "TIME", "DATETIME", "DATE", "RECORD", "STRUCT"].freeze
+          TYPES = ["STRING", "INTEGER", "INT64", "FLOAT", "FLOAT64", "NUMERIC", "BIGNUMERIC", "BOOLEAN", "BOOL",
+                   "BYTES", "TIMESTAMP", "TIME", "DATETIME", "DATE", "RECORD", "STRUCT"].freeze
 
           ##
           # The name of the field.
@@ -72,10 +72,10 @@ module Google
           #
           # @return [String] The field data type. Possible values include
           #   `STRING`, `BYTES`, `INTEGER`, `INT64` (same as `INTEGER`),
-          #   `FLOAT`, `FLOAT64` (same as `FLOAT`), `NUMERIC`, `BOOLEAN`, `BOOL`
-          #   (same as `BOOLEAN`), `TIMESTAMP`, `DATE`, `TIME`, `DATETIME`,
-          #   `RECORD` (where `RECORD` indicates that the field contains a
-          #   nested schema) or `STRUCT` (same as `RECORD`).
+          #   `FLOAT`, `FLOAT64` (same as `FLOAT`), `NUMERIC`, `BIGNUMERIC`,
+          #   `BOOLEAN`, `BOOL` (same as `BOOLEAN`), `TIMESTAMP`, `DATE`,
+          #   `TIME`, `DATETIME`, `RECORD` (where `RECORD` indicates that the
+          #   field contains a nested schema) or `STRUCT` (same as `RECORD`).
           #
           def type
             @gapi.type
@@ -86,10 +86,10 @@ module Google
           #
           # @param [String] new_type The data type. Possible values include
           #   `STRING`, `BYTES`, `INTEGER`, `INT64` (same as `INTEGER`),
-          #   `FLOAT`, `FLOAT64` (same as `FLOAT`), `NUMERIC`, `BOOLEAN`, `BOOL`
-          #   (same as `BOOLEAN`), `TIMESTAMP`, `DATE`, `TIME`, `DATETIME`,
-          #   `RECORD` (where `RECORD` indicates that the field contains a
-          #   nested schema) or `STRUCT` (same as `RECORD`).
+          #   `FLOAT`, `FLOAT64` (same as `FLOAT`), `NUMERIC`, `BIGNUMERIC`,
+          #   `BOOLEAN`, `BOOL` (same as `BOOLEAN`), `TIMESTAMP`, `DATE`,
+          #   `TIME`, `DATETIME`, `RECORD` (where `RECORD` indicates that the
+          #   field contains a nested schema) or `STRUCT` (same as `RECORD`).
           #
           def type= new_type
             @gapi.update! type: verify_type(new_type)
@@ -200,6 +200,15 @@ module Google
           end
 
           ##
+          # Checks if the type of the field is `BIGNUMERIC`.
+          #
+          # @return [Boolean] `true` when `BIGNUMERIC`, `false` otherwise.
+          #
+          def bignumeric?
+            type == "BIGNUMERIC"
+          end
+
+          ##
           # Checks if the type of the field is `BOOLEAN`.
           #
           # @return [Boolean] `true` when `BOOLEAN`, `false` otherwise.
@@ -299,6 +308,7 @@ module Google
           # * `:INT64`
           # * `:FLOAT64`
           # * `:NUMERIC`
+          # * `:BIGNUMERIC`
           # * `:STRING`
           # * `:DATETIME`
           # * `:DATE`

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/standard_sql.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/standard_sql.rb
@@ -274,6 +274,17 @@ module Google
           end
 
           ##
+          # Checks if the {#type_kind} of the field is `BIGNUMERIC`.
+          #
+          # @return [Boolean] `true` when `BIGNUMERIC`, `false` otherwise.
+          #
+          # @!group Helpers
+          #
+          def bignumeric?
+            type_kind == "BIGNUMERIC".freeze
+          end
+
+          ##
           # Checks if the {#type_kind} of the field is `BOOL`.
           #
           # @return [Boolean] `true` when `BOOL`, `false` otherwise.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -2318,10 +2318,10 @@ module Google
         #   BigQuery Troubleshooting: Metadata errors for streaming inserts
         #
         # @param [Hash, Array<Hash>] rows A hash object or array of hash objects
-        #   containing the data. Required. BigDecimal values will be rounded to
-        #   scale 9 to conform with the BigQuery NUMERIC data type. To avoid
-        #   rounding BIGNUMERIC type values with scale greater than 9, use String
-        #   instead of BigDecimal.
+        #   containing the data. Required. `BigDecimal` values will be rounded to
+        #   scale 9 to conform with the BigQuery `NUMERIC` data type. To avoid
+        #   rounding `BIGNUMERIC` type values with scale greater than 9, use `String`
+        #   instead of `BigDecimal`.
         # @param [Array<String|Symbol>, Symbol] insert_ids A unique ID for each row. BigQuery uses this property to
         #   detect duplicate insertion requests on a best-effort basis. For more information, see [data
         #   consistency](https://cloud.google.com/bigquery/streaming-data-into-bigquery#dataconsistency). Optional. If
@@ -2364,7 +2364,7 @@ module Google
         #   ]
         #   table.insert rows
         #
-        # @example Provide BIGNUMERIC values as a String to avoid rounding to scale 9 in the conversion from BigDecimal:
+        # @example Pass `BIGNUMERIC` value as a string to avoid rounding to scale 9 in the conversion from `BigDecimal`:
         #   require "google/cloud/bigquery"
         #
         #   bigquery = Google::Cloud::Bigquery.new

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -2305,6 +2305,21 @@ module Google
         # need to complete a load operation before the data can appear in query
         # results.
         #
+        # Simple Ruby types are generally accepted per JSON rules, along with the following support for BigQuery's more
+        # complex types:
+        #
+        # | BigQuery     | Ruby                                 | Notes                                              |
+        # |--------------|--------------------------------------|----------------------------------------------------|
+        # | `NUMERIC`    | `BigDecimal`                         | `BigDecimal` values will be rounded to scale 9.    |
+        # | `BIGNUMERIC` | `String`                             | Pass as `String` to avoid rounding to scale 9.     |
+        # | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.             |
+        # | `DATE`       | `Date`                               |                                                    |
+        # | `TIMESTAMP`  | `Time`                               |                                                    |
+        # | `TIME`       | `Google::Cloud::BigQuery::Time`      |                                                    |
+        # | `BYTES`      | `File`, `IO`, `StringIO`, or similar |                                                    |
+        # | `ARRAY`      | `Array`                              | Nested arrays, `nil` values are not supported.     |
+        # | `STRUCT`     | `Hash`                               | Hash keys may be strings or symbols.               |
+        #
         # Because BigQuery's streaming API is designed for high insertion rates,
         # modifications to the underlying table metadata are eventually
         # consistent when interacting with the streaming system. In most cases

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -3229,9 +3229,18 @@ module Google
           end
 
           ##
-          # Adds a numeric number field to the schema. Numeric is a
-          # fixed-precision numeric type with 38 decimal digits, 9 that follow
-          # the decimal point.
+          # Adds a numeric number field to the schema. `NUMERIC` is a decimal
+          # type with fixed precision and scale. Precision is the number of
+          # digits that the number contains. Scale is how many of these
+          # digits appear after the decimal point. It supports:
+          #
+          # Precision: 38
+          # Scale: 9
+          # Min: -9.9999999999999999999999999999999999999E+28
+          # Max: 9.9999999999999999999999999999999999999E+28
+          #
+          # This type can represent decimal fractions exactly, and is suitable
+          # for financial calculations.
           #
           # See {Schema#numeric}
           #
@@ -3256,6 +3265,45 @@ module Google
           # @!group Schema
           def numeric name, description: nil, mode: :nullable
             schema.numeric name, description: description, mode: mode
+          end
+
+          ##
+          # Adds a bignumeric number field to the schema. `BIGNUMERIC` is a
+          # decimal type with fixed precision and scale. Precision is the
+          # number of digits that the number contains. Scale is how many of
+          # these digits appear after the decimal point. It supports:
+          #
+          # Precision: 76.76 (the 77th digit is partial)
+          # Scale: 38
+          # Min: -5.7896044618658097711785492504343953926634992332820282019728792003956564819968E+38
+          # Max: 5.7896044618658097711785492504343953926634992332820282019728792003956564819967E+38
+          #
+          # This type can represent decimal fractions exactly, and is suitable
+          # for financial calculations.
+          #
+          # See {Schema#bignumeric}
+          #
+          # @param [String] name The field name. The name must contain only
+          #   letters (a-z, A-Z), numbers (0-9), or underscores (_), and must
+          #   start with a letter or underscore. The maximum length is 128
+          #   characters.
+          # @param [String] description A description of the field.
+          # @param [Symbol] mode The field's mode. The possible values are
+          #   `:nullable`, `:required`, and `:repeated`. The default value is
+          #   `:nullable`.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #   table = dataset.create_table "my_table" do |schema|
+          #     schema.bignumeric "total_cost", mode: :required
+          #   end
+          #
+          # @!group Schema
+          def bignumeric name, description: nil, mode: :nullable
+            schema.bignumeric name, description: description, mode: mode
           end
 
           ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -2318,7 +2318,10 @@ module Google
         #   BigQuery Troubleshooting: Metadata errors for streaming inserts
         #
         # @param [Hash, Array<Hash>] rows A hash object or array of hash objects
-        #   containing the data. Required.
+        #   containing the data. Required. BigDecimal values will be rounded to
+        #   scale 9 to conform with the BigQuery NUMERIC data type. To avoid
+        #   rounding BIGNUMERIC type values with scale greater than 9, use String
+        #   instead of BigDecimal.
         # @param [Array<String|Symbol>, Symbol] insert_ids A unique ID for each row. BigQuery uses this property to
         #   detect duplicate insertion requests on a best-effort basis. For more information, see [data
         #   consistency](https://cloud.google.com/bigquery/streaming-data-into-bigquery#dataconsistency). Optional. If
@@ -2360,6 +2363,19 @@ module Google
         #     { "first_name" => "Bob", "age" => 22 }
         #   ]
         #   table.insert rows
+        #
+        # @example Provide BIGNUMERIC values as a String to avoid rounding to scale 9 in the conversion from BigDecimal:
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #   table = dataset.table "my_table"
+        #
+        #   row = {
+        #     "my_numeric" => BigDecimal("123456798.987654321"),
+        #     "my_bignumeric" => "123456798.98765432100001" # BigDecimal would be rounded, use String instead!
+        #   }
+        #   table.insert row
         #
         # @!group Data
         #

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table/async_inserter.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table/async_inserter.rb
@@ -115,7 +115,10 @@ module Google
           #   BigQuery Troubleshooting: Metadata errors for streaming inserts
           #
           # @param [Hash, Array<Hash>] rows A hash object or array of hash
-          #   objects containing the data.
+          #   objects containing the data. BigDecimal values will be rounded to
+          #   scale 9 to conform with the BigQuery NUMERIC data type. To avoid
+          #   rounding BIGNUMERIC type values with scale greater than 9, use String
+          #   instead of BigDecimal.
           # @param [Array<String|Symbol>, Symbol] insert_ids A unique ID for each row. BigQuery uses this property to
           #   detect duplicate insertion requests on a best-effort basis. For more information, see [data
           #   consistency](https://cloud.google.com/bigquery/streaming-data-into-bigquery#dataconsistency). Optional. If

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table/async_inserter.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table/async_inserter.rb
@@ -114,11 +114,11 @@ module Google
           # @see https://cloud.google.com/bigquery/troubleshooting-errors#metadata-errors-for-streaming-inserts
           #   BigQuery Troubleshooting: Metadata errors for streaming inserts
           #
-          # @param [Hash, Array<Hash>] rows A hash object or array of hash
-          #   objects containing the data. BigDecimal values will be rounded to
-          #   scale 9 to conform with the BigQuery NUMERIC data type. To avoid
-          #   rounding BIGNUMERIC type values with scale greater than 9, use String
-          #   instead of BigDecimal.
+          # @param [Hash, Array<Hash>] rows A hash object or array of hash objects
+          #   containing the data. Required. `BigDecimal` values will be rounded to
+          #   scale 9 to conform with the BigQuery `NUMERIC` data type. To avoid
+          #   rounding `BIGNUMERIC` type values with scale greater than 9, use `String`
+          #   instead of `BigDecimal`.
           # @param [Array<String|Symbol>, Symbol] insert_ids A unique ID for each row. BigQuery uses this property to
           #   detect duplicate insertion requests on a best-effort basis. For more information, see [data
           #   consistency](https://cloud.google.com/bigquery/streaming-data-into-bigquery#dataconsistency). Optional. If

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table/async_inserter.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table/async_inserter.rb
@@ -101,6 +101,21 @@ module Google
           # collected in batches and inserted together.
           # See {Google::Cloud::Bigquery::Table#insert_async}.
           #
+          # Simple Ruby types are generally accepted per JSON rules, along with the following support for BigQuery's
+          # more complex types:
+          #
+          # | BigQuery     | Ruby                                 | Notes                                              |
+          # |--------------|--------------------------------------|----------------------------------------------------|
+          # | `NUMERIC`    | `BigDecimal`                         | `BigDecimal` values will be rounded to scale 9.    |
+          # | `BIGNUMERIC` | `String`                             | Pass as `String` to avoid rounding to scale 9.     |
+          # | `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.             |
+          # | `DATE`       | `Date`                               |                                                    |
+          # | `TIMESTAMP`  | `Time`                               |                                                    |
+          # | `TIME`       | `Google::Cloud::BigQuery::Time`      |                                                    |
+          # | `BYTES`      | `File`, `IO`, `StringIO`, or similar |                                                    |
+          # | `ARRAY`      | `Array`                              | Nested arrays, `nil` values are not supported.     |
+          # | `STRUCT`     | `Hash`                               | Hash keys may be strings or symbols.               |
+          #
           # Because BigQuery's streaming API is designed for high insertion
           # rates, modifications to the underlying table metadata are eventually
           # consistent when interacting with the streaming system. In most cases

--- a/google-cloud-bigquery/test/google/cloud/bigquery/convert_to_query_param_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/convert_to_query_param_test.rb
@@ -191,6 +191,50 @@ describe Google::Cloud::Bigquery::Convert, :to_query_param do
     end
   end
 
+  describe :BIGNUMERIC do
+    it "allows BigDecimal when using type" do
+      expected = Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "BIGNUMERIC"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "123456798.98765432100001"
+        )
+      )
+
+      actual = Google::Cloud::Bigquery::Convert.to_query_param BigDecimal("123456798.98765432100001"), :BIGNUMERIC
+      assert_equal expected.to_h, actual.to_h
+    end
+
+    it "allows string when using type" do
+      expected = Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "BIGNUMERIC"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "123456798.98765432100001"
+        )
+      )
+
+      actual = Google::Cloud::Bigquery::Convert.to_query_param "123456798.98765432100001", :BIGNUMERIC
+      assert_equal expected.to_h, actual.to_h
+    end
+
+    it "allows nil when using type" do
+      expected = Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "BIGNUMERIC"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: nil
+        )
+      )
+
+      actual = Google::Cloud::Bigquery::Convert.to_query_param nil, :BIGNUMERIC
+      assert_equal expected.to_h, actual.to_h
+    end
+  end
+
   describe :STRING do
     it "identifies by value" do
       expected = Google::Apis::BigqueryV2::QueryParameter.new(

--- a/google-cloud-bigquery/test/google/cloud/bigquery/data_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/data_test.rb
@@ -111,8 +111,8 @@ describe Google::Cloud::Bigquery::Data, :mock_bigquery do
     _(data.schema).must_be_kind_of Google::Cloud::Bigquery::Schema
     _(data.schema).must_be :frozen?
     _(data.fields).must_equal data.schema.fields
-    _(data.headers).must_equal [:name, :age, :score, :pi, :active, :avatar, :started_at, :duration, :target_end, :birthday]
-    _(data.param_types).must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
+    _(data.headers).must_equal [:name, :age, :score, :pi, :my_bignumeric, :active, :avatar, :started_at, :duration, :target_end, :birthday]
+    _(data.param_types).must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, my_bignumeric: :BIGNUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
   end
 
   it "handles missing rows and fields" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_insert_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_insert_test.rb
@@ -216,20 +216,22 @@ describe Google::Cloud::Bigquery::Dataset, :insert, :mock_bigquery do
   end
 
   it "properly formats values when inserting" do
+    string_numeric = "123456798.987654321"
+    string_bignumeric = "123456798.98765432100001"
     inserting_row = {
       id: 2,
       name: "Gandalf",
       age: 1000,
       weight: 198.6,
       is_magic: true,
-      scores: [100.0, 99.0, 0.001],
+      scores: [100.0, BigDecimal(string_numeric), string_bignumeric], # BigDecimal BIGNUMERIC would be rounded!
       spells: [
         { name: "Skydragon",
           discovered_by: "Firebreather",
           properties: [
             { name: "Flying", power: 1.0 },
-            { name: "Creature", power: 1.0 },
-            { name: "Explodey", power: 11.0 }
+            { name: "Creature", power: BigDecimal(string_numeric) },
+            { name: "Explodey", power: string_bignumeric } # BigDecimal would be rounded, use String instead!
           ],
           icon: File.open("acceptance/data/kitten-test-data.json", "rb"),
           last_used: Time.parse("2015-10-31 23:59:56 UTC")
@@ -237,11 +239,49 @@ describe Google::Cloud::Bigquery::Dataset, :insert, :mock_bigquery do
       ],
       tea_time: Google::Cloud::Bigquery::Time.new("15:00:00"),
       next_vacation: Date.parse("2666-06-06"),
-      favorite_time: Time.parse("2001-12-19T23:59:59 UTC").utc.to_datetime
+      favorite_time: Time.parse("2001-12-19T23:59:59 UTC").utc.to_datetime,
+      my_numeric: BigDecimal(string_numeric),
+      my_bignumeric: string_bignumeric, # BigDecimal would be rounded, use String instead!
+      my_rounded_bignumeric: BigDecimal(string_bignumeric)
     }
     inserted_row_hash = {
       insertId: insert_id,
-      json: {"id"=>2, "name"=>"Gandalf", "age"=>1000, "weight"=>198.6, "is_magic"=>true, "scores"=>[100.0, 99.0, 0.001], "spells"=>[{"name"=>"Skydragon", "discovered_by"=>"Firebreather", "properties"=>[{"name"=>"Flying", "power"=>1.0}, {"name"=>"Creature", "power"=>1.0}, {"name"=>"Explodey", "power"=>11.0}], "icon"=> Google::Cloud::Bigquery::Convert.to_json_value(File.open("acceptance/data/kitten-test-data.json", "rb")), "last_used"=>"2015-10-31 23:59:56.000000+00:00"}], "tea_time"=>"15:00:00", "next_vacation"=>"2666-06-06", "favorite_time"=>"2001-12-19 23:59:59.000000"}
+      json: {
+        "id"=>2,
+        "name"=>"Gandalf",
+        "age"=>1000,
+        "weight"=>198.6,
+        "is_magic"=>true,
+        "scores"=>[100.0, string_numeric, string_bignumeric],
+        "spells"=>[
+          {
+            "name"=>"Skydragon",
+            "discovered_by"=>"Firebreather",
+            "properties"=>[
+              {
+                "name"=>"Flying",
+                "power"=>1.0
+              },
+              {
+                "name"=>"Creature",
+                "power"=>string_numeric
+              },
+              {
+                "name"=>"Explodey",
+                "power"=>string_bignumeric
+              }
+            ],
+            "icon"=>Google::Cloud::Bigquery::Convert.to_json_value(File.open("acceptance/data/kitten-test-data.json", "rb")),
+            "last_used"=>"2015-10-31 23:59:56.000000+00:00"
+          }
+        ],
+        "tea_time"=>"15:00:00",
+        "next_vacation"=>"2666-06-06",
+        "favorite_time"=>"2001-12-19 23:59:59.000000",
+        "my_numeric"=>string_numeric,
+        "my_bignumeric"=>string_bignumeric,
+        "my_rounded_bignumeric"=>string_numeric
+      }
     }
     mock = Minitest::Mock.new
     insert_req = {

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_schema_test.rb
@@ -42,6 +42,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :schema, :mock_bigquery do
         { mode: "NULLABLE", name: "age", type: "INTEGER", description: nil, fields: [] },
         { mode: "NULLABLE", name: "score", type: "FLOAT", description: "A score from 0.0 to 10.0", fields: [] },
         { mode: "NULLABLE", name: "price", type: "NUMERIC", description: nil, fields: [] },
+        { mode: "NULLABLE", name: "my_bignumeric", type: "BIGNUMERIC", description: nil, fields: [] },
         { mode: "NULLABLE", name: "active", type: "BOOLEAN", description: nil, fields: [] },
         { mode: "NULLABLE", name: "avatar", type: "BYTES", description: nil, fields: [] },
         { mode: "REQUIRED", name: "dob", type: "TIMESTAMP", description: nil, fields: [] }
@@ -100,6 +101,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :schema, :mock_bigquery do
       job.schema.integer "age"
       job.schema.float "score", description: "A score from 0.0 to 10.0"
       job.schema.numeric "price"
+      job.schema.bignumeric "my_bignumeric"
       job.schema.boolean "active"
       job.schema.bytes "avatar"
       job.schema.timestamp "dob", mode: :required
@@ -148,6 +150,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :schema, :mock_bigquery do
       job.schema.integer "age"
       job.schema.float "score", description: "A score from 0.0 to 10.0"
       job.schema.numeric "price"
+      job.schema.bignumeric "my_bignumeric"
       job.schema.boolean "active"
       job.schema.bytes "avatar"
       job.schema.timestamp "dob", mode: :required
@@ -191,6 +194,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :schema, :mock_bigquery do
     schema.integer "age"
     schema.float "score", description: "A score from 0.0 to 10.0"
     schema.numeric "price"
+    schema.bignumeric "my_bignumeric"
     schema.boolean "active"
     schema.bytes "avatar"
     schema.timestamp "dob", mode: :required
@@ -234,6 +238,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :schema, :mock_bigquery do
     job = dataset.load_job table_id, load_file, create: :needed, schema: schema do |schema|
       schema.float "score", description: "A score from 0.0 to 10.0"
       schema.numeric "price"
+      schema.bignumeric "my_bignumeric"
       schema.boolean "active"
       schema.bytes "avatar"
       schema.timestamp "dob", mode: :required

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_named_params_test.rb
@@ -446,7 +446,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
     _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
-  it "queries the data with an array parameter" do
+  it "queries the data with an array of string values parameter" do
     query_job_gapi.configuration.query.query = "#{query} WHERE name IN @names"
     query_job_gapi.configuration.query.query_parameters = [
       Google::Apis::BigqueryV2::QueryParameter.new(
@@ -472,6 +472,42 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
     mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
 
     job = dataset.query_job "#{query} WHERE name IN @names", params: { names: %w{name1 name2 name3} }
+    mock.verify
+
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
+  it "queries the data with an array of bignumeric values parameter" do
+    param_1 = BigDecimal("123456789.1234567891")
+    param_2 = BigDecimal("123456789.1234567892")
+    param_3 = BigDecimal("123456789.1234567893")
+    query_job_gapi.configuration.query.query = "#{query} WHERE my_bignumeric IN @my_params"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "my_params",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "ARRAY",
+          array_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+            type: "BIGNUMERIC"
+          )
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          array_values: [
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "123456789.1234567891"),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "123456789.1234567892"),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "123456789.1234567893")
+          ]
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = dataset.query_job "#{query} WHERE my_bignumeric IN @my_params",
+                            params: { my_params: [param_1, param_2, param_3] },
+                            types: { my_params: [:BIGNUMERIC] }
     mock.verify
 
     _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_named_params_test.rb
@@ -125,6 +125,32 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
     _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
+  it "queries the data with a bignumeric parameter and types option" do
+    query_job_gapi.configuration.query.query = "#{query} WHERE my_bignumeric = @my_bignumeric"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "my_bignumeric",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "BIGNUMERIC"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "123456798.98765432100001"
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = dataset.query_job "#{query} WHERE my_bignumeric = @my_bignumeric",
+                            params: { my_bignumeric: BigDecimal("123456798.98765432100001") },
+                            types: { my_bignumeric: :BIGNUMERIC }
+    mock.verify
+
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
   it "queries the data with a true parameter" do
     query_job_gapi.configuration.query.query = "#{query} WHERE active = @active"
     query_job_gapi.configuration.query.query_parameters = [

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_named_params_test.rb
@@ -77,6 +77,30 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
     _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
+  it "queries the data with an integer parameter with types option" do
+    query_job_gapi.configuration.query.query = "#{query} WHERE age > @age"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "age",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "INT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "35"
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = dataset.query_job "#{query} WHERE age > @age", params: { age: "35" }, types: { age: :INT64 }
+    mock.verify
+
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
   it "queries the data with a float parameter" do
     query_job_gapi.configuration.query.query = "#{query} WHERE score > @score"
     query_job_gapi.configuration.query.query_parameters = [
@@ -513,6 +537,37 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
     _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
+  it "queries the data with an array parameter with types option" do
+    query_job_gapi.configuration.query.query = "#{query} WHERE age IN @ages"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "ages",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "ARRAY",
+          array_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+            type: "INT64"
+          )
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          array_values: [
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "1"),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "2"),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "3")
+          ]
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = dataset.query_job "#{query} WHERE age IN @ages", params: { ages: ["1", "2", "3"] }, types: { ages: [:INT64] }
+    mock.verify
+
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
   it "queries the data with a struct parameter" do
     query_job_gapi.configuration.query.query = "#{query} WHERE meta = @meta"
     query_job_gapi.configuration.query.query_parameters = [
@@ -551,6 +606,37 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :named_params, :mock_bigq
     mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
 
     job = dataset.query_job "#{query} WHERE meta = @meta", params: { meta: { name: "Testy McTesterson", age: 42, active: false, score: 98.7 } }
+    mock.verify
+
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
+  it "queries the data with a struct parameter with types option" do
+    query_job_gapi.configuration.query.query = "#{query} WHERE meta = @meta"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "meta",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "STRUCT",
+          struct_types: [
+            Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
+              name: "age",
+              type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "INT64"))
+          ]
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          struct_values: {
+            "age"    => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "42")
+          }
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = dataset.query_job "#{query} WHERE meta = @meta", params: { meta: { age: "42" } }, types: { meta: { age: :INT64 } }
     mock.verify
 
     _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_positional_params_test.rb
@@ -121,6 +121,31 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
     _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
+  it "queries the data with a bignumeric parameter and types option" do
+    query_job_gapi.configuration.query.query = "#{query} WHERE my_bignumeric = ?"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "BIGNUMERIC"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "123456798.98765432100001"
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = dataset.query_job "#{query} WHERE my_bignumeric = ?",
+                            params: [BigDecimal("123456798.98765432100001")],
+                            types: [:BIGNUMERIC]
+    mock.verify
+
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
   it "queries the data with a true parameter" do
     query_job_gapi.configuration.query.query = "#{query} WHERE active = ?"
     query_job_gapi.configuration.query.query_parameters = [

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_positional_params_test.rb
@@ -421,7 +421,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
     _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
-  it "queries the data with an array parameter" do
+  it "queries the data with an array of string values parameter" do
     query_job_gapi.configuration.query.query = "#{query} WHERE name IN ?"
     query_job_gapi.configuration.query.query_parameters = [
       Google::Apis::BigqueryV2::QueryParameter.new(
@@ -446,6 +446,39 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
     mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
 
     job = dataset.query_job "#{query} WHERE name IN ?", params: [%w{name1 name2 name3}]
+    mock.verify
+
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
+  it "queries the data with an array of bignumeric values parameter" do
+    param_1 = BigDecimal("123456789.1234567891")
+    param_2 = BigDecimal("123456789.1234567892")
+    param_3 = BigDecimal("123456789.1234567893")
+    query_job_gapi.configuration.query.query = "#{query} WHERE my_bignumeric IN ?"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "ARRAY",
+          array_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+            type: "BIGNUMERIC"
+          )
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          array_values: [
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "123456789.1234567891"),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "123456789.1234567892"),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "123456789.1234567893")
+          ]
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = dataset.query_job "#{query} WHERE my_bignumeric IN ?", params: [[param_1, param_2, param_3]], types: [[:BIGNUMERIC]]
     mock.verify
 
     _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_positional_params_test.rb
@@ -75,6 +75,29 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
     _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
+  it "queries the data with an integer parameter with types option" do
+    query_job_gapi.configuration.query.query = "#{query} WHERE age > ?"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "INT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "35"
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = dataset.query_job "#{query} WHERE age > ?", params: ["35"], types: [:INT64]
+    mock.verify
+
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
   it "queries the data with a float parameter" do
     query_job_gapi.configuration.query.query = "#{query} WHERE score > ?"
     query_job_gapi.configuration.query.query_parameters = [
@@ -484,6 +507,36 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
     _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
+  it "queries the data with an array parameter with types option" do
+    query_job_gapi.configuration.query.query = "#{query} WHERE age IN ?"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "ARRAY",
+          array_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+            type: "INT64"
+          )
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          array_values: [
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "1"),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "2"),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "3")
+          ]
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = dataset.query_job "#{query} WHERE age IN ?", params: [["1","2","3"]], types: [[:INT64]]
+    mock.verify
+
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
   it "queries the data with a struct parameter" do
     query_job_gapi.configuration.query.query = "#{query} WHERE meta = ?"
     query_job_gapi.configuration.query.query_parameters = [
@@ -521,6 +574,36 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :positional_params, :mock
     mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
 
     job = dataset.query_job "#{query} WHERE meta = ?", params: [{name: "Testy McTesterson", age: 42, active: false, score: 98.7}]
+    mock.verify
+
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
+  it "queries the data with a struct parameter with types option" do
+    query_job_gapi.configuration.query.query = "#{query} WHERE meta = ?"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "STRUCT",
+          struct_types: [
+            Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
+              name: "age",
+              type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "INT64"))
+          ]
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          struct_values: {
+            "age"    => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "42")
+          }
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = dataset.query_job "#{query} WHERE meta = ?", params: [{ age: "42" }], types: [{ age: :INT64 }]
     mock.verify
 
     _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_named_params_test.rb
@@ -151,6 +151,40 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
     assert_valid_data data
   end
 
+  it "queries the data with a bignumeric parameter and types option" do
+    job_gapi = query_job_gapi "#{query} WHERE my_bignumeric = @my_bignumeric", parameter_mode: "NAMED", dataset: dataset_id
+    job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "my_bignumeric",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "BIGNUMERIC"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "123456798.98765432100001"
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    mock.expect :insert_job, query_job_resp_gapi(query, job_id: job_id), [project, job_gapi]
+    mock.expect :get_job_query_results,
+                query_data_gapi,
+                [project, job_id, {location: "US", max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
+    mock.expect :list_table_data,
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
+
+    data = dataset.query "#{query} WHERE my_bignumeric = @my_bignumeric",
+                         params: { my_bignumeric: BigDecimal("123456798.98765432100001") },
+                         types: { my_bignumeric: :BIGNUMERIC}
+    mock.verify
+
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
+    assert_valid_data data
+  end
+
   it "queries the data with a true parameter" do
     job_gapi = query_job_gapi "#{query} WHERE active = @active", parameter_mode: "NAMED", dataset: dataset_id
     job_gapi.configuration.query.query_parameters = [

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_named_params_test.rb
@@ -552,7 +552,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
     assert_valid_data data
   end
 
-  it "queries the data with an array parameter" do
+  it "queries the data with an array of string values parameter" do
     job_gapi = query_job_gapi "#{query} WHERE name IN @names", parameter_mode: "NAMED", dataset: dataset_id
     job_gapi.configuration.query.query_parameters = [
       Google::Apis::BigqueryV2::QueryParameter.new(
@@ -585,6 +585,50 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
                 [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = dataset.query "#{query} WHERE name IN @names", params: { names: %w{name1 name2 name3} }
+    mock.verify
+
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
+    assert_valid_data data
+  end
+
+  it "queries the data with an array of bignumeric values parameter" do
+    param_1 = BigDecimal("123456789.1234567891")
+    param_2 = BigDecimal("123456789.1234567892")
+    param_3 = BigDecimal("123456789.1234567893")
+    job_gapi = query_job_gapi "#{query} WHERE my_bignumeric IN @my_params", parameter_mode: "NAMED", dataset: dataset_id
+    job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "my_params",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "ARRAY",
+          array_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+            type: "BIGNUMERIC"
+          )
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          array_values: [
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "123456789.1234567891"),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "123456789.1234567892"),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "123456789.1234567893")
+          ]
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    mock.expect :insert_job, query_job_resp_gapi(query, job_id: job_id), [project, job_gapi]
+    mock.expect :get_job_query_results,
+                query_data_gapi,
+                [project, job_id, {location: "US", max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
+    mock.expect :list_table_data,
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
+
+    data = dataset.query "#{query} WHERE my_bignumeric IN @my_params",
+                         params: { my_params: [param_1, param_2, param_3] },
+                         types: { my_params: [:BIGNUMERIC] }
     mock.verify
 
     _(data.class).must_equal Google::Cloud::Bigquery::Data

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_named_params_test.rb
@@ -87,6 +87,38 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
     assert_valid_data data
   end
 
+  it "queries the data with an integer parameter with types option" do
+    job_gapi = query_job_gapi "#{query} WHERE age > @age", parameter_mode: "NAMED", dataset: dataset_id
+    job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "age",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "INT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "35"
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    mock.expect :insert_job, query_job_resp_gapi(query, job_id: job_id), [project, job_gapi]
+    mock.expect :get_job_query_results,
+                query_data_gapi,
+                [project, job_id, {location: "US", max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
+    mock.expect :list_table_data,
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
+
+    data = dataset.query "#{query} WHERE age > @age", params: { age: "35" }, types: { age: :INT64 }
+    mock.verify
+
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
+    assert_valid_data data
+  end
+
   it "queries the data with a float parameter" do
     job_gapi = query_job_gapi "#{query} WHERE score > @score", parameter_mode: "NAMED", dataset: dataset_id
     job_gapi.configuration.query.query_parameters = [
@@ -635,6 +667,45 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
     assert_valid_data data
   end
 
+  it "queries the data with an array parameter with types option" do
+    job_gapi = query_job_gapi "#{query} WHERE age IN @ages", parameter_mode: "NAMED", dataset: dataset_id
+    job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "ages",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "ARRAY",
+          array_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+            type: "INT64"
+          )
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          array_values: [
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "1"),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "2"),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "3")
+          ]
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    mock.expect :insert_job, query_job_resp_gapi(query, job_id: job_id), [project, job_gapi]
+    mock.expect :get_job_query_results,
+                query_data_gapi,
+                [project, job_id, {location: "US", max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
+    mock.expect :list_table_data,
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
+
+    data = dataset.query "#{query} WHERE age IN @ages", params: { ages: ["1", "2", "3"] }, types: { ages: [:INT64] }
+    mock.verify
+
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
+    assert_valid_data data
+  end
+
   it "queries the data with a struct parameter" do
     job_gapi = query_job_gapi "#{query} WHERE meta = @meta", parameter_mode: "NAMED", dataset: dataset_id
     job_gapi.configuration.query.query_parameters = [
@@ -680,6 +751,45 @@ describe Google::Cloud::Bigquery::Dataset, :query, :named_params, :mock_bigquery
                 [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = dataset.query "#{query} WHERE meta = @meta", params: { meta: { name: "Testy McTesterson", age: 42, active: false, score: 98.7 } }
+    mock.verify
+
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
+    assert_valid_data data
+  end
+
+  it "queries the data with a struct parameter with types option" do
+    job_gapi = query_job_gapi "#{query} WHERE meta = @meta", parameter_mode: "NAMED", dataset: dataset_id
+    job_gapi.configuration.query.query_parameters =  [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "meta",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "STRUCT",
+          struct_types: [
+            Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
+              name: "age",
+              type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "INT64"))
+          ]
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          struct_values: {
+            "age"    => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "42")
+          }
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    mock.expect :insert_job, query_job_resp_gapi(query, job_id: job_id), [project, job_gapi]
+    mock.expect :get_job_query_results,
+                query_data_gapi,
+                [project, job_id, {location: "US", max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
+    mock.expect :list_table_data,
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
+
+    data = dataset.query "#{query} WHERE meta = @meta", params: { meta: { age: "42" } }, types: { meta: { age: :INT64 } }
     mock.verify
 
     _(data.class).must_equal Google::Cloud::Bigquery::Data

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_positional_params_test.rb
@@ -528,7 +528,7 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
     assert_valid_data data
   end
 
-  it "queries the data with an array parameter" do
+  it "queries the data with an array of string values parameter" do
     job_gapi = query_job_gapi "#{query} WHERE name IN ?", parameter_mode: "POSITIONAL", dataset: dataset_id
     job_gapi.configuration.query.query_parameters = [
       Google::Apis::BigqueryV2::QueryParameter.new(
@@ -560,6 +560,47 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
                 [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = dataset.query "#{query} WHERE name IN ?", params: [%w{name1 name2 name3}]
+    mock.verify
+
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
+    assert_valid_data data
+  end
+
+  it "queries the data with an array of bignumeric values parameter" do
+    param_1 = BigDecimal("123456789.1234567891")
+    param_2 = BigDecimal("123456789.1234567892")
+    param_3 = BigDecimal("123456789.1234567893")
+    job_gapi = query_job_gapi "#{query} WHERE my_bignumeric IN ?", parameter_mode: "POSITIONAL", dataset: dataset_id
+    job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "ARRAY",
+          array_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+            type: "BIGNUMERIC"
+          )
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          array_values: [
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "123456789.1234567891"),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "123456789.1234567892"),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "123456789.1234567893")
+          ]
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    mock.expect :insert_job, query_job_resp_gapi(query, job_id: job_id), [project, job_gapi]
+    mock.expect :get_job_query_results,
+                query_data_gapi,
+                [project, job_id, {location: "US", max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
+    mock.expect :list_table_data,
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
+
+    data = dataset.query "#{query} WHERE my_bignumeric IN ?", params: [[param_1, param_2, param_3]], types: [[:BIGNUMERIC]]
     mock.verify
 
     _(data.class).must_equal Google::Cloud::Bigquery::Data

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_positional_params_test.rb
@@ -148,6 +148,39 @@ describe Google::Cloud::Bigquery::Dataset, :query, :positional_params, :mock_big
     assert_valid_data data
   end
 
+  it "queries the data with a bignumeric parameter and types option" do
+    job_gapi = query_job_gapi "#{query} WHERE my_bignumeric = ?", parameter_mode: "POSITIONAL", dataset: dataset_id
+    job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "BIGNUMERIC"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "123456798.98765432100001"
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    mock.expect :insert_job, query_job_resp_gapi(query, job_id: job_id), [project, job_gapi]
+    mock.expect :get_job_query_results,
+                query_data_gapi,
+                [project, job_id, {location: "US", max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
+    mock.expect :list_table_data,
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
+
+    data = dataset.query "#{query} WHERE my_bignumeric = ?",
+                         params: [BigDecimal("123456798.98765432100001")],
+                         types: [:BIGNUMERIC]
+    mock.verify
+
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
+    assert_valid_data data
+  end
+
   it "queries the data with a true parameter" do
     job_gapi = query_job_gapi "#{query} WHERE active = ?", parameter_mode: "POSITIONAL", dataset: dataset_id
     job_gapi.configuration.query.query_parameters = [

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
@@ -348,6 +348,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "age",           type: "INTEGER", description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "score",         type: "FLOAT", description: "A score from 0.0 to 10.0", fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "cost",          type: "NUMERIC", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "my_bignumeric", type: "BIGNUMERIC", description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "active",        type: "BOOLEAN", description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "avatar",        type: "BYTES", description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "creation_date", type: "TIMESTAMP", description: nil, fields: []),
@@ -368,6 +369,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
       schema.integer "age"
       schema.float "score", description: "A score from 0.0 to 10.0"
       schema.numeric "cost"
+      schema.bignumeric "my_bignumeric"
       schema.boolean "active"
       schema.bytes "avatar"
       schema.timestamp "creation_date"

--- a/google-cloud-bigquery/test/google/cloud/bigquery/external_csv_source_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/external_csv_source_test.rb
@@ -195,6 +195,7 @@ describe Google::Cloud::Bigquery::External::CsvSource do
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "age",           type: "INTEGER", description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "score",         type: "FLOAT", description: "A score from 0.0 to 10.0", fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "pi",            type: "NUMERIC", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "my_bignumeric", type: "BIGNUMERIC", description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "active",        type: "BOOLEAN", description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "avatar",        type: "BYTES", description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "started_at",    type: "TIMESTAMP", description: nil, fields: []),
@@ -213,6 +214,7 @@ describe Google::Cloud::Bigquery::External::CsvSource do
       s.integer "age"
       s.float "score", description: "A score from 0.0 to 10.0"
       s.numeric "pi"
+      s.bignumeric "my_bignumeric"
       s.boolean "active"
       s.bytes "avatar"
       s.timestamp "started_at"
@@ -224,9 +226,9 @@ describe Google::Cloud::Bigquery::External::CsvSource do
     _(table.schema).wont_be :empty?
     _(table.fields).must_equal table.schema.fields
     _(table.headers).must_equal table.schema.headers
-    _(table.headers).must_equal [:name, :age, :score, :pi, :active, :avatar, :started_at, :duration, :target_end, :birthday]
+    _(table.headers).must_equal [:name, :age, :score, :pi, :my_bignumeric, :active, :avatar, :started_at, :duration, :target_end, :birthday]
     _(table.param_types).must_equal table.schema.param_types
-    _(table.param_types).must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
+    _(table.param_types).must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, my_bignumeric: :BIGNUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
 
     _(table.to_gapi.to_h).must_equal table_gapi.to_h
   end
@@ -244,6 +246,7 @@ describe Google::Cloud::Bigquery::External::CsvSource do
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "age",           type: "INTEGER", description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "score",         type: "FLOAT", description: "A score from 0.0 to 10.0", fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "pi",            type: "NUMERIC", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "my_bignumeric", type: "BIGNUMERIC", description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "active",        type: "BOOLEAN", description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "avatar",        type: "BYTES", description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "started_at",    type: "TIMESTAMP", description: nil, fields: []),
@@ -263,6 +266,7 @@ describe Google::Cloud::Bigquery::External::CsvSource do
     schema.integer "age"
     schema.float "score", description: "A score from 0.0 to 10.0"
     schema.numeric "pi"
+    schema.bignumeric "my_bignumeric"
     schema.boolean "active"
     schema.bytes "avatar"
     schema.timestamp "started_at"
@@ -275,9 +279,9 @@ describe Google::Cloud::Bigquery::External::CsvSource do
     _(table.schema).wont_be :empty?
     _(table.fields).must_equal table.schema.fields
     _(table.headers).must_equal table.schema.headers
-    _(table.headers).must_equal [:name, :age, :score, :pi, :active, :avatar, :started_at, :duration, :target_end, :birthday]
+    _(table.headers).must_equal [:name, :age, :score, :pi, :my_bignumeric, :active, :avatar, :started_at, :duration, :target_end, :birthday]
     _(table.param_types).must_equal table.schema.param_types
-    _(table.param_types).must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
+    _(table.param_types).must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, my_bignumeric: :BIGNUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
 
     _(table.to_gapi.to_h).must_equal table_gapi.to_h
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/external_json_source_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/external_json_source_test.rb
@@ -52,6 +52,7 @@ describe Google::Cloud::Bigquery::External::JsonSource do
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "age",           type: "INTEGER", description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "score",         type: "FLOAT", description: "A score from 0.0 to 10.0", fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "pi",            type: "NUMERIC", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "my_bignumeric", type: "BIGNUMERIC", description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "active",        type: "BOOLEAN", description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "avatar",        type: "BYTES", description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "started_at",    type: "TIMESTAMP", description: nil, fields: []),
@@ -69,6 +70,7 @@ describe Google::Cloud::Bigquery::External::JsonSource do
       s.integer "age"
       s.float "score", description: "A score from 0.0 to 10.0"
       s.numeric "pi"
+      s.bignumeric "my_bignumeric"
       s.boolean "active"
       s.bytes "avatar"
       s.timestamp "started_at"
@@ -80,9 +82,9 @@ describe Google::Cloud::Bigquery::External::JsonSource do
     _(table.schema).wont_be :empty?
     _(table.fields).must_equal table.schema.fields
     _(table.headers).must_equal table.schema.headers
-    _(table.headers).must_equal [:name, :age, :score, :pi, :active, :avatar, :started_at, :duration, :target_end, :birthday]
+    _(table.headers).must_equal [:name, :age, :score, :pi, :my_bignumeric, :active, :avatar, :started_at, :duration, :target_end, :birthday]
     _(table.param_types).must_equal table.schema.param_types
-    _(table.param_types).must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
+    _(table.param_types).must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, my_bignumeric: :BIGNUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
 
     _(table.to_gapi.to_h).must_equal table_gapi.to_h
   end
@@ -100,6 +102,7 @@ describe Google::Cloud::Bigquery::External::JsonSource do
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "age",           type: "INTEGER", description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "score",         type: "FLOAT", description: "A score from 0.0 to 10.0", fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "pi",            type: "NUMERIC", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "my_bignumeric", type: "BIGNUMERIC", description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "active",        type: "BOOLEAN", description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "avatar",        type: "BYTES", description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "started_at",    type: "TIMESTAMP", description: nil, fields: []),
@@ -118,6 +121,7 @@ describe Google::Cloud::Bigquery::External::JsonSource do
     schema.integer "age"
     schema.float "score", description: "A score from 0.0 to 10.0"
     schema.numeric "pi"
+    schema.bignumeric "my_bignumeric"
     schema.boolean "active"
     schema.bytes "avatar"
     schema.timestamp "started_at"
@@ -130,9 +134,9 @@ describe Google::Cloud::Bigquery::External::JsonSource do
     _(table.schema).wont_be :empty?
     _(table.fields).must_equal table.schema.fields
     _(table.headers).must_equal table.schema.headers
-    _(table.headers).must_equal [:name, :age, :score, :pi, :active, :avatar, :started_at, :duration, :target_end, :birthday]
+    _(table.headers).must_equal [:name, :age, :score, :pi, :my_bignumeric, :active, :avatar, :started_at, :duration, :target_end, :birthday]
     _(table.param_types).must_equal table.schema.param_types
-    _(table.param_types).must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
+    _(table.param_types).must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, my_bignumeric: :BIGNUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
 
     _(table.to_gapi.to_h).must_equal table_gapi.to_h
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/load_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/load_job_test.rb
@@ -95,7 +95,7 @@ describe Google::Cloud::Bigquery::LoadJob, :mock_bigquery do
     _(job.schema).must_be_kind_of Google::Cloud::Bigquery::Schema
     _(job.schema).must_be :frozen?
     _(job.schema.fields).wont_be :empty?
-    _(job.schema.fields.map(&:name)).must_equal ["name", "age", "score", "pi", "active", "avatar", "started_at", "duration", "target_end", "birthday"]
+    _(job.schema.fields.map(&:name)).must_equal ["name", "age", "score", "pi", "my_bignumeric", "active", "avatar", "started_at", "duration", "target_end", "birthday"]
   end
 
   it "knows its load config" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_named_params_test.rb
@@ -80,6 +80,30 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
     _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
+  it "queries the data with an integer parameter with types option" do
+    query_job_gapi.configuration.query.query = "#{query} WHERE age > @age"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "age",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "INT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "35"
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = bigquery.query_job "#{query} WHERE age > @age", params: { age: "35" }, types: { age: :INT64 }
+    mock.verify
+
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
   it "queries the data with a float parameter" do
     query_job_gapi.configuration.query.query = "#{query} WHERE score > @score"
     query_job_gapi.configuration.query.query_parameters = [
@@ -516,6 +540,37 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
     _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
+  it "queries the data with an array parameter with types option" do
+    query_job_gapi.configuration.query.query = "#{query} WHERE age IN @ages"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "ages",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "ARRAY",
+          array_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+            type: "INT64"
+          )
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          array_values: [
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "1"),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "2"),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "3")
+          ]
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = bigquery.query_job "#{query} WHERE age IN @ages", params: { ages: ["1", "2", "3"] }, types: { ages: [:INT64] }
+    mock.verify
+
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
   it "queries the data with a struct parameter" do
     query_job_gapi.configuration.query.query = "#{query} WHERE meta = @meta"
     query_job_gapi.configuration.query.query_parameters = [
@@ -554,6 +609,37 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
     mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
 
     job = bigquery.query_job "#{query} WHERE meta = @meta", params: { meta: { name: "Testy McTesterson", age: 42, active: false, score: 98.7 } }
+    mock.verify
+
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
+  it "queries the data with a struct parameter with types option" do
+    query_job_gapi.configuration.query.query = "#{query} WHERE meta = @meta"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "meta",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "STRUCT",
+          struct_types: [
+            Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
+              name: "age",
+              type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "INT64"))
+          ]
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          struct_values: {
+            "age"    => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "42")
+          }
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = bigquery.query_job "#{query} WHERE meta = @meta", params: { meta: { age: "42" } }, types: { meta: { age: :INT64 } }
     mock.verify
 
     _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_named_params_test.rb
@@ -449,7 +449,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
     _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
-  it "queries the data with an array parameter" do
+  it "queries the data with an array of string values parameter" do
     query_job_gapi.configuration.query.query = "#{query} WHERE name IN @names"
     query_job_gapi.configuration.query.query_parameters = [
       Google::Apis::BigqueryV2::QueryParameter.new(
@@ -475,6 +475,42 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
     mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
 
     job = bigquery.query_job "#{query} WHERE name IN @names", params: { names: %w{name1 name2 name3} }
+    mock.verify
+
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
+  it "queries the data with an array of bignumeric values parameter" do
+    param_1 = BigDecimal("123456789.1234567891")
+    param_2 = BigDecimal("123456789.1234567892")
+    param_3 = BigDecimal("123456789.1234567893")
+    query_job_gapi.configuration.query.query = "#{query} WHERE my_bignumeric IN @my_params"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "my_params",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "ARRAY",
+          array_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+            type: "BIGNUMERIC"
+          )
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          array_values: [
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "123456789.1234567891"),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "123456789.1234567892"),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "123456789.1234567893")
+          ]
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = bigquery.query_job "#{query} WHERE my_bignumeric IN @my_params",
+                             params: { my_params: [param_1, param_2, param_3] },
+                             types: { my_params: [:BIGNUMERIC] }
     mock.verify
 
     _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_named_params_test.rb
@@ -128,6 +128,32 @@ describe Google::Cloud::Bigquery::Project, :query_job, :named_params, :mock_bigq
     _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
+  it "queries the data with a bignumeric parameter and types option" do
+    query_job_gapi.configuration.query.query = "#{query} WHERE my_bignumeric = @my_bignumeric"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "my_bignumeric",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "BIGNUMERIC"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "123456798.98765432100001"
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = bigquery.query_job "#{query} WHERE my_bignumeric = @my_bignumeric",
+                             params: { my_bignumeric: BigDecimal("123456798.98765432100001") },
+                             types: { my_bignumeric: :BIGNUMERIC }
+    mock.verify
+
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
   it "queries the data with a true parameter" do
     query_job_gapi.configuration.query.query = "#{query} WHERE active = @active"
     query_job_gapi.configuration.query.query_parameters = [

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_positional_params_test.rb
@@ -78,6 +78,29 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
     _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
+  it "queries the data with an integer parameter with types option" do
+    query_job_gapi.configuration.query.query = "#{query} WHERE age > ?"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "INT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "35"
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = bigquery.query_job "#{query} WHERE age > ?", params: ["35"], types: [:INT64]
+    mock.verify
+
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
   it "queries the data with a float parameter" do
     query_job_gapi.configuration.query.query = "#{query} WHERE score > ?"
     query_job_gapi.configuration.query.query_parameters = [
@@ -487,6 +510,36 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
     _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
+  it "queries the data with an array parameter with types option" do
+    query_job_gapi.configuration.query.query = "#{query} WHERE age IN ?"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "ARRAY",
+          array_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+            type: "INT64"
+          )
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          array_values: [
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "1"),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "2"),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "3")
+          ]
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = bigquery.query_job "#{query} WHERE age IN ?", params: [["1","2","3"]], types: [[:INT64]]
+    mock.verify
+
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
   it "queries the data with a struct parameter" do
     query_job_gapi.configuration.query.query = "#{query} WHERE meta = ?"
     query_job_gapi.configuration.query.query_parameters = [
@@ -524,6 +577,36 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
     mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
 
     job = bigquery.query_job "#{query} WHERE meta = ?", params: [{name: "Testy McTesterson", age: 42, active: false, score: 98.7}]
+    mock.verify
+
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
+  it "queries the data with a struct parameter with types option" do
+    query_job_gapi.configuration.query.query = "#{query} WHERE meta = ?"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "STRUCT",
+          struct_types: [
+            Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
+              name: "age",
+              type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "INT64"))
+          ]
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          struct_values: {
+            "age"    => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "42")
+          }
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = bigquery.query_job "#{query} WHERE meta = ?", params: [{ age: "42" }], types: [{ age: :INT64 }]
     mock.verify
 
     _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_positional_params_test.rb
@@ -124,6 +124,31 @@ describe Google::Cloud::Bigquery::Project, :query_job, :positional_params, :mock
     _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
   end
 
+  it "queries the data with a bignumeric parameter and types option" do
+    query_job_gapi.configuration.query.query = "#{query} WHERE my_bignumeric = ?"
+    query_job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "BIGNUMERIC"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "123456798.98765432100001"
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :insert_job, query_job_gapi, [project, query_job_gapi]
+
+    job = bigquery.query_job "#{query} WHERE my_bignumeric = ?",
+                             params: [BigDecimal("123456798.98765432100001")],
+                             types: [:BIGNUMERIC]
+    mock.verify
+
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+  end
+
   it "queries the data with a true parameter" do
     query_job_gapi.configuration.query.query = "#{query} WHERE active = ?"
     query_job_gapi.configuration.query.query_parameters = [

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_named_params_test.rb
@@ -154,6 +154,40 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
     assert_valid_data data
   end
 
+  it "queries the data with a bignumeric parameter and types option" do
+    job_gapi = query_job_gapi "#{query} WHERE my_bignumeric = @my_bignumeric", parameter_mode: "NAMED", location: nil
+    job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "my_bignumeric",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "BIGNUMERIC"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "123456798.98765432100001"
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    mock.expect :insert_job, query_job_resp_gapi(query, job_id: job_id), [project, job_gapi]
+    mock.expect :get_job_query_results,
+                query_data_gapi,
+                [project, job_id, {location: "US", max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
+    mock.expect :list_table_data,
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
+
+    data = bigquery.query "#{query} WHERE my_bignumeric = @my_bignumeric",
+                          params: { my_bignumeric: BigDecimal("123456798.98765432100001") },
+                          types: { my_bignumeric: :BIGNUMERIC}
+    mock.verify
+
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
+    assert_valid_data data
+  end
+
   it "queries the data with a true parameter" do
     job_gapi = query_job_gapi "#{query} WHERE active = @active", parameter_mode: "NAMED", location: nil
     job_gapi.configuration.query.query_parameters = [

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_named_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_named_params_test.rb
@@ -90,6 +90,38 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
     assert_valid_data data
   end
 
+  it "queries the data with an integer parameter with types option" do
+    job_gapi = query_job_gapi "#{query} WHERE age > @age", parameter_mode: "NAMED", location: nil
+    job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "age",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "INT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "35"
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    mock.expect :insert_job, query_job_resp_gapi(query, job_id: job_id), [project, job_gapi]
+    mock.expect :get_job_query_results,
+                query_data_gapi,
+                [project, job_id, {location: "US", max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
+    mock.expect :list_table_data,
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
+
+    data = bigquery.query "#{query} WHERE age > @age", params: { age: "35" }, types: { age: :INT64 }
+    mock.verify
+
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
+    assert_valid_data data
+  end
+
   it "queries the data with a float parameter" do
     job_gapi = query_job_gapi "#{query} WHERE score > @score", parameter_mode: "NAMED", location: nil
     job_gapi.configuration.query.query_parameters = [
@@ -638,6 +670,45 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
     assert_valid_data data
   end
 
+  it "queries the data with an array parameter with types option" do
+    job_gapi = query_job_gapi "#{query} WHERE age IN @ages", parameter_mode: "NAMED", location: nil
+    job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "ages",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "ARRAY",
+          array_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+            type: "INT64"
+          )
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          array_values: [
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "1"),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "2"),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "3")
+          ]
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    mock.expect :insert_job, query_job_resp_gapi(query, job_id: job_id), [project, job_gapi]
+    mock.expect :get_job_query_results,
+                query_data_gapi,
+                [project, job_id, {location: "US", max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
+    mock.expect :list_table_data,
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
+
+    data = bigquery.query "#{query} WHERE age IN @ages", params: { ages: ["1", "2", "3"] }, types: { ages: [:INT64] }
+    mock.verify
+
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
+    assert_valid_data data
+  end
+
   it "queries the data with a struct parameter" do
     job_gapi = query_job_gapi "#{query} WHERE meta = @meta", parameter_mode: "NAMED", location: nil
     job_gapi.configuration.query.query_parameters = [
@@ -683,6 +754,45 @@ describe Google::Cloud::Bigquery::Project, :query, :named_params, :mock_bigquery
                 [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = bigquery.query "#{query} WHERE meta = @meta", params: { meta: { name: "Testy McTesterson", age: 42, active: false, score: 98.7 } }
+    mock.verify
+
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
+    assert_valid_data data
+  end
+
+  it "queries the data with a struct parameter with types option" do
+    job_gapi = query_job_gapi "#{query} WHERE meta = @meta", parameter_mode: "NAMED", location: nil
+    job_gapi.configuration.query.query_parameters =  [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        name: "meta",
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "STRUCT",
+          struct_types: [
+            Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
+              name: "age",
+              type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "INT64"))
+          ]
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          struct_values: {
+            "age"    => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "42")
+          }
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    mock.expect :insert_job, query_job_resp_gapi(query, job_id: job_id), [project, job_gapi]
+    mock.expect :get_job_query_results,
+                query_data_gapi,
+                [project, job_id, {location: "US", max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
+    mock.expect :list_table_data,
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
+
+    data = bigquery.query "#{query} WHERE meta = @meta", params: { meta: { age: "42" } }, types: { meta: { age: :INT64 } }
     mock.verify
 
     _(data.class).must_equal Google::Cloud::Bigquery::Data

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_positional_params_test.rb
@@ -151,6 +151,39 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
     assert_valid_data data
   end
 
+  it "queries the data with a bignumeric parameter and types option" do
+    job_gapi = query_job_gapi "#{query} WHERE my_bignumeric = ?", parameter_mode: "POSITIONAL", location: nil
+    job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "BIGNUMERIC"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "123456798.98765432100001"
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    mock.expect :insert_job, query_job_resp_gapi(query, job_id: job_id), [project, job_gapi]
+    mock.expect :get_job_query_results,
+                query_data_gapi,
+                [project, job_id, {location: "US", max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
+    mock.expect :list_table_data,
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
+
+    data = bigquery.query "#{query} WHERE my_bignumeric = ?",
+                          params: [BigDecimal("123456798.98765432100001")],
+                          types: [:BIGNUMERIC]
+    mock.verify
+
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
+    assert_valid_data data
+  end
+
   it "queries the data with a true parameter" do
     job_gapi = query_job_gapi "#{query} WHERE active = ?", parameter_mode: "POSITIONAL", location: nil
     job_gapi.configuration.query.query_parameters = [

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_positional_params_test.rb
@@ -531,7 +531,7 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
     assert_valid_data data
   end
 
-  it "queries the data with an array parameter" do
+  it "queries the data with an array of string values parameter" do
     job_gapi = query_job_gapi "#{query} WHERE name IN ?", parameter_mode: "POSITIONAL", location: nil
     job_gapi.configuration.query.query_parameters = [
       Google::Apis::BigqueryV2::QueryParameter.new(
@@ -563,6 +563,47 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
                 [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = bigquery.query "#{query} WHERE name IN ?", params: [%w{name1 name2 name3}]
+    mock.verify
+
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
+    assert_valid_data data
+  end
+
+  it "queries the data with an array of bignumeric values parameter" do
+    param_1 = BigDecimal("123456789.1234567891")
+    param_2 = BigDecimal("123456789.1234567892")
+    param_3 = BigDecimal("123456789.1234567893")
+    job_gapi = query_job_gapi "#{query} WHERE my_bignumeric IN ?", parameter_mode: "POSITIONAL", location: nil
+    job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "ARRAY",
+          array_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+            type: "BIGNUMERIC"
+          )
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          array_values: [
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "123456789.1234567891"),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "123456789.1234567892"),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "123456789.1234567893")
+          ]
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    mock.expect :insert_job, query_job_resp_gapi(query, job_id: job_id), [project, job_gapi]
+    mock.expect :get_job_query_results,
+                query_data_gapi,
+                [project, job_id, {location: "US", max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
+    mock.expect :list_table_data,
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
+
+    data = bigquery.query "#{query} WHERE my_bignumeric IN ?", params: [[param_1, param_2, param_3]], types: [[:BIGNUMERIC]]
     mock.verify
 
     _(data.class).must_equal Google::Cloud::Bigquery::Data

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_positional_params_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_positional_params_test.rb
@@ -89,6 +89,37 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
     assert_valid_data data
   end
 
+  it "queries the data with an integer parameter with types option" do
+    job_gapi = query_job_gapi "#{query} WHERE age > ?", parameter_mode: "POSITIONAL", location: nil
+    job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "INT64"
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          value: "35"
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    mock.expect :insert_job, query_job_resp_gapi(query, job_id: job_id), [project, job_gapi]
+    mock.expect :get_job_query_results,
+                query_data_gapi,
+                [project, job_id, {location: "US", max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
+    mock.expect :list_table_data,
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
+
+    data = bigquery.query "#{query} WHERE age > ?", params: ["35"], types: [:INT64]
+    mock.verify
+
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
+    assert_valid_data data
+  end
+
   it "queries the data with a float parameter" do
     job_gapi = query_job_gapi "#{query} WHERE score > ?", parameter_mode: "POSITIONAL", location: nil
     job_gapi.configuration.query.query_parameters = [
@@ -610,6 +641,44 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
     assert_valid_data data
   end
 
+  it "queries the data with an array parameter with types option" do
+    job_gapi = query_job_gapi "#{query} WHERE age IN ?", parameter_mode: "POSITIONAL", location: nil
+    job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "ARRAY",
+          array_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+            type: "INT64"
+          )
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          array_values: [
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "1"),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "2"),
+            Google::Apis::BigqueryV2::QueryParameterValue.new(value: "3")
+          ]
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    mock.expect :insert_job, query_job_resp_gapi(query, job_id: job_id), [project, job_gapi]
+    mock.expect :get_job_query_results,
+                query_data_gapi,
+                [project, job_id, {location: "US", max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
+    mock.expect :list_table_data,
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
+
+    data = bigquery.query "#{query} WHERE age IN ?", params: [["1","2","3"]], types: [[:INT64]]
+    mock.verify
+
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
+    assert_valid_data data
+  end
+
   it "queries the data with a struct parameter" do
     job_gapi = query_job_gapi "#{query} WHERE meta = ?", parameter_mode: "POSITIONAL", location: nil
     job_gapi.configuration.query.query_parameters = [
@@ -654,6 +723,44 @@ describe Google::Cloud::Bigquery::Project, :query, :positional_params, :mock_big
                 [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
 
     data = bigquery.query "#{query} WHERE meta = ?", params: [{name: "Testy McTesterson", age: 42, active: false, score: 98.7}]
+    mock.verify
+
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
+    assert_valid_data data
+  end
+
+  it "queries the data with a struct parameter with types option" do
+    job_gapi = query_job_gapi "#{query} WHERE meta = ?", parameter_mode: "POSITIONAL", location: nil
+    job_gapi.configuration.query.query_parameters = [
+      Google::Apis::BigqueryV2::QueryParameter.new(
+        parameter_type: Google::Apis::BigqueryV2::QueryParameterType.new(
+          type: "STRUCT",
+          struct_types: [
+            Google::Apis::BigqueryV2::QueryParameterType::StructType.new(
+              name: "age",
+              type: Google::Apis::BigqueryV2::QueryParameterType.new(type: "INT64"))
+          ]
+        ),
+        parameter_value: Google::Apis::BigqueryV2::QueryParameterValue.new(
+          struct_values: {
+            "age"    => Google::Apis::BigqueryV2::QueryParameterValue.new(value: "42")
+          }
+        )
+      )
+    ]
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    mock.expect :insert_job, query_job_resp_gapi(query, job_id: job_id), [project, job_gapi]
+    mock.expect :get_job_query_results,
+                query_data_gapi,
+                [project, job_id, {location: "US", max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
+    mock.expect :list_table_data,
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
+
+    data = bigquery.query "#{query} WHERE meta = ?", params: [{ age: "42" }], types: [{ age: :INT64 }]
     mock.verify
 
     _(data.class).must_equal Google::Cloud::Bigquery::Data

--- a/google-cloud-bigquery/test/google/cloud/bigquery/schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/schema_test.rb
@@ -39,6 +39,11 @@ describe Google::Cloud::Bigquery::Schema, :mock_bigquery do
           "mode" => "NULLABLE"
         },
         {
+          "name" => "my_bignumeric",
+          "type" => "BIGNUMERIC",
+          "mode" => "NULLABLE"
+        },
+        {
           "name" => "active",
           "type" => "BOOLEAN",
           "mode" => "NULLABLE"
@@ -121,7 +126,7 @@ describe Google::Cloud::Bigquery::Schema, :mock_bigquery do
   it "has basic values" do
     _(schema).must_be_kind_of Google::Cloud::Bigquery::Schema
     _(schema.fields).wont_be :empty?
-    _(schema.fields.map(&:name)).must_equal ["name", "age", "score", "pi", "active", "avatar", "started_at", "duration", "target_end", "birthday", "alts"]
+    _(schema.fields.map(&:name)).must_equal ["name", "age", "score", "pi", "my_bignumeric", "active", "avatar", "started_at", "duration", "target_end", "birthday", "alts"]
   end
 
   it "can access fields with a symbol" do
@@ -152,6 +157,13 @@ describe Google::Cloud::Bigquery::Schema, :mock_bigquery do
     _(schema.field(:pi).mode).must_equal "NULLABLE"
     _(schema.field(:pi)).must_be :numeric?
     _(schema.field(:pi)).must_be :nullable?
+
+    _(schema.field(:my_bignumeric)).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field(:my_bignumeric).name).must_equal "my_bignumeric"
+    _(schema.field(:my_bignumeric).type).must_equal "BIGNUMERIC"
+    _(schema.field(:my_bignumeric).mode).must_equal "NULLABLE"
+    _(schema.field(:my_bignumeric)).must_be :bignumeric?
+    _(schema.field(:my_bignumeric)).must_be :nullable?
 
     _(schema.field(:active)).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
     _(schema.field(:active).name).must_equal "active"
@@ -261,6 +273,13 @@ describe Google::Cloud::Bigquery::Schema, :mock_bigquery do
     _(schema.field("pi").mode).must_equal "NULLABLE"
     _(schema.field("pi")).must_be :numeric?
     _(schema.field("pi")).must_be :nullable?
+
+    _(schema.field("my_bignumeric")).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
+    _(schema.field("my_bignumeric").name).must_equal "my_bignumeric"
+    _(schema.field("my_bignumeric").type).must_equal "BIGNUMERIC"
+    _(schema.field("my_bignumeric").mode).must_equal "NULLABLE"
+    _(schema.field("my_bignumeric")).must_be :bignumeric?
+    _(schema.field("my_bignumeric")).must_be :nullable?
 
     _(schema.field("active")).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
     _(schema.field("active").name).must_equal "active"
@@ -528,7 +547,7 @@ describe Google::Cloud::Bigquery::Schema, :mock_bigquery do
         file.delete
       end
     end
-    _(json.length).must_equal 11
+    _(json.length).must_equal 12
 
     name = json.find { |record| record["name"] == "name" }
     _(name["type"]).must_equal "STRING"
@@ -544,6 +563,10 @@ describe Google::Cloud::Bigquery::Schema, :mock_bigquery do
 
     score = json.find { |record| record["name"] == "pi" }
     _(score["type"]).must_equal "NUMERIC"
+    _(score["mode"]).must_equal "NULLABLE"
+
+    score = json.find { |record| record["name"] == "my_bignumeric" }
+    _(score["type"]).must_equal "BIGNUMERIC"
     _(score["mode"]).must_equal "NULLABLE"
 
     active = json.find { |record| record["name"] == "active" }
@@ -608,7 +631,7 @@ describe Google::Cloud::Bigquery::Schema, :mock_bigquery do
         file.delete
       end
     end
-    _(json.length).must_equal 11
+    _(json.length).must_equal 12
 
     name = json.find { |record| record["name"] == "name" }
     _(name["type"]).must_equal "STRING"
@@ -624,6 +647,10 @@ describe Google::Cloud::Bigquery::Schema, :mock_bigquery do
 
     score = json.find { |record| record["name"] == "pi" }
     _(score["type"]).must_equal "NUMERIC"
+    _(score["mode"]).must_equal "NULLABLE"
+
+    score = json.find { |record| record["name"] == "my_bignumeric" }
+    _(score["type"]).must_equal "BIGNUMERIC"
     _(score["mode"]).must_equal "NULLABLE"
 
     active = json.find { |record| record["name"] == "active" }
@@ -696,10 +723,10 @@ describe Google::Cloud::Bigquery::Schema, :mock_bigquery do
         file.delete
       end
     end
-    _(json.length).must_equal 11
+    _(json.length).must_equal 12
 
     fields = json.map { |record| record["name"] }
     _(fields).wont_be :empty?
-    _(fields).must_equal %w[name age score pi active avatar started_at duration target_end birthday alts]
+    _(fields).must_equal %w[name age score pi my_bignumeric active avatar started_at duration target_end birthday alts]
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/standard_sql/array_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/standard_sql/array_test.rb
@@ -99,6 +99,34 @@ describe Google::Cloud::Bigquery::StandardSql, :array do
     _(field.type).wont_be :struct?
   end
 
+  it "represents a BIGNUMERIC Array field" do
+    field = array_field "bignumeric_array_col", "BIGNUMERIC"
+
+    _(field.name).must_equal "bignumeric_array_col"
+
+    _(field.type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.type_kind).must_equal "ARRAY"
+    _(field.type.array_element_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.array_element_type.type_kind).must_equal "BIGNUMERIC"
+    _(field.type.array_element_type.array_element_type).must_be_nil
+    _(field.type.array_element_type.struct_type).must_be_nil
+    _(field.type.struct_type).must_be_nil
+
+    _(field.type).wont_be :int?
+    _(field.type).wont_be :float?
+    _(field.type).wont_be :numeric?
+    _(field.type).wont_be :boolean?
+    _(field.type).wont_be :string?
+    _(field.type).wont_be :bytes?
+    _(field.type).wont_be :date?
+    _(field.type).wont_be :datetime?
+    _(field.type).wont_be :geography?
+    _(field.type).wont_be :time?
+    _(field.type).wont_be :timestamp?
+    _(field.type).must_be :array?
+    _(field.type).wont_be :struct?
+  end
+
   it "represents a BOOL Array field" do
     field = array_field "bool_array_col", "BOOL"
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/standard_sql/struct_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/standard_sql/struct_test.rb
@@ -32,6 +32,7 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     _(field.type).wont_be :int?
     _(field.type).wont_be :float?
     _(field.type).wont_be :numeric?
+    _(field.type).wont_be :bignumeric?
     _(field.type).wont_be :boolean?
     _(field.type).wont_be :string?
     _(field.type).wont_be :bytes?
@@ -55,6 +56,7 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     _(field.type.struct_type.fields[0].type).must_be :int?
     _(field.type.struct_type.fields[0].type).wont_be :float?
     _(field.type.struct_type.fields[0].type).wont_be :numeric?
+    _(field.type.struct_type.fields[0].type).wont_be :bignumeric?
     _(field.type.struct_type.fields[0].type).wont_be :boolean?
     _(field.type.struct_type.fields[0].type).wont_be :string?
     _(field.type.struct_type.fields[0].type).wont_be :bytes?
@@ -84,6 +86,7 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     _(field.type).wont_be :int?
     _(field.type).wont_be :float?
     _(field.type).wont_be :numeric?
+    _(field.type).wont_be :bignumeric?
     _(field.type).wont_be :boolean?
     _(field.type).wont_be :string?
     _(field.type).wont_be :bytes?
@@ -107,6 +110,7 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     _(field.type.struct_type.fields[0].type).must_be :int?
     _(field.type.struct_type.fields[0].type).wont_be :float?
     _(field.type.struct_type.fields[0].type).wont_be :numeric?
+    _(field.type.struct_type.fields[0].type).wont_be :bignumeric?
     _(field.type.struct_type.fields[0].type).wont_be :boolean?
     _(field.type.struct_type.fields[0].type).wont_be :string?
     _(field.type.struct_type.fields[0].type).wont_be :bytes?
@@ -136,6 +140,7 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     _(field.type).wont_be :int?
     _(field.type).wont_be :float?
     _(field.type).wont_be :numeric?
+    _(field.type).wont_be :bignumeric?
     _(field.type).wont_be :boolean?
     _(field.type).wont_be :string?
     _(field.type).wont_be :bytes?
@@ -159,6 +164,7 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     _(field.type.struct_type.fields[0].type).must_be :int?
     _(field.type.struct_type.fields[0].type).wont_be :float?
     _(field.type.struct_type.fields[0].type).wont_be :numeric?
+    _(field.type.struct_type.fields[0].type).wont_be :bignumeric?
     _(field.type.struct_type.fields[0].type).wont_be :boolean?
     _(field.type.struct_type.fields[0].type).wont_be :string?
     _(field.type.struct_type.fields[0].type).wont_be :bytes?
@@ -186,6 +192,7 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     _(field.type).wont_be :int?
     _(field.type).wont_be :float?
     _(field.type).wont_be :numeric?
+    _(field.type).wont_be :bignumeric?
     _(field.type).wont_be :boolean?
     _(field.type).wont_be :string?
     _(field.type).wont_be :bytes?
@@ -222,6 +229,7 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     _(field.type).wont_be :int?
     _(field.type).wont_be :float?
     _(field.type).wont_be :numeric?
+    _(field.type).wont_be :bignumeric?
     _(field.type).wont_be :boolean?
     _(field.type).wont_be :string?
     _(field.type).wont_be :bytes?
@@ -245,6 +253,7 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     _(field.type.struct_type.fields[0].type).wont_be :int?
     _(field.type.struct_type.fields[0].type).wont_be :float?
     _(field.type.struct_type.fields[0].type).wont_be :numeric?
+    _(field.type.struct_type.fields[0].type).wont_be :bignumeric?
     _(field.type.struct_type.fields[0].type).wont_be :boolean?
     _(field.type.struct_type.fields[0].type).wont_be :string?
     _(field.type.struct_type.fields[0].type).wont_be :bytes?
@@ -265,6 +274,7 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     _(field.type.struct_type.fields[0].type.struct_type.fields[0].type).must_be :int?
     _(field.type.struct_type.fields[0].type.struct_type.fields[0].type).wont_be :float?
     _(field.type.struct_type.fields[0].type.struct_type.fields[0].type).wont_be :numeric?
+    _(field.type.struct_type.fields[0].type.struct_type.fields[0].type).wont_be :bignumeric?
     _(field.type.struct_type.fields[0].type.struct_type.fields[0].type).wont_be :boolean?
     _(field.type.struct_type.fields[0].type.struct_type.fields[0].type).wont_be :string?
     _(field.type.struct_type.fields[0].type.struct_type.fields[0].type).wont_be :bytes?
@@ -289,7 +299,8 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
       value_field("datetime_col", "DATETIME"),
       value_field("geo_col", "GEOGRAPHY"),
       value_field("time_col", "TIME"),
-      value_field("ts_col", "TIMESTAMP")
+      value_field("ts_col", "TIMESTAMP"),
+      value_field("bignumeric_col", "BIGNUMERIC")
     ]
 
     struct_type = Google::Cloud::Bigquery::StandardSql::StructType.new fields: fields
@@ -306,6 +317,7 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     _(field.type).wont_be :int?
     _(field.type).wont_be :float?
     _(field.type).wont_be :numeric?
+    _(field.type).wont_be :bignumeric?
     _(field.type).wont_be :boolean?
     _(field.type).wont_be :string?
     _(field.type).wont_be :bytes?
@@ -318,7 +330,7 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     _(field.type).must_be :struct?
 
     _(field.type.struct_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::StructType
-    _(field.type.struct_type.fields.count).must_equal 11
+    _(field.type.struct_type.fields.count).must_equal 12
 
     _(field.type.struct_type.fields[0]).must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
     _(field.type.struct_type.fields[0].name).must_equal "int_col"
@@ -329,6 +341,7 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     _(field.type.struct_type.fields[0].type).must_be :int?
     _(field.type.struct_type.fields[0].type).wont_be :float?
     _(field.type.struct_type.fields[0].type).wont_be :numeric?
+    _(field.type.struct_type.fields[0].type).wont_be :bignumeric?
     _(field.type.struct_type.fields[0].type).wont_be :boolean?
     _(field.type.struct_type.fields[0].type).wont_be :string?
     _(field.type.struct_type.fields[0].type).wont_be :bytes?
@@ -349,6 +362,7 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     _(field.type.struct_type.fields[1].type).wont_be :int?
     _(field.type.struct_type.fields[1].type).must_be :float?
     _(field.type.struct_type.fields[1].type).wont_be :numeric?
+    _(field.type.struct_type.fields[1].type).wont_be :bignumeric?
     _(field.type.struct_type.fields[1].type).wont_be :boolean?
     _(field.type.struct_type.fields[1].type).wont_be :string?
     _(field.type.struct_type.fields[1].type).wont_be :bytes?
@@ -369,6 +383,7 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     _(field.type.struct_type.fields[2].type).wont_be :int?
     _(field.type.struct_type.fields[2].type).wont_be :float?
     _(field.type.struct_type.fields[2].type).must_be :numeric?
+    _(field.type.struct_type.fields[2].type).wont_be :bignumeric?
     _(field.type.struct_type.fields[2].type).wont_be :boolean?
     _(field.type.struct_type.fields[2].type).wont_be :string?
     _(field.type.struct_type.fields[2].type).wont_be :bytes?
@@ -389,6 +404,7 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     _(field.type.struct_type.fields[3].type).wont_be :int?
     _(field.type.struct_type.fields[3].type).wont_be :float?
     _(field.type.struct_type.fields[3].type).wont_be :numeric?
+    _(field.type.struct_type.fields[3].type).wont_be :bignumeric?
     _(field.type.struct_type.fields[3].type).must_be :boolean?
     _(field.type.struct_type.fields[3].type).wont_be :string?
     _(field.type.struct_type.fields[3].type).wont_be :bytes?
@@ -409,6 +425,7 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     _(field.type.struct_type.fields[4].type).wont_be :int?
     _(field.type.struct_type.fields[4].type).wont_be :float?
     _(field.type.struct_type.fields[4].type).wont_be :numeric?
+    _(field.type.struct_type.fields[4].type).wont_be :bignumeric?
     _(field.type.struct_type.fields[4].type).wont_be :boolean?
     _(field.type.struct_type.fields[4].type).must_be :string?
     _(field.type.struct_type.fields[4].type).wont_be :bytes?
@@ -429,6 +446,7 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     _(field.type.struct_type.fields[5].type).wont_be :int?
     _(field.type.struct_type.fields[5].type).wont_be :float?
     _(field.type.struct_type.fields[5].type).wont_be :numeric?
+    _(field.type.struct_type.fields[5].type).wont_be :bignumeric?
     _(field.type.struct_type.fields[5].type).wont_be :boolean?
     _(field.type.struct_type.fields[5].type).wont_be :string?
     _(field.type.struct_type.fields[5].type).must_be :bytes?
@@ -449,6 +467,7 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     _(field.type.struct_type.fields[6].type).wont_be :int?
     _(field.type.struct_type.fields[6].type).wont_be :float?
     _(field.type.struct_type.fields[6].type).wont_be :numeric?
+    _(field.type.struct_type.fields[6].type).wont_be :bignumeric?
     _(field.type.struct_type.fields[6].type).wont_be :boolean?
     _(field.type.struct_type.fields[6].type).wont_be :string?
     _(field.type.struct_type.fields[6].type).wont_be :bytes?
@@ -469,6 +488,7 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     _(field.type.struct_type.fields[7].type).wont_be :int?
     _(field.type.struct_type.fields[7].type).wont_be :float?
     _(field.type.struct_type.fields[7].type).wont_be :numeric?
+    _(field.type.struct_type.fields[7].type).wont_be :bignumeric?
     _(field.type.struct_type.fields[7].type).wont_be :boolean?
     _(field.type.struct_type.fields[7].type).wont_be :string?
     _(field.type.struct_type.fields[7].type).wont_be :bytes?
@@ -489,6 +509,7 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     _(field.type.struct_type.fields[8].type).wont_be :int?
     _(field.type.struct_type.fields[8].type).wont_be :float?
     _(field.type.struct_type.fields[8].type).wont_be :numeric?
+    _(field.type.struct_type.fields[8].type).wont_be :bignumeric?
     _(field.type.struct_type.fields[8].type).wont_be :boolean?
     _(field.type.struct_type.fields[8].type).wont_be :string?
     _(field.type.struct_type.fields[8].type).wont_be :bytes?
@@ -509,6 +530,7 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     _(field.type.struct_type.fields[9].type).wont_be :int?
     _(field.type.struct_type.fields[9].type).wont_be :float?
     _(field.type.struct_type.fields[9].type).wont_be :numeric?
+    _(field.type.struct_type.fields[9].type).wont_be :bignumeric?
     _(field.type.struct_type.fields[9].type).wont_be :boolean?
     _(field.type.struct_type.fields[9].type).wont_be :string?
     _(field.type.struct_type.fields[9].type).wont_be :bytes?
@@ -529,6 +551,7 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     _(field.type.struct_type.fields[10].type).wont_be :int?
     _(field.type.struct_type.fields[10].type).wont_be :float?
     _(field.type.struct_type.fields[10].type).wont_be :numeric?
+    _(field.type.struct_type.fields[10].type).wont_be :bignumeric?
     _(field.type.struct_type.fields[10].type).wont_be :boolean?
     _(field.type.struct_type.fields[10].type).wont_be :string?
     _(field.type.struct_type.fields[10].type).wont_be :bytes?
@@ -539,6 +562,27 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     _(field.type.struct_type.fields[10].type).must_be :timestamp?
     _(field.type.struct_type.fields[10].type).wont_be :array?
     _(field.type.struct_type.fields[10].type).wont_be :struct?
+
+    _(field.type.struct_type.fields[11]).must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
+    _(field.type.struct_type.fields[11].name).must_equal "bignumeric_col"
+    _(field.type.struct_type.fields[11].type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.struct_type.fields[11].type.type_kind).must_equal "BIGNUMERIC"
+    _(field.type.struct_type.fields[11].type.array_element_type).must_be_nil
+    _(field.type.struct_type.fields[11].type.struct_type).must_be_nil
+    _(field.type.struct_type.fields[11].type).wont_be :int?
+    _(field.type.struct_type.fields[11].type).wont_be :float?
+    _(field.type.struct_type.fields[11].type).wont_be :numeric?
+    _(field.type.struct_type.fields[11].type).must_be :bignumeric?
+    _(field.type.struct_type.fields[11].type).wont_be :boolean?
+    _(field.type.struct_type.fields[11].type).wont_be :string?
+    _(field.type.struct_type.fields[11].type).wont_be :bytes?
+    _(field.type.struct_type.fields[11].type).wont_be :date?
+    _(field.type.struct_type.fields[11].type).wont_be :datetime?
+    _(field.type.struct_type.fields[11].type).wont_be :geography?
+    _(field.type.struct_type.fields[11].type).wont_be :time?
+    _(field.type.struct_type.fields[11].type).wont_be :timestamp?
+    _(field.type.struct_type.fields[11].type).wont_be :array?
+    _(field.type.struct_type.fields[11].type).wont_be :struct?
   end
 
   it "represents all types of array fields" do
@@ -553,7 +597,8 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
       array_field("datetime_array_col", "DATETIME"),
       array_field("geo_array_col", "GEOGRAPHY"),
       array_field("time_array_col", "TIME"),
-      array_field("ts_array_col", "TIMESTAMP")
+      array_field("ts_array_col", "TIMESTAMP"),
+      array_field("bignumeric_col", "BIGNUMERIC")
     ]
 
     struct_type = Google::Cloud::Bigquery::StandardSql::StructType.new fields: fields
@@ -570,6 +615,7 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     _(field.type).wont_be :int?
     _(field.type).wont_be :float?
     _(field.type).wont_be :numeric?
+    _(field.type).wont_be :bignumeric?
     _(field.type).wont_be :boolean?
     _(field.type).wont_be :string?
     _(field.type).wont_be :bytes?
@@ -582,7 +628,7 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     _(field.type).must_be :struct?
 
     _(field.type.struct_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::StructType
-    _(field.type.struct_type.fields.count).must_equal 11
+    _(field.type.struct_type.fields.count).must_equal 12
 
     _(field.type.struct_type.fields[0]).must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
     _(field.type.struct_type.fields[0].name).must_equal "int_array_col"
@@ -596,6 +642,7 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     _(field.type.struct_type.fields[0].type).wont_be :int?
     _(field.type.struct_type.fields[0].type).wont_be :float?
     _(field.type.struct_type.fields[0].type).wont_be :numeric?
+    _(field.type.struct_type.fields[0].type).wont_be :bignumeric?
     _(field.type.struct_type.fields[0].type).wont_be :boolean?
     _(field.type.struct_type.fields[0].type).wont_be :string?
     _(field.type.struct_type.fields[0].type).wont_be :bytes?
@@ -619,6 +666,7 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     _(field.type.struct_type.fields[1].type).wont_be :int?
     _(field.type.struct_type.fields[1].type).wont_be :float?
     _(field.type.struct_type.fields[1].type).wont_be :numeric?
+    _(field.type.struct_type.fields[1].type).wont_be :bignumeric?
     _(field.type.struct_type.fields[1].type).wont_be :boolean?
     _(field.type.struct_type.fields[1].type).wont_be :string?
     _(field.type.struct_type.fields[1].type).wont_be :bytes?
@@ -642,6 +690,7 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     _(field.type.struct_type.fields[2].type).wont_be :int?
     _(field.type.struct_type.fields[2].type).wont_be :float?
     _(field.type.struct_type.fields[2].type).wont_be :numeric?
+    _(field.type.struct_type.fields[2].type).wont_be :bignumeric?
     _(field.type.struct_type.fields[2].type).wont_be :boolean?
     _(field.type.struct_type.fields[2].type).wont_be :string?
     _(field.type.struct_type.fields[2].type).wont_be :bytes?
@@ -665,6 +714,7 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     _(field.type.struct_type.fields[3].type).wont_be :int?
     _(field.type.struct_type.fields[3].type).wont_be :float?
     _(field.type.struct_type.fields[3].type).wont_be :numeric?
+    _(field.type.struct_type.fields[3].type).wont_be :bignumeric?
     _(field.type.struct_type.fields[3].type).wont_be :boolean?
     _(field.type.struct_type.fields[3].type).wont_be :string?
     _(field.type.struct_type.fields[3].type).wont_be :bytes?
@@ -688,6 +738,7 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     _(field.type.struct_type.fields[4].type).wont_be :int?
     _(field.type.struct_type.fields[4].type).wont_be :float?
     _(field.type.struct_type.fields[4].type).wont_be :numeric?
+    _(field.type.struct_type.fields[4].type).wont_be :bignumeric?
     _(field.type.struct_type.fields[4].type).wont_be :boolean?
     _(field.type.struct_type.fields[4].type).wont_be :string?
     _(field.type.struct_type.fields[4].type).wont_be :bytes?
@@ -711,6 +762,7 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     _(field.type.struct_type.fields[5].type).wont_be :int?
     _(field.type.struct_type.fields[5].type).wont_be :float?
     _(field.type.struct_type.fields[5].type).wont_be :numeric?
+    _(field.type.struct_type.fields[5].type).wont_be :bignumeric?
     _(field.type.struct_type.fields[5].type).wont_be :boolean?
     _(field.type.struct_type.fields[5].type).wont_be :string?
     _(field.type.struct_type.fields[5].type).wont_be :bytes?
@@ -734,6 +786,7 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     _(field.type.struct_type.fields[6].type).wont_be :int?
     _(field.type.struct_type.fields[6].type).wont_be :float?
     _(field.type.struct_type.fields[6].type).wont_be :numeric?
+    _(field.type.struct_type.fields[6].type).wont_be :bignumeric?
     _(field.type.struct_type.fields[6].type).wont_be :boolean?
     _(field.type.struct_type.fields[6].type).wont_be :string?
     _(field.type.struct_type.fields[6].type).wont_be :bytes?
@@ -757,6 +810,7 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     _(field.type.struct_type.fields[7].type).wont_be :int?
     _(field.type.struct_type.fields[7].type).wont_be :float?
     _(field.type.struct_type.fields[7].type).wont_be :numeric?
+    _(field.type.struct_type.fields[7].type).wont_be :bignumeric?
     _(field.type.struct_type.fields[7].type).wont_be :boolean?
     _(field.type.struct_type.fields[7].type).wont_be :string?
     _(field.type.struct_type.fields[7].type).wont_be :bytes?
@@ -780,6 +834,7 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     _(field.type.struct_type.fields[8].type).wont_be :int?
     _(field.type.struct_type.fields[8].type).wont_be :float?
     _(field.type.struct_type.fields[8].type).wont_be :numeric?
+    _(field.type.struct_type.fields[8].type).wont_be :bignumeric?
     _(field.type.struct_type.fields[8].type).wont_be :boolean?
     _(field.type.struct_type.fields[8].type).wont_be :string?
     _(field.type.struct_type.fields[8].type).wont_be :bytes?
@@ -803,6 +858,7 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     _(field.type.struct_type.fields[9].type).wont_be :int?
     _(field.type.struct_type.fields[9].type).wont_be :float?
     _(field.type.struct_type.fields[9].type).wont_be :numeric?
+    _(field.type.struct_type.fields[9].type).wont_be :bignumeric?
     _(field.type.struct_type.fields[9].type).wont_be :boolean?
     _(field.type.struct_type.fields[9].type).wont_be :string?
     _(field.type.struct_type.fields[9].type).wont_be :bytes?
@@ -826,6 +882,7 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     _(field.type.struct_type.fields[10].type).wont_be :int?
     _(field.type.struct_type.fields[10].type).wont_be :float?
     _(field.type.struct_type.fields[10].type).wont_be :numeric?
+    _(field.type.struct_type.fields[10].type).wont_be :bignumeric?
     _(field.type.struct_type.fields[10].type).wont_be :boolean?
     _(field.type.struct_type.fields[10].type).wont_be :string?
     _(field.type.struct_type.fields[10].type).wont_be :bytes?
@@ -836,6 +893,30 @@ describe Google::Cloud::Bigquery::StandardSql, :struct do
     _(field.type.struct_type.fields[10].type).wont_be :timestamp?
     _(field.type.struct_type.fields[10].type).must_be :array?
     _(field.type.struct_type.fields[10].type).wont_be :struct?
+
+    _(field.type.struct_type.fields[11]).must_be_kind_of Google::Cloud::Bigquery::StandardSql::Field
+    _(field.type.struct_type.fields[11].name).must_equal "bignumeric_col"
+    _(field.type.struct_type.fields[11].type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.struct_type.fields[11].type.type_kind).must_equal "ARRAY"
+    _(field.type.struct_type.fields[11].type.array_element_type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.struct_type.fields[11].type.array_element_type.type_kind).must_equal "BIGNUMERIC"
+    _(field.type.struct_type.fields[11].type.array_element_type.array_element_type).must_be_nil
+    _(field.type.struct_type.fields[11].type.array_element_type.struct_type).must_be_nil
+    _(field.type.struct_type.fields[11].type.struct_type).must_be_nil
+    _(field.type.struct_type.fields[11].type).wont_be :int?
+    _(field.type.struct_type.fields[11].type).wont_be :float?
+    _(field.type.struct_type.fields[11].type).wont_be :numeric?
+    _(field.type.struct_type.fields[11].type).wont_be :bignumeric?
+    _(field.type.struct_type.fields[11].type).wont_be :boolean?
+    _(field.type.struct_type.fields[11].type).wont_be :string?
+    _(field.type.struct_type.fields[11].type).wont_be :bytes?
+    _(field.type.struct_type.fields[11].type).wont_be :date?
+    _(field.type.struct_type.fields[11].type).wont_be :datetime?
+    _(field.type.struct_type.fields[11].type).wont_be :geography?
+    _(field.type.struct_type.fields[11].type).wont_be :time?
+    _(field.type.struct_type.fields[11].type).wont_be :timestamp?
+    _(field.type.struct_type.fields[11].type).must_be :array?
+    _(field.type.struct_type.fields[11].type).wont_be :struct?
   end
 
   def value_field name, type_kind

--- a/google-cloud-bigquery/test/google/cloud/bigquery/standard_sql/value_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/standard_sql/value_test.rb
@@ -50,6 +50,7 @@ describe Google::Cloud::Bigquery::StandardSql, :value do
     _(field.type).must_be :int?
     _(field.type).wont_be :float?
     _(field.type).wont_be :numeric?
+    _(field.type).wont_be :bignumeric?
     _(field.type).wont_be :boolean?
     _(field.type).wont_be :string?
     _(field.type).wont_be :bytes?
@@ -75,6 +76,7 @@ describe Google::Cloud::Bigquery::StandardSql, :value do
     _(field.type).wont_be :int?
     _(field.type).must_be :float?
     _(field.type).wont_be :numeric?
+    _(field.type).wont_be :bignumeric?
     _(field.type).wont_be :boolean?
     _(field.type).wont_be :string?
     _(field.type).wont_be :bytes?
@@ -100,6 +102,33 @@ describe Google::Cloud::Bigquery::StandardSql, :value do
     _(field.type).wont_be :int?
     _(field.type).wont_be :float?
     _(field.type).must_be :numeric?
+    _(field.type).wont_be :bignumeric?
+    _(field.type).wont_be :boolean?
+    _(field.type).wont_be :string?
+    _(field.type).wont_be :bytes?
+    _(field.type).wont_be :date?
+    _(field.type).wont_be :datetime?
+    _(field.type).wont_be :geography?
+    _(field.type).wont_be :time?
+    _(field.type).wont_be :timestamp?
+    _(field.type).wont_be :array?
+    _(field.type).wont_be :struct?
+  end
+
+  it "represents a BIGNUMERIC field" do
+    field = Google::Cloud::Bigquery::StandardSql::Field.new name: "bignumeric_col", type: "BIGNUMERIC"
+
+    _(field.name).must_equal "bignumeric_col"
+
+    _(field.type).must_be_kind_of Google::Cloud::Bigquery::StandardSql::DataType
+    _(field.type.type_kind).must_equal "BIGNUMERIC"
+    _(field.type.array_element_type).must_be_nil
+    _(field.type.struct_type).must_be_nil
+
+    _(field.type).wont_be :int?
+    _(field.type).wont_be :float?
+    _(field.type).wont_be :numeric?
+    _(field.type).must_be :bignumeric?
     _(field.type).wont_be :boolean?
     _(field.type).wont_be :string?
     _(field.type).wont_be :bytes?
@@ -125,6 +154,7 @@ describe Google::Cloud::Bigquery::StandardSql, :value do
     _(field.type).wont_be :int?
     _(field.type).wont_be :float?
     _(field.type).wont_be :numeric?
+    _(field.type).wont_be :bignumeric?
     _(field.type).must_be :boolean?
     _(field.type).wont_be :string?
     _(field.type).wont_be :bytes?
@@ -150,6 +180,7 @@ describe Google::Cloud::Bigquery::StandardSql, :value do
     _(field.type).wont_be :int?
     _(field.type).wont_be :float?
     _(field.type).wont_be :numeric?
+    _(field.type).wont_be :bignumeric?
     _(field.type).wont_be :boolean?
     _(field.type).must_be :string?
     _(field.type).wont_be :bytes?
@@ -175,6 +206,7 @@ describe Google::Cloud::Bigquery::StandardSql, :value do
     _(field.type).wont_be :int?
     _(field.type).wont_be :float?
     _(field.type).wont_be :numeric?
+    _(field.type).wont_be :bignumeric?
     _(field.type).wont_be :boolean?
     _(field.type).wont_be :string?
     _(field.type).must_be :bytes?
@@ -200,6 +232,7 @@ describe Google::Cloud::Bigquery::StandardSql, :value do
     _(field.type).wont_be :int?
     _(field.type).wont_be :float?
     _(field.type).wont_be :numeric?
+    _(field.type).wont_be :bignumeric?
     _(field.type).wont_be :boolean?
     _(field.type).wont_be :string?
     _(field.type).wont_be :bytes?
@@ -225,6 +258,7 @@ describe Google::Cloud::Bigquery::StandardSql, :value do
     _(field.type).wont_be :int?
     _(field.type).wont_be :float?
     _(field.type).wont_be :numeric?
+    _(field.type).wont_be :bignumeric?
     _(field.type).wont_be :boolean?
     _(field.type).wont_be :string?
     _(field.type).wont_be :bytes?
@@ -250,6 +284,7 @@ describe Google::Cloud::Bigquery::StandardSql, :value do
     _(field.type).wont_be :int?
     _(field.type).wont_be :float?
     _(field.type).wont_be :numeric?
+    _(field.type).wont_be :bignumeric?
     _(field.type).wont_be :boolean?
     _(field.type).wont_be :string?
     _(field.type).wont_be :bytes?
@@ -275,6 +310,7 @@ describe Google::Cloud::Bigquery::StandardSql, :value do
     _(field.type).wont_be :int?
     _(field.type).wont_be :float?
     _(field.type).wont_be :numeric?
+    _(field.type).wont_be :bignumeric?
     _(field.type).wont_be :boolean?
     _(field.type).wont_be :string?
     _(field.type).wont_be :bytes?
@@ -300,6 +336,7 @@ describe Google::Cloud::Bigquery::StandardSql, :value do
     _(field.type).wont_be :int?
     _(field.type).wont_be :float?
     _(field.type).wont_be :numeric?
+    _(field.type).wont_be :bignumeric?
     _(field.type).wont_be :boolean?
     _(field.type).wont_be :string?
     _(field.type).wont_be :bytes?

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_attributes_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_attributes_test.rb
@@ -95,8 +95,8 @@ describe Google::Cloud::Bigquery::Table, :attributes, :mock_bigquery do
     _(table.schema).must_be :frozen?
     _(table.schema.fields).wont_be :empty?
     _(table.fields).wont_be :empty?
-    _(table.headers).must_equal [:name, :age, :score, :pi, :active, :avatar, :started_at, :duration, :target_end, :birthday]
-    _(table.param_types).must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
+    _(table.headers).must_equal [:name, :age, :score, :pi, :my_bignumeric, :active, :avatar, :started_at, :duration, :target_end, :birthday]
+    _(table.param_types).must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, my_bignumeric: :BIGNUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
 
     mock.verify
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
@@ -38,6 +38,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
   let(:field_integer_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "rank", type: "INTEGER", description: "An integer value from 1 to 100", mode: "NULLABLE", fields: [] }
   let(:field_float_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "accuracy", type: "FLOAT", mode: "NULLABLE", description: nil, fields: [] }
   let(:field_numeric_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "pi", type: "NUMERIC", mode: "NULLABLE", description: nil, fields: [] }
+  let(:field_bignumeric_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "my_bignumeric", type: "BIGNUMERIC", mode: "NULLABLE", description: nil, fields: [] }
   let(:field_boolean_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "approved", type: "BOOLEAN", mode: "NULLABLE", description: nil, fields: [] }
   let(:field_bytes_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "avatar", type: "BYTES", mode: "NULLABLE", description: nil, fields: [] }
   let(:field_timestamp_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "started_at", type: "TIMESTAMP", mode: "NULLABLE", description: nil, fields: [] }
@@ -72,7 +73,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
   it "gets the schema, fields, and headers" do
     _(table.schema).must_be_kind_of Google::Cloud::Bigquery::Schema
     _(table.schema).must_be :frozen?
-    _(table.schema.fields.count).must_equal 10
+    _(table.schema.fields.count).must_equal 11
 
     _(table.schema.fields[0].name).must_equal "name"
     _(table.schema.fields[0].type).must_equal "STRING"
@@ -94,40 +95,45 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     _(table.schema.fields[3].description).must_be :nil?
     _(table.schema.fields[3].mode).must_equal "NULLABLE"
 
-    _(table.schema.fields[4].name).must_equal "active"
-    _(table.schema.fields[4].type).must_equal "BOOLEAN"
+    _(table.schema.fields[4].name).must_equal "my_bignumeric"
+    _(table.schema.fields[4].type).must_equal "BIGNUMERIC"
     _(table.schema.fields[4].description).must_be :nil?
     _(table.schema.fields[4].mode).must_equal "NULLABLE"
 
-    _(table.schema.fields[5].name).must_equal "avatar"
-    _(table.schema.fields[5].type).must_equal "BYTES"
+    _(table.schema.fields[5].name).must_equal "active"
+    _(table.schema.fields[5].type).must_equal "BOOLEAN"
     _(table.schema.fields[5].description).must_be :nil?
     _(table.schema.fields[5].mode).must_equal "NULLABLE"
 
-    _(table.schema.fields[6].name).must_equal "started_at"
-    _(table.schema.fields[6].type).must_equal "TIMESTAMP"
+    _(table.schema.fields[6].name).must_equal "avatar"
+    _(table.schema.fields[6].type).must_equal "BYTES"
     _(table.schema.fields[6].description).must_be :nil?
     _(table.schema.fields[6].mode).must_equal "NULLABLE"
 
-    _(table.schema.fields[7].name).must_equal "duration"
-    _(table.schema.fields[7].type).must_equal "TIME"
+    _(table.schema.fields[7].name).must_equal "started_at"
+    _(table.schema.fields[7].type).must_equal "TIMESTAMP"
     _(table.schema.fields[7].description).must_be :nil?
     _(table.schema.fields[7].mode).must_equal "NULLABLE"
 
-    _(table.schema.fields[8].name).must_equal "target_end"
-    _(table.schema.fields[8].type).must_equal "DATETIME"
+    _(table.schema.fields[8].name).must_equal "duration"
+    _(table.schema.fields[8].type).must_equal "TIME"
     _(table.schema.fields[8].description).must_be :nil?
     _(table.schema.fields[8].mode).must_equal "NULLABLE"
 
-    _(table.schema.fields[9].name).must_equal "birthday"
-    _(table.schema.fields[9].type).must_equal "DATE"
+    _(table.schema.fields[9].name).must_equal "target_end"
+    _(table.schema.fields[9].type).must_equal "DATETIME"
     _(table.schema.fields[9].description).must_be :nil?
     _(table.schema.fields[9].mode).must_equal "NULLABLE"
 
-    _(table.fields.count).must_equal 10
+    _(table.schema.fields[10].name).must_equal "birthday"
+    _(table.schema.fields[10].type).must_equal "DATE"
+    _(table.schema.fields[10].description).must_be :nil?
+    _(table.schema.fields[10].mode).must_equal "NULLABLE"
+
+    _(table.fields.count).must_equal 11
     _(table.fields.map(&:name)).must_equal table.schema.fields.map(&:name)
-    _(table.headers).must_equal [:name, :age, :score, :pi, :active, :avatar, :started_at, :duration, :target_end, :birthday]
-    _(table.param_types).must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
+    _(table.headers).must_equal [:name, :age, :score, :pi, :my_bignumeric, :active, :avatar, :started_at, :duration, :target_end, :birthday]
+    _(table.param_types).must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, my_bignumeric: :BIGNUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
   end
 
   it "sets a flat schema via a block with replace option true" do
@@ -136,6 +142,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
                field_integer_gapi,
                field_float_gapi,
                field_numeric_gapi,
+               field_bignumeric_gapi,
                field_boolean_gapi,
                field_bytes_gapi,
                field_timestamp_gapi,
@@ -157,6 +164,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
       schema.integer "rank", description: "An integer value from 1 to 100"
       schema.float "accuracy"
       schema.numeric "pi"
+      schema.bignumeric "my_bignumeric"
       schema.boolean "approved"
       schema.bytes "avatar"
       schema.timestamp "started_at"

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_test.rb
@@ -102,8 +102,8 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     _(table.schema).must_be_kind_of Google::Cloud::Bigquery::Schema
     _(table.schema).must_be :frozen?
     _(table.fields.map(&:name)).must_equal table.schema.fields.map(&:name)
-    _(table.headers).must_equal [:name, :age, :score, :pi, :active, :avatar, :started_at, :duration, :target_end, :birthday]
-    _(table.param_types).must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
+    _(table.headers).must_equal [:name, :age, :score, :pi, :my_bignumeric, :active, :avatar, :started_at, :duration, :target_end, :birthday]
+    _(table.param_types).must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, my_bignumeric: :BIGNUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
   end
 
   it "knows its streaming buffer attributes" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/view_attributes_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/view_attributes_test.rb
@@ -79,8 +79,8 @@ describe Google::Cloud::Bigquery::Table, :view, :attributes, :mock_bigquery do
     _(view.schema).must_be :frozen?
     _(view.schema.fields).wont_be :empty?
     _(view.fields).wont_be :empty?
-    _(view.headers).must_equal [:name, :age, :score, :pi, :active, :avatar, :started_at, :duration, :target_end, :birthday]
-    _(view.param_types).must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
+    _(view.headers).must_equal [:name, :age, :score, :pi, :my_bignumeric, :active, :avatar, :started_at, :duration, :target_end, :birthday]
+    _(view.param_types).must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, my_bignumeric: :BIGNUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
 
     mock.verify
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/view_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/view_test.rb
@@ -64,8 +64,8 @@ describe Google::Cloud::Bigquery::Table, :view, :mock_bigquery do
     _(view.schema).must_be_kind_of Google::Cloud::Bigquery::Schema
     _(view.schema).must_be :frozen?
     _(view.fields.map(&:name)).must_equal view.schema.fields.map(&:name)
-    _(view.headers).must_equal [:name, :age, :score, :pi, :active, :avatar, :started_at, :duration, :target_end, :birthday]
-    _(view.param_types).must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
+    _(view.headers).must_equal [:name, :age, :score, :pi, :my_bignumeric, :active, :avatar, :started_at, :duration, :target_end, :birthday]
+    _(view.param_types).must_equal({ name: :STRING, age: :INTEGER, score: :FLOAT, pi: :NUMERIC, my_bignumeric: :BIGNUMERIC, active: :BOOLEAN, avatar: :BYTES, started_at: :TIMESTAMP, duration: :TIME, target_end: :DATETIME, birthday: :DATE })
   end
 
   it "can test its existence" do

--- a/google-cloud-bigquery/test/helper.rb
+++ b/google-cloud-bigquery/test/helper.rb
@@ -138,6 +138,11 @@ class MockBigquery < Minitest::Spec
           "mode" => "NULLABLE"
         },
         {
+          "name" => "my_bignumeric",
+          "type" => "BIGNUMERIC",
+          "mode" => "NULLABLE"
+        },
+        {
           "name" => "active",
           "type" => "BOOLEAN",
           "mode" => "NULLABLE"
@@ -179,6 +184,7 @@ class MockBigquery < Minitest::Spec
           { "v" => "36" },
           { "v" => "7.65" },
           { "v" => "3.141592654" },
+          { "v" => "3.141592654" },
           { "v" => "true" },
           { "v" => "aW1hZ2UgZGF0YQ==" },
           { "v" => "1482670800.0" },
@@ -193,6 +199,7 @@ class MockBigquery < Minitest::Spec
           { "v" => "42" },
           { "v" => "8.15" },
           { "v" => nil },
+          { "v" => nil },
           { "v" => "false" },
           { "v" => nil },
           { "v" => nil },
@@ -204,6 +211,7 @@ class MockBigquery < Minitest::Spec
       {
         "f" => [
           { "v" => "Sally" },
+          { "v" => nil },
           { "v" => nil },
           { "v" => nil },
           { "v" => nil },


### PR DESCRIPTION
closes: #10094

### How it is now

The existing implementation automatically converts Ruby `BigDecimal` types to BigQuery `NUMERIC` types as shown in this table (from the current `master` branch). As noted, the existing implementation automatically rounds `BigDecimal` values greater than scale 9.

| BigQuery    | Ruby           | Notes  |
|-------------|----------------|---|
| `BOOL`      | `true`/`false` | |
| `INT64`     | `Integer`      | |
| `FLOAT64`   | `Float`        | |
| `NUMERIC`   | `BigDecimal`   | Will be rounded to 9 decimal places |
| `STRING`    | `String`       | |
| `DATETIME`  | `DateTime`     | `DATETIME` does not support time zone. |
| `DATE`      | `Date`         | |
| `TIMESTAMP` | `Time`         | |
| `TIME`      | `Google::Cloud::BigQuery::Time` | |
| `BYTES`     | `File`, `IO`, `StringIO`, or similar | |
| `ARRAY`     | `Array` | Nested arrays and `nil` values are not supported. |
| `STRUCT`    | `Hash`         | Hash keys may be strings or symbols. |

### Proposed changes

This PR enables users to use the existing `types` option to explicitly map `BigDecimal` values provided for **query param arguments** to BigQuery `BIGNUMERIC` types, with a simple conversion that does not round the value (even if it is out of range for `BIGNUMERIC`.) The table above is updated as follows:

| BigQuery     | Ruby                                 | Notes                                                        |
|------------- |--------------------------------------|--------------------------------------------------------------|
| `BOOL`       | `true`/`false`                       |                                                              |
| `INT64`      | `Integer`                            |                                                              |
| `FLOAT64`    | `Float`                              |                                                              |
| `NUMERIC`    | `BigDecimal`                         | `BigDecimal` values will be rounded to scale 9.                |
| `BIGNUMERIC` |converted to `BigDecimal`            | Pass data as `String` and map query param value in `types`.
| `STRING`     | `String`                             |                                                              |
| `DATETIME`   | `DateTime`                           | `DATETIME` does not support time zone.                       |
| `DATE`       | `Date`                               |                                                              |
| `TIMESTAMP`  | `Time`                               |                                                              |
| `TIME`       | `Google::Cloud::BigQuery::Time`      |                                                              |
| `BYTES`      | `File`, `IO`, `StringIO`, or similar |                                                              |
| `ARRAY`      | `Array`                              | Nested arrays, `nil` values are not supported.               |
| `STRUCT`     | `Hash`                               | Hash keys may be strings or symbols.                         |

The table advises the user: "converted to `BigDecimal` - Pass data as `String` and map query param value in `types`." The advice about data is explained in the note below.

#### **NOTE:**

There is no existing `types` option for the client `insert` methods that insert table data, because the BigQuery API does not accept types for inserts--just the JSON data, which is always in strings. The user has no way to explicitly map the conversion of Ruby types to string values in the JSON data. Therefore, the new version of the table above recommends that the user provides data for `BIGNUMERIC` columns as strings, not `BigDecimal`, with the following warning in the inline docs:

```
        # @param [Hash, Array<Hash>] rows A hash object or array of hash objects
        #   containing the data. Required. `BigDecimal` values will be rounded to
        #   scale 9 to conform with the BigQuery `NUMERIC` data type. To avoid
        #   rounding `BIGNUMERIC` type values with scale greater than 9, use `String`
        #   instead of `BigDecimal`.
```

And demonstrated as follows:

```
        # @example Pass `BIGNUMERIC` value as a string to avoid rounding to scale 9 in the conversion from `BigDecimal`:
        #   require "google/cloud/bigquery"
        #
        #   bigquery = Google::Cloud::Bigquery.new
        #   dataset = bigquery.dataset "my_dataset"
        #
        #   row = {
        #     "my_numeric" => BigDecimal("123456798.987654321"),
        #     "my_bignumeric" => "123456798.98765432100001" # BigDecimal would be rounded, use String instead!
        #   }
        #   dataset.insert "my_table", row
```