### PR TITLE
chore: publish to cloudrad on gem release

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -482,6 +482,7 @@ namespace :kokoro do
   task :release do
     kokoro.release
     Rake::Task["release"].invoke kokoro.tag
+    kokoro.cloudrad
   end
 
   task :release_please, :gem, :token do |t, args|

--- a/rakelib/kokoro/kokoro.rb
+++ b/rakelib/kokoro/kokoro.rb
@@ -62,7 +62,7 @@ class Kokoro < Command
   def cloudrad
     run_ci @gem, true do
       header "Building Doc YAMLs"
-      FileUtils.remove_dir  "doc" if Dir.exists?  "doc"
+      FileUtils.remove_dir "doc" if Dir.exists? "doc"
       run "bundle exec rake cloudrad", 1800
       RepoMetadata.from_source(".repo-metadata.json").build "."
       header "Uploading Doc YAMLs"

--- a/rakelib/kokoro/kokoro.rb
+++ b/rakelib/kokoro/kokoro.rb
@@ -60,7 +60,7 @@ class Kokoro < Command
   end
 
   def cloudrad
-    run_ci @gem, true do
+    run_ci @gem do
       header "Building Doc YAMLs"
       FileUtils.remove_dir "doc" if Dir.exists? "doc"
       run "bundle exec rake cloudrad", 1800

--- a/rakelib/kokoro/kokoro.rb
+++ b/rakelib/kokoro/kokoro.rb
@@ -72,7 +72,7 @@ class Kokoro < Command
         "--metadata-file=./docs.metadata",
         "--destination-prefix docfx"
       ]
-      run "python3 -m docuploader upload . #{opts.join ' '}"
+      run "python3 -m docuploader upload doc #{opts.join ' '}"
     end
   end
 

--- a/rakelib/kokoro/kokoro.rb
+++ b/rakelib/kokoro/kokoro.rb
@@ -6,6 +6,7 @@ require "open3"
 
 require_relative "command"
 require_relative "kokoro_builder"
+require_relative "../devsite/repo_metadata"
 
 class Kokoro < Command
   # Normally true. Set to false temporarily when releases are frozen.
@@ -56,6 +57,23 @@ class Kokoro < Command
       local_docs_test if should_link_check?
     end
     release_please if @should_release && @updated
+  end
+
+  def cloudrad
+    run_ci @gem, true do
+      header "Building Doc YAMLs"
+      FileUtils.remove_dir  "doc" if Dir.exists?  "doc"
+      run "bundle exec rake cloudrad", 1800
+      RepoMetadata.from_source(".repo-metadata.json").build "."
+      header "Uploading Doc YAMLs"
+      opts = [
+        "--credentials=#{ENV['KOKORO_KEYSTORE_DIR']}/73713_docuploader_service_account",
+        "--staging-bucket=#{ENV.fetch 'V2_STAGING_BUCKET', 'docs-staging-v2-dev'}",
+        "--metadata-file=./docs.metadata",
+        "--destination-prefix docfx"
+      ]
+      run "python3 -m docuploader upload . #{opts.join ' '}"
+    end
   end
 
   def samples_presubmit


### PR DESCRIPTION
builds/publishes cloudrad docs after the rest of the release pipeline has completed

this doesn't need to use all the DevisteBuilder/YardBuilder stuff until we want to publish old versions