### PR TITLE
chore: Update gapic-metadata and gapic-common dependency for all versioned gems

### DIFF
--- a/google-analytics-admin-v1alpha/gapic_metadata.json
+++ b/google-analytics-admin-v1alpha/gapic_metadata.json
@@ -9,151 +9,247 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Analytics::Admin::V1alpha::AnalyticsAdminService::Client",
-          "methods": {
-            "GetAccount": [
-              "get_account"
-            ],
-            "ListAccounts": [
-              "list_accounts"
-            ],
-            "DeleteAccount": [
-              "delete_account"
-            ],
-            "UpdateAccount": [
-              "update_account"
-            ],
-            "ProvisionAccountTicket": [
-              "provision_account_ticket"
-            ],
-            "ListAccountSummaries": [
-              "list_account_summaries"
-            ],
-            "GetProperty": [
-              "get_property"
-            ],
-            "ListProperties": [
-              "list_properties"
-            ],
-            "CreateProperty": [
-              "create_property"
-            ],
-            "DeleteProperty": [
-              "delete_property"
-            ],
-            "UpdateProperty": [
-              "update_property"
-            ],
-            "GetUserLink": [
-              "get_user_link"
-            ],
-            "BatchGetUserLinks": [
-              "batch_get_user_links"
-            ],
-            "ListUserLinks": [
-              "list_user_links"
-            ],
-            "AuditUserLinks": [
-              "audit_user_links"
-            ],
-            "CreateUserLink": [
-              "create_user_link"
-            ],
-            "BatchCreateUserLinks": [
-              "batch_create_user_links"
-            ],
-            "UpdateUserLink": [
-              "update_user_link"
-            ],
-            "BatchUpdateUserLinks": [
-              "batch_update_user_links"
-            ],
-            "DeleteUserLink": [
-              "delete_user_link"
-            ],
-            "BatchDeleteUserLinks": [
-              "batch_delete_user_links"
-            ],
-            "GetWebDataStream": [
-              "get_web_data_stream"
-            ],
-            "DeleteWebDataStream": [
-              "delete_web_data_stream"
-            ],
-            "UpdateWebDataStream": [
-              "update_web_data_stream"
-            ],
-            "CreateWebDataStream": [
-              "create_web_data_stream"
-            ],
-            "ListWebDataStreams": [
-              "list_web_data_streams"
-            ],
-            "GetIosAppDataStream": [
-              "get_ios_app_data_stream"
-            ],
-            "DeleteIosAppDataStream": [
-              "delete_ios_app_data_stream"
-            ],
-            "UpdateIosAppDataStream": [
-              "update_ios_app_data_stream"
-            ],
-            "CreateIosAppDataStream": [
-              "create_ios_app_data_stream"
-            ],
-            "ListIosAppDataStreams": [
-              "list_ios_app_data_streams"
-            ],
-            "GetAndroidAppDataStream": [
-              "get_android_app_data_stream"
-            ],
-            "DeleteAndroidAppDataStream": [
-              "delete_android_app_data_stream"
-            ],
-            "UpdateAndroidAppDataStream": [
-              "update_android_app_data_stream"
-            ],
-            "CreateAndroidAppDataStream": [
-              "create_android_app_data_stream"
-            ],
-            "ListAndroidAppDataStreams": [
-              "list_android_app_data_streams"
-            ],
-            "GetEnhancedMeasurementSettings": [
-              "get_enhanced_measurement_settings"
-            ],
-            "UpdateEnhancedMeasurementSettings": [
-              "update_enhanced_measurement_settings"
-            ],
-            "CreateFirebaseLink": [
-              "create_firebase_link"
-            ],
-            "UpdateFirebaseLink": [
-              "update_firebase_link"
-            ],
-            "DeleteFirebaseLink": [
-              "delete_firebase_link"
-            ],
-            "ListFirebaseLinks": [
-              "list_firebase_links"
-            ],
-            "GetGlobalSiteTag": [
-              "get_global_site_tag"
-            ],
-            "CreateGoogleAdsLink": [
-              "create_google_ads_link"
-            ],
-            "UpdateGoogleAdsLink": [
-              "update_google_ads_link"
-            ],
-            "DeleteGoogleAdsLink": [
-              "delete_google_ads_link"
-            ],
-            "ListGoogleAdsLinks": [
-              "list_google_ads_links"
-            ],
-            "GetDataSharingSettings": [
-              "get_data_sharing_settings"
-            ]
+          "rpcs": {
+            "GetAccount": {
+              "methods": [
+                "get_account"
+              ]
+            },
+            "ListAccounts": {
+              "methods": [
+                "list_accounts"
+              ]
+            },
+            "DeleteAccount": {
+              "methods": [
+                "delete_account"
+              ]
+            },
+            "UpdateAccount": {
+              "methods": [
+                "update_account"
+              ]
+            },
+            "ProvisionAccountTicket": {
+              "methods": [
+                "provision_account_ticket"
+              ]
+            },
+            "ListAccountSummaries": {
+              "methods": [
+                "list_account_summaries"
+              ]
+            },
+            "GetProperty": {
+              "methods": [
+                "get_property"
+              ]
+            },
+            "ListProperties": {
+              "methods": [
+                "list_properties"
+              ]
+            },
+            "CreateProperty": {
+              "methods": [
+                "create_property"
+              ]
+            },
+            "DeleteProperty": {
+              "methods": [
+                "delete_property"
+              ]
+            },
+            "UpdateProperty": {
+              "methods": [
+                "update_property"
+              ]
+            },
+            "GetUserLink": {
+              "methods": [
+                "get_user_link"
+              ]
+            },
+            "BatchGetUserLinks": {
+              "methods": [
+                "batch_get_user_links"
+              ]
+            },
+            "ListUserLinks": {
+              "methods": [
+                "list_user_links"
+              ]
+            },
+            "AuditUserLinks": {
+              "methods": [
+                "audit_user_links"
+              ]
+            },
+            "CreateUserLink": {
+              "methods": [
+                "create_user_link"
+              ]
+            },
+            "BatchCreateUserLinks": {
+              "methods": [
+                "batch_create_user_links"
+              ]
+            },
+            "UpdateUserLink": {
+              "methods": [
+                "update_user_link"
+              ]
+            },
+            "BatchUpdateUserLinks": {
+              "methods": [
+                "batch_update_user_links"
+              ]
+            },
+            "DeleteUserLink": {
+              "methods": [
+                "delete_user_link"
+              ]
+            },
+            "BatchDeleteUserLinks": {
+              "methods": [
+                "batch_delete_user_links"
+              ]
+            },
+            "GetWebDataStream": {
+              "methods": [
+                "get_web_data_stream"
+              ]
+            },
+            "DeleteWebDataStream": {
+              "methods": [
+                "delete_web_data_stream"
+              ]
+            },
+            "UpdateWebDataStream": {
+              "methods": [
+                "update_web_data_stream"
+              ]
+            },
+            "CreateWebDataStream": {
+              "methods": [
+                "create_web_data_stream"
+              ]
+            },
+            "ListWebDataStreams": {
+              "methods": [
+                "list_web_data_streams"
+              ]
+            },
+            "GetIosAppDataStream": {
+              "methods": [
+                "get_ios_app_data_stream"
+              ]
+            },
+            "DeleteIosAppDataStream": {
+              "methods": [
+                "delete_ios_app_data_stream"
+              ]
+            },
+            "UpdateIosAppDataStream": {
+              "methods": [
+                "update_ios_app_data_stream"
+              ]
+            },
+            "CreateIosAppDataStream": {
+              "methods": [
+                "create_ios_app_data_stream"
+              ]
+            },
+            "ListIosAppDataStreams": {
+              "methods": [
+                "list_ios_app_data_streams"
+              ]
+            },
+            "GetAndroidAppDataStream": {
+              "methods": [
+                "get_android_app_data_stream"
+              ]
+            },
+            "DeleteAndroidAppDataStream": {
+              "methods": [
+                "delete_android_app_data_stream"
+              ]
+            },
+            "UpdateAndroidAppDataStream": {
+              "methods": [
+                "update_android_app_data_stream"
+              ]
+            },
+            "CreateAndroidAppDataStream": {
+              "methods": [
+                "create_android_app_data_stream"
+              ]
+            },
+            "ListAndroidAppDataStreams": {
+              "methods": [
+                "list_android_app_data_streams"
+              ]
+            },
+            "GetEnhancedMeasurementSettings": {
+              "methods": [
+                "get_enhanced_measurement_settings"
+              ]
+            },
+            "UpdateEnhancedMeasurementSettings": {
+              "methods": [
+                "update_enhanced_measurement_settings"
+              ]
+            },
+            "CreateFirebaseLink": {
+              "methods": [
+                "create_firebase_link"
+              ]
+            },
+            "UpdateFirebaseLink": {
+              "methods": [
+                "update_firebase_link"
+              ]
+            },
+            "DeleteFirebaseLink": {
+              "methods": [
+                "delete_firebase_link"
+              ]
+            },
+            "ListFirebaseLinks": {
+              "methods": [
+                "list_firebase_links"
+              ]
+            },
+            "GetGlobalSiteTag": {
+              "methods": [
+                "get_global_site_tag"
+              ]
+            },
+            "CreateGoogleAdsLink": {
+              "methods": [
+                "create_google_ads_link"
+              ]
+            },
+            "UpdateGoogleAdsLink": {
+              "methods": [
+                "update_google_ads_link"
+              ]
+            },
+            "DeleteGoogleAdsLink": {
+              "methods": [
+                "delete_google_ads_link"
+              ]
+            },
+            "ListGoogleAdsLinks": {
+              "methods": [
+                "list_google_ads_links"
+              ]
+            },
+            "GetDataSharingSettings": {
+              "methods": [
+                "get_data_sharing_settings"
+              ]
+            }
           }
         }
       }

--- a/google-analytics-admin-v1alpha/google-analytics-admin-v1alpha.gemspec
+++ b/google-analytics-admin-v1alpha/google-analytics-admin-v1alpha.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-analytics-data-v1alpha/gapic_metadata.json
+++ b/google-analytics-data-v1alpha/gapic_metadata.json
@@ -9,25 +9,37 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Analytics::Data::V1alpha::AnalyticsData::Client",
-          "methods": {
-            "RunReport": [
-              "run_report"
-            ],
-            "RunPivotReport": [
-              "run_pivot_report"
-            ],
-            "BatchRunReports": [
-              "batch_run_reports"
-            ],
-            "BatchRunPivotReports": [
-              "batch_run_pivot_reports"
-            ],
-            "GetMetadata": [
-              "get_metadata"
-            ],
-            "RunRealtimeReport": [
-              "run_realtime_report"
-            ]
+          "rpcs": {
+            "RunReport": {
+              "methods": [
+                "run_report"
+              ]
+            },
+            "RunPivotReport": {
+              "methods": [
+                "run_pivot_report"
+              ]
+            },
+            "BatchRunReports": {
+              "methods": [
+                "batch_run_reports"
+              ]
+            },
+            "BatchRunPivotReports": {
+              "methods": [
+                "batch_run_pivot_reports"
+              ]
+            },
+            "GetMetadata": {
+              "methods": [
+                "get_metadata"
+              ]
+            },
+            "RunRealtimeReport": {
+              "methods": [
+                "run_realtime_report"
+              ]
+            }
           }
         }
       }

--- a/google-analytics-data-v1alpha/google-analytics-data-v1alpha.gemspec
+++ b/google-analytics-data-v1alpha/google-analytics-data-v1alpha.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-area120-tables-v1alpha1/gapic_metadata.json
+++ b/google-area120-tables-v1alpha1/gapic_metadata.json
@@ -9,43 +9,67 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Area120::Tables::V1alpha1::TablesService::Client",
-          "methods": {
-            "GetTable": [
-              "get_table"
-            ],
-            "ListTables": [
-              "list_tables"
-            ],
-            "GetWorkspace": [
-              "get_workspace"
-            ],
-            "ListWorkspaces": [
-              "list_workspaces"
-            ],
-            "GetRow": [
-              "get_row"
-            ],
-            "ListRows": [
-              "list_rows"
-            ],
-            "CreateRow": [
-              "create_row"
-            ],
-            "BatchCreateRows": [
-              "batch_create_rows"
-            ],
-            "UpdateRow": [
-              "update_row"
-            ],
-            "BatchUpdateRows": [
-              "batch_update_rows"
-            ],
-            "DeleteRow": [
-              "delete_row"
-            ],
-            "BatchDeleteRows": [
-              "batch_delete_rows"
-            ]
+          "rpcs": {
+            "GetTable": {
+              "methods": [
+                "get_table"
+              ]
+            },
+            "ListTables": {
+              "methods": [
+                "list_tables"
+              ]
+            },
+            "GetWorkspace": {
+              "methods": [
+                "get_workspace"
+              ]
+            },
+            "ListWorkspaces": {
+              "methods": [
+                "list_workspaces"
+              ]
+            },
+            "GetRow": {
+              "methods": [
+                "get_row"
+              ]
+            },
+            "ListRows": {
+              "methods": [
+                "list_rows"
+              ]
+            },
+            "CreateRow": {
+              "methods": [
+                "create_row"
+              ]
+            },
+            "BatchCreateRows": {
+              "methods": [
+                "batch_create_rows"
+              ]
+            },
+            "UpdateRow": {
+              "methods": [
+                "update_row"
+              ]
+            },
+            "BatchUpdateRows": {
+              "methods": [
+                "batch_update_rows"
+              ]
+            },
+            "DeleteRow": {
+              "methods": [
+                "delete_row"
+              ]
+            },
+            "BatchDeleteRows": {
+              "methods": [
+                "batch_delete_rows"
+              ]
+            }
           }
         }
       }

--- a/google-area120-tables-v1alpha1/google-area120-tables-v1alpha1.gemspec
+++ b/google-area120-tables-v1alpha1/google-area120-tables-v1alpha1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-access_approval-v1/gapic_metadata.json
+++ b/google-cloud-access_approval-v1/gapic_metadata.json
@@ -9,28 +9,42 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::AccessApproval::V1::AccessApproval::Client",
-          "methods": {
-            "ListApprovalRequests": [
-              "list_approval_requests"
-            ],
-            "GetApprovalRequest": [
-              "get_approval_request"
-            ],
-            "ApproveApprovalRequest": [
-              "approve_approval_request"
-            ],
-            "DismissApprovalRequest": [
-              "dismiss_approval_request"
-            ],
-            "GetAccessApprovalSettings": [
-              "get_access_approval_settings"
-            ],
-            "UpdateAccessApprovalSettings": [
-              "update_access_approval_settings"
-            ],
-            "DeleteAccessApprovalSettings": [
-              "delete_access_approval_settings"
-            ]
+          "rpcs": {
+            "ListApprovalRequests": {
+              "methods": [
+                "list_approval_requests"
+              ]
+            },
+            "GetApprovalRequest": {
+              "methods": [
+                "get_approval_request"
+              ]
+            },
+            "ApproveApprovalRequest": {
+              "methods": [
+                "approve_approval_request"
+              ]
+            },
+            "DismissApprovalRequest": {
+              "methods": [
+                "dismiss_approval_request"
+              ]
+            },
+            "GetAccessApprovalSettings": {
+              "methods": [
+                "get_access_approval_settings"
+              ]
+            },
+            "UpdateAccessApprovalSettings": {
+              "methods": [
+                "update_access_approval_settings"
+              ]
+            },
+            "DeleteAccessApprovalSettings": {
+              "methods": [
+                "delete_access_approval_settings"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-access_approval-v1/google-cloud-access_approval-v1.gemspec
+++ b/google-cloud-access_approval-v1/google-cloud-access_approval-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-app_engine-v1/gapic_metadata.json
+++ b/google-cloud-app_engine-v1/gapic_metadata.json
@@ -9,19 +9,27 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::AppEngine::V1::Applications::Client",
-          "methods": {
-            "GetApplication": [
-              "get_application"
-            ],
-            "CreateApplication": [
-              "create_application"
-            ],
-            "UpdateApplication": [
-              "update_application"
-            ],
-            "RepairApplication": [
-              "repair_application"
-            ]
+          "rpcs": {
+            "GetApplication": {
+              "methods": [
+                "get_application"
+              ]
+            },
+            "CreateApplication": {
+              "methods": [
+                "create_application"
+              ]
+            },
+            "UpdateApplication": {
+              "methods": [
+                "update_application"
+              ]
+            },
+            "RepairApplication": {
+              "methods": [
+                "repair_application"
+              ]
+            }
           }
         }
       }
@@ -30,19 +38,27 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::AppEngine::V1::Services::Client",
-          "methods": {
-            "ListServices": [
-              "list_services"
-            ],
-            "GetService": [
-              "get_service"
-            ],
-            "UpdateService": [
-              "update_service"
-            ],
-            "DeleteService": [
-              "delete_service"
-            ]
+          "rpcs": {
+            "ListServices": {
+              "methods": [
+                "list_services"
+              ]
+            },
+            "GetService": {
+              "methods": [
+                "get_service"
+              ]
+            },
+            "UpdateService": {
+              "methods": [
+                "update_service"
+              ]
+            },
+            "DeleteService": {
+              "methods": [
+                "delete_service"
+              ]
+            }
           }
         }
       }
@@ -51,22 +67,32 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::AppEngine::V1::Versions::Client",
-          "methods": {
-            "ListVersions": [
-              "list_versions"
-            ],
-            "GetVersion": [
-              "get_version"
-            ],
-            "CreateVersion": [
-              "create_version"
-            ],
-            "UpdateVersion": [
-              "update_version"
-            ],
-            "DeleteVersion": [
-              "delete_version"
-            ]
+          "rpcs": {
+            "ListVersions": {
+              "methods": [
+                "list_versions"
+              ]
+            },
+            "GetVersion": {
+              "methods": [
+                "get_version"
+              ]
+            },
+            "CreateVersion": {
+              "methods": [
+                "create_version"
+              ]
+            },
+            "UpdateVersion": {
+              "methods": [
+                "update_version"
+              ]
+            },
+            "DeleteVersion": {
+              "methods": [
+                "delete_version"
+              ]
+            }
           }
         }
       }
@@ -75,19 +101,27 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::AppEngine::V1::Instances::Client",
-          "methods": {
-            "ListInstances": [
-              "list_instances"
-            ],
-            "GetInstance": [
-              "get_instance"
-            ],
-            "DeleteInstance": [
-              "delete_instance"
-            ],
-            "DebugInstance": [
-              "debug_instance"
-            ]
+          "rpcs": {
+            "ListInstances": {
+              "methods": [
+                "list_instances"
+              ]
+            },
+            "GetInstance": {
+              "methods": [
+                "get_instance"
+              ]
+            },
+            "DeleteInstance": {
+              "methods": [
+                "delete_instance"
+              ]
+            },
+            "DebugInstance": {
+              "methods": [
+                "debug_instance"
+              ]
+            }
           }
         }
       }
@@ -96,25 +130,37 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::AppEngine::V1::Firewall::Client",
-          "methods": {
-            "ListIngressRules": [
-              "list_ingress_rules"
-            ],
-            "BatchUpdateIngressRules": [
-              "batch_update_ingress_rules"
-            ],
-            "CreateIngressRule": [
-              "create_ingress_rule"
-            ],
-            "GetIngressRule": [
-              "get_ingress_rule"
-            ],
-            "UpdateIngressRule": [
-              "update_ingress_rule"
-            ],
-            "DeleteIngressRule": [
-              "delete_ingress_rule"
-            ]
+          "rpcs": {
+            "ListIngressRules": {
+              "methods": [
+                "list_ingress_rules"
+              ]
+            },
+            "BatchUpdateIngressRules": {
+              "methods": [
+                "batch_update_ingress_rules"
+              ]
+            },
+            "CreateIngressRule": {
+              "methods": [
+                "create_ingress_rule"
+              ]
+            },
+            "GetIngressRule": {
+              "methods": [
+                "get_ingress_rule"
+              ]
+            },
+            "UpdateIngressRule": {
+              "methods": [
+                "update_ingress_rule"
+              ]
+            },
+            "DeleteIngressRule": {
+              "methods": [
+                "delete_ingress_rule"
+              ]
+            }
           }
         }
       }
@@ -123,10 +169,12 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::AppEngine::V1::AuthorizedDomains::Client",
-          "methods": {
-            "ListAuthorizedDomains": [
-              "list_authorized_domains"
-            ]
+          "rpcs": {
+            "ListAuthorizedDomains": {
+              "methods": [
+                "list_authorized_domains"
+              ]
+            }
           }
         }
       }
@@ -135,22 +183,32 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::AppEngine::V1::AuthorizedCertificates::Client",
-          "methods": {
-            "ListAuthorizedCertificates": [
-              "list_authorized_certificates"
-            ],
-            "GetAuthorizedCertificate": [
-              "get_authorized_certificate"
-            ],
-            "CreateAuthorizedCertificate": [
-              "create_authorized_certificate"
-            ],
-            "UpdateAuthorizedCertificate": [
-              "update_authorized_certificate"
-            ],
-            "DeleteAuthorizedCertificate": [
-              "delete_authorized_certificate"
-            ]
+          "rpcs": {
+            "ListAuthorizedCertificates": {
+              "methods": [
+                "list_authorized_certificates"
+              ]
+            },
+            "GetAuthorizedCertificate": {
+              "methods": [
+                "get_authorized_certificate"
+              ]
+            },
+            "CreateAuthorizedCertificate": {
+              "methods": [
+                "create_authorized_certificate"
+              ]
+            },
+            "UpdateAuthorizedCertificate": {
+              "methods": [
+                "update_authorized_certificate"
+              ]
+            },
+            "DeleteAuthorizedCertificate": {
+              "methods": [
+                "delete_authorized_certificate"
+              ]
+            }
           }
         }
       }
@@ -159,22 +217,32 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::AppEngine::V1::DomainMappings::Client",
-          "methods": {
-            "ListDomainMappings": [
-              "list_domain_mappings"
-            ],
-            "GetDomainMapping": [
-              "get_domain_mapping"
-            ],
-            "CreateDomainMapping": [
-              "create_domain_mapping"
-            ],
-            "UpdateDomainMapping": [
-              "update_domain_mapping"
-            ],
-            "DeleteDomainMapping": [
-              "delete_domain_mapping"
-            ]
+          "rpcs": {
+            "ListDomainMappings": {
+              "methods": [
+                "list_domain_mappings"
+              ]
+            },
+            "GetDomainMapping": {
+              "methods": [
+                "get_domain_mapping"
+              ]
+            },
+            "CreateDomainMapping": {
+              "methods": [
+                "create_domain_mapping"
+              ]
+            },
+            "UpdateDomainMapping": {
+              "methods": [
+                "update_domain_mapping"
+              ]
+            },
+            "DeleteDomainMapping": {
+              "methods": [
+                "delete_domain_mapping"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-app_engine-v1/google-cloud-app_engine-v1.gemspec
+++ b/google-cloud-app_engine-v1/google-cloud-app_engine-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-artifact_registry-v1beta2/gapic_metadata.json
+++ b/google-cloud-artifact_registry-v1beta2/gapic_metadata.json
@@ -9,70 +9,112 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::ArtifactRegistry::V1beta2::ArtifactRegistry::Client",
-          "methods": {
-            "ListRepositories": [
-              "list_repositories"
-            ],
-            "GetRepository": [
-              "get_repository"
-            ],
-            "CreateRepository": [
-              "create_repository"
-            ],
-            "UpdateRepository": [
-              "update_repository"
-            ],
-            "DeleteRepository": [
-              "delete_repository"
-            ],
-            "ListPackages": [
-              "list_packages"
-            ],
-            "GetPackage": [
-              "get_package"
-            ],
-            "DeletePackage": [
-              "delete_package"
-            ],
-            "ListVersions": [
-              "list_versions"
-            ],
-            "GetVersion": [
-              "get_version"
-            ],
-            "DeleteVersion": [
-              "delete_version"
-            ],
-            "ListFiles": [
-              "list_files"
-            ],
-            "GetFile": [
-              "get_file"
-            ],
-            "ListTags": [
-              "list_tags"
-            ],
-            "GetTag": [
-              "get_tag"
-            ],
-            "CreateTag": [
-              "create_tag"
-            ],
-            "UpdateTag": [
-              "update_tag"
-            ],
-            "DeleteTag": [
-              "delete_tag"
-            ],
-            "SetIamPolicy": [
-              "set_iam_policy"
-            ],
-            "GetIamPolicy": [
-              "get_iam_policy"
-            ],
-            "TestIamPermissions": [
-              "test_iam_permissions"
-            ]
+          "rpcs": {
+            "ListRepositories": {
+              "methods": [
+                "list_repositories"
+              ]
+            },
+            "GetRepository": {
+              "methods": [
+                "get_repository"
+              ]
+            },
+            "CreateRepository": {
+              "methods": [
+                "create_repository"
+              ]
+            },
+            "UpdateRepository": {
+              "methods": [
+                "update_repository"
+              ]
+            },
+            "DeleteRepository": {
+              "methods": [
+                "delete_repository"
+              ]
+            },
+            "ListPackages": {
+              "methods": [
+                "list_packages"
+              ]
+            },
+            "GetPackage": {
+              "methods": [
+                "get_package"
+              ]
+            },
+            "DeletePackage": {
+              "methods": [
+                "delete_package"
+              ]
+            },
+            "ListVersions": {
+              "methods": [
+                "list_versions"
+              ]
+            },
+            "GetVersion": {
+              "methods": [
+                "get_version"
+              ]
+            },
+            "DeleteVersion": {
+              "methods": [
+                "delete_version"
+              ]
+            },
+            "ListFiles": {
+              "methods": [
+                "list_files"
+              ]
+            },
+            "GetFile": {
+              "methods": [
+                "get_file"
+              ]
+            },
+            "ListTags": {
+              "methods": [
+                "list_tags"
+              ]
+            },
+            "GetTag": {
+              "methods": [
+                "get_tag"
+              ]
+            },
+            "CreateTag": {
+              "methods": [
+                "create_tag"
+              ]
+            },
+            "UpdateTag": {
+              "methods": [
+                "update_tag"
+              ]
+            },
+            "DeleteTag": {
+              "methods": [
+                "delete_tag"
+              ]
+            },
+            "SetIamPolicy": {
+              "methods": [
+                "set_iam_policy"
+              ]
+            },
+            "GetIamPolicy": {
+              "methods": [
+                "get_iam_policy"
+              ]
+            },
+            "TestIamPermissions": {
+              "methods": [
+                "test_iam_permissions"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-artifact_registry-v1beta2/google-cloud-artifact_registry-v1beta2.gemspec
+++ b/google-cloud-artifact_registry-v1beta2/google-cloud-artifact_registry-v1beta2.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
   gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.0"
 

--- a/google-cloud-asset-v1/gapic_metadata.json
+++ b/google-cloud-asset-v1/gapic_metadata.json
@@ -9,40 +9,62 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Asset::V1::AssetService::Client",
-          "methods": {
-            "ExportAssets": [
-              "export_assets"
-            ],
-            "BatchGetAssetsHistory": [
-              "batch_get_assets_history"
-            ],
-            "CreateFeed": [
-              "create_feed"
-            ],
-            "GetFeed": [
-              "get_feed"
-            ],
-            "ListFeeds": [
-              "list_feeds"
-            ],
-            "UpdateFeed": [
-              "update_feed"
-            ],
-            "DeleteFeed": [
-              "delete_feed"
-            ],
-            "SearchAllResources": [
-              "search_all_resources"
-            ],
-            "SearchAllIamPolicies": [
-              "search_all_iam_policies"
-            ],
-            "AnalyzeIamPolicy": [
-              "analyze_iam_policy"
-            ],
-            "AnalyzeIamPolicyLongrunning": [
-              "analyze_iam_policy_longrunning"
-            ]
+          "rpcs": {
+            "ExportAssets": {
+              "methods": [
+                "export_assets"
+              ]
+            },
+            "BatchGetAssetsHistory": {
+              "methods": [
+                "batch_get_assets_history"
+              ]
+            },
+            "CreateFeed": {
+              "methods": [
+                "create_feed"
+              ]
+            },
+            "GetFeed": {
+              "methods": [
+                "get_feed"
+              ]
+            },
+            "ListFeeds": {
+              "methods": [
+                "list_feeds"
+              ]
+            },
+            "UpdateFeed": {
+              "methods": [
+                "update_feed"
+              ]
+            },
+            "DeleteFeed": {
+              "methods": [
+                "delete_feed"
+              ]
+            },
+            "SearchAllResources": {
+              "methods": [
+                "search_all_resources"
+              ]
+            },
+            "SearchAllIamPolicies": {
+              "methods": [
+                "search_all_iam_policies"
+              ]
+            },
+            "AnalyzeIamPolicy": {
+              "methods": [
+                "analyze_iam_policy"
+              ]
+            },
+            "AnalyzeIamPolicyLongrunning": {
+              "methods": [
+                "analyze_iam_policy_longrunning"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-asset-v1/google-cloud-asset-v1.gemspec
+++ b/google-cloud-asset-v1/google-cloud-asset-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
   gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.0"
 

--- a/google-cloud-assured_workloads-v1beta1/gapic_metadata.json
+++ b/google-cloud-assured_workloads-v1beta1/gapic_metadata.json
@@ -9,22 +9,32 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::AssuredWorkloads::V1beta1::AssuredWorkloadsService::Client",
-          "methods": {
-            "CreateWorkload": [
-              "create_workload"
-            ],
-            "UpdateWorkload": [
-              "update_workload"
-            ],
-            "DeleteWorkload": [
-              "delete_workload"
-            ],
-            "GetWorkload": [
-              "get_workload"
-            ],
-            "ListWorkloads": [
-              "list_workloads"
-            ]
+          "rpcs": {
+            "CreateWorkload": {
+              "methods": [
+                "create_workload"
+              ]
+            },
+            "UpdateWorkload": {
+              "methods": [
+                "update_workload"
+              ]
+            },
+            "DeleteWorkload": {
+              "methods": [
+                "delete_workload"
+              ]
+            },
+            "GetWorkload": {
+              "methods": [
+                "get_workload"
+              ]
+            },
+            "ListWorkloads": {
+              "methods": [
+                "list_workloads"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-assured_workloads-v1beta1/google-cloud-assured_workloads-v1beta1.gemspec
+++ b/google-cloud-assured_workloads-v1beta1/google-cloud-assured_workloads-v1beta1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-automl-v1/gapic_metadata.json
+++ b/google-cloud-automl-v1/gapic_metadata.json
@@ -9,13 +9,17 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::AutoML::V1::PredictionService::Client",
-          "methods": {
-            "Predict": [
-              "predict"
-            ],
-            "BatchPredict": [
-              "batch_predict"
-            ]
+          "rpcs": {
+            "Predict": {
+              "methods": [
+                "predict"
+              ]
+            },
+            "BatchPredict": {
+              "methods": [
+                "batch_predict"
+              ]
+            }
           }
         }
       }
@@ -24,61 +28,97 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::AutoML::V1::AutoML::Client",
-          "methods": {
-            "CreateDataset": [
-              "create_dataset"
-            ],
-            "GetDataset": [
-              "get_dataset"
-            ],
-            "ListDatasets": [
-              "list_datasets"
-            ],
-            "UpdateDataset": [
-              "update_dataset"
-            ],
-            "DeleteDataset": [
-              "delete_dataset"
-            ],
-            "ImportData": [
-              "import_data"
-            ],
-            "ExportData": [
-              "export_data"
-            ],
-            "GetAnnotationSpec": [
-              "get_annotation_spec"
-            ],
-            "CreateModel": [
-              "create_model"
-            ],
-            "GetModel": [
-              "get_model"
-            ],
-            "ListModels": [
-              "list_models"
-            ],
-            "DeleteModel": [
-              "delete_model"
-            ],
-            "UpdateModel": [
-              "update_model"
-            ],
-            "DeployModel": [
-              "deploy_model"
-            ],
-            "UndeployModel": [
-              "undeploy_model"
-            ],
-            "ExportModel": [
-              "export_model"
-            ],
-            "GetModelEvaluation": [
-              "get_model_evaluation"
-            ],
-            "ListModelEvaluations": [
-              "list_model_evaluations"
-            ]
+          "rpcs": {
+            "CreateDataset": {
+              "methods": [
+                "create_dataset"
+              ]
+            },
+            "GetDataset": {
+              "methods": [
+                "get_dataset"
+              ]
+            },
+            "ListDatasets": {
+              "methods": [
+                "list_datasets"
+              ]
+            },
+            "UpdateDataset": {
+              "methods": [
+                "update_dataset"
+              ]
+            },
+            "DeleteDataset": {
+              "methods": [
+                "delete_dataset"
+              ]
+            },
+            "ImportData": {
+              "methods": [
+                "import_data"
+              ]
+            },
+            "ExportData": {
+              "methods": [
+                "export_data"
+              ]
+            },
+            "GetAnnotationSpec": {
+              "methods": [
+                "get_annotation_spec"
+              ]
+            },
+            "CreateModel": {
+              "methods": [
+                "create_model"
+              ]
+            },
+            "GetModel": {
+              "methods": [
+                "get_model"
+              ]
+            },
+            "ListModels": {
+              "methods": [
+                "list_models"
+              ]
+            },
+            "DeleteModel": {
+              "methods": [
+                "delete_model"
+              ]
+            },
+            "UpdateModel": {
+              "methods": [
+                "update_model"
+              ]
+            },
+            "DeployModel": {
+              "methods": [
+                "deploy_model"
+              ]
+            },
+            "UndeployModel": {
+              "methods": [
+                "undeploy_model"
+              ]
+            },
+            "ExportModel": {
+              "methods": [
+                "export_model"
+              ]
+            },
+            "GetModelEvaluation": {
+              "methods": [
+                "get_model_evaluation"
+              ]
+            },
+            "ListModelEvaluations": {
+              "methods": [
+                "list_model_evaluations"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-automl-v1/google-cloud-automl-v1.gemspec
+++ b/google-cloud-automl-v1/google-cloud-automl-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-automl-v1beta1/gapic_metadata.json
+++ b/google-cloud-automl-v1beta1/gapic_metadata.json
@@ -9,13 +9,17 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::AutoML::V1beta1::PredictionService::Client",
-          "methods": {
-            "Predict": [
-              "predict"
-            ],
-            "BatchPredict": [
-              "batch_predict"
-            ]
+          "rpcs": {
+            "Predict": {
+              "methods": [
+                "predict"
+              ]
+            },
+            "BatchPredict": {
+              "methods": [
+                "batch_predict"
+              ]
+            }
           }
         }
       }
@@ -24,79 +28,127 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::AutoML::V1beta1::AutoML::Client",
-          "methods": {
-            "CreateDataset": [
-              "create_dataset"
-            ],
-            "GetDataset": [
-              "get_dataset"
-            ],
-            "ListDatasets": [
-              "list_datasets"
-            ],
-            "UpdateDataset": [
-              "update_dataset"
-            ],
-            "DeleteDataset": [
-              "delete_dataset"
-            ],
-            "ImportData": [
-              "import_data"
-            ],
-            "ExportData": [
-              "export_data"
-            ],
-            "GetAnnotationSpec": [
-              "get_annotation_spec"
-            ],
-            "GetTableSpec": [
-              "get_table_spec"
-            ],
-            "ListTableSpecs": [
-              "list_table_specs"
-            ],
-            "UpdateTableSpec": [
-              "update_table_spec"
-            ],
-            "GetColumnSpec": [
-              "get_column_spec"
-            ],
-            "ListColumnSpecs": [
-              "list_column_specs"
-            ],
-            "UpdateColumnSpec": [
-              "update_column_spec"
-            ],
-            "CreateModel": [
-              "create_model"
-            ],
-            "GetModel": [
-              "get_model"
-            ],
-            "ListModels": [
-              "list_models"
-            ],
-            "DeleteModel": [
-              "delete_model"
-            ],
-            "DeployModel": [
-              "deploy_model"
-            ],
-            "UndeployModel": [
-              "undeploy_model"
-            ],
-            "ExportModel": [
-              "export_model"
-            ],
-            "ExportEvaluatedExamples": [
-              "export_evaluated_examples"
-            ],
-            "GetModelEvaluation": [
-              "get_model_evaluation"
-            ],
-            "ListModelEvaluations": [
-              "list_model_evaluations"
-            ]
+          "rpcs": {
+            "CreateDataset": {
+              "methods": [
+                "create_dataset"
+              ]
+            },
+            "GetDataset": {
+              "methods": [
+                "get_dataset"
+              ]
+            },
+            "ListDatasets": {
+              "methods": [
+                "list_datasets"
+              ]
+            },
+            "UpdateDataset": {
+              "methods": [
+                "update_dataset"
+              ]
+            },
+            "DeleteDataset": {
+              "methods": [
+                "delete_dataset"
+              ]
+            },
+            "ImportData": {
+              "methods": [
+                "import_data"
+              ]
+            },
+            "ExportData": {
+              "methods": [
+                "export_data"
+              ]
+            },
+            "GetAnnotationSpec": {
+              "methods": [
+                "get_annotation_spec"
+              ]
+            },
+            "GetTableSpec": {
+              "methods": [
+                "get_table_spec"
+              ]
+            },
+            "ListTableSpecs": {
+              "methods": [
+                "list_table_specs"
+              ]
+            },
+            "UpdateTableSpec": {
+              "methods": [
+                "update_table_spec"
+              ]
+            },
+            "GetColumnSpec": {
+              "methods": [
+                "get_column_spec"
+              ]
+            },
+            "ListColumnSpecs": {
+              "methods": [
+                "list_column_specs"
+              ]
+            },
+            "UpdateColumnSpec": {
+              "methods": [
+                "update_column_spec"
+              ]
+            },
+            "CreateModel": {
+              "methods": [
+                "create_model"
+              ]
+            },
+            "GetModel": {
+              "methods": [
+                "get_model"
+              ]
+            },
+            "ListModels": {
+              "methods": [
+                "list_models"
+              ]
+            },
+            "DeleteModel": {
+              "methods": [
+                "delete_model"
+              ]
+            },
+            "DeployModel": {
+              "methods": [
+                "deploy_model"
+              ]
+            },
+            "UndeployModel": {
+              "methods": [
+                "undeploy_model"
+              ]
+            },
+            "ExportModel": {
+              "methods": [
+                "export_model"
+              ]
+            },
+            "ExportEvaluatedExamples": {
+              "methods": [
+                "export_evaluated_examples"
+              ]
+            },
+            "GetModelEvaluation": {
+              "methods": [
+                "get_model_evaluation"
+              ]
+            },
+            "ListModelEvaluations": {
+              "methods": [
+                "list_model_evaluations"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-automl-v1beta1/google-cloud-automl-v1beta1.gemspec
+++ b/google-cloud-automl-v1beta1/google-cloud-automl-v1beta1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-bigquery-connection-v1/gapic_metadata.json
+++ b/google-cloud-bigquery-connection-v1/gapic_metadata.json
@@ -9,31 +9,47 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Bigquery::Connection::V1::ConnectionService::Client",
-          "methods": {
-            "CreateConnection": [
-              "create_connection"
-            ],
-            "GetConnection": [
-              "get_connection"
-            ],
-            "ListConnections": [
-              "list_connections"
-            ],
-            "UpdateConnection": [
-              "update_connection"
-            ],
-            "DeleteConnection": [
-              "delete_connection"
-            ],
-            "GetIamPolicy": [
-              "get_iam_policy"
-            ],
-            "SetIamPolicy": [
-              "set_iam_policy"
-            ],
-            "TestIamPermissions": [
-              "test_iam_permissions"
-            ]
+          "rpcs": {
+            "CreateConnection": {
+              "methods": [
+                "create_connection"
+              ]
+            },
+            "GetConnection": {
+              "methods": [
+                "get_connection"
+              ]
+            },
+            "ListConnections": {
+              "methods": [
+                "list_connections"
+              ]
+            },
+            "UpdateConnection": {
+              "methods": [
+                "update_connection"
+              ]
+            },
+            "DeleteConnection": {
+              "methods": [
+                "delete_connection"
+              ]
+            },
+            "GetIamPolicy": {
+              "methods": [
+                "get_iam_policy"
+              ]
+            },
+            "SetIamPolicy": {
+              "methods": [
+                "set_iam_policy"
+              ]
+            },
+            "TestIamPermissions": {
+              "methods": [
+                "test_iam_permissions"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-bigquery-connection-v1/google-cloud-bigquery-connection-v1.gemspec
+++ b/google-cloud-bigquery-connection-v1/google-cloud-bigquery-connection-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
   gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.0"
 

--- a/google-cloud-bigquery-data_transfer-v1/gapic_metadata.json
+++ b/google-cloud-bigquery-data_transfer-v1/gapic_metadata.json
@@ -9,49 +9,77 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Bigquery::DataTransfer::V1::DataTransferService::Client",
-          "methods": {
-            "GetDataSource": [
-              "get_data_source"
-            ],
-            "ListDataSources": [
-              "list_data_sources"
-            ],
-            "CreateTransferConfig": [
-              "create_transfer_config"
-            ],
-            "UpdateTransferConfig": [
-              "update_transfer_config"
-            ],
-            "DeleteTransferConfig": [
-              "delete_transfer_config"
-            ],
-            "GetTransferConfig": [
-              "get_transfer_config"
-            ],
-            "ListTransferConfigs": [
-              "list_transfer_configs"
-            ],
-            "ScheduleTransferRuns": [
-              "schedule_transfer_runs"
-            ],
-            "StartManualTransferRuns": [
-              "start_manual_transfer_runs"
-            ],
-            "GetTransferRun": [
-              "get_transfer_run"
-            ],
-            "DeleteTransferRun": [
-              "delete_transfer_run"
-            ],
-            "ListTransferRuns": [
-              "list_transfer_runs"
-            ],
-            "ListTransferLogs": [
-              "list_transfer_logs"
-            ],
-            "CheckValidCreds": [
-              "check_valid_creds"
-            ]
+          "rpcs": {
+            "GetDataSource": {
+              "methods": [
+                "get_data_source"
+              ]
+            },
+            "ListDataSources": {
+              "methods": [
+                "list_data_sources"
+              ]
+            },
+            "CreateTransferConfig": {
+              "methods": [
+                "create_transfer_config"
+              ]
+            },
+            "UpdateTransferConfig": {
+              "methods": [
+                "update_transfer_config"
+              ]
+            },
+            "DeleteTransferConfig": {
+              "methods": [
+                "delete_transfer_config"
+              ]
+            },
+            "GetTransferConfig": {
+              "methods": [
+                "get_transfer_config"
+              ]
+            },
+            "ListTransferConfigs": {
+              "methods": [
+                "list_transfer_configs"
+              ]
+            },
+            "ScheduleTransferRuns": {
+              "methods": [
+                "schedule_transfer_runs"
+              ]
+            },
+            "StartManualTransferRuns": {
+              "methods": [
+                "start_manual_transfer_runs"
+              ]
+            },
+            "GetTransferRun": {
+              "methods": [
+                "get_transfer_run"
+              ]
+            },
+            "DeleteTransferRun": {
+              "methods": [
+                "delete_transfer_run"
+              ]
+            },
+            "ListTransferRuns": {
+              "methods": [
+                "list_transfer_runs"
+              ]
+            },
+            "ListTransferLogs": {
+              "methods": [
+                "list_transfer_logs"
+              ]
+            },
+            "CheckValidCreds": {
+              "methods": [
+                "check_valid_creds"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-bigquery-data_transfer-v1/google-cloud-bigquery-data_transfer-v1.gemspec
+++ b/google-cloud-bigquery-data_transfer-v1/google-cloud-bigquery-data_transfer-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-bigquery-reservation-v1/gapic_metadata.json
+++ b/google-cloud-bigquery-reservation-v1/gapic_metadata.json
@@ -9,64 +9,102 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Bigquery::Reservation::V1::ReservationService::Client",
-          "methods": {
-            "CreateReservation": [
-              "create_reservation"
-            ],
-            "ListReservations": [
-              "list_reservations"
-            ],
-            "GetReservation": [
-              "get_reservation"
-            ],
-            "DeleteReservation": [
-              "delete_reservation"
-            ],
-            "UpdateReservation": [
-              "update_reservation"
-            ],
-            "CreateCapacityCommitment": [
-              "create_capacity_commitment"
-            ],
-            "ListCapacityCommitments": [
-              "list_capacity_commitments"
-            ],
-            "GetCapacityCommitment": [
-              "get_capacity_commitment"
-            ],
-            "DeleteCapacityCommitment": [
-              "delete_capacity_commitment"
-            ],
-            "UpdateCapacityCommitment": [
-              "update_capacity_commitment"
-            ],
-            "SplitCapacityCommitment": [
-              "split_capacity_commitment"
-            ],
-            "MergeCapacityCommitments": [
-              "merge_capacity_commitments"
-            ],
-            "CreateAssignment": [
-              "create_assignment"
-            ],
-            "ListAssignments": [
-              "list_assignments"
-            ],
-            "DeleteAssignment": [
-              "delete_assignment"
-            ],
-            "SearchAssignments": [
-              "search_assignments"
-            ],
-            "MoveAssignment": [
-              "move_assignment"
-            ],
-            "GetBiReservation": [
-              "get_bi_reservation"
-            ],
-            "UpdateBiReservation": [
-              "update_bi_reservation"
-            ]
+          "rpcs": {
+            "CreateReservation": {
+              "methods": [
+                "create_reservation"
+              ]
+            },
+            "ListReservations": {
+              "methods": [
+                "list_reservations"
+              ]
+            },
+            "GetReservation": {
+              "methods": [
+                "get_reservation"
+              ]
+            },
+            "DeleteReservation": {
+              "methods": [
+                "delete_reservation"
+              ]
+            },
+            "UpdateReservation": {
+              "methods": [
+                "update_reservation"
+              ]
+            },
+            "CreateCapacityCommitment": {
+              "methods": [
+                "create_capacity_commitment"
+              ]
+            },
+            "ListCapacityCommitments": {
+              "methods": [
+                "list_capacity_commitments"
+              ]
+            },
+            "GetCapacityCommitment": {
+              "methods": [
+                "get_capacity_commitment"
+              ]
+            },
+            "DeleteCapacityCommitment": {
+              "methods": [
+                "delete_capacity_commitment"
+              ]
+            },
+            "UpdateCapacityCommitment": {
+              "methods": [
+                "update_capacity_commitment"
+              ]
+            },
+            "SplitCapacityCommitment": {
+              "methods": [
+                "split_capacity_commitment"
+              ]
+            },
+            "MergeCapacityCommitments": {
+              "methods": [
+                "merge_capacity_commitments"
+              ]
+            },
+            "CreateAssignment": {
+              "methods": [
+                "create_assignment"
+              ]
+            },
+            "ListAssignments": {
+              "methods": [
+                "list_assignments"
+              ]
+            },
+            "DeleteAssignment": {
+              "methods": [
+                "delete_assignment"
+              ]
+            },
+            "SearchAssignments": {
+              "methods": [
+                "search_assignments"
+              ]
+            },
+            "MoveAssignment": {
+              "methods": [
+                "move_assignment"
+              ]
+            },
+            "GetBiReservation": {
+              "methods": [
+                "get_bi_reservation"
+              ]
+            },
+            "UpdateBiReservation": {
+              "methods": [
+                "update_bi_reservation"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-bigquery-reservation-v1/google-cloud-bigquery-reservation-v1.gemspec
+++ b/google-cloud-bigquery-reservation-v1/google-cloud-bigquery-reservation-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-bigquery-storage-v1/gapic_metadata.json
+++ b/google-cloud-bigquery-storage-v1/gapic_metadata.json
@@ -9,16 +9,22 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Bigquery::Storage::V1::BigQueryRead::Client",
-          "methods": {
-            "CreateReadSession": [
-              "create_read_session"
-            ],
-            "ReadRows": [
-              "read_rows"
-            ],
-            "SplitReadStream": [
-              "split_read_stream"
-            ]
+          "rpcs": {
+            "CreateReadSession": {
+              "methods": [
+                "create_read_session"
+              ]
+            },
+            "ReadRows": {
+              "methods": [
+                "read_rows"
+              ]
+            },
+            "SplitReadStream": {
+              "methods": [
+                "split_read_stream"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-bigquery-storage-v1/google-cloud-bigquery-storage-v1.gemspec
+++ b/google-cloud-bigquery-storage-v1/google-cloud-bigquery-storage-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-bigtable-admin-v2/gapic_metadata.json
+++ b/google-cloud-bigtable-admin-v2/gapic_metadata.json
@@ -9,64 +9,102 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdmin::Client",
-          "methods": {
-            "CreateInstance": [
-              "create_instance"
-            ],
-            "GetInstance": [
-              "get_instance"
-            ],
-            "ListInstances": [
-              "list_instances"
-            ],
-            "UpdateInstance": [
-              "update_instance"
-            ],
-            "PartialUpdateInstance": [
-              "partial_update_instance"
-            ],
-            "DeleteInstance": [
-              "delete_instance"
-            ],
-            "CreateCluster": [
-              "create_cluster"
-            ],
-            "GetCluster": [
-              "get_cluster"
-            ],
-            "ListClusters": [
-              "list_clusters"
-            ],
-            "UpdateCluster": [
-              "update_cluster"
-            ],
-            "DeleteCluster": [
-              "delete_cluster"
-            ],
-            "CreateAppProfile": [
-              "create_app_profile"
-            ],
-            "GetAppProfile": [
-              "get_app_profile"
-            ],
-            "ListAppProfiles": [
-              "list_app_profiles"
-            ],
-            "UpdateAppProfile": [
-              "update_app_profile"
-            ],
-            "DeleteAppProfile": [
-              "delete_app_profile"
-            ],
-            "GetIamPolicy": [
-              "get_iam_policy"
-            ],
-            "SetIamPolicy": [
-              "set_iam_policy"
-            ],
-            "TestIamPermissions": [
-              "test_iam_permissions"
-            ]
+          "rpcs": {
+            "CreateInstance": {
+              "methods": [
+                "create_instance"
+              ]
+            },
+            "GetInstance": {
+              "methods": [
+                "get_instance"
+              ]
+            },
+            "ListInstances": {
+              "methods": [
+                "list_instances"
+              ]
+            },
+            "UpdateInstance": {
+              "methods": [
+                "update_instance"
+              ]
+            },
+            "PartialUpdateInstance": {
+              "methods": [
+                "partial_update_instance"
+              ]
+            },
+            "DeleteInstance": {
+              "methods": [
+                "delete_instance"
+              ]
+            },
+            "CreateCluster": {
+              "methods": [
+                "create_cluster"
+              ]
+            },
+            "GetCluster": {
+              "methods": [
+                "get_cluster"
+              ]
+            },
+            "ListClusters": {
+              "methods": [
+                "list_clusters"
+              ]
+            },
+            "UpdateCluster": {
+              "methods": [
+                "update_cluster"
+              ]
+            },
+            "DeleteCluster": {
+              "methods": [
+                "delete_cluster"
+              ]
+            },
+            "CreateAppProfile": {
+              "methods": [
+                "create_app_profile"
+              ]
+            },
+            "GetAppProfile": {
+              "methods": [
+                "get_app_profile"
+              ]
+            },
+            "ListAppProfiles": {
+              "methods": [
+                "list_app_profiles"
+              ]
+            },
+            "UpdateAppProfile": {
+              "methods": [
+                "update_app_profile"
+              ]
+            },
+            "DeleteAppProfile": {
+              "methods": [
+                "delete_app_profile"
+              ]
+            },
+            "GetIamPolicy": {
+              "methods": [
+                "get_iam_policy"
+              ]
+            },
+            "SetIamPolicy": {
+              "methods": [
+                "set_iam_policy"
+              ]
+            },
+            "TestIamPermissions": {
+              "methods": [
+                "test_iam_permissions"
+              ]
+            }
           }
         }
       }
@@ -75,73 +113,117 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Bigtable::Admin::V2::BigtableTableAdmin::Client",
-          "methods": {
-            "CreateTable": [
-              "create_table"
-            ],
-            "CreateTableFromSnapshot": [
-              "create_table_from_snapshot"
-            ],
-            "ListTables": [
-              "list_tables"
-            ],
-            "GetTable": [
-              "get_table"
-            ],
-            "DeleteTable": [
-              "delete_table"
-            ],
-            "ModifyColumnFamilies": [
-              "modify_column_families"
-            ],
-            "DropRowRange": [
-              "drop_row_range"
-            ],
-            "GenerateConsistencyToken": [
-              "generate_consistency_token"
-            ],
-            "CheckConsistency": [
-              "check_consistency"
-            ],
-            "SnapshotTable": [
-              "snapshot_table"
-            ],
-            "GetSnapshot": [
-              "get_snapshot"
-            ],
-            "ListSnapshots": [
-              "list_snapshots"
-            ],
-            "DeleteSnapshot": [
-              "delete_snapshot"
-            ],
-            "CreateBackup": [
-              "create_backup"
-            ],
-            "GetBackup": [
-              "get_backup"
-            ],
-            "UpdateBackup": [
-              "update_backup"
-            ],
-            "DeleteBackup": [
-              "delete_backup"
-            ],
-            "ListBackups": [
-              "list_backups"
-            ],
-            "RestoreTable": [
-              "restore_table"
-            ],
-            "GetIamPolicy": [
-              "get_iam_policy"
-            ],
-            "SetIamPolicy": [
-              "set_iam_policy"
-            ],
-            "TestIamPermissions": [
-              "test_iam_permissions"
-            ]
+          "rpcs": {
+            "CreateTable": {
+              "methods": [
+                "create_table"
+              ]
+            },
+            "CreateTableFromSnapshot": {
+              "methods": [
+                "create_table_from_snapshot"
+              ]
+            },
+            "ListTables": {
+              "methods": [
+                "list_tables"
+              ]
+            },
+            "GetTable": {
+              "methods": [
+                "get_table"
+              ]
+            },
+            "DeleteTable": {
+              "methods": [
+                "delete_table"
+              ]
+            },
+            "ModifyColumnFamilies": {
+              "methods": [
+                "modify_column_families"
+              ]
+            },
+            "DropRowRange": {
+              "methods": [
+                "drop_row_range"
+              ]
+            },
+            "GenerateConsistencyToken": {
+              "methods": [
+                "generate_consistency_token"
+              ]
+            },
+            "CheckConsistency": {
+              "methods": [
+                "check_consistency"
+              ]
+            },
+            "SnapshotTable": {
+              "methods": [
+                "snapshot_table"
+              ]
+            },
+            "GetSnapshot": {
+              "methods": [
+                "get_snapshot"
+              ]
+            },
+            "ListSnapshots": {
+              "methods": [
+                "list_snapshots"
+              ]
+            },
+            "DeleteSnapshot": {
+              "methods": [
+                "delete_snapshot"
+              ]
+            },
+            "CreateBackup": {
+              "methods": [
+                "create_backup"
+              ]
+            },
+            "GetBackup": {
+              "methods": [
+                "get_backup"
+              ]
+            },
+            "UpdateBackup": {
+              "methods": [
+                "update_backup"
+              ]
+            },
+            "DeleteBackup": {
+              "methods": [
+                "delete_backup"
+              ]
+            },
+            "ListBackups": {
+              "methods": [
+                "list_backups"
+              ]
+            },
+            "RestoreTable": {
+              "methods": [
+                "restore_table"
+              ]
+            },
+            "GetIamPolicy": {
+              "methods": [
+                "get_iam_policy"
+              ]
+            },
+            "SetIamPolicy": {
+              "methods": [
+                "set_iam_policy"
+              ]
+            },
+            "TestIamPermissions": {
+              "methods": [
+                "test_iam_permissions"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-bigtable-admin-v2/google-cloud-bigtable-admin-v2.gemspec
+++ b/google-cloud-bigtable-admin-v2/google-cloud-bigtable-admin-v2.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
   gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.0"
 

--- a/google-cloud-bigtable-v2/gapic_metadata.json
+++ b/google-cloud-bigtable-v2/gapic_metadata.json
@@ -9,25 +9,37 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Bigtable::V2::Bigtable::Client",
-          "methods": {
-            "ReadRows": [
-              "read_rows"
-            ],
-            "SampleRowKeys": [
-              "sample_row_keys"
-            ],
-            "MutateRow": [
-              "mutate_row"
-            ],
-            "MutateRows": [
-              "mutate_rows"
-            ],
-            "CheckAndMutateRow": [
-              "check_and_mutate_row"
-            ],
-            "ReadModifyWriteRow": [
-              "read_modify_write_row"
-            ]
+          "rpcs": {
+            "ReadRows": {
+              "methods": [
+                "read_rows"
+              ]
+            },
+            "SampleRowKeys": {
+              "methods": [
+                "sample_row_keys"
+              ]
+            },
+            "MutateRow": {
+              "methods": [
+                "mutate_row"
+              ]
+            },
+            "MutateRows": {
+              "methods": [
+                "mutate_rows"
+              ]
+            },
+            "CheckAndMutateRow": {
+              "methods": [
+                "check_and_mutate_row"
+              ]
+            },
+            "ReadModifyWriteRow": {
+              "methods": [
+                "read_modify_write_row"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-bigtable-v2/google-cloud-bigtable-v2.gemspec
+++ b/google-cloud-bigtable-v2/google-cloud-bigtable-v2.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-billing-budgets-v1beta1/gapic_metadata.json
+++ b/google-cloud-billing-budgets-v1beta1/gapic_metadata.json
@@ -9,22 +9,32 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Billing::Budgets::V1beta1::BudgetService::Client",
-          "methods": {
-            "CreateBudget": [
-              "create_budget"
-            ],
-            "UpdateBudget": [
-              "update_budget"
-            ],
-            "GetBudget": [
-              "get_budget"
-            ],
-            "ListBudgets": [
-              "list_budgets"
-            ],
-            "DeleteBudget": [
-              "delete_budget"
-            ]
+          "rpcs": {
+            "CreateBudget": {
+              "methods": [
+                "create_budget"
+              ]
+            },
+            "UpdateBudget": {
+              "methods": [
+                "update_budget"
+              ]
+            },
+            "GetBudget": {
+              "methods": [
+                "get_budget"
+              ]
+            },
+            "ListBudgets": {
+              "methods": [
+                "list_budgets"
+              ]
+            },
+            "DeleteBudget": {
+              "methods": [
+                "delete_budget"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-billing-budgets-v1beta1/google-cloud-billing-budgets-v1beta1.gemspec
+++ b/google-cloud-billing-budgets-v1beta1/google-cloud-billing-budgets-v1beta1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-billing-v1/gapic_metadata.json
+++ b/google-cloud-billing-v1/gapic_metadata.json
@@ -9,37 +9,57 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Billing::V1::CloudBilling::Client",
-          "methods": {
-            "GetBillingAccount": [
-              "get_billing_account"
-            ],
-            "ListBillingAccounts": [
-              "list_billing_accounts"
-            ],
-            "UpdateBillingAccount": [
-              "update_billing_account"
-            ],
-            "CreateBillingAccount": [
-              "create_billing_account"
-            ],
-            "ListProjectBillingInfo": [
-              "list_project_billing_info"
-            ],
-            "GetProjectBillingInfo": [
-              "get_project_billing_info"
-            ],
-            "UpdateProjectBillingInfo": [
-              "update_project_billing_info"
-            ],
-            "GetIamPolicy": [
-              "get_iam_policy"
-            ],
-            "SetIamPolicy": [
-              "set_iam_policy"
-            ],
-            "TestIamPermissions": [
-              "test_iam_permissions"
-            ]
+          "rpcs": {
+            "GetBillingAccount": {
+              "methods": [
+                "get_billing_account"
+              ]
+            },
+            "ListBillingAccounts": {
+              "methods": [
+                "list_billing_accounts"
+              ]
+            },
+            "UpdateBillingAccount": {
+              "methods": [
+                "update_billing_account"
+              ]
+            },
+            "CreateBillingAccount": {
+              "methods": [
+                "create_billing_account"
+              ]
+            },
+            "ListProjectBillingInfo": {
+              "methods": [
+                "list_project_billing_info"
+              ]
+            },
+            "GetProjectBillingInfo": {
+              "methods": [
+                "get_project_billing_info"
+              ]
+            },
+            "UpdateProjectBillingInfo": {
+              "methods": [
+                "update_project_billing_info"
+              ]
+            },
+            "GetIamPolicy": {
+              "methods": [
+                "get_iam_policy"
+              ]
+            },
+            "SetIamPolicy": {
+              "methods": [
+                "set_iam_policy"
+              ]
+            },
+            "TestIamPermissions": {
+              "methods": [
+                "test_iam_permissions"
+              ]
+            }
           }
         }
       }
@@ -48,13 +68,17 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Billing::V1::CloudCatalog::Client",
-          "methods": {
-            "ListServices": [
-              "list_services"
-            ],
-            "ListSkus": [
-              "list_skus"
-            ]
+          "rpcs": {
+            "ListServices": {
+              "methods": [
+                "list_services"
+              ]
+            },
+            "ListSkus": {
+              "methods": [
+                "list_skus"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-billing-v1/google-cloud-billing-v1.gemspec
+++ b/google-cloud-billing-v1/google-cloud-billing-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
   gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.0"
 

--- a/google-cloud-binary_authorization-v1beta1/gapic_metadata.json
+++ b/google-cloud-binary_authorization-v1beta1/gapic_metadata.json
@@ -9,28 +9,42 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::BinaryAuthorization::V1beta1::BinauthzManagementService::Client",
-          "methods": {
-            "GetPolicy": [
-              "get_policy"
-            ],
-            "UpdatePolicy": [
-              "update_policy"
-            ],
-            "CreateAttestor": [
-              "create_attestor"
-            ],
-            "GetAttestor": [
-              "get_attestor"
-            ],
-            "UpdateAttestor": [
-              "update_attestor"
-            ],
-            "ListAttestors": [
-              "list_attestors"
-            ],
-            "DeleteAttestor": [
-              "delete_attestor"
-            ]
+          "rpcs": {
+            "GetPolicy": {
+              "methods": [
+                "get_policy"
+              ]
+            },
+            "UpdatePolicy": {
+              "methods": [
+                "update_policy"
+              ]
+            },
+            "CreateAttestor": {
+              "methods": [
+                "create_attestor"
+              ]
+            },
+            "GetAttestor": {
+              "methods": [
+                "get_attestor"
+              ]
+            },
+            "UpdateAttestor": {
+              "methods": [
+                "update_attestor"
+              ]
+            },
+            "ListAttestors": {
+              "methods": [
+                "list_attestors"
+              ]
+            },
+            "DeleteAttestor": {
+              "methods": [
+                "delete_attestor"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-binary_authorization-v1beta1/google-cloud-binary_authorization-v1beta1.gemspec
+++ b/google-cloud-binary_authorization-v1beta1/google-cloud-binary_authorization-v1beta1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-build-v1/gapic_metadata.json
+++ b/google-cloud-build-v1/gapic_metadata.json
@@ -9,58 +9,92 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Build::V1::CloudBuild::Client",
-          "methods": {
-            "CreateBuild": [
-              "create_build"
-            ],
-            "GetBuild": [
-              "get_build"
-            ],
-            "ListBuilds": [
-              "list_builds"
-            ],
-            "CancelBuild": [
-              "cancel_build"
-            ],
-            "RetryBuild": [
-              "retry_build"
-            ],
-            "CreateBuildTrigger": [
-              "create_build_trigger"
-            ],
-            "GetBuildTrigger": [
-              "get_build_trigger"
-            ],
-            "ListBuildTriggers": [
-              "list_build_triggers"
-            ],
-            "DeleteBuildTrigger": [
-              "delete_build_trigger"
-            ],
-            "UpdateBuildTrigger": [
-              "update_build_trigger"
-            ],
-            "RunBuildTrigger": [
-              "run_build_trigger"
-            ],
-            "ReceiveTriggerWebhook": [
-              "receive_trigger_webhook"
-            ],
-            "CreateWorkerPool": [
-              "create_worker_pool"
-            ],
-            "GetWorkerPool": [
-              "get_worker_pool"
-            ],
-            "DeleteWorkerPool": [
-              "delete_worker_pool"
-            ],
-            "UpdateWorkerPool": [
-              "update_worker_pool"
-            ],
-            "ListWorkerPools": [
-              "list_worker_pools"
-            ]
+          "rpcs": {
+            "CreateBuild": {
+              "methods": [
+                "create_build"
+              ]
+            },
+            "GetBuild": {
+              "methods": [
+                "get_build"
+              ]
+            },
+            "ListBuilds": {
+              "methods": [
+                "list_builds"
+              ]
+            },
+            "CancelBuild": {
+              "methods": [
+                "cancel_build"
+              ]
+            },
+            "RetryBuild": {
+              "methods": [
+                "retry_build"
+              ]
+            },
+            "CreateBuildTrigger": {
+              "methods": [
+                "create_build_trigger"
+              ]
+            },
+            "GetBuildTrigger": {
+              "methods": [
+                "get_build_trigger"
+              ]
+            },
+            "ListBuildTriggers": {
+              "methods": [
+                "list_build_triggers"
+              ]
+            },
+            "DeleteBuildTrigger": {
+              "methods": [
+                "delete_build_trigger"
+              ]
+            },
+            "UpdateBuildTrigger": {
+              "methods": [
+                "update_build_trigger"
+              ]
+            },
+            "RunBuildTrigger": {
+              "methods": [
+                "run_build_trigger"
+              ]
+            },
+            "ReceiveTriggerWebhook": {
+              "methods": [
+                "receive_trigger_webhook"
+              ]
+            },
+            "CreateWorkerPool": {
+              "methods": [
+                "create_worker_pool"
+              ]
+            },
+            "GetWorkerPool": {
+              "methods": [
+                "get_worker_pool"
+              ]
+            },
+            "DeleteWorkerPool": {
+              "methods": [
+                "delete_worker_pool"
+              ]
+            },
+            "UpdateWorkerPool": {
+              "methods": [
+                "update_worker_pool"
+              ]
+            },
+            "ListWorkerPools": {
+              "methods": [
+                "list_worker_pools"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-build-v1/google-cloud-build-v1.gemspec
+++ b/google-cloud-build-v1/google-cloud-build-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-channel-v1/gapic_metadata.json
+++ b/google-cloud-channel-v1/gapic_metadata.json
@@ -9,106 +9,172 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Channel::V1::CloudChannelService::Client",
-          "methods": {
-            "ListCustomers": [
-              "list_customers"
-            ],
-            "GetCustomer": [
-              "get_customer"
-            ],
-            "CheckCloudIdentityAccountsExist": [
-              "check_cloud_identity_accounts_exist"
-            ],
-            "CreateCustomer": [
-              "create_customer"
-            ],
-            "UpdateCustomer": [
-              "update_customer"
-            ],
-            "DeleteCustomer": [
-              "delete_customer"
-            ],
-            "ProvisionCloudIdentity": [
-              "provision_cloud_identity"
-            ],
-            "ListEntitlements": [
-              "list_entitlements"
-            ],
-            "ListTransferableSkus": [
-              "list_transferable_skus"
-            ],
-            "ListTransferableOffers": [
-              "list_transferable_offers"
-            ],
-            "GetEntitlement": [
-              "get_entitlement"
-            ],
-            "CreateEntitlement": [
-              "create_entitlement"
-            ],
-            "ChangeParameters": [
-              "change_parameters"
-            ],
-            "ChangeRenewalSettings": [
-              "change_renewal_settings"
-            ],
-            "ChangeOffer": [
-              "change_offer"
-            ],
-            "StartPaidService": [
-              "start_paid_service"
-            ],
-            "SuspendEntitlement": [
-              "suspend_entitlement"
-            ],
-            "CancelEntitlement": [
-              "cancel_entitlement"
-            ],
-            "ActivateEntitlement": [
-              "activate_entitlement"
-            ],
-            "TransferEntitlements": [
-              "transfer_entitlements"
-            ],
-            "TransferEntitlementsToGoogle": [
-              "transfer_entitlements_to_google"
-            ],
-            "ListChannelPartnerLinks": [
-              "list_channel_partner_links"
-            ],
-            "GetChannelPartnerLink": [
-              "get_channel_partner_link"
-            ],
-            "CreateChannelPartnerLink": [
-              "create_channel_partner_link"
-            ],
-            "UpdateChannelPartnerLink": [
-              "update_channel_partner_link"
-            ],
-            "ListProducts": [
-              "list_products"
-            ],
-            "ListSkus": [
-              "list_skus"
-            ],
-            "ListOffers": [
-              "list_offers"
-            ],
-            "ListPurchasableSkus": [
-              "list_purchasable_skus"
-            ],
-            "ListPurchasableOffers": [
-              "list_purchasable_offers"
-            ],
-            "RegisterSubscriber": [
-              "register_subscriber"
-            ],
-            "UnregisterSubscriber": [
-              "unregister_subscriber"
-            ],
-            "ListSubscribers": [
-              "list_subscribers"
-            ]
+          "rpcs": {
+            "ListCustomers": {
+              "methods": [
+                "list_customers"
+              ]
+            },
+            "GetCustomer": {
+              "methods": [
+                "get_customer"
+              ]
+            },
+            "CheckCloudIdentityAccountsExist": {
+              "methods": [
+                "check_cloud_identity_accounts_exist"
+              ]
+            },
+            "CreateCustomer": {
+              "methods": [
+                "create_customer"
+              ]
+            },
+            "UpdateCustomer": {
+              "methods": [
+                "update_customer"
+              ]
+            },
+            "DeleteCustomer": {
+              "methods": [
+                "delete_customer"
+              ]
+            },
+            "ProvisionCloudIdentity": {
+              "methods": [
+                "provision_cloud_identity"
+              ]
+            },
+            "ListEntitlements": {
+              "methods": [
+                "list_entitlements"
+              ]
+            },
+            "ListTransferableSkus": {
+              "methods": [
+                "list_transferable_skus"
+              ]
+            },
+            "ListTransferableOffers": {
+              "methods": [
+                "list_transferable_offers"
+              ]
+            },
+            "GetEntitlement": {
+              "methods": [
+                "get_entitlement"
+              ]
+            },
+            "CreateEntitlement": {
+              "methods": [
+                "create_entitlement"
+              ]
+            },
+            "ChangeParameters": {
+              "methods": [
+                "change_parameters"
+              ]
+            },
+            "ChangeRenewalSettings": {
+              "methods": [
+                "change_renewal_settings"
+              ]
+            },
+            "ChangeOffer": {
+              "methods": [
+                "change_offer"
+              ]
+            },
+            "StartPaidService": {
+              "methods": [
+                "start_paid_service"
+              ]
+            },
+            "SuspendEntitlement": {
+              "methods": [
+                "suspend_entitlement"
+              ]
+            },
+            "CancelEntitlement": {
+              "methods": [
+                "cancel_entitlement"
+              ]
+            },
+            "ActivateEntitlement": {
+              "methods": [
+                "activate_entitlement"
+              ]
+            },
+            "TransferEntitlements": {
+              "methods": [
+                "transfer_entitlements"
+              ]
+            },
+            "TransferEntitlementsToGoogle": {
+              "methods": [
+                "transfer_entitlements_to_google"
+              ]
+            },
+            "ListChannelPartnerLinks": {
+              "methods": [
+                "list_channel_partner_links"
+              ]
+            },
+            "GetChannelPartnerLink": {
+              "methods": [
+                "get_channel_partner_link"
+              ]
+            },
+            "CreateChannelPartnerLink": {
+              "methods": [
+                "create_channel_partner_link"
+              ]
+            },
+            "UpdateChannelPartnerLink": {
+              "methods": [
+                "update_channel_partner_link"
+              ]
+            },
+            "ListProducts": {
+              "methods": [
+                "list_products"
+              ]
+            },
+            "ListSkus": {
+              "methods": [
+                "list_skus"
+              ]
+            },
+            "ListOffers": {
+              "methods": [
+                "list_offers"
+              ]
+            },
+            "ListPurchasableSkus": {
+              "methods": [
+                "list_purchasable_skus"
+              ]
+            },
+            "ListPurchasableOffers": {
+              "methods": [
+                "list_purchasable_offers"
+              ]
+            },
+            "RegisterSubscriber": {
+              "methods": [
+                "register_subscriber"
+              ]
+            },
+            "UnregisterSubscriber": {
+              "methods": [
+                "unregister_subscriber"
+              ]
+            },
+            "ListSubscribers": {
+              "methods": [
+                "list_subscribers"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-channel-v1/google-cloud-channel-v1.gemspec
+++ b/google-cloud-channel-v1/google-cloud-channel-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-container-v1/gapic_metadata.json
+++ b/google-cloud-container-v1/gapic_metadata.json
@@ -9,103 +9,167 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Container::V1::ClusterManager::Client",
-          "methods": {
-            "ListClusters": [
-              "list_clusters"
-            ],
-            "GetCluster": [
-              "get_cluster"
-            ],
-            "CreateCluster": [
-              "create_cluster"
-            ],
-            "UpdateCluster": [
-              "update_cluster"
-            ],
-            "UpdateNodePool": [
-              "update_node_pool"
-            ],
-            "SetNodePoolAutoscaling": [
-              "set_node_pool_autoscaling"
-            ],
-            "SetLoggingService": [
-              "set_logging_service"
-            ],
-            "SetMonitoringService": [
-              "set_monitoring_service"
-            ],
-            "SetAddonsConfig": [
-              "set_addons_config"
-            ],
-            "SetLocations": [
-              "set_locations"
-            ],
-            "UpdateMaster": [
-              "update_master"
-            ],
-            "SetMasterAuth": [
-              "set_master_auth"
-            ],
-            "DeleteCluster": [
-              "delete_cluster"
-            ],
-            "ListOperations": [
-              "list_operations"
-            ],
-            "GetOperation": [
-              "get_operation"
-            ],
-            "CancelOperation": [
-              "cancel_operation"
-            ],
-            "GetServerConfig": [
-              "get_server_config"
-            ],
-            "GetJSONWebKeys": [
-              "get_json_web_keys"
-            ],
-            "ListNodePools": [
-              "list_node_pools"
-            ],
-            "GetNodePool": [
-              "get_node_pool"
-            ],
-            "CreateNodePool": [
-              "create_node_pool"
-            ],
-            "DeleteNodePool": [
-              "delete_node_pool"
-            ],
-            "RollbackNodePoolUpgrade": [
-              "rollback_node_pool_upgrade"
-            ],
-            "SetNodePoolManagement": [
-              "set_node_pool_management"
-            ],
-            "SetLabels": [
-              "set_labels"
-            ],
-            "SetLegacyAbac": [
-              "set_legacy_abac"
-            ],
-            "StartIPRotation": [
-              "start_ip_rotation"
-            ],
-            "CompleteIPRotation": [
-              "complete_ip_rotation"
-            ],
-            "SetNodePoolSize": [
-              "set_node_pool_size"
-            ],
-            "SetNetworkPolicy": [
-              "set_network_policy"
-            ],
-            "SetMaintenancePolicy": [
-              "set_maintenance_policy"
-            ],
-            "ListUsableSubnetworks": [
-              "list_usable_subnetworks"
-            ]
+          "rpcs": {
+            "ListClusters": {
+              "methods": [
+                "list_clusters"
+              ]
+            },
+            "GetCluster": {
+              "methods": [
+                "get_cluster"
+              ]
+            },
+            "CreateCluster": {
+              "methods": [
+                "create_cluster"
+              ]
+            },
+            "UpdateCluster": {
+              "methods": [
+                "update_cluster"
+              ]
+            },
+            "UpdateNodePool": {
+              "methods": [
+                "update_node_pool"
+              ]
+            },
+            "SetNodePoolAutoscaling": {
+              "methods": [
+                "set_node_pool_autoscaling"
+              ]
+            },
+            "SetLoggingService": {
+              "methods": [
+                "set_logging_service"
+              ]
+            },
+            "SetMonitoringService": {
+              "methods": [
+                "set_monitoring_service"
+              ]
+            },
+            "SetAddonsConfig": {
+              "methods": [
+                "set_addons_config"
+              ]
+            },
+            "SetLocations": {
+              "methods": [
+                "set_locations"
+              ]
+            },
+            "UpdateMaster": {
+              "methods": [
+                "update_master"
+              ]
+            },
+            "SetMasterAuth": {
+              "methods": [
+                "set_master_auth"
+              ]
+            },
+            "DeleteCluster": {
+              "methods": [
+                "delete_cluster"
+              ]
+            },
+            "ListOperations": {
+              "methods": [
+                "list_operations"
+              ]
+            },
+            "GetOperation": {
+              "methods": [
+                "get_operation"
+              ]
+            },
+            "CancelOperation": {
+              "methods": [
+                "cancel_operation"
+              ]
+            },
+            "GetServerConfig": {
+              "methods": [
+                "get_server_config"
+              ]
+            },
+            "GetJSONWebKeys": {
+              "methods": [
+                "get_json_web_keys"
+              ]
+            },
+            "ListNodePools": {
+              "methods": [
+                "list_node_pools"
+              ]
+            },
+            "GetNodePool": {
+              "methods": [
+                "get_node_pool"
+              ]
+            },
+            "CreateNodePool": {
+              "methods": [
+                "create_node_pool"
+              ]
+            },
+            "DeleteNodePool": {
+              "methods": [
+                "delete_node_pool"
+              ]
+            },
+            "RollbackNodePoolUpgrade": {
+              "methods": [
+                "rollback_node_pool_upgrade"
+              ]
+            },
+            "SetNodePoolManagement": {
+              "methods": [
+                "set_node_pool_management"
+              ]
+            },
+            "SetLabels": {
+              "methods": [
+                "set_labels"
+              ]
+            },
+            "SetLegacyAbac": {
+              "methods": [
+                "set_legacy_abac"
+              ]
+            },
+            "StartIPRotation": {
+              "methods": [
+                "start_ip_rotation"
+              ]
+            },
+            "CompleteIPRotation": {
+              "methods": [
+                "complete_ip_rotation"
+              ]
+            },
+            "SetNodePoolSize": {
+              "methods": [
+                "set_node_pool_size"
+              ]
+            },
+            "SetNetworkPolicy": {
+              "methods": [
+                "set_network_policy"
+              ]
+            },
+            "SetMaintenancePolicy": {
+              "methods": [
+                "set_maintenance_policy"
+              ]
+            },
+            "ListUsableSubnetworks": {
+              "methods": [
+                "list_usable_subnetworks"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-container-v1/google-cloud-container-v1.gemspec
+++ b/google-cloud-container-v1/google-cloud-container-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-container-v1beta1/gapic_metadata.json
+++ b/google-cloud-container-v1beta1/gapic_metadata.json
@@ -9,106 +9,172 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Container::V1beta1::ClusterManager::Client",
-          "methods": {
-            "ListClusters": [
-              "list_clusters"
-            ],
-            "GetCluster": [
-              "get_cluster"
-            ],
-            "CreateCluster": [
-              "create_cluster"
-            ],
-            "UpdateCluster": [
-              "update_cluster"
-            ],
-            "UpdateNodePool": [
-              "update_node_pool"
-            ],
-            "SetNodePoolAutoscaling": [
-              "set_node_pool_autoscaling"
-            ],
-            "SetLoggingService": [
-              "set_logging_service"
-            ],
-            "SetMonitoringService": [
-              "set_monitoring_service"
-            ],
-            "SetAddonsConfig": [
-              "set_addons_config"
-            ],
-            "SetLocations": [
-              "set_locations"
-            ],
-            "UpdateMaster": [
-              "update_master"
-            ],
-            "SetMasterAuth": [
-              "set_master_auth"
-            ],
-            "DeleteCluster": [
-              "delete_cluster"
-            ],
-            "ListOperations": [
-              "list_operations"
-            ],
-            "GetOperation": [
-              "get_operation"
-            ],
-            "CancelOperation": [
-              "cancel_operation"
-            ],
-            "GetServerConfig": [
-              "get_server_config"
-            ],
-            "ListNodePools": [
-              "list_node_pools"
-            ],
-            "GetJSONWebKeys": [
-              "get_json_web_keys"
-            ],
-            "GetNodePool": [
-              "get_node_pool"
-            ],
-            "CreateNodePool": [
-              "create_node_pool"
-            ],
-            "DeleteNodePool": [
-              "delete_node_pool"
-            ],
-            "RollbackNodePoolUpgrade": [
-              "rollback_node_pool_upgrade"
-            ],
-            "SetNodePoolManagement": [
-              "set_node_pool_management"
-            ],
-            "SetLabels": [
-              "set_labels"
-            ],
-            "SetLegacyAbac": [
-              "set_legacy_abac"
-            ],
-            "StartIPRotation": [
-              "start_ip_rotation"
-            ],
-            "CompleteIPRotation": [
-              "complete_ip_rotation"
-            ],
-            "SetNodePoolSize": [
-              "set_node_pool_size"
-            ],
-            "SetNetworkPolicy": [
-              "set_network_policy"
-            ],
-            "SetMaintenancePolicy": [
-              "set_maintenance_policy"
-            ],
-            "ListUsableSubnetworks": [
-              "list_usable_subnetworks"
-            ],
-            "ListLocations": [
-              "list_locations"
-            ]
+          "rpcs": {
+            "ListClusters": {
+              "methods": [
+                "list_clusters"
+              ]
+            },
+            "GetCluster": {
+              "methods": [
+                "get_cluster"
+              ]
+            },
+            "CreateCluster": {
+              "methods": [
+                "create_cluster"
+              ]
+            },
+            "UpdateCluster": {
+              "methods": [
+                "update_cluster"
+              ]
+            },
+            "UpdateNodePool": {
+              "methods": [
+                "update_node_pool"
+              ]
+            },
+            "SetNodePoolAutoscaling": {
+              "methods": [
+                "set_node_pool_autoscaling"
+              ]
+            },
+            "SetLoggingService": {
+              "methods": [
+                "set_logging_service"
+              ]
+            },
+            "SetMonitoringService": {
+              "methods": [
+                "set_monitoring_service"
+              ]
+            },
+            "SetAddonsConfig": {
+              "methods": [
+                "set_addons_config"
+              ]
+            },
+            "SetLocations": {
+              "methods": [
+                "set_locations"
+              ]
+            },
+            "UpdateMaster": {
+              "methods": [
+                "update_master"
+              ]
+            },
+            "SetMasterAuth": {
+              "methods": [
+                "set_master_auth"
+              ]
+            },
+            "DeleteCluster": {
+              "methods": [
+                "delete_cluster"
+              ]
+            },
+            "ListOperations": {
+              "methods": [
+                "list_operations"
+              ]
+            },
+            "GetOperation": {
+              "methods": [
+                "get_operation"
+              ]
+            },
+            "CancelOperation": {
+              "methods": [
+                "cancel_operation"
+              ]
+            },
+            "GetServerConfig": {
+              "methods": [
+                "get_server_config"
+              ]
+            },
+            "ListNodePools": {
+              "methods": [
+                "list_node_pools"
+              ]
+            },
+            "GetJSONWebKeys": {
+              "methods": [
+                "get_json_web_keys"
+              ]
+            },
+            "GetNodePool": {
+              "methods": [
+                "get_node_pool"
+              ]
+            },
+            "CreateNodePool": {
+              "methods": [
+                "create_node_pool"
+              ]
+            },
+            "DeleteNodePool": {
+              "methods": [
+                "delete_node_pool"
+              ]
+            },
+            "RollbackNodePoolUpgrade": {
+              "methods": [
+                "rollback_node_pool_upgrade"
+              ]
+            },
+            "SetNodePoolManagement": {
+              "methods": [
+                "set_node_pool_management"
+              ]
+            },
+            "SetLabels": {
+              "methods": [
+                "set_labels"
+              ]
+            },
+            "SetLegacyAbac": {
+              "methods": [
+                "set_legacy_abac"
+              ]
+            },
+            "StartIPRotation": {
+              "methods": [
+                "start_ip_rotation"
+              ]
+            },
+            "CompleteIPRotation": {
+              "methods": [
+                "complete_ip_rotation"
+              ]
+            },
+            "SetNodePoolSize": {
+              "methods": [
+                "set_node_pool_size"
+              ]
+            },
+            "SetNetworkPolicy": {
+              "methods": [
+                "set_network_policy"
+              ]
+            },
+            "SetMaintenancePolicy": {
+              "methods": [
+                "set_maintenance_policy"
+              ]
+            },
+            "ListUsableSubnetworks": {
+              "methods": [
+                "list_usable_subnetworks"
+              ]
+            },
+            "ListLocations": {
+              "methods": [
+                "list_locations"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-container-v1beta1/google-cloud-container-v1beta1.gemspec
+++ b/google-cloud-container-v1beta1/google-cloud-container-v1beta1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-container_analysis-v1/gapic_metadata.json
+++ b/google-cloud-container_analysis-v1/gapic_metadata.json
@@ -9,19 +9,27 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::ContainerAnalysis::V1::ContainerAnalysis::Client",
-          "methods": {
-            "SetIamPolicy": [
-              "set_iam_policy"
-            ],
-            "GetIamPolicy": [
-              "get_iam_policy"
-            ],
-            "TestIamPermissions": [
-              "test_iam_permissions"
-            ],
-            "GetVulnerabilityOccurrencesSummary": [
-              "get_vulnerability_occurrences_summary"
-            ]
+          "rpcs": {
+            "SetIamPolicy": {
+              "methods": [
+                "set_iam_policy"
+              ]
+            },
+            "GetIamPolicy": {
+              "methods": [
+                "get_iam_policy"
+              ]
+            },
+            "TestIamPermissions": {
+              "methods": [
+                "test_iam_permissions"
+              ]
+            },
+            "GetVulnerabilityOccurrencesSummary": {
+              "methods": [
+                "get_vulnerability_occurrences_summary"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-container_analysis-v1/google-cloud-container_analysis-v1.gemspec
+++ b/google-cloud-container_analysis-v1/google-cloud-container_analysis-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
   gem.add_dependency "grafeas-v1", "~> 0.0"
   gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.0"

--- a/google-cloud-data_catalog-v1/gapic_metadata.json
+++ b/google-cloud-data_catalog-v1/gapic_metadata.json
@@ -9,88 +9,142 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::DataCatalog::V1::DataCatalog::Client",
-          "methods": {
-            "SearchCatalog": [
-              "search_catalog"
-            ],
-            "CreateEntryGroup": [
-              "create_entry_group"
-            ],
-            "GetEntryGroup": [
-              "get_entry_group"
-            ],
-            "UpdateEntryGroup": [
-              "update_entry_group"
-            ],
-            "DeleteEntryGroup": [
-              "delete_entry_group"
-            ],
-            "ListEntryGroups": [
-              "list_entry_groups"
-            ],
-            "CreateEntry": [
-              "create_entry"
-            ],
-            "UpdateEntry": [
-              "update_entry"
-            ],
-            "DeleteEntry": [
-              "delete_entry"
-            ],
-            "GetEntry": [
-              "get_entry"
-            ],
-            "LookupEntry": [
-              "lookup_entry"
-            ],
-            "ListEntries": [
-              "list_entries"
-            ],
-            "CreateTagTemplate": [
-              "create_tag_template"
-            ],
-            "GetTagTemplate": [
-              "get_tag_template"
-            ],
-            "UpdateTagTemplate": [
-              "update_tag_template"
-            ],
-            "DeleteTagTemplate": [
-              "delete_tag_template"
-            ],
-            "CreateTagTemplateField": [
-              "create_tag_template_field"
-            ],
-            "UpdateTagTemplateField": [
-              "update_tag_template_field"
-            ],
-            "RenameTagTemplateField": [
-              "rename_tag_template_field"
-            ],
-            "DeleteTagTemplateField": [
-              "delete_tag_template_field"
-            ],
-            "CreateTag": [
-              "create_tag"
-            ],
-            "UpdateTag": [
-              "update_tag"
-            ],
-            "DeleteTag": [
-              "delete_tag"
-            ],
-            "ListTags": [
-              "list_tags"
-            ],
-            "SetIamPolicy": [
-              "set_iam_policy"
-            ],
-            "GetIamPolicy": [
-              "get_iam_policy"
-            ],
-            "TestIamPermissions": [
-              "test_iam_permissions"
-            ]
+          "rpcs": {
+            "SearchCatalog": {
+              "methods": [
+                "search_catalog"
+              ]
+            },
+            "CreateEntryGroup": {
+              "methods": [
+                "create_entry_group"
+              ]
+            },
+            "GetEntryGroup": {
+              "methods": [
+                "get_entry_group"
+              ]
+            },
+            "UpdateEntryGroup": {
+              "methods": [
+                "update_entry_group"
+              ]
+            },
+            "DeleteEntryGroup": {
+              "methods": [
+                "delete_entry_group"
+              ]
+            },
+            "ListEntryGroups": {
+              "methods": [
+                "list_entry_groups"
+              ]
+            },
+            "CreateEntry": {
+              "methods": [
+                "create_entry"
+              ]
+            },
+            "UpdateEntry": {
+              "methods": [
+                "update_entry"
+              ]
+            },
+            "DeleteEntry": {
+              "methods": [
+                "delete_entry"
+              ]
+            },
+            "GetEntry": {
+              "methods": [
+                "get_entry"
+              ]
+            },
+            "LookupEntry": {
+              "methods": [
+                "lookup_entry"
+              ]
+            },
+            "ListEntries": {
+              "methods": [
+                "list_entries"
+              ]
+            },
+            "CreateTagTemplate": {
+              "methods": [
+                "create_tag_template"
+              ]
+            },
+            "GetTagTemplate": {
+              "methods": [
+                "get_tag_template"
+              ]
+            },
+            "UpdateTagTemplate": {
+              "methods": [
+                "update_tag_template"
+              ]
+            },
+            "DeleteTagTemplate": {
+              "methods": [
+                "delete_tag_template"
+              ]
+            },
+            "CreateTagTemplateField": {
+              "methods": [
+                "create_tag_template_field"
+              ]
+            },
+            "UpdateTagTemplateField": {
+              "methods": [
+                "update_tag_template_field"
+              ]
+            },
+            "RenameTagTemplateField": {
+              "methods": [
+                "rename_tag_template_field"
+              ]
+            },
+            "DeleteTagTemplateField": {
+              "methods": [
+                "delete_tag_template_field"
+              ]
+            },
+            "CreateTag": {
+              "methods": [
+                "create_tag"
+              ]
+            },
+            "UpdateTag": {
+              "methods": [
+                "update_tag"
+              ]
+            },
+            "DeleteTag": {
+              "methods": [
+                "delete_tag"
+              ]
+            },
+            "ListTags": {
+              "methods": [
+                "list_tags"
+              ]
+            },
+            "SetIamPolicy": {
+              "methods": [
+                "set_iam_policy"
+              ]
+            },
+            "GetIamPolicy": {
+              "methods": [
+                "get_iam_policy"
+              ]
+            },
+            "TestIamPermissions": {
+              "methods": [
+                "test_iam_permissions"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-data_catalog-v1/google-cloud-data_catalog-v1.gemspec
+++ b/google-cloud-data_catalog-v1/google-cloud-data_catalog-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
   gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.0"
 

--- a/google-cloud-data_labeling-v1beta1/gapic_metadata.json
+++ b/google-cloud-data_labeling-v1beta1/gapic_metadata.json
@@ -9,109 +9,177 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::DataLabeling::V1beta1::DataLabelingService::Client",
-          "methods": {
-            "CreateDataset": [
-              "create_dataset"
-            ],
-            "GetDataset": [
-              "get_dataset"
-            ],
-            "ListDatasets": [
-              "list_datasets"
-            ],
-            "DeleteDataset": [
-              "delete_dataset"
-            ],
-            "ImportData": [
-              "import_data"
-            ],
-            "ExportData": [
-              "export_data"
-            ],
-            "GetDataItem": [
-              "get_data_item"
-            ],
-            "ListDataItems": [
-              "list_data_items"
-            ],
-            "GetAnnotatedDataset": [
-              "get_annotated_dataset"
-            ],
-            "ListAnnotatedDatasets": [
-              "list_annotated_datasets"
-            ],
-            "DeleteAnnotatedDataset": [
-              "delete_annotated_dataset"
-            ],
-            "LabelImage": [
-              "label_image"
-            ],
-            "LabelVideo": [
-              "label_video"
-            ],
-            "LabelText": [
-              "label_text"
-            ],
-            "GetExample": [
-              "get_example"
-            ],
-            "ListExamples": [
-              "list_examples"
-            ],
-            "CreateAnnotationSpecSet": [
-              "create_annotation_spec_set"
-            ],
-            "GetAnnotationSpecSet": [
-              "get_annotation_spec_set"
-            ],
-            "ListAnnotationSpecSets": [
-              "list_annotation_spec_sets"
-            ],
-            "DeleteAnnotationSpecSet": [
-              "delete_annotation_spec_set"
-            ],
-            "CreateInstruction": [
-              "create_instruction"
-            ],
-            "GetInstruction": [
-              "get_instruction"
-            ],
-            "ListInstructions": [
-              "list_instructions"
-            ],
-            "DeleteInstruction": [
-              "delete_instruction"
-            ],
-            "GetEvaluation": [
-              "get_evaluation"
-            ],
-            "SearchEvaluations": [
-              "search_evaluations"
-            ],
-            "SearchExampleComparisons": [
-              "search_example_comparisons"
-            ],
-            "CreateEvaluationJob": [
-              "create_evaluation_job"
-            ],
-            "UpdateEvaluationJob": [
-              "update_evaluation_job"
-            ],
-            "GetEvaluationJob": [
-              "get_evaluation_job"
-            ],
-            "PauseEvaluationJob": [
-              "pause_evaluation_job"
-            ],
-            "ResumeEvaluationJob": [
-              "resume_evaluation_job"
-            ],
-            "DeleteEvaluationJob": [
-              "delete_evaluation_job"
-            ],
-            "ListEvaluationJobs": [
-              "list_evaluation_jobs"
-            ]
+          "rpcs": {
+            "CreateDataset": {
+              "methods": [
+                "create_dataset"
+              ]
+            },
+            "GetDataset": {
+              "methods": [
+                "get_dataset"
+              ]
+            },
+            "ListDatasets": {
+              "methods": [
+                "list_datasets"
+              ]
+            },
+            "DeleteDataset": {
+              "methods": [
+                "delete_dataset"
+              ]
+            },
+            "ImportData": {
+              "methods": [
+                "import_data"
+              ]
+            },
+            "ExportData": {
+              "methods": [
+                "export_data"
+              ]
+            },
+            "GetDataItem": {
+              "methods": [
+                "get_data_item"
+              ]
+            },
+            "ListDataItems": {
+              "methods": [
+                "list_data_items"
+              ]
+            },
+            "GetAnnotatedDataset": {
+              "methods": [
+                "get_annotated_dataset"
+              ]
+            },
+            "ListAnnotatedDatasets": {
+              "methods": [
+                "list_annotated_datasets"
+              ]
+            },
+            "DeleteAnnotatedDataset": {
+              "methods": [
+                "delete_annotated_dataset"
+              ]
+            },
+            "LabelImage": {
+              "methods": [
+                "label_image"
+              ]
+            },
+            "LabelVideo": {
+              "methods": [
+                "label_video"
+              ]
+            },
+            "LabelText": {
+              "methods": [
+                "label_text"
+              ]
+            },
+            "GetExample": {
+              "methods": [
+                "get_example"
+              ]
+            },
+            "ListExamples": {
+              "methods": [
+                "list_examples"
+              ]
+            },
+            "CreateAnnotationSpecSet": {
+              "methods": [
+                "create_annotation_spec_set"
+              ]
+            },
+            "GetAnnotationSpecSet": {
+              "methods": [
+                "get_annotation_spec_set"
+              ]
+            },
+            "ListAnnotationSpecSets": {
+              "methods": [
+                "list_annotation_spec_sets"
+              ]
+            },
+            "DeleteAnnotationSpecSet": {
+              "methods": [
+                "delete_annotation_spec_set"
+              ]
+            },
+            "CreateInstruction": {
+              "methods": [
+                "create_instruction"
+              ]
+            },
+            "GetInstruction": {
+              "methods": [
+                "get_instruction"
+              ]
+            },
+            "ListInstructions": {
+              "methods": [
+                "list_instructions"
+              ]
+            },
+            "DeleteInstruction": {
+              "methods": [
+                "delete_instruction"
+              ]
+            },
+            "GetEvaluation": {
+              "methods": [
+                "get_evaluation"
+              ]
+            },
+            "SearchEvaluations": {
+              "methods": [
+                "search_evaluations"
+              ]
+            },
+            "SearchExampleComparisons": {
+              "methods": [
+                "search_example_comparisons"
+              ]
+            },
+            "CreateEvaluationJob": {
+              "methods": [
+                "create_evaluation_job"
+              ]
+            },
+            "UpdateEvaluationJob": {
+              "methods": [
+                "update_evaluation_job"
+              ]
+            },
+            "GetEvaluationJob": {
+              "methods": [
+                "get_evaluation_job"
+              ]
+            },
+            "PauseEvaluationJob": {
+              "methods": [
+                "pause_evaluation_job"
+              ]
+            },
+            "ResumeEvaluationJob": {
+              "methods": [
+                "resume_evaluation_job"
+              ]
+            },
+            "DeleteEvaluationJob": {
+              "methods": [
+                "delete_evaluation_job"
+              ]
+            },
+            "ListEvaluationJobs": {
+              "methods": [
+                "list_evaluation_jobs"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-data_labeling-v1beta1/google-cloud-data_labeling-v1beta1.gemspec
+++ b/google-cloud-data_labeling-v1beta1/google-cloud-data_labeling-v1beta1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-dataproc-v1/gapic_metadata.json
+++ b/google-cloud-dataproc-v1/gapic_metadata.json
@@ -9,22 +9,32 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Dataproc::V1::AutoscalingPolicyService::Client",
-          "methods": {
-            "CreateAutoscalingPolicy": [
-              "create_autoscaling_policy"
-            ],
-            "UpdateAutoscalingPolicy": [
-              "update_autoscaling_policy"
-            ],
-            "GetAutoscalingPolicy": [
-              "get_autoscaling_policy"
-            ],
-            "ListAutoscalingPolicies": [
-              "list_autoscaling_policies"
-            ],
-            "DeleteAutoscalingPolicy": [
-              "delete_autoscaling_policy"
-            ]
+          "rpcs": {
+            "CreateAutoscalingPolicy": {
+              "methods": [
+                "create_autoscaling_policy"
+              ]
+            },
+            "UpdateAutoscalingPolicy": {
+              "methods": [
+                "update_autoscaling_policy"
+              ]
+            },
+            "GetAutoscalingPolicy": {
+              "methods": [
+                "get_autoscaling_policy"
+              ]
+            },
+            "ListAutoscalingPolicies": {
+              "methods": [
+                "list_autoscaling_policies"
+              ]
+            },
+            "DeleteAutoscalingPolicy": {
+              "methods": [
+                "delete_autoscaling_policy"
+              ]
+            }
           }
         }
       }
@@ -33,25 +43,37 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Dataproc::V1::ClusterController::Client",
-          "methods": {
-            "CreateCluster": [
-              "create_cluster"
-            ],
-            "UpdateCluster": [
-              "update_cluster"
-            ],
-            "DeleteCluster": [
-              "delete_cluster"
-            ],
-            "GetCluster": [
-              "get_cluster"
-            ],
-            "ListClusters": [
-              "list_clusters"
-            ],
-            "DiagnoseCluster": [
-              "diagnose_cluster"
-            ]
+          "rpcs": {
+            "CreateCluster": {
+              "methods": [
+                "create_cluster"
+              ]
+            },
+            "UpdateCluster": {
+              "methods": [
+                "update_cluster"
+              ]
+            },
+            "DeleteCluster": {
+              "methods": [
+                "delete_cluster"
+              ]
+            },
+            "GetCluster": {
+              "methods": [
+                "get_cluster"
+              ]
+            },
+            "ListClusters": {
+              "methods": [
+                "list_clusters"
+              ]
+            },
+            "DiagnoseCluster": {
+              "methods": [
+                "diagnose_cluster"
+              ]
+            }
           }
         }
       }
@@ -60,28 +82,42 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Dataproc::V1::JobController::Client",
-          "methods": {
-            "SubmitJob": [
-              "submit_job"
-            ],
-            "SubmitJobAsOperation": [
-              "submit_job_as_operation"
-            ],
-            "GetJob": [
-              "get_job"
-            ],
-            "ListJobs": [
-              "list_jobs"
-            ],
-            "UpdateJob": [
-              "update_job"
-            ],
-            "CancelJob": [
-              "cancel_job"
-            ],
-            "DeleteJob": [
-              "delete_job"
-            ]
+          "rpcs": {
+            "SubmitJob": {
+              "methods": [
+                "submit_job"
+              ]
+            },
+            "SubmitJobAsOperation": {
+              "methods": [
+                "submit_job_as_operation"
+              ]
+            },
+            "GetJob": {
+              "methods": [
+                "get_job"
+              ]
+            },
+            "ListJobs": {
+              "methods": [
+                "list_jobs"
+              ]
+            },
+            "UpdateJob": {
+              "methods": [
+                "update_job"
+              ]
+            },
+            "CancelJob": {
+              "methods": [
+                "cancel_job"
+              ]
+            },
+            "DeleteJob": {
+              "methods": [
+                "delete_job"
+              ]
+            }
           }
         }
       }
@@ -90,28 +126,42 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Dataproc::V1::WorkflowTemplateService::Client",
-          "methods": {
-            "CreateWorkflowTemplate": [
-              "create_workflow_template"
-            ],
-            "GetWorkflowTemplate": [
-              "get_workflow_template"
-            ],
-            "InstantiateWorkflowTemplate": [
-              "instantiate_workflow_template"
-            ],
-            "InstantiateInlineWorkflowTemplate": [
-              "instantiate_inline_workflow_template"
-            ],
-            "UpdateWorkflowTemplate": [
-              "update_workflow_template"
-            ],
-            "ListWorkflowTemplates": [
-              "list_workflow_templates"
-            ],
-            "DeleteWorkflowTemplate": [
-              "delete_workflow_template"
-            ]
+          "rpcs": {
+            "CreateWorkflowTemplate": {
+              "methods": [
+                "create_workflow_template"
+              ]
+            },
+            "GetWorkflowTemplate": {
+              "methods": [
+                "get_workflow_template"
+              ]
+            },
+            "InstantiateWorkflowTemplate": {
+              "methods": [
+                "instantiate_workflow_template"
+              ]
+            },
+            "InstantiateInlineWorkflowTemplate": {
+              "methods": [
+                "instantiate_inline_workflow_template"
+              ]
+            },
+            "UpdateWorkflowTemplate": {
+              "methods": [
+                "update_workflow_template"
+              ]
+            },
+            "ListWorkflowTemplates": {
+              "methods": [
+                "list_workflow_templates"
+              ]
+            },
+            "DeleteWorkflowTemplate": {
+              "methods": [
+                "delete_workflow_template"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-dataproc-v1/google-cloud-dataproc-v1.gemspec
+++ b/google-cloud-dataproc-v1/google-cloud-dataproc-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-dataproc-v1beta2/gapic_metadata.json
+++ b/google-cloud-dataproc-v1beta2/gapic_metadata.json
@@ -9,22 +9,32 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Dataproc::V1beta2::AutoscalingPolicyService::Client",
-          "methods": {
-            "CreateAutoscalingPolicy": [
-              "create_autoscaling_policy"
-            ],
-            "UpdateAutoscalingPolicy": [
-              "update_autoscaling_policy"
-            ],
-            "GetAutoscalingPolicy": [
-              "get_autoscaling_policy"
-            ],
-            "ListAutoscalingPolicies": [
-              "list_autoscaling_policies"
-            ],
-            "DeleteAutoscalingPolicy": [
-              "delete_autoscaling_policy"
-            ]
+          "rpcs": {
+            "CreateAutoscalingPolicy": {
+              "methods": [
+                "create_autoscaling_policy"
+              ]
+            },
+            "UpdateAutoscalingPolicy": {
+              "methods": [
+                "update_autoscaling_policy"
+              ]
+            },
+            "GetAutoscalingPolicy": {
+              "methods": [
+                "get_autoscaling_policy"
+              ]
+            },
+            "ListAutoscalingPolicies": {
+              "methods": [
+                "list_autoscaling_policies"
+              ]
+            },
+            "DeleteAutoscalingPolicy": {
+              "methods": [
+                "delete_autoscaling_policy"
+              ]
+            }
           }
         }
       }
@@ -33,25 +43,37 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Dataproc::V1beta2::ClusterController::Client",
-          "methods": {
-            "CreateCluster": [
-              "create_cluster"
-            ],
-            "UpdateCluster": [
-              "update_cluster"
-            ],
-            "DeleteCluster": [
-              "delete_cluster"
-            ],
-            "GetCluster": [
-              "get_cluster"
-            ],
-            "ListClusters": [
-              "list_clusters"
-            ],
-            "DiagnoseCluster": [
-              "diagnose_cluster"
-            ]
+          "rpcs": {
+            "CreateCluster": {
+              "methods": [
+                "create_cluster"
+              ]
+            },
+            "UpdateCluster": {
+              "methods": [
+                "update_cluster"
+              ]
+            },
+            "DeleteCluster": {
+              "methods": [
+                "delete_cluster"
+              ]
+            },
+            "GetCluster": {
+              "methods": [
+                "get_cluster"
+              ]
+            },
+            "ListClusters": {
+              "methods": [
+                "list_clusters"
+              ]
+            },
+            "DiagnoseCluster": {
+              "methods": [
+                "diagnose_cluster"
+              ]
+            }
           }
         }
       }
@@ -60,28 +82,42 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Dataproc::V1beta2::JobController::Client",
-          "methods": {
-            "SubmitJob": [
-              "submit_job"
-            ],
-            "SubmitJobAsOperation": [
-              "submit_job_as_operation"
-            ],
-            "GetJob": [
-              "get_job"
-            ],
-            "ListJobs": [
-              "list_jobs"
-            ],
-            "UpdateJob": [
-              "update_job"
-            ],
-            "CancelJob": [
-              "cancel_job"
-            ],
-            "DeleteJob": [
-              "delete_job"
-            ]
+          "rpcs": {
+            "SubmitJob": {
+              "methods": [
+                "submit_job"
+              ]
+            },
+            "SubmitJobAsOperation": {
+              "methods": [
+                "submit_job_as_operation"
+              ]
+            },
+            "GetJob": {
+              "methods": [
+                "get_job"
+              ]
+            },
+            "ListJobs": {
+              "methods": [
+                "list_jobs"
+              ]
+            },
+            "UpdateJob": {
+              "methods": [
+                "update_job"
+              ]
+            },
+            "CancelJob": {
+              "methods": [
+                "cancel_job"
+              ]
+            },
+            "DeleteJob": {
+              "methods": [
+                "delete_job"
+              ]
+            }
           }
         }
       }
@@ -90,28 +126,42 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Dataproc::V1beta2::WorkflowTemplateService::Client",
-          "methods": {
-            "CreateWorkflowTemplate": [
-              "create_workflow_template"
-            ],
-            "GetWorkflowTemplate": [
-              "get_workflow_template"
-            ],
-            "InstantiateWorkflowTemplate": [
-              "instantiate_workflow_template"
-            ],
-            "InstantiateInlineWorkflowTemplate": [
-              "instantiate_inline_workflow_template"
-            ],
-            "UpdateWorkflowTemplate": [
-              "update_workflow_template"
-            ],
-            "ListWorkflowTemplates": [
-              "list_workflow_templates"
-            ],
-            "DeleteWorkflowTemplate": [
-              "delete_workflow_template"
-            ]
+          "rpcs": {
+            "CreateWorkflowTemplate": {
+              "methods": [
+                "create_workflow_template"
+              ]
+            },
+            "GetWorkflowTemplate": {
+              "methods": [
+                "get_workflow_template"
+              ]
+            },
+            "InstantiateWorkflowTemplate": {
+              "methods": [
+                "instantiate_workflow_template"
+              ]
+            },
+            "InstantiateInlineWorkflowTemplate": {
+              "methods": [
+                "instantiate_inline_workflow_template"
+              ]
+            },
+            "UpdateWorkflowTemplate": {
+              "methods": [
+                "update_workflow_template"
+              ]
+            },
+            "ListWorkflowTemplates": {
+              "methods": [
+                "list_workflow_templates"
+              ]
+            },
+            "DeleteWorkflowTemplate": {
+              "methods": [
+                "delete_workflow_template"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-dataproc-v1beta2/google-cloud-dataproc-v1beta2.gemspec
+++ b/google-cloud-dataproc-v1beta2/google-cloud-dataproc-v1beta2.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-dataqna-v1alpha/gapic_metadata.json
+++ b/google-cloud-dataqna-v1alpha/gapic_metadata.json
@@ -9,10 +9,12 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::DataQnA::V1alpha::AutoSuggestionService::Client",
-          "methods": {
-            "SuggestQueries": [
-              "suggest_queries"
-            ]
+          "rpcs": {
+            "SuggestQueries": {
+              "methods": [
+                "suggest_queries"
+              ]
+            }
           }
         }
       }
@@ -21,22 +23,32 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::DataQnA::V1alpha::QuestionService::Client",
-          "methods": {
-            "GetQuestion": [
-              "get_question"
-            ],
-            "CreateQuestion": [
-              "create_question"
-            ],
-            "ExecuteQuestion": [
-              "execute_question"
-            ],
-            "GetUserFeedback": [
-              "get_user_feedback"
-            ],
-            "UpdateUserFeedback": [
-              "update_user_feedback"
-            ]
+          "rpcs": {
+            "GetQuestion": {
+              "methods": [
+                "get_question"
+              ]
+            },
+            "CreateQuestion": {
+              "methods": [
+                "create_question"
+              ]
+            },
+            "ExecuteQuestion": {
+              "methods": [
+                "execute_question"
+              ]
+            },
+            "GetUserFeedback": {
+              "methods": [
+                "get_user_feedback"
+              ]
+            },
+            "UpdateUserFeedback": {
+              "methods": [
+                "update_user_feedback"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-dataqna-v1alpha/google-cloud-dataqna-v1alpha.gemspec
+++ b/google-cloud-dataqna-v1alpha/google-cloud-dataqna-v1alpha.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-datastore-admin-v1/gapic_metadata.json
+++ b/google-cloud-datastore-admin-v1/gapic_metadata.json
@@ -9,25 +9,37 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Datastore::Admin::V1::DatastoreAdmin::Client",
-          "methods": {
-            "ExportEntities": [
-              "export_entities"
-            ],
-            "ImportEntities": [
-              "import_entities"
-            ],
-            "CreateIndex": [
-              "create_index"
-            ],
-            "DeleteIndex": [
-              "delete_index"
-            ],
-            "GetIndex": [
-              "get_index"
-            ],
-            "ListIndexes": [
-              "list_indexes"
-            ]
+          "rpcs": {
+            "ExportEntities": {
+              "methods": [
+                "export_entities"
+              ]
+            },
+            "ImportEntities": {
+              "methods": [
+                "import_entities"
+              ]
+            },
+            "CreateIndex": {
+              "methods": [
+                "create_index"
+              ]
+            },
+            "DeleteIndex": {
+              "methods": [
+                "delete_index"
+              ]
+            },
+            "GetIndex": {
+              "methods": [
+                "get_index"
+              ]
+            },
+            "ListIndexes": {
+              "methods": [
+                "list_indexes"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-datastore-admin-v1/google-cloud-datastore-admin-v1.gemspec
+++ b/google-cloud-datastore-admin-v1/google-cloud-datastore-admin-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-datastore-v1/gapic_metadata.json
+++ b/google-cloud-datastore-v1/gapic_metadata.json
@@ -9,28 +9,42 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Datastore::V1::Datastore::Client",
-          "methods": {
-            "Lookup": [
-              "lookup"
-            ],
-            "RunQuery": [
-              "run_query"
-            ],
-            "BeginTransaction": [
-              "begin_transaction"
-            ],
-            "Commit": [
-              "commit"
-            ],
-            "Rollback": [
-              "rollback"
-            ],
-            "AllocateIds": [
-              "allocate_ids"
-            ],
-            "ReserveIds": [
-              "reserve_ids"
-            ]
+          "rpcs": {
+            "Lookup": {
+              "methods": [
+                "lookup"
+              ]
+            },
+            "RunQuery": {
+              "methods": [
+                "run_query"
+              ]
+            },
+            "BeginTransaction": {
+              "methods": [
+                "begin_transaction"
+              ]
+            },
+            "Commit": {
+              "methods": [
+                "commit"
+              ]
+            },
+            "Rollback": {
+              "methods": [
+                "rollback"
+              ]
+            },
+            "AllocateIds": {
+              "methods": [
+                "allocate_ids"
+              ]
+            },
+            "ReserveIds": {
+              "methods": [
+                "reserve_ids"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-datastore-v1/google-cloud-datastore-v1.gemspec
+++ b/google-cloud-datastore-v1/google-cloud-datastore-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-debugger-v2/gapic_metadata.json
+++ b/google-cloud-debugger-v2/gapic_metadata.json
@@ -9,16 +9,22 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Debugger::V2::Controller::Client",
-          "methods": {
-            "RegisterDebuggee": [
-              "register_debuggee"
-            ],
-            "ListActiveBreakpoints": [
-              "list_active_breakpoints"
-            ],
-            "UpdateActiveBreakpoint": [
-              "update_active_breakpoint"
-            ]
+          "rpcs": {
+            "RegisterDebuggee": {
+              "methods": [
+                "register_debuggee"
+              ]
+            },
+            "ListActiveBreakpoints": {
+              "methods": [
+                "list_active_breakpoints"
+              ]
+            },
+            "UpdateActiveBreakpoint": {
+              "methods": [
+                "update_active_breakpoint"
+              ]
+            }
           }
         }
       }
@@ -27,22 +33,32 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Debugger::V2::Debugger::Client",
-          "methods": {
-            "SetBreakpoint": [
-              "set_breakpoint"
-            ],
-            "GetBreakpoint": [
-              "get_breakpoint"
-            ],
-            "DeleteBreakpoint": [
-              "delete_breakpoint"
-            ],
-            "ListBreakpoints": [
-              "list_breakpoints"
-            ],
-            "ListDebuggees": [
-              "list_debuggees"
-            ]
+          "rpcs": {
+            "SetBreakpoint": {
+              "methods": [
+                "set_breakpoint"
+              ]
+            },
+            "GetBreakpoint": {
+              "methods": [
+                "get_breakpoint"
+              ]
+            },
+            "DeleteBreakpoint": {
+              "methods": [
+                "delete_breakpoint"
+              ]
+            },
+            "ListBreakpoints": {
+              "methods": [
+                "list_breakpoints"
+              ]
+            },
+            "ListDebuggees": {
+              "methods": [
+                "list_debuggees"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-debugger-v2/google-cloud-debugger-v2.gemspec
+++ b/google-cloud-debugger-v2/google-cloud-debugger-v2.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-dialogflow-v2/gapic_metadata.json
+++ b/google-cloud-dialogflow-v2/gapic_metadata.json
@@ -9,34 +9,52 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Dialogflow::V2::Agents::Client",
-          "methods": {
-            "GetAgent": [
-              "get_agent"
-            ],
-            "SetAgent": [
-              "set_agent"
-            ],
-            "DeleteAgent": [
-              "delete_agent"
-            ],
-            "SearchAgents": [
-              "search_agents"
-            ],
-            "TrainAgent": [
-              "train_agent"
-            ],
-            "ExportAgent": [
-              "export_agent"
-            ],
-            "ImportAgent": [
-              "import_agent"
-            ],
-            "RestoreAgent": [
-              "restore_agent"
-            ],
-            "GetValidationResult": [
-              "get_validation_result"
-            ]
+          "rpcs": {
+            "GetAgent": {
+              "methods": [
+                "get_agent"
+              ]
+            },
+            "SetAgent": {
+              "methods": [
+                "set_agent"
+              ]
+            },
+            "DeleteAgent": {
+              "methods": [
+                "delete_agent"
+              ]
+            },
+            "SearchAgents": {
+              "methods": [
+                "search_agents"
+              ]
+            },
+            "TrainAgent": {
+              "methods": [
+                "train_agent"
+              ]
+            },
+            "ExportAgent": {
+              "methods": [
+                "export_agent"
+              ]
+            },
+            "ImportAgent": {
+              "methods": [
+                "import_agent"
+              ]
+            },
+            "RestoreAgent": {
+              "methods": [
+                "restore_agent"
+              ]
+            },
+            "GetValidationResult": {
+              "methods": [
+                "get_validation_result"
+              ]
+            }
           }
         }
       }
@@ -45,25 +63,37 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Dialogflow::V2::Contexts::Client",
-          "methods": {
-            "ListContexts": [
-              "list_contexts"
-            ],
-            "GetContext": [
-              "get_context"
-            ],
-            "CreateContext": [
-              "create_context"
-            ],
-            "UpdateContext": [
-              "update_context"
-            ],
-            "DeleteContext": [
-              "delete_context"
-            ],
-            "DeleteAllContexts": [
-              "delete_all_contexts"
-            ]
+          "rpcs": {
+            "ListContexts": {
+              "methods": [
+                "list_contexts"
+              ]
+            },
+            "GetContext": {
+              "methods": [
+                "get_context"
+              ]
+            },
+            "CreateContext": {
+              "methods": [
+                "create_context"
+              ]
+            },
+            "UpdateContext": {
+              "methods": [
+                "update_context"
+              ]
+            },
+            "DeleteContext": {
+              "methods": [
+                "delete_context"
+              ]
+            },
+            "DeleteAllContexts": {
+              "methods": [
+                "delete_all_contexts"
+              ]
+            }
           }
         }
       }
@@ -72,28 +102,42 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Dialogflow::V2::Intents::Client",
-          "methods": {
-            "ListIntents": [
-              "list_intents"
-            ],
-            "GetIntent": [
-              "get_intent"
-            ],
-            "CreateIntent": [
-              "create_intent"
-            ],
-            "UpdateIntent": [
-              "update_intent"
-            ],
-            "DeleteIntent": [
-              "delete_intent"
-            ],
-            "BatchUpdateIntents": [
-              "batch_update_intents"
-            ],
-            "BatchDeleteIntents": [
-              "batch_delete_intents"
-            ]
+          "rpcs": {
+            "ListIntents": {
+              "methods": [
+                "list_intents"
+              ]
+            },
+            "GetIntent": {
+              "methods": [
+                "get_intent"
+              ]
+            },
+            "CreateIntent": {
+              "methods": [
+                "create_intent"
+              ]
+            },
+            "UpdateIntent": {
+              "methods": [
+                "update_intent"
+              ]
+            },
+            "DeleteIntent": {
+              "methods": [
+                "delete_intent"
+              ]
+            },
+            "BatchUpdateIntents": {
+              "methods": [
+                "batch_update_intents"
+              ]
+            },
+            "BatchDeleteIntents": {
+              "methods": [
+                "batch_delete_intents"
+              ]
+            }
           }
         }
       }
@@ -102,37 +146,57 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Dialogflow::V2::EntityTypes::Client",
-          "methods": {
-            "ListEntityTypes": [
-              "list_entity_types"
-            ],
-            "GetEntityType": [
-              "get_entity_type"
-            ],
-            "CreateEntityType": [
-              "create_entity_type"
-            ],
-            "UpdateEntityType": [
-              "update_entity_type"
-            ],
-            "DeleteEntityType": [
-              "delete_entity_type"
-            ],
-            "BatchUpdateEntityTypes": [
-              "batch_update_entity_types"
-            ],
-            "BatchDeleteEntityTypes": [
-              "batch_delete_entity_types"
-            ],
-            "BatchCreateEntities": [
-              "batch_create_entities"
-            ],
-            "BatchUpdateEntities": [
-              "batch_update_entities"
-            ],
-            "BatchDeleteEntities": [
-              "batch_delete_entities"
-            ]
+          "rpcs": {
+            "ListEntityTypes": {
+              "methods": [
+                "list_entity_types"
+              ]
+            },
+            "GetEntityType": {
+              "methods": [
+                "get_entity_type"
+              ]
+            },
+            "CreateEntityType": {
+              "methods": [
+                "create_entity_type"
+              ]
+            },
+            "UpdateEntityType": {
+              "methods": [
+                "update_entity_type"
+              ]
+            },
+            "DeleteEntityType": {
+              "methods": [
+                "delete_entity_type"
+              ]
+            },
+            "BatchUpdateEntityTypes": {
+              "methods": [
+                "batch_update_entity_types"
+              ]
+            },
+            "BatchDeleteEntityTypes": {
+              "methods": [
+                "batch_delete_entity_types"
+              ]
+            },
+            "BatchCreateEntities": {
+              "methods": [
+                "batch_create_entities"
+              ]
+            },
+            "BatchUpdateEntities": {
+              "methods": [
+                "batch_update_entities"
+              ]
+            },
+            "BatchDeleteEntities": {
+              "methods": [
+                "batch_delete_entities"
+              ]
+            }
           }
         }
       }
@@ -141,22 +205,32 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Dialogflow::V2::SessionEntityTypes::Client",
-          "methods": {
-            "ListSessionEntityTypes": [
-              "list_session_entity_types"
-            ],
-            "GetSessionEntityType": [
-              "get_session_entity_type"
-            ],
-            "CreateSessionEntityType": [
-              "create_session_entity_type"
-            ],
-            "UpdateSessionEntityType": [
-              "update_session_entity_type"
-            ],
-            "DeleteSessionEntityType": [
-              "delete_session_entity_type"
-            ]
+          "rpcs": {
+            "ListSessionEntityTypes": {
+              "methods": [
+                "list_session_entity_types"
+              ]
+            },
+            "GetSessionEntityType": {
+              "methods": [
+                "get_session_entity_type"
+              ]
+            },
+            "CreateSessionEntityType": {
+              "methods": [
+                "create_session_entity_type"
+              ]
+            },
+            "UpdateSessionEntityType": {
+              "methods": [
+                "update_session_entity_type"
+              ]
+            },
+            "DeleteSessionEntityType": {
+              "methods": [
+                "delete_session_entity_type"
+              ]
+            }
           }
         }
       }
@@ -165,13 +239,17 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Dialogflow::V2::Sessions::Client",
-          "methods": {
-            "DetectIntent": [
-              "detect_intent"
-            ],
-            "StreamingDetectIntent": [
-              "streaming_detect_intent"
-            ]
+          "rpcs": {
+            "DetectIntent": {
+              "methods": [
+                "detect_intent"
+              ]
+            },
+            "StreamingDetectIntent": {
+              "methods": [
+                "streaming_detect_intent"
+              ]
+            }
           }
         }
       }
@@ -180,28 +258,42 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Dialogflow::V2::Participants::Client",
-          "methods": {
-            "CreateParticipant": [
-              "create_participant"
-            ],
-            "GetParticipant": [
-              "get_participant"
-            ],
-            "ListParticipants": [
-              "list_participants"
-            ],
-            "UpdateParticipant": [
-              "update_participant"
-            ],
-            "AnalyzeContent": [
-              "analyze_content"
-            ],
-            "SuggestArticles": [
-              "suggest_articles"
-            ],
-            "SuggestFaqAnswers": [
-              "suggest_faq_answers"
-            ]
+          "rpcs": {
+            "CreateParticipant": {
+              "methods": [
+                "create_participant"
+              ]
+            },
+            "GetParticipant": {
+              "methods": [
+                "get_participant"
+              ]
+            },
+            "ListParticipants": {
+              "methods": [
+                "list_participants"
+              ]
+            },
+            "UpdateParticipant": {
+              "methods": [
+                "update_participant"
+              ]
+            },
+            "AnalyzeContent": {
+              "methods": [
+                "analyze_content"
+              ]
+            },
+            "SuggestArticles": {
+              "methods": [
+                "suggest_articles"
+              ]
+            },
+            "SuggestFaqAnswers": {
+              "methods": [
+                "suggest_faq_answers"
+              ]
+            }
           }
         }
       }
@@ -210,13 +302,17 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Dialogflow::V2::AnswerRecords::Client",
-          "methods": {
-            "ListAnswerRecords": [
-              "list_answer_records"
-            ],
-            "UpdateAnswerRecord": [
-              "update_answer_record"
-            ]
+          "rpcs": {
+            "ListAnswerRecords": {
+              "methods": [
+                "list_answer_records"
+              ]
+            },
+            "UpdateAnswerRecord": {
+              "methods": [
+                "update_answer_record"
+              ]
+            }
           }
         }
       }
@@ -225,22 +321,32 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Dialogflow::V2::Conversations::Client",
-          "methods": {
-            "CreateConversation": [
-              "create_conversation"
-            ],
-            "ListConversations": [
-              "list_conversations"
-            ],
-            "GetConversation": [
-              "get_conversation"
-            ],
-            "CompleteConversation": [
-              "complete_conversation"
-            ],
-            "ListMessages": [
-              "list_messages"
-            ]
+          "rpcs": {
+            "CreateConversation": {
+              "methods": [
+                "create_conversation"
+              ]
+            },
+            "ListConversations": {
+              "methods": [
+                "list_conversations"
+              ]
+            },
+            "GetConversation": {
+              "methods": [
+                "get_conversation"
+              ]
+            },
+            "CompleteConversation": {
+              "methods": [
+                "complete_conversation"
+              ]
+            },
+            "ListMessages": {
+              "methods": [
+                "list_messages"
+              ]
+            }
           }
         }
       }
@@ -249,22 +355,32 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Dialogflow::V2::ConversationProfiles::Client",
-          "methods": {
-            "ListConversationProfiles": [
-              "list_conversation_profiles"
-            ],
-            "GetConversationProfile": [
-              "get_conversation_profile"
-            ],
-            "CreateConversationProfile": [
-              "create_conversation_profile"
-            ],
-            "UpdateConversationProfile": [
-              "update_conversation_profile"
-            ],
-            "DeleteConversationProfile": [
-              "delete_conversation_profile"
-            ]
+          "rpcs": {
+            "ListConversationProfiles": {
+              "methods": [
+                "list_conversation_profiles"
+              ]
+            },
+            "GetConversationProfile": {
+              "methods": [
+                "get_conversation_profile"
+              ]
+            },
+            "CreateConversationProfile": {
+              "methods": [
+                "create_conversation_profile"
+              ]
+            },
+            "UpdateConversationProfile": {
+              "methods": [
+                "update_conversation_profile"
+              ]
+            },
+            "DeleteConversationProfile": {
+              "methods": [
+                "delete_conversation_profile"
+              ]
+            }
           }
         }
       }
@@ -273,25 +389,37 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Dialogflow::V2::Documents::Client",
-          "methods": {
-            "ListDocuments": [
-              "list_documents"
-            ],
-            "GetDocument": [
-              "get_document"
-            ],
-            "CreateDocument": [
-              "create_document"
-            ],
-            "DeleteDocument": [
-              "delete_document"
-            ],
-            "UpdateDocument": [
-              "update_document"
-            ],
-            "ReloadDocument": [
-              "reload_document"
-            ]
+          "rpcs": {
+            "ListDocuments": {
+              "methods": [
+                "list_documents"
+              ]
+            },
+            "GetDocument": {
+              "methods": [
+                "get_document"
+              ]
+            },
+            "CreateDocument": {
+              "methods": [
+                "create_document"
+              ]
+            },
+            "DeleteDocument": {
+              "methods": [
+                "delete_document"
+              ]
+            },
+            "UpdateDocument": {
+              "methods": [
+                "update_document"
+              ]
+            },
+            "ReloadDocument": {
+              "methods": [
+                "reload_document"
+              ]
+            }
           }
         }
       }
@@ -300,10 +428,12 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Dialogflow::V2::Environments::Client",
-          "methods": {
-            "ListEnvironments": [
-              "list_environments"
-            ]
+          "rpcs": {
+            "ListEnvironments": {
+              "methods": [
+                "list_environments"
+              ]
+            }
           }
         }
       }
@@ -312,22 +442,32 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Dialogflow::V2::KnowledgeBases::Client",
-          "methods": {
-            "ListKnowledgeBases": [
-              "list_knowledge_bases"
-            ],
-            "GetKnowledgeBase": [
-              "get_knowledge_base"
-            ],
-            "CreateKnowledgeBase": [
-              "create_knowledge_base"
-            ],
-            "DeleteKnowledgeBase": [
-              "delete_knowledge_base"
-            ],
-            "UpdateKnowledgeBase": [
-              "update_knowledge_base"
-            ]
+          "rpcs": {
+            "ListKnowledgeBases": {
+              "methods": [
+                "list_knowledge_bases"
+              ]
+            },
+            "GetKnowledgeBase": {
+              "methods": [
+                "get_knowledge_base"
+              ]
+            },
+            "CreateKnowledgeBase": {
+              "methods": [
+                "create_knowledge_base"
+              ]
+            },
+            "DeleteKnowledgeBase": {
+              "methods": [
+                "delete_knowledge_base"
+              ]
+            },
+            "UpdateKnowledgeBase": {
+              "methods": [
+                "update_knowledge_base"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-dialogflow-v2/google-cloud-dialogflow-v2.gemspec
+++ b/google-cloud-dialogflow-v2/google-cloud-dialogflow-v2.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-dlp-v2/gapic_metadata.json
+++ b/google-cloud-dlp-v2/gapic_metadata.json
@@ -9,109 +9,177 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Dlp::V2::DlpService::Client",
-          "methods": {
-            "InspectContent": [
-              "inspect_content"
-            ],
-            "RedactImage": [
-              "redact_image"
-            ],
-            "DeidentifyContent": [
-              "deidentify_content"
-            ],
-            "ReidentifyContent": [
-              "reidentify_content"
-            ],
-            "ListInfoTypes": [
-              "list_info_types"
-            ],
-            "CreateInspectTemplate": [
-              "create_inspect_template"
-            ],
-            "UpdateInspectTemplate": [
-              "update_inspect_template"
-            ],
-            "GetInspectTemplate": [
-              "get_inspect_template"
-            ],
-            "ListInspectTemplates": [
-              "list_inspect_templates"
-            ],
-            "DeleteInspectTemplate": [
-              "delete_inspect_template"
-            ],
-            "CreateDeidentifyTemplate": [
-              "create_deidentify_template"
-            ],
-            "UpdateDeidentifyTemplate": [
-              "update_deidentify_template"
-            ],
-            "GetDeidentifyTemplate": [
-              "get_deidentify_template"
-            ],
-            "ListDeidentifyTemplates": [
-              "list_deidentify_templates"
-            ],
-            "DeleteDeidentifyTemplate": [
-              "delete_deidentify_template"
-            ],
-            "CreateJobTrigger": [
-              "create_job_trigger"
-            ],
-            "UpdateJobTrigger": [
-              "update_job_trigger"
-            ],
-            "HybridInspectJobTrigger": [
-              "hybrid_inspect_job_trigger"
-            ],
-            "GetJobTrigger": [
-              "get_job_trigger"
-            ],
-            "ListJobTriggers": [
-              "list_job_triggers"
-            ],
-            "DeleteJobTrigger": [
-              "delete_job_trigger"
-            ],
-            "ActivateJobTrigger": [
-              "activate_job_trigger"
-            ],
-            "CreateDlpJob": [
-              "create_dlp_job"
-            ],
-            "ListDlpJobs": [
-              "list_dlp_jobs"
-            ],
-            "GetDlpJob": [
-              "get_dlp_job"
-            ],
-            "DeleteDlpJob": [
-              "delete_dlp_job"
-            ],
-            "CancelDlpJob": [
-              "cancel_dlp_job"
-            ],
-            "CreateStoredInfoType": [
-              "create_stored_info_type"
-            ],
-            "UpdateStoredInfoType": [
-              "update_stored_info_type"
-            ],
-            "GetStoredInfoType": [
-              "get_stored_info_type"
-            ],
-            "ListStoredInfoTypes": [
-              "list_stored_info_types"
-            ],
-            "DeleteStoredInfoType": [
-              "delete_stored_info_type"
-            ],
-            "HybridInspectDlpJob": [
-              "hybrid_inspect_dlp_job"
-            ],
-            "FinishDlpJob": [
-              "finish_dlp_job"
-            ]
+          "rpcs": {
+            "InspectContent": {
+              "methods": [
+                "inspect_content"
+              ]
+            },
+            "RedactImage": {
+              "methods": [
+                "redact_image"
+              ]
+            },
+            "DeidentifyContent": {
+              "methods": [
+                "deidentify_content"
+              ]
+            },
+            "ReidentifyContent": {
+              "methods": [
+                "reidentify_content"
+              ]
+            },
+            "ListInfoTypes": {
+              "methods": [
+                "list_info_types"
+              ]
+            },
+            "CreateInspectTemplate": {
+              "methods": [
+                "create_inspect_template"
+              ]
+            },
+            "UpdateInspectTemplate": {
+              "methods": [
+                "update_inspect_template"
+              ]
+            },
+            "GetInspectTemplate": {
+              "methods": [
+                "get_inspect_template"
+              ]
+            },
+            "ListInspectTemplates": {
+              "methods": [
+                "list_inspect_templates"
+              ]
+            },
+            "DeleteInspectTemplate": {
+              "methods": [
+                "delete_inspect_template"
+              ]
+            },
+            "CreateDeidentifyTemplate": {
+              "methods": [
+                "create_deidentify_template"
+              ]
+            },
+            "UpdateDeidentifyTemplate": {
+              "methods": [
+                "update_deidentify_template"
+              ]
+            },
+            "GetDeidentifyTemplate": {
+              "methods": [
+                "get_deidentify_template"
+              ]
+            },
+            "ListDeidentifyTemplates": {
+              "methods": [
+                "list_deidentify_templates"
+              ]
+            },
+            "DeleteDeidentifyTemplate": {
+              "methods": [
+                "delete_deidentify_template"
+              ]
+            },
+            "CreateJobTrigger": {
+              "methods": [
+                "create_job_trigger"
+              ]
+            },
+            "UpdateJobTrigger": {
+              "methods": [
+                "update_job_trigger"
+              ]
+            },
+            "HybridInspectJobTrigger": {
+              "methods": [
+                "hybrid_inspect_job_trigger"
+              ]
+            },
+            "GetJobTrigger": {
+              "methods": [
+                "get_job_trigger"
+              ]
+            },
+            "ListJobTriggers": {
+              "methods": [
+                "list_job_triggers"
+              ]
+            },
+            "DeleteJobTrigger": {
+              "methods": [
+                "delete_job_trigger"
+              ]
+            },
+            "ActivateJobTrigger": {
+              "methods": [
+                "activate_job_trigger"
+              ]
+            },
+            "CreateDlpJob": {
+              "methods": [
+                "create_dlp_job"
+              ]
+            },
+            "ListDlpJobs": {
+              "methods": [
+                "list_dlp_jobs"
+              ]
+            },
+            "GetDlpJob": {
+              "methods": [
+                "get_dlp_job"
+              ]
+            },
+            "DeleteDlpJob": {
+              "methods": [
+                "delete_dlp_job"
+              ]
+            },
+            "CancelDlpJob": {
+              "methods": [
+                "cancel_dlp_job"
+              ]
+            },
+            "CreateStoredInfoType": {
+              "methods": [
+                "create_stored_info_type"
+              ]
+            },
+            "UpdateStoredInfoType": {
+              "methods": [
+                "update_stored_info_type"
+              ]
+            },
+            "GetStoredInfoType": {
+              "methods": [
+                "get_stored_info_type"
+              ]
+            },
+            "ListStoredInfoTypes": {
+              "methods": [
+                "list_stored_info_types"
+              ]
+            },
+            "DeleteStoredInfoType": {
+              "methods": [
+                "delete_stored_info_type"
+              ]
+            },
+            "HybridInspectDlpJob": {
+              "methods": [
+                "hybrid_inspect_dlp_job"
+              ]
+            },
+            "FinishDlpJob": {
+              "methods": [
+                "finish_dlp_job"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-dlp-v2/google-cloud-dlp-v2.gemspec
+++ b/google-cloud-dlp-v2/google-cloud-dlp-v2.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-document_ai-v1beta3/gapic_metadata.json
+++ b/google-cloud-document_ai-v1beta3/gapic_metadata.json
@@ -9,16 +9,22 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::DocumentAI::V1beta3::DocumentProcessorService::Client",
-          "methods": {
-            "ProcessDocument": [
-              "process_document"
-            ],
-            "BatchProcessDocuments": [
-              "batch_process_documents"
-            ],
-            "ReviewDocument": [
-              "review_document"
-            ]
+          "rpcs": {
+            "ProcessDocument": {
+              "methods": [
+                "process_document"
+              ]
+            },
+            "BatchProcessDocuments": {
+              "methods": [
+                "batch_process_documents"
+              ]
+            },
+            "ReviewDocument": {
+              "methods": [
+                "review_document"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-document_ai-v1beta3/google-cloud-document_ai-v1beta3.gemspec
+++ b/google-cloud-document_ai-v1beta3/google-cloud-document_ai-v1beta3.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-domains-v1beta1/gapic_metadata.json
+++ b/google-cloud-domains-v1beta1/gapic_metadata.json
@@ -9,46 +9,72 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Domains::V1beta1::Domains::Client",
-          "methods": {
-            "SearchDomains": [
-              "search_domains"
-            ],
-            "RetrieveRegisterParameters": [
-              "retrieve_register_parameters"
-            ],
-            "RegisterDomain": [
-              "register_domain"
-            ],
-            "ListRegistrations": [
-              "list_registrations"
-            ],
-            "GetRegistration": [
-              "get_registration"
-            ],
-            "UpdateRegistration": [
-              "update_registration"
-            ],
-            "ConfigureManagementSettings": [
-              "configure_management_settings"
-            ],
-            "ConfigureDnsSettings": [
-              "configure_dns_settings"
-            ],
-            "ConfigureContactSettings": [
-              "configure_contact_settings"
-            ],
-            "ExportRegistration": [
-              "export_registration"
-            ],
-            "DeleteRegistration": [
-              "delete_registration"
-            ],
-            "RetrieveAuthorizationCode": [
-              "retrieve_authorization_code"
-            ],
-            "ResetAuthorizationCode": [
-              "reset_authorization_code"
-            ]
+          "rpcs": {
+            "SearchDomains": {
+              "methods": [
+                "search_domains"
+              ]
+            },
+            "RetrieveRegisterParameters": {
+              "methods": [
+                "retrieve_register_parameters"
+              ]
+            },
+            "RegisterDomain": {
+              "methods": [
+                "register_domain"
+              ]
+            },
+            "ListRegistrations": {
+              "methods": [
+                "list_registrations"
+              ]
+            },
+            "GetRegistration": {
+              "methods": [
+                "get_registration"
+              ]
+            },
+            "UpdateRegistration": {
+              "methods": [
+                "update_registration"
+              ]
+            },
+            "ConfigureManagementSettings": {
+              "methods": [
+                "configure_management_settings"
+              ]
+            },
+            "ConfigureDnsSettings": {
+              "methods": [
+                "configure_dns_settings"
+              ]
+            },
+            "ConfigureContactSettings": {
+              "methods": [
+                "configure_contact_settings"
+              ]
+            },
+            "ExportRegistration": {
+              "methods": [
+                "export_registration"
+              ]
+            },
+            "DeleteRegistration": {
+              "methods": [
+                "delete_registration"
+              ]
+            },
+            "RetrieveAuthorizationCode": {
+              "methods": [
+                "retrieve_authorization_code"
+              ]
+            },
+            "ResetAuthorizationCode": {
+              "methods": [
+                "reset_authorization_code"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-domains-v1beta1/google-cloud-domains-v1beta1.gemspec
+++ b/google-cloud-domains-v1beta1/google-cloud-domains-v1beta1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-error_reporting-v1beta1/gapic_metadata.json
+++ b/google-cloud-error_reporting-v1beta1/gapic_metadata.json
@@ -9,13 +9,17 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::ErrorReporting::V1beta1::ErrorGroupService::Client",
-          "methods": {
-            "GetGroup": [
-              "get_group"
-            ],
-            "UpdateGroup": [
-              "update_group"
-            ]
+          "rpcs": {
+            "GetGroup": {
+              "methods": [
+                "get_group"
+              ]
+            },
+            "UpdateGroup": {
+              "methods": [
+                "update_group"
+              ]
+            }
           }
         }
       }
@@ -24,16 +28,22 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::ErrorReporting::V1beta1::ErrorStatsService::Client",
-          "methods": {
-            "ListGroupStats": [
-              "list_group_stats"
-            ],
-            "ListEvents": [
-              "list_events"
-            ],
-            "DeleteEvents": [
-              "delete_events"
-            ]
+          "rpcs": {
+            "ListGroupStats": {
+              "methods": [
+                "list_group_stats"
+              ]
+            },
+            "ListEvents": {
+              "methods": [
+                "list_events"
+              ]
+            },
+            "DeleteEvents": {
+              "methods": [
+                "delete_events"
+              ]
+            }
           }
         }
       }
@@ -42,10 +52,12 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::ErrorReporting::V1beta1::ReportErrorsService::Client",
-          "methods": {
-            "ReportErrorEvent": [
-              "report_error_event"
-            ]
+          "rpcs": {
+            "ReportErrorEvent": {
+              "methods": [
+                "report_error_event"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-error_reporting-v1beta1/google-cloud-error_reporting-v1beta1.gemspec
+++ b/google-cloud-error_reporting-v1beta1/google-cloud-error_reporting-v1beta1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-firestore-admin-v1/gapic_metadata.json
+++ b/google-cloud-firestore-admin-v1/gapic_metadata.json
@@ -9,34 +9,52 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Firestore::Admin::V1::FirestoreAdmin::Client",
-          "methods": {
-            "CreateIndex": [
-              "create_index"
-            ],
-            "ListIndexes": [
-              "list_indexes"
-            ],
-            "GetIndex": [
-              "get_index"
-            ],
-            "DeleteIndex": [
-              "delete_index"
-            ],
-            "GetField": [
-              "get_field"
-            ],
-            "UpdateField": [
-              "update_field"
-            ],
-            "ListFields": [
-              "list_fields"
-            ],
-            "ExportDocuments": [
-              "export_documents"
-            ],
-            "ImportDocuments": [
-              "import_documents"
-            ]
+          "rpcs": {
+            "CreateIndex": {
+              "methods": [
+                "create_index"
+              ]
+            },
+            "ListIndexes": {
+              "methods": [
+                "list_indexes"
+              ]
+            },
+            "GetIndex": {
+              "methods": [
+                "get_index"
+              ]
+            },
+            "DeleteIndex": {
+              "methods": [
+                "delete_index"
+              ]
+            },
+            "GetField": {
+              "methods": [
+                "get_field"
+              ]
+            },
+            "UpdateField": {
+              "methods": [
+                "update_field"
+              ]
+            },
+            "ListFields": {
+              "methods": [
+                "list_fields"
+              ]
+            },
+            "ExportDocuments": {
+              "methods": [
+                "export_documents"
+              ]
+            },
+            "ImportDocuments": {
+              "methods": [
+                "import_documents"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-firestore-admin-v1/google-cloud-firestore-admin-v1.gemspec
+++ b/google-cloud-firestore-admin-v1/google-cloud-firestore-admin-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-firestore-v1/gapic_metadata.json
+++ b/google-cloud-firestore-v1/gapic_metadata.json
@@ -9,52 +9,82 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Firestore::V1::Firestore::Client",
-          "methods": {
-            "GetDocument": [
-              "get_document"
-            ],
-            "ListDocuments": [
-              "list_documents"
-            ],
-            "UpdateDocument": [
-              "update_document"
-            ],
-            "DeleteDocument": [
-              "delete_document"
-            ],
-            "BatchGetDocuments": [
-              "batch_get_documents"
-            ],
-            "BeginTransaction": [
-              "begin_transaction"
-            ],
-            "Commit": [
-              "commit"
-            ],
-            "Rollback": [
-              "rollback"
-            ],
-            "RunQuery": [
-              "run_query"
-            ],
-            "PartitionQuery": [
-              "partition_query"
-            ],
-            "Write": [
-              "write"
-            ],
-            "Listen": [
-              "listen"
-            ],
-            "ListCollectionIds": [
-              "list_collection_ids"
-            ],
-            "BatchWrite": [
-              "batch_write"
-            ],
-            "CreateDocument": [
-              "create_document"
-            ]
+          "rpcs": {
+            "GetDocument": {
+              "methods": [
+                "get_document"
+              ]
+            },
+            "ListDocuments": {
+              "methods": [
+                "list_documents"
+              ]
+            },
+            "UpdateDocument": {
+              "methods": [
+                "update_document"
+              ]
+            },
+            "DeleteDocument": {
+              "methods": [
+                "delete_document"
+              ]
+            },
+            "BatchGetDocuments": {
+              "methods": [
+                "batch_get_documents"
+              ]
+            },
+            "BeginTransaction": {
+              "methods": [
+                "begin_transaction"
+              ]
+            },
+            "Commit": {
+              "methods": [
+                "commit"
+              ]
+            },
+            "Rollback": {
+              "methods": [
+                "rollback"
+              ]
+            },
+            "RunQuery": {
+              "methods": [
+                "run_query"
+              ]
+            },
+            "PartitionQuery": {
+              "methods": [
+                "partition_query"
+              ]
+            },
+            "Write": {
+              "methods": [
+                "write"
+              ]
+            },
+            "Listen": {
+              "methods": [
+                "listen"
+              ]
+            },
+            "ListCollectionIds": {
+              "methods": [
+                "list_collection_ids"
+              ]
+            },
+            "BatchWrite": {
+              "methods": [
+                "batch_write"
+              ]
+            },
+            "CreateDocument": {
+              "methods": [
+                "create_document"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-firestore-v1/google-cloud-firestore-v1.gemspec
+++ b/google-cloud-firestore-v1/google-cloud-firestore-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-functions-v1/gapic_metadata.json
+++ b/google-cloud-functions-v1/gapic_metadata.json
@@ -9,40 +9,62 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Functions::V1::CloudFunctionsService::Client",
-          "methods": {
-            "ListFunctions": [
-              "list_functions"
-            ],
-            "GetFunction": [
-              "get_function"
-            ],
-            "CreateFunction": [
-              "create_function"
-            ],
-            "UpdateFunction": [
-              "update_function"
-            ],
-            "DeleteFunction": [
-              "delete_function"
-            ],
-            "CallFunction": [
-              "call_function"
-            ],
-            "GenerateUploadUrl": [
-              "generate_upload_url"
-            ],
-            "GenerateDownloadUrl": [
-              "generate_download_url"
-            ],
-            "SetIamPolicy": [
-              "set_iam_policy"
-            ],
-            "GetIamPolicy": [
-              "get_iam_policy"
-            ],
-            "TestIamPermissions": [
-              "test_iam_permissions"
-            ]
+          "rpcs": {
+            "ListFunctions": {
+              "methods": [
+                "list_functions"
+              ]
+            },
+            "GetFunction": {
+              "methods": [
+                "get_function"
+              ]
+            },
+            "CreateFunction": {
+              "methods": [
+                "create_function"
+              ]
+            },
+            "UpdateFunction": {
+              "methods": [
+                "update_function"
+              ]
+            },
+            "DeleteFunction": {
+              "methods": [
+                "delete_function"
+              ]
+            },
+            "CallFunction": {
+              "methods": [
+                "call_function"
+              ]
+            },
+            "GenerateUploadUrl": {
+              "methods": [
+                "generate_upload_url"
+              ]
+            },
+            "GenerateDownloadUrl": {
+              "methods": [
+                "generate_download_url"
+              ]
+            },
+            "SetIamPolicy": {
+              "methods": [
+                "set_iam_policy"
+              ]
+            },
+            "GetIamPolicy": {
+              "methods": [
+                "get_iam_policy"
+              ]
+            },
+            "TestIamPermissions": {
+              "methods": [
+                "test_iam_permissions"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-functions-v1/google-cloud-functions-v1.gemspec
+++ b/google-cloud-functions-v1/google-cloud-functions-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
   gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.0"
 

--- a/google-cloud-gaming-v1/gapic_metadata.json
+++ b/google-cloud-gaming-v1/gapic_metadata.json
@@ -9,31 +9,47 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Gaming::V1::GameServerClustersService::Client",
-          "methods": {
-            "ListGameServerClusters": [
-              "list_game_server_clusters"
-            ],
-            "GetGameServerCluster": [
-              "get_game_server_cluster"
-            ],
-            "CreateGameServerCluster": [
-              "create_game_server_cluster"
-            ],
-            "PreviewCreateGameServerCluster": [
-              "preview_create_game_server_cluster"
-            ],
-            "DeleteGameServerCluster": [
-              "delete_game_server_cluster"
-            ],
-            "PreviewDeleteGameServerCluster": [
-              "preview_delete_game_server_cluster"
-            ],
-            "UpdateGameServerCluster": [
-              "update_game_server_cluster"
-            ],
-            "PreviewUpdateGameServerCluster": [
-              "preview_update_game_server_cluster"
-            ]
+          "rpcs": {
+            "ListGameServerClusters": {
+              "methods": [
+                "list_game_server_clusters"
+              ]
+            },
+            "GetGameServerCluster": {
+              "methods": [
+                "get_game_server_cluster"
+              ]
+            },
+            "CreateGameServerCluster": {
+              "methods": [
+                "create_game_server_cluster"
+              ]
+            },
+            "PreviewCreateGameServerCluster": {
+              "methods": [
+                "preview_create_game_server_cluster"
+              ]
+            },
+            "DeleteGameServerCluster": {
+              "methods": [
+                "delete_game_server_cluster"
+              ]
+            },
+            "PreviewDeleteGameServerCluster": {
+              "methods": [
+                "preview_delete_game_server_cluster"
+              ]
+            },
+            "UpdateGameServerCluster": {
+              "methods": [
+                "update_game_server_cluster"
+              ]
+            },
+            "PreviewUpdateGameServerCluster": {
+              "methods": [
+                "preview_update_game_server_cluster"
+              ]
+            }
           }
         }
       }
@@ -42,19 +58,27 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Gaming::V1::GameServerConfigsService::Client",
-          "methods": {
-            "ListGameServerConfigs": [
-              "list_game_server_configs"
-            ],
-            "GetGameServerConfig": [
-              "get_game_server_config"
-            ],
-            "CreateGameServerConfig": [
-              "create_game_server_config"
-            ],
-            "DeleteGameServerConfig": [
-              "delete_game_server_config"
-            ]
+          "rpcs": {
+            "ListGameServerConfigs": {
+              "methods": [
+                "list_game_server_configs"
+              ]
+            },
+            "GetGameServerConfig": {
+              "methods": [
+                "get_game_server_config"
+              ]
+            },
+            "CreateGameServerConfig": {
+              "methods": [
+                "create_game_server_config"
+              ]
+            },
+            "DeleteGameServerConfig": {
+              "methods": [
+                "delete_game_server_config"
+              ]
+            }
           }
         }
       }
@@ -63,34 +87,52 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Gaming::V1::GameServerDeploymentsService::Client",
-          "methods": {
-            "ListGameServerDeployments": [
-              "list_game_server_deployments"
-            ],
-            "GetGameServerDeployment": [
-              "get_game_server_deployment"
-            ],
-            "CreateGameServerDeployment": [
-              "create_game_server_deployment"
-            ],
-            "DeleteGameServerDeployment": [
-              "delete_game_server_deployment"
-            ],
-            "UpdateGameServerDeployment": [
-              "update_game_server_deployment"
-            ],
-            "GetGameServerDeploymentRollout": [
-              "get_game_server_deployment_rollout"
-            ],
-            "UpdateGameServerDeploymentRollout": [
-              "update_game_server_deployment_rollout"
-            ],
-            "PreviewGameServerDeploymentRollout": [
-              "preview_game_server_deployment_rollout"
-            ],
-            "FetchDeploymentState": [
-              "fetch_deployment_state"
-            ]
+          "rpcs": {
+            "ListGameServerDeployments": {
+              "methods": [
+                "list_game_server_deployments"
+              ]
+            },
+            "GetGameServerDeployment": {
+              "methods": [
+                "get_game_server_deployment"
+              ]
+            },
+            "CreateGameServerDeployment": {
+              "methods": [
+                "create_game_server_deployment"
+              ]
+            },
+            "DeleteGameServerDeployment": {
+              "methods": [
+                "delete_game_server_deployment"
+              ]
+            },
+            "UpdateGameServerDeployment": {
+              "methods": [
+                "update_game_server_deployment"
+              ]
+            },
+            "GetGameServerDeploymentRollout": {
+              "methods": [
+                "get_game_server_deployment_rollout"
+              ]
+            },
+            "UpdateGameServerDeploymentRollout": {
+              "methods": [
+                "update_game_server_deployment_rollout"
+              ]
+            },
+            "PreviewGameServerDeploymentRollout": {
+              "methods": [
+                "preview_game_server_deployment_rollout"
+              ]
+            },
+            "FetchDeploymentState": {
+              "methods": [
+                "fetch_deployment_state"
+              ]
+            }
           }
         }
       }
@@ -99,25 +141,37 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Gaming::V1::RealmsService::Client",
-          "methods": {
-            "ListRealms": [
-              "list_realms"
-            ],
-            "GetRealm": [
-              "get_realm"
-            ],
-            "CreateRealm": [
-              "create_realm"
-            ],
-            "DeleteRealm": [
-              "delete_realm"
-            ],
-            "UpdateRealm": [
-              "update_realm"
-            ],
-            "PreviewRealmUpdate": [
-              "preview_realm_update"
-            ]
+          "rpcs": {
+            "ListRealms": {
+              "methods": [
+                "list_realms"
+              ]
+            },
+            "GetRealm": {
+              "methods": [
+                "get_realm"
+              ]
+            },
+            "CreateRealm": {
+              "methods": [
+                "create_realm"
+              ]
+            },
+            "DeleteRealm": {
+              "methods": [
+                "delete_realm"
+              ]
+            },
+            "UpdateRealm": {
+              "methods": [
+                "update_realm"
+              ]
+            },
+            "PreviewRealmUpdate": {
+              "methods": [
+                "preview_realm_update"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-gaming-v1/google-cloud-gaming-v1.gemspec
+++ b/google-cloud-gaming-v1/google-cloud-gaming-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-gke_hub-v1beta1/gapic_metadata.json
+++ b/google-cloud-gke_hub-v1beta1/gapic_metadata.json
@@ -9,31 +9,47 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::GkeHub::V1beta1::GkeHubMembershipService::Client",
-          "methods": {
-            "ListMemberships": [
-              "list_memberships"
-            ],
-            "GetMembership": [
-              "get_membership"
-            ],
-            "CreateMembership": [
-              "create_membership"
-            ],
-            "DeleteMembership": [
-              "delete_membership"
-            ],
-            "UpdateMembership": [
-              "update_membership"
-            ],
-            "GenerateConnectManifest": [
-              "generate_connect_manifest"
-            ],
-            "ValidateExclusivity": [
-              "validate_exclusivity"
-            ],
-            "GenerateExclusivityManifest": [
-              "generate_exclusivity_manifest"
-            ]
+          "rpcs": {
+            "ListMemberships": {
+              "methods": [
+                "list_memberships"
+              ]
+            },
+            "GetMembership": {
+              "methods": [
+                "get_membership"
+              ]
+            },
+            "CreateMembership": {
+              "methods": [
+                "create_membership"
+              ]
+            },
+            "DeleteMembership": {
+              "methods": [
+                "delete_membership"
+              ]
+            },
+            "UpdateMembership": {
+              "methods": [
+                "update_membership"
+              ]
+            },
+            "GenerateConnectManifest": {
+              "methods": [
+                "generate_connect_manifest"
+              ]
+            },
+            "ValidateExclusivity": {
+              "methods": [
+                "validate_exclusivity"
+              ]
+            },
+            "GenerateExclusivityManifest": {
+              "methods": [
+                "generate_exclusivity_manifest"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-gke_hub-v1beta1/google-cloud-gke_hub-v1beta1.gemspec
+++ b/google-cloud-gke_hub-v1beta1/google-cloud-gke_hub-v1beta1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-iot-v1/gapic_metadata.json
+++ b/google-cloud-iot-v1/gapic_metadata.json
@@ -9,64 +9,102 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Iot::V1::DeviceManager::Client",
-          "methods": {
-            "CreateDeviceRegistry": [
-              "create_device_registry"
-            ],
-            "GetDeviceRegistry": [
-              "get_device_registry"
-            ],
-            "UpdateDeviceRegistry": [
-              "update_device_registry"
-            ],
-            "DeleteDeviceRegistry": [
-              "delete_device_registry"
-            ],
-            "ListDeviceRegistries": [
-              "list_device_registries"
-            ],
-            "CreateDevice": [
-              "create_device"
-            ],
-            "GetDevice": [
-              "get_device"
-            ],
-            "UpdateDevice": [
-              "update_device"
-            ],
-            "DeleteDevice": [
-              "delete_device"
-            ],
-            "ListDevices": [
-              "list_devices"
-            ],
-            "ModifyCloudToDeviceConfig": [
-              "modify_cloud_to_device_config"
-            ],
-            "ListDeviceConfigVersions": [
-              "list_device_config_versions"
-            ],
-            "ListDeviceStates": [
-              "list_device_states"
-            ],
-            "SetIamPolicy": [
-              "set_iam_policy"
-            ],
-            "GetIamPolicy": [
-              "get_iam_policy"
-            ],
-            "TestIamPermissions": [
-              "test_iam_permissions"
-            ],
-            "SendCommandToDevice": [
-              "send_command_to_device"
-            ],
-            "BindDeviceToGateway": [
-              "bind_device_to_gateway"
-            ],
-            "UnbindDeviceFromGateway": [
-              "unbind_device_from_gateway"
-            ]
+          "rpcs": {
+            "CreateDeviceRegistry": {
+              "methods": [
+                "create_device_registry"
+              ]
+            },
+            "GetDeviceRegistry": {
+              "methods": [
+                "get_device_registry"
+              ]
+            },
+            "UpdateDeviceRegistry": {
+              "methods": [
+                "update_device_registry"
+              ]
+            },
+            "DeleteDeviceRegistry": {
+              "methods": [
+                "delete_device_registry"
+              ]
+            },
+            "ListDeviceRegistries": {
+              "methods": [
+                "list_device_registries"
+              ]
+            },
+            "CreateDevice": {
+              "methods": [
+                "create_device"
+              ]
+            },
+            "GetDevice": {
+              "methods": [
+                "get_device"
+              ]
+            },
+            "UpdateDevice": {
+              "methods": [
+                "update_device"
+              ]
+            },
+            "DeleteDevice": {
+              "methods": [
+                "delete_device"
+              ]
+            },
+            "ListDevices": {
+              "methods": [
+                "list_devices"
+              ]
+            },
+            "ModifyCloudToDeviceConfig": {
+              "methods": [
+                "modify_cloud_to_device_config"
+              ]
+            },
+            "ListDeviceConfigVersions": {
+              "methods": [
+                "list_device_config_versions"
+              ]
+            },
+            "ListDeviceStates": {
+              "methods": [
+                "list_device_states"
+              ]
+            },
+            "SetIamPolicy": {
+              "methods": [
+                "set_iam_policy"
+              ]
+            },
+            "GetIamPolicy": {
+              "methods": [
+                "get_iam_policy"
+              ]
+            },
+            "TestIamPermissions": {
+              "methods": [
+                "test_iam_permissions"
+              ]
+            },
+            "SendCommandToDevice": {
+              "methods": [
+                "send_command_to_device"
+              ]
+            },
+            "BindDeviceToGateway": {
+              "methods": [
+                "bind_device_to_gateway"
+              ]
+            },
+            "UnbindDeviceFromGateway": {
+              "methods": [
+                "unbind_device_from_gateway"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-iot-v1/google-cloud-iot-v1.gemspec
+++ b/google-cloud-iot-v1/google-cloud-iot-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
   gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.0"
 

--- a/google-cloud-kms-v1/gapic_metadata.json
+++ b/google-cloud-kms-v1/gapic_metadata.json
@@ -9,76 +9,122 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Kms::V1::KeyManagementService::Client",
-          "methods": {
-            "ListKeyRings": [
-              "list_key_rings"
-            ],
-            "ListCryptoKeys": [
-              "list_crypto_keys"
-            ],
-            "ListCryptoKeyVersions": [
-              "list_crypto_key_versions"
-            ],
-            "ListImportJobs": [
-              "list_import_jobs"
-            ],
-            "GetKeyRing": [
-              "get_key_ring"
-            ],
-            "GetCryptoKey": [
-              "get_crypto_key"
-            ],
-            "GetCryptoKeyVersion": [
-              "get_crypto_key_version"
-            ],
-            "GetPublicKey": [
-              "get_public_key"
-            ],
-            "GetImportJob": [
-              "get_import_job"
-            ],
-            "CreateKeyRing": [
-              "create_key_ring"
-            ],
-            "CreateCryptoKey": [
-              "create_crypto_key"
-            ],
-            "CreateCryptoKeyVersion": [
-              "create_crypto_key_version"
-            ],
-            "ImportCryptoKeyVersion": [
-              "import_crypto_key_version"
-            ],
-            "CreateImportJob": [
-              "create_import_job"
-            ],
-            "UpdateCryptoKey": [
-              "update_crypto_key"
-            ],
-            "UpdateCryptoKeyVersion": [
-              "update_crypto_key_version"
-            ],
-            "Encrypt": [
-              "encrypt"
-            ],
-            "Decrypt": [
-              "decrypt"
-            ],
-            "AsymmetricSign": [
-              "asymmetric_sign"
-            ],
-            "AsymmetricDecrypt": [
-              "asymmetric_decrypt"
-            ],
-            "UpdateCryptoKeyPrimaryVersion": [
-              "update_crypto_key_primary_version"
-            ],
-            "DestroyCryptoKeyVersion": [
-              "destroy_crypto_key_version"
-            ],
-            "RestoreCryptoKeyVersion": [
-              "restore_crypto_key_version"
-            ]
+          "rpcs": {
+            "ListKeyRings": {
+              "methods": [
+                "list_key_rings"
+              ]
+            },
+            "ListCryptoKeys": {
+              "methods": [
+                "list_crypto_keys"
+              ]
+            },
+            "ListCryptoKeyVersions": {
+              "methods": [
+                "list_crypto_key_versions"
+              ]
+            },
+            "ListImportJobs": {
+              "methods": [
+                "list_import_jobs"
+              ]
+            },
+            "GetKeyRing": {
+              "methods": [
+                "get_key_ring"
+              ]
+            },
+            "GetCryptoKey": {
+              "methods": [
+                "get_crypto_key"
+              ]
+            },
+            "GetCryptoKeyVersion": {
+              "methods": [
+                "get_crypto_key_version"
+              ]
+            },
+            "GetPublicKey": {
+              "methods": [
+                "get_public_key"
+              ]
+            },
+            "GetImportJob": {
+              "methods": [
+                "get_import_job"
+              ]
+            },
+            "CreateKeyRing": {
+              "methods": [
+                "create_key_ring"
+              ]
+            },
+            "CreateCryptoKey": {
+              "methods": [
+                "create_crypto_key"
+              ]
+            },
+            "CreateCryptoKeyVersion": {
+              "methods": [
+                "create_crypto_key_version"
+              ]
+            },
+            "ImportCryptoKeyVersion": {
+              "methods": [
+                "import_crypto_key_version"
+              ]
+            },
+            "CreateImportJob": {
+              "methods": [
+                "create_import_job"
+              ]
+            },
+            "UpdateCryptoKey": {
+              "methods": [
+                "update_crypto_key"
+              ]
+            },
+            "UpdateCryptoKeyVersion": {
+              "methods": [
+                "update_crypto_key_version"
+              ]
+            },
+            "Encrypt": {
+              "methods": [
+                "encrypt"
+              ]
+            },
+            "Decrypt": {
+              "methods": [
+                "decrypt"
+              ]
+            },
+            "AsymmetricSign": {
+              "methods": [
+                "asymmetric_sign"
+              ]
+            },
+            "AsymmetricDecrypt": {
+              "methods": [
+                "asymmetric_decrypt"
+              ]
+            },
+            "UpdateCryptoKeyPrimaryVersion": {
+              "methods": [
+                "update_crypto_key_primary_version"
+              ]
+            },
+            "DestroyCryptoKeyVersion": {
+              "methods": [
+                "destroy_crypto_key_version"
+              ]
+            },
+            "RestoreCryptoKeyVersion": {
+              "methods": [
+                "restore_crypto_key_version"
+              ]
+            }
           }
         }
       }
@@ -87,16 +133,22 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Kms::V1::IAMPolicy::Client",
-          "methods": {
-            "SetIamPolicy": [
-              "set_iam_policy"
-            ],
-            "GetIamPolicy": [
-              "get_iam_policy"
-            ],
-            "TestIamPermissions": [
-              "test_iam_permissions"
-            ]
+          "rpcs": {
+            "SetIamPolicy": {
+              "methods": [
+                "set_iam_policy"
+              ]
+            },
+            "GetIamPolicy": {
+              "methods": [
+                "get_iam_policy"
+              ]
+            },
+            "TestIamPermissions": {
+              "methods": [
+                "test_iam_permissions"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-kms-v1/google-cloud-kms-v1.gemspec
+++ b/google-cloud-kms-v1/google-cloud-kms-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
   gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.0"
 

--- a/google-cloud-language-v1/gapic_metadata.json
+++ b/google-cloud-language-v1/gapic_metadata.json
@@ -9,25 +9,37 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Language::V1::LanguageService::Client",
-          "methods": {
-            "AnalyzeSentiment": [
-              "analyze_sentiment"
-            ],
-            "AnalyzeEntities": [
-              "analyze_entities"
-            ],
-            "AnalyzeEntitySentiment": [
-              "analyze_entity_sentiment"
-            ],
-            "AnalyzeSyntax": [
-              "analyze_syntax"
-            ],
-            "ClassifyText": [
-              "classify_text"
-            ],
-            "AnnotateText": [
-              "annotate_text"
-            ]
+          "rpcs": {
+            "AnalyzeSentiment": {
+              "methods": [
+                "analyze_sentiment"
+              ]
+            },
+            "AnalyzeEntities": {
+              "methods": [
+                "analyze_entities"
+              ]
+            },
+            "AnalyzeEntitySentiment": {
+              "methods": [
+                "analyze_entity_sentiment"
+              ]
+            },
+            "AnalyzeSyntax": {
+              "methods": [
+                "analyze_syntax"
+              ]
+            },
+            "ClassifyText": {
+              "methods": [
+                "classify_text"
+              ]
+            },
+            "AnnotateText": {
+              "methods": [
+                "annotate_text"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-language-v1/google-cloud-language-v1.gemspec
+++ b/google-cloud-language-v1/google-cloud-language-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-language-v1beta2/gapic_metadata.json
+++ b/google-cloud-language-v1beta2/gapic_metadata.json
@@ -9,25 +9,37 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Language::V1beta2::LanguageService::Client",
-          "methods": {
-            "AnalyzeSentiment": [
-              "analyze_sentiment"
-            ],
-            "AnalyzeEntities": [
-              "analyze_entities"
-            ],
-            "AnalyzeEntitySentiment": [
-              "analyze_entity_sentiment"
-            ],
-            "AnalyzeSyntax": [
-              "analyze_syntax"
-            ],
-            "ClassifyText": [
-              "classify_text"
-            ],
-            "AnnotateText": [
-              "annotate_text"
-            ]
+          "rpcs": {
+            "AnalyzeSentiment": {
+              "methods": [
+                "analyze_sentiment"
+              ]
+            },
+            "AnalyzeEntities": {
+              "methods": [
+                "analyze_entities"
+              ]
+            },
+            "AnalyzeEntitySentiment": {
+              "methods": [
+                "analyze_entity_sentiment"
+              ]
+            },
+            "AnalyzeSyntax": {
+              "methods": [
+                "analyze_syntax"
+              ]
+            },
+            "ClassifyText": {
+              "methods": [
+                "classify_text"
+              ]
+            },
+            "AnnotateText": {
+              "methods": [
+                "annotate_text"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-language-v1beta2/google-cloud-language-v1beta2.gemspec
+++ b/google-cloud-language-v1beta2/google-cloud-language-v1beta2.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-logging-v2/gapic_metadata.json
+++ b/google-cloud-logging-v2/gapic_metadata.json
@@ -9,76 +9,122 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Logging::V2::ConfigService::Client",
-          "methods": {
-            "ListBuckets": [
-              "list_buckets"
-            ],
-            "GetBucket": [
-              "get_bucket"
-            ],
-            "CreateBucket": [
-              "create_bucket"
-            ],
-            "UpdateBucket": [
-              "update_bucket"
-            ],
-            "DeleteBucket": [
-              "delete_bucket"
-            ],
-            "UndeleteBucket": [
-              "undelete_bucket"
-            ],
-            "ListViews": [
-              "list_views"
-            ],
-            "GetView": [
-              "get_view"
-            ],
-            "CreateView": [
-              "create_view"
-            ],
-            "UpdateView": [
-              "update_view"
-            ],
-            "DeleteView": [
-              "delete_view"
-            ],
-            "ListSinks": [
-              "list_sinks"
-            ],
-            "GetSink": [
-              "get_sink"
-            ],
-            "CreateSink": [
-              "create_sink"
-            ],
-            "UpdateSink": [
-              "update_sink"
-            ],
-            "DeleteSink": [
-              "delete_sink"
-            ],
-            "ListExclusions": [
-              "list_exclusions"
-            ],
-            "GetExclusion": [
-              "get_exclusion"
-            ],
-            "CreateExclusion": [
-              "create_exclusion"
-            ],
-            "UpdateExclusion": [
-              "update_exclusion"
-            ],
-            "DeleteExclusion": [
-              "delete_exclusion"
-            ],
-            "GetCmekSettings": [
-              "get_cmek_settings"
-            ],
-            "UpdateCmekSettings": [
-              "update_cmek_settings"
-            ]
+          "rpcs": {
+            "ListBuckets": {
+              "methods": [
+                "list_buckets"
+              ]
+            },
+            "GetBucket": {
+              "methods": [
+                "get_bucket"
+              ]
+            },
+            "CreateBucket": {
+              "methods": [
+                "create_bucket"
+              ]
+            },
+            "UpdateBucket": {
+              "methods": [
+                "update_bucket"
+              ]
+            },
+            "DeleteBucket": {
+              "methods": [
+                "delete_bucket"
+              ]
+            },
+            "UndeleteBucket": {
+              "methods": [
+                "undelete_bucket"
+              ]
+            },
+            "ListViews": {
+              "methods": [
+                "list_views"
+              ]
+            },
+            "GetView": {
+              "methods": [
+                "get_view"
+              ]
+            },
+            "CreateView": {
+              "methods": [
+                "create_view"
+              ]
+            },
+            "UpdateView": {
+              "methods": [
+                "update_view"
+              ]
+            },
+            "DeleteView": {
+              "methods": [
+                "delete_view"
+              ]
+            },
+            "ListSinks": {
+              "methods": [
+                "list_sinks"
+              ]
+            },
+            "GetSink": {
+              "methods": [
+                "get_sink"
+              ]
+            },
+            "CreateSink": {
+              "methods": [
+                "create_sink"
+              ]
+            },
+            "UpdateSink": {
+              "methods": [
+                "update_sink"
+              ]
+            },
+            "DeleteSink": {
+              "methods": [
+                "delete_sink"
+              ]
+            },
+            "ListExclusions": {
+              "methods": [
+                "list_exclusions"
+              ]
+            },
+            "GetExclusion": {
+              "methods": [
+                "get_exclusion"
+              ]
+            },
+            "CreateExclusion": {
+              "methods": [
+                "create_exclusion"
+              ]
+            },
+            "UpdateExclusion": {
+              "methods": [
+                "update_exclusion"
+              ]
+            },
+            "DeleteExclusion": {
+              "methods": [
+                "delete_exclusion"
+              ]
+            },
+            "GetCmekSettings": {
+              "methods": [
+                "get_cmek_settings"
+              ]
+            },
+            "UpdateCmekSettings": {
+              "methods": [
+                "update_cmek_settings"
+              ]
+            }
           }
         }
       }
@@ -87,25 +133,37 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Logging::V2::LoggingService::Client",
-          "methods": {
-            "DeleteLog": [
-              "delete_log"
-            ],
-            "WriteLogEntries": [
-              "write_log_entries"
-            ],
-            "ListLogEntries": [
-              "list_log_entries"
-            ],
-            "ListMonitoredResourceDescriptors": [
-              "list_monitored_resource_descriptors"
-            ],
-            "ListLogs": [
-              "list_logs"
-            ],
-            "TailLogEntries": [
-              "tail_log_entries"
-            ]
+          "rpcs": {
+            "DeleteLog": {
+              "methods": [
+                "delete_log"
+              ]
+            },
+            "WriteLogEntries": {
+              "methods": [
+                "write_log_entries"
+              ]
+            },
+            "ListLogEntries": {
+              "methods": [
+                "list_log_entries"
+              ]
+            },
+            "ListMonitoredResourceDescriptors": {
+              "methods": [
+                "list_monitored_resource_descriptors"
+              ]
+            },
+            "ListLogs": {
+              "methods": [
+                "list_logs"
+              ]
+            },
+            "TailLogEntries": {
+              "methods": [
+                "tail_log_entries"
+              ]
+            }
           }
         }
       }
@@ -114,22 +172,32 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Logging::V2::MetricsService::Client",
-          "methods": {
-            "ListLogMetrics": [
-              "list_log_metrics"
-            ],
-            "GetLogMetric": [
-              "get_log_metric"
-            ],
-            "CreateLogMetric": [
-              "create_log_metric"
-            ],
-            "UpdateLogMetric": [
-              "update_log_metric"
-            ],
-            "DeleteLogMetric": [
-              "delete_log_metric"
-            ]
+          "rpcs": {
+            "ListLogMetrics": {
+              "methods": [
+                "list_log_metrics"
+              ]
+            },
+            "GetLogMetric": {
+              "methods": [
+                "get_log_metric"
+              ]
+            },
+            "CreateLogMetric": {
+              "methods": [
+                "create_log_metric"
+              ]
+            },
+            "UpdateLogMetric": {
+              "methods": [
+                "update_log_metric"
+              ]
+            },
+            "DeleteLogMetric": {
+              "methods": [
+                "delete_log_metric"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-logging-v2/google-cloud-logging-v2.gemspec
+++ b/google-cloud-logging-v2/google-cloud-logging-v2.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-managed_identities-v1/gapic_metadata.json
+++ b/google-cloud-managed_identities-v1/gapic_metadata.json
@@ -9,37 +9,57 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::ManagedIdentities::V1::ManagedIdentitiesService::Client",
-          "methods": {
-            "CreateMicrosoftAdDomain": [
-              "create_microsoft_ad_domain"
-            ],
-            "ResetAdminPassword": [
-              "reset_admin_password"
-            ],
-            "ListDomains": [
-              "list_domains"
-            ],
-            "GetDomain": [
-              "get_domain"
-            ],
-            "UpdateDomain": [
-              "update_domain"
-            ],
-            "DeleteDomain": [
-              "delete_domain"
-            ],
-            "AttachTrust": [
-              "attach_trust"
-            ],
-            "ReconfigureTrust": [
-              "reconfigure_trust"
-            ],
-            "DetachTrust": [
-              "detach_trust"
-            ],
-            "ValidateTrust": [
-              "validate_trust"
-            ]
+          "rpcs": {
+            "CreateMicrosoftAdDomain": {
+              "methods": [
+                "create_microsoft_ad_domain"
+              ]
+            },
+            "ResetAdminPassword": {
+              "methods": [
+                "reset_admin_password"
+              ]
+            },
+            "ListDomains": {
+              "methods": [
+                "list_domains"
+              ]
+            },
+            "GetDomain": {
+              "methods": [
+                "get_domain"
+              ]
+            },
+            "UpdateDomain": {
+              "methods": [
+                "update_domain"
+              ]
+            },
+            "DeleteDomain": {
+              "methods": [
+                "delete_domain"
+              ]
+            },
+            "AttachTrust": {
+              "methods": [
+                "attach_trust"
+              ]
+            },
+            "ReconfigureTrust": {
+              "methods": [
+                "reconfigure_trust"
+              ]
+            },
+            "DetachTrust": {
+              "methods": [
+                "detach_trust"
+              ]
+            },
+            "ValidateTrust": {
+              "methods": [
+                "validate_trust"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-managed_identities-v1/google-cloud-managed_identities-v1.gemspec
+++ b/google-cloud-managed_identities-v1/google-cloud-managed_identities-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-media_translation-v1beta1/gapic_metadata.json
+++ b/google-cloud-media_translation-v1beta1/gapic_metadata.json
@@ -9,10 +9,12 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::MediaTranslation::V1beta1::SpeechTranslationService::Client",
-          "methods": {
-            "StreamingTranslateSpeech": [
-              "streaming_translate_speech"
-            ]
+          "rpcs": {
+            "StreamingTranslateSpeech": {
+              "methods": [
+                "streaming_translate_speech"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-media_translation-v1beta1/google-cloud-media_translation-v1beta1.gemspec
+++ b/google-cloud-media_translation-v1beta1/google-cloud-media_translation-v1beta1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-memcache-v1/gapic_metadata.json
+++ b/google-cloud-memcache-v1/gapic_metadata.json
@@ -9,28 +9,42 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Memcache::V1::CloudMemcache::Client",
-          "methods": {
-            "ListInstances": [
-              "list_instances"
-            ],
-            "GetInstance": [
-              "get_instance"
-            ],
-            "CreateInstance": [
-              "create_instance"
-            ],
-            "UpdateInstance": [
-              "update_instance"
-            ],
-            "UpdateParameters": [
-              "update_parameters"
-            ],
-            "DeleteInstance": [
-              "delete_instance"
-            ],
-            "ApplyParameters": [
-              "apply_parameters"
-            ]
+          "rpcs": {
+            "ListInstances": {
+              "methods": [
+                "list_instances"
+              ]
+            },
+            "GetInstance": {
+              "methods": [
+                "get_instance"
+              ]
+            },
+            "CreateInstance": {
+              "methods": [
+                "create_instance"
+              ]
+            },
+            "UpdateInstance": {
+              "methods": [
+                "update_instance"
+              ]
+            },
+            "UpdateParameters": {
+              "methods": [
+                "update_parameters"
+              ]
+            },
+            "DeleteInstance": {
+              "methods": [
+                "delete_instance"
+              ]
+            },
+            "ApplyParameters": {
+              "methods": [
+                "apply_parameters"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-memcache-v1/google-cloud-memcache-v1.gemspec
+++ b/google-cloud-memcache-v1/google-cloud-memcache-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-memcache-v1beta2/gapic_metadata.json
+++ b/google-cloud-memcache-v1beta2/gapic_metadata.json
@@ -9,31 +9,47 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Memcache::V1beta2::CloudMemcache::Client",
-          "methods": {
-            "ListInstances": [
-              "list_instances"
-            ],
-            "GetInstance": [
-              "get_instance"
-            ],
-            "CreateInstance": [
-              "create_instance"
-            ],
-            "UpdateInstance": [
-              "update_instance"
-            ],
-            "UpdateParameters": [
-              "update_parameters"
-            ],
-            "DeleteInstance": [
-              "delete_instance"
-            ],
-            "ApplyParameters": [
-              "apply_parameters"
-            ],
-            "ApplySoftwareUpdate": [
-              "apply_software_update"
-            ]
+          "rpcs": {
+            "ListInstances": {
+              "methods": [
+                "list_instances"
+              ]
+            },
+            "GetInstance": {
+              "methods": [
+                "get_instance"
+              ]
+            },
+            "CreateInstance": {
+              "methods": [
+                "create_instance"
+              ]
+            },
+            "UpdateInstance": {
+              "methods": [
+                "update_instance"
+              ]
+            },
+            "UpdateParameters": {
+              "methods": [
+                "update_parameters"
+              ]
+            },
+            "DeleteInstance": {
+              "methods": [
+                "delete_instance"
+              ]
+            },
+            "ApplyParameters": {
+              "methods": [
+                "apply_parameters"
+              ]
+            },
+            "ApplySoftwareUpdate": {
+              "methods": [
+                "apply_software_update"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-memcache-v1beta2/google-cloud-memcache-v1beta2.gemspec
+++ b/google-cloud-memcache-v1beta2/google-cloud-memcache-v1beta2.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-monitoring-dashboard-v1/gapic_metadata.json
+++ b/google-cloud-monitoring-dashboard-v1/gapic_metadata.json
@@ -9,22 +9,32 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Monitoring::Dashboard::V1::DashboardsService::Client",
-          "methods": {
-            "CreateDashboard": [
-              "create_dashboard"
-            ],
-            "ListDashboards": [
-              "list_dashboards"
-            ],
-            "GetDashboard": [
-              "get_dashboard"
-            ],
-            "DeleteDashboard": [
-              "delete_dashboard"
-            ],
-            "UpdateDashboard": [
-              "update_dashboard"
-            ]
+          "rpcs": {
+            "CreateDashboard": {
+              "methods": [
+                "create_dashboard"
+              ]
+            },
+            "ListDashboards": {
+              "methods": [
+                "list_dashboards"
+              ]
+            },
+            "GetDashboard": {
+              "methods": [
+                "get_dashboard"
+              ]
+            },
+            "DeleteDashboard": {
+              "methods": [
+                "delete_dashboard"
+              ]
+            },
+            "UpdateDashboard": {
+              "methods": [
+                "update_dashboard"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-monitoring-dashboard-v1/google-cloud-monitoring-dashboard-v1.gemspec
+++ b/google-cloud-monitoring-dashboard-v1/google-cloud-monitoring-dashboard-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-monitoring-v3/gapic_metadata.json
+++ b/google-cloud-monitoring-v3/gapic_metadata.json
@@ -9,22 +9,32 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Monitoring::V3::AlertPolicyService::Client",
-          "methods": {
-            "ListAlertPolicies": [
-              "list_alert_policies"
-            ],
-            "GetAlertPolicy": [
-              "get_alert_policy"
-            ],
-            "CreateAlertPolicy": [
-              "create_alert_policy"
-            ],
-            "DeleteAlertPolicy": [
-              "delete_alert_policy"
-            ],
-            "UpdateAlertPolicy": [
-              "update_alert_policy"
-            ]
+          "rpcs": {
+            "ListAlertPolicies": {
+              "methods": [
+                "list_alert_policies"
+              ]
+            },
+            "GetAlertPolicy": {
+              "methods": [
+                "get_alert_policy"
+              ]
+            },
+            "CreateAlertPolicy": {
+              "methods": [
+                "create_alert_policy"
+              ]
+            },
+            "DeleteAlertPolicy": {
+              "methods": [
+                "delete_alert_policy"
+              ]
+            },
+            "UpdateAlertPolicy": {
+              "methods": [
+                "update_alert_policy"
+              ]
+            }
           }
         }
       }
@@ -33,25 +43,37 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Monitoring::V3::GroupService::Client",
-          "methods": {
-            "ListGroups": [
-              "list_groups"
-            ],
-            "GetGroup": [
-              "get_group"
-            ],
-            "CreateGroup": [
-              "create_group"
-            ],
-            "UpdateGroup": [
-              "update_group"
-            ],
-            "DeleteGroup": [
-              "delete_group"
-            ],
-            "ListGroupMembers": [
-              "list_group_members"
-            ]
+          "rpcs": {
+            "ListGroups": {
+              "methods": [
+                "list_groups"
+              ]
+            },
+            "GetGroup": {
+              "methods": [
+                "get_group"
+              ]
+            },
+            "CreateGroup": {
+              "methods": [
+                "create_group"
+              ]
+            },
+            "UpdateGroup": {
+              "methods": [
+                "update_group"
+              ]
+            },
+            "DeleteGroup": {
+              "methods": [
+                "delete_group"
+              ]
+            },
+            "ListGroupMembers": {
+              "methods": [
+                "list_group_members"
+              ]
+            }
           }
         }
       }
@@ -60,31 +82,47 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Monitoring::V3::MetricService::Client",
-          "methods": {
-            "ListMonitoredResourceDescriptors": [
-              "list_monitored_resource_descriptors"
-            ],
-            "GetMonitoredResourceDescriptor": [
-              "get_monitored_resource_descriptor"
-            ],
-            "ListMetricDescriptors": [
-              "list_metric_descriptors"
-            ],
-            "GetMetricDescriptor": [
-              "get_metric_descriptor"
-            ],
-            "CreateMetricDescriptor": [
-              "create_metric_descriptor"
-            ],
-            "DeleteMetricDescriptor": [
-              "delete_metric_descriptor"
-            ],
-            "ListTimeSeries": [
-              "list_time_series"
-            ],
-            "CreateTimeSeries": [
-              "create_time_series"
-            ]
+          "rpcs": {
+            "ListMonitoredResourceDescriptors": {
+              "methods": [
+                "list_monitored_resource_descriptors"
+              ]
+            },
+            "GetMonitoredResourceDescriptor": {
+              "methods": [
+                "get_monitored_resource_descriptor"
+              ]
+            },
+            "ListMetricDescriptors": {
+              "methods": [
+                "list_metric_descriptors"
+              ]
+            },
+            "GetMetricDescriptor": {
+              "methods": [
+                "get_metric_descriptor"
+              ]
+            },
+            "CreateMetricDescriptor": {
+              "methods": [
+                "create_metric_descriptor"
+              ]
+            },
+            "DeleteMetricDescriptor": {
+              "methods": [
+                "delete_metric_descriptor"
+              ]
+            },
+            "ListTimeSeries": {
+              "methods": [
+                "list_time_series"
+              ]
+            },
+            "CreateTimeSeries": {
+              "methods": [
+                "create_time_series"
+              ]
+            }
           }
         }
       }
@@ -93,37 +131,57 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Monitoring::V3::NotificationChannelService::Client",
-          "methods": {
-            "ListNotificationChannelDescriptors": [
-              "list_notification_channel_descriptors"
-            ],
-            "GetNotificationChannelDescriptor": [
-              "get_notification_channel_descriptor"
-            ],
-            "ListNotificationChannels": [
-              "list_notification_channels"
-            ],
-            "GetNotificationChannel": [
-              "get_notification_channel"
-            ],
-            "CreateNotificationChannel": [
-              "create_notification_channel"
-            ],
-            "UpdateNotificationChannel": [
-              "update_notification_channel"
-            ],
-            "DeleteNotificationChannel": [
-              "delete_notification_channel"
-            ],
-            "SendNotificationChannelVerificationCode": [
-              "send_notification_channel_verification_code"
-            ],
-            "GetNotificationChannelVerificationCode": [
-              "get_notification_channel_verification_code"
-            ],
-            "VerifyNotificationChannel": [
-              "verify_notification_channel"
-            ]
+          "rpcs": {
+            "ListNotificationChannelDescriptors": {
+              "methods": [
+                "list_notification_channel_descriptors"
+              ]
+            },
+            "GetNotificationChannelDescriptor": {
+              "methods": [
+                "get_notification_channel_descriptor"
+              ]
+            },
+            "ListNotificationChannels": {
+              "methods": [
+                "list_notification_channels"
+              ]
+            },
+            "GetNotificationChannel": {
+              "methods": [
+                "get_notification_channel"
+              ]
+            },
+            "CreateNotificationChannel": {
+              "methods": [
+                "create_notification_channel"
+              ]
+            },
+            "UpdateNotificationChannel": {
+              "methods": [
+                "update_notification_channel"
+              ]
+            },
+            "DeleteNotificationChannel": {
+              "methods": [
+                "delete_notification_channel"
+              ]
+            },
+            "SendNotificationChannelVerificationCode": {
+              "methods": [
+                "send_notification_channel_verification_code"
+              ]
+            },
+            "GetNotificationChannelVerificationCode": {
+              "methods": [
+                "get_notification_channel_verification_code"
+              ]
+            },
+            "VerifyNotificationChannel": {
+              "methods": [
+                "verify_notification_channel"
+              ]
+            }
           }
         }
       }
@@ -132,10 +190,12 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Monitoring::V3::QueryService::Client",
-          "methods": {
-            "QueryTimeSeries": [
-              "query_time_series"
-            ]
+          "rpcs": {
+            "QueryTimeSeries": {
+              "methods": [
+                "query_time_series"
+              ]
+            }
           }
         }
       }
@@ -144,37 +204,57 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Monitoring::V3::ServiceMonitoringService::Client",
-          "methods": {
-            "CreateService": [
-              "create_service"
-            ],
-            "GetService": [
-              "get_service"
-            ],
-            "ListServices": [
-              "list_services"
-            ],
-            "UpdateService": [
-              "update_service"
-            ],
-            "DeleteService": [
-              "delete_service"
-            ],
-            "CreateServiceLevelObjective": [
-              "create_service_level_objective"
-            ],
-            "GetServiceLevelObjective": [
-              "get_service_level_objective"
-            ],
-            "ListServiceLevelObjectives": [
-              "list_service_level_objectives"
-            ],
-            "UpdateServiceLevelObjective": [
-              "update_service_level_objective"
-            ],
-            "DeleteServiceLevelObjective": [
-              "delete_service_level_objective"
-            ]
+          "rpcs": {
+            "CreateService": {
+              "methods": [
+                "create_service"
+              ]
+            },
+            "GetService": {
+              "methods": [
+                "get_service"
+              ]
+            },
+            "ListServices": {
+              "methods": [
+                "list_services"
+              ]
+            },
+            "UpdateService": {
+              "methods": [
+                "update_service"
+              ]
+            },
+            "DeleteService": {
+              "methods": [
+                "delete_service"
+              ]
+            },
+            "CreateServiceLevelObjective": {
+              "methods": [
+                "create_service_level_objective"
+              ]
+            },
+            "GetServiceLevelObjective": {
+              "methods": [
+                "get_service_level_objective"
+              ]
+            },
+            "ListServiceLevelObjectives": {
+              "methods": [
+                "list_service_level_objectives"
+              ]
+            },
+            "UpdateServiceLevelObjective": {
+              "methods": [
+                "update_service_level_objective"
+              ]
+            },
+            "DeleteServiceLevelObjective": {
+              "methods": [
+                "delete_service_level_objective"
+              ]
+            }
           }
         }
       }
@@ -183,25 +263,37 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Monitoring::V3::UptimeCheckService::Client",
-          "methods": {
-            "ListUptimeCheckConfigs": [
-              "list_uptime_check_configs"
-            ],
-            "GetUptimeCheckConfig": [
-              "get_uptime_check_config"
-            ],
-            "CreateUptimeCheckConfig": [
-              "create_uptime_check_config"
-            ],
-            "UpdateUptimeCheckConfig": [
-              "update_uptime_check_config"
-            ],
-            "DeleteUptimeCheckConfig": [
-              "delete_uptime_check_config"
-            ],
-            "ListUptimeCheckIps": [
-              "list_uptime_check_ips"
-            ]
+          "rpcs": {
+            "ListUptimeCheckConfigs": {
+              "methods": [
+                "list_uptime_check_configs"
+              ]
+            },
+            "GetUptimeCheckConfig": {
+              "methods": [
+                "get_uptime_check_config"
+              ]
+            },
+            "CreateUptimeCheckConfig": {
+              "methods": [
+                "create_uptime_check_config"
+              ]
+            },
+            "UpdateUptimeCheckConfig": {
+              "methods": [
+                "update_uptime_check_config"
+              ]
+            },
+            "DeleteUptimeCheckConfig": {
+              "methods": [
+                "delete_uptime_check_config"
+              ]
+            },
+            "ListUptimeCheckIps": {
+              "methods": [
+                "list_uptime_check_ips"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-monitoring-v3/google-cloud-monitoring-v3.gemspec
+++ b/google-cloud-monitoring-v3/google-cloud-monitoring-v3.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-network_connectivity-v1alpha1/gapic_metadata.json
+++ b/google-cloud-network_connectivity-v1alpha1/gapic_metadata.json
@@ -9,37 +9,57 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::NetworkConnectivity::V1alpha1::HubService::Client",
-          "methods": {
-            "ListHubs": [
-              "list_hubs"
-            ],
-            "GetHub": [
-              "get_hub"
-            ],
-            "CreateHub": [
-              "create_hub"
-            ],
-            "UpdateHub": [
-              "update_hub"
-            ],
-            "DeleteHub": [
-              "delete_hub"
-            ],
-            "ListSpokes": [
-              "list_spokes"
-            ],
-            "GetSpoke": [
-              "get_spoke"
-            ],
-            "CreateSpoke": [
-              "create_spoke"
-            ],
-            "UpdateSpoke": [
-              "update_spoke"
-            ],
-            "DeleteSpoke": [
-              "delete_spoke"
-            ]
+          "rpcs": {
+            "ListHubs": {
+              "methods": [
+                "list_hubs"
+              ]
+            },
+            "GetHub": {
+              "methods": [
+                "get_hub"
+              ]
+            },
+            "CreateHub": {
+              "methods": [
+                "create_hub"
+              ]
+            },
+            "UpdateHub": {
+              "methods": [
+                "update_hub"
+              ]
+            },
+            "DeleteHub": {
+              "methods": [
+                "delete_hub"
+              ]
+            },
+            "ListSpokes": {
+              "methods": [
+                "list_spokes"
+              ]
+            },
+            "GetSpoke": {
+              "methods": [
+                "get_spoke"
+              ]
+            },
+            "CreateSpoke": {
+              "methods": [
+                "create_spoke"
+              ]
+            },
+            "UpdateSpoke": {
+              "methods": [
+                "update_spoke"
+              ]
+            },
+            "DeleteSpoke": {
+              "methods": [
+                "delete_spoke"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-network_connectivity-v1alpha1/google-cloud-network_connectivity-v1alpha1.gemspec
+++ b/google-cloud-network_connectivity-v1alpha1/google-cloud-network_connectivity-v1alpha1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-notebooks-v1beta1/gapic_metadata.json
+++ b/google-cloud-notebooks-v1beta1/gapic_metadata.json
@@ -9,64 +9,102 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Notebooks::V1beta1::NotebookService::Client",
-          "methods": {
-            "ListInstances": [
-              "list_instances"
-            ],
-            "GetInstance": [
-              "get_instance"
-            ],
-            "CreateInstance": [
-              "create_instance"
-            ],
-            "RegisterInstance": [
-              "register_instance"
-            ],
-            "SetInstanceAccelerator": [
-              "set_instance_accelerator"
-            ],
-            "SetInstanceMachineType": [
-              "set_instance_machine_type"
-            ],
-            "SetInstanceLabels": [
-              "set_instance_labels"
-            ],
-            "DeleteInstance": [
-              "delete_instance"
-            ],
-            "StartInstance": [
-              "start_instance"
-            ],
-            "StopInstance": [
-              "stop_instance"
-            ],
-            "ResetInstance": [
-              "reset_instance"
-            ],
-            "ReportInstanceInfo": [
-              "report_instance_info"
-            ],
-            "IsInstanceUpgradeable": [
-              "is_instance_upgradeable"
-            ],
-            "UpgradeInstance": [
-              "upgrade_instance"
-            ],
-            "UpgradeInstanceInternal": [
-              "upgrade_instance_internal"
-            ],
-            "ListEnvironments": [
-              "list_environments"
-            ],
-            "GetEnvironment": [
-              "get_environment"
-            ],
-            "CreateEnvironment": [
-              "create_environment"
-            ],
-            "DeleteEnvironment": [
-              "delete_environment"
-            ]
+          "rpcs": {
+            "ListInstances": {
+              "methods": [
+                "list_instances"
+              ]
+            },
+            "GetInstance": {
+              "methods": [
+                "get_instance"
+              ]
+            },
+            "CreateInstance": {
+              "methods": [
+                "create_instance"
+              ]
+            },
+            "RegisterInstance": {
+              "methods": [
+                "register_instance"
+              ]
+            },
+            "SetInstanceAccelerator": {
+              "methods": [
+                "set_instance_accelerator"
+              ]
+            },
+            "SetInstanceMachineType": {
+              "methods": [
+                "set_instance_machine_type"
+              ]
+            },
+            "SetInstanceLabels": {
+              "methods": [
+                "set_instance_labels"
+              ]
+            },
+            "DeleteInstance": {
+              "methods": [
+                "delete_instance"
+              ]
+            },
+            "StartInstance": {
+              "methods": [
+                "start_instance"
+              ]
+            },
+            "StopInstance": {
+              "methods": [
+                "stop_instance"
+              ]
+            },
+            "ResetInstance": {
+              "methods": [
+                "reset_instance"
+              ]
+            },
+            "ReportInstanceInfo": {
+              "methods": [
+                "report_instance_info"
+              ]
+            },
+            "IsInstanceUpgradeable": {
+              "methods": [
+                "is_instance_upgradeable"
+              ]
+            },
+            "UpgradeInstance": {
+              "methods": [
+                "upgrade_instance"
+              ]
+            },
+            "UpgradeInstanceInternal": {
+              "methods": [
+                "upgrade_instance_internal"
+              ]
+            },
+            "ListEnvironments": {
+              "methods": [
+                "list_environments"
+              ]
+            },
+            "GetEnvironment": {
+              "methods": [
+                "get_environment"
+              ]
+            },
+            "CreateEnvironment": {
+              "methods": [
+                "create_environment"
+              ]
+            },
+            "DeleteEnvironment": {
+              "methods": [
+                "delete_environment"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-notebooks-v1beta1/google-cloud-notebooks-v1beta1.gemspec
+++ b/google-cloud-notebooks-v1beta1/google-cloud-notebooks-v1beta1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-org_policy-v2/gapic_metadata.json
+++ b/google-cloud-org_policy-v2/gapic_metadata.json
@@ -9,28 +9,42 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::OrgPolicy::V2::OrgPolicy::Client",
-          "methods": {
-            "ListConstraints": [
-              "list_constraints"
-            ],
-            "ListPolicies": [
-              "list_policies"
-            ],
-            "GetPolicy": [
-              "get_policy"
-            ],
-            "GetEffectivePolicy": [
-              "get_effective_policy"
-            ],
-            "CreatePolicy": [
-              "create_policy"
-            ],
-            "UpdatePolicy": [
-              "update_policy"
-            ],
-            "DeletePolicy": [
-              "delete_policy"
-            ]
+          "rpcs": {
+            "ListConstraints": {
+              "methods": [
+                "list_constraints"
+              ]
+            },
+            "ListPolicies": {
+              "methods": [
+                "list_policies"
+              ]
+            },
+            "GetPolicy": {
+              "methods": [
+                "get_policy"
+              ]
+            },
+            "GetEffectivePolicy": {
+              "methods": [
+                "get_effective_policy"
+              ]
+            },
+            "CreatePolicy": {
+              "methods": [
+                "create_policy"
+              ]
+            },
+            "UpdatePolicy": {
+              "methods": [
+                "update_policy"
+              ]
+            },
+            "DeletePolicy": {
+              "methods": [
+                "delete_policy"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-org_policy-v2/google-cloud-org_policy-v2.gemspec
+++ b/google-cloud-org_policy-v2/google-cloud-org_policy-v2.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-os_config-v1/gapic_metadata.json
+++ b/google-cloud-os_config-v1/gapic_metadata.json
@@ -9,34 +9,52 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::OsConfig::V1::OsConfigService::Client",
-          "methods": {
-            "ExecutePatchJob": [
-              "execute_patch_job"
-            ],
-            "GetPatchJob": [
-              "get_patch_job"
-            ],
-            "CancelPatchJob": [
-              "cancel_patch_job"
-            ],
-            "ListPatchJobs": [
-              "list_patch_jobs"
-            ],
-            "ListPatchJobInstanceDetails": [
-              "list_patch_job_instance_details"
-            ],
-            "CreatePatchDeployment": [
-              "create_patch_deployment"
-            ],
-            "GetPatchDeployment": [
-              "get_patch_deployment"
-            ],
-            "ListPatchDeployments": [
-              "list_patch_deployments"
-            ],
-            "DeletePatchDeployment": [
-              "delete_patch_deployment"
-            ]
+          "rpcs": {
+            "ExecutePatchJob": {
+              "methods": [
+                "execute_patch_job"
+              ]
+            },
+            "GetPatchJob": {
+              "methods": [
+                "get_patch_job"
+              ]
+            },
+            "CancelPatchJob": {
+              "methods": [
+                "cancel_patch_job"
+              ]
+            },
+            "ListPatchJobs": {
+              "methods": [
+                "list_patch_jobs"
+              ]
+            },
+            "ListPatchJobInstanceDetails": {
+              "methods": [
+                "list_patch_job_instance_details"
+              ]
+            },
+            "CreatePatchDeployment": {
+              "methods": [
+                "create_patch_deployment"
+              ]
+            },
+            "GetPatchDeployment": {
+              "methods": [
+                "get_patch_deployment"
+              ]
+            },
+            "ListPatchDeployments": {
+              "methods": [
+                "list_patch_deployments"
+              ]
+            },
+            "DeletePatchDeployment": {
+              "methods": [
+                "delete_patch_deployment"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-os_config-v1/google-cloud-os_config-v1.gemspec
+++ b/google-cloud-os_config-v1/google-cloud-os_config-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-os_login-v1/gapic_metadata.json
+++ b/google-cloud-os_login-v1/gapic_metadata.json
@@ -9,25 +9,37 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::OsLogin::V1::OsLoginService::Client",
-          "methods": {
-            "DeletePosixAccount": [
-              "delete_posix_account"
-            ],
-            "DeleteSshPublicKey": [
-              "delete_ssh_public_key"
-            ],
-            "GetLoginProfile": [
-              "get_login_profile"
-            ],
-            "GetSshPublicKey": [
-              "get_ssh_public_key"
-            ],
-            "ImportSshPublicKey": [
-              "import_ssh_public_key"
-            ],
-            "UpdateSshPublicKey": [
-              "update_ssh_public_key"
-            ]
+          "rpcs": {
+            "DeletePosixAccount": {
+              "methods": [
+                "delete_posix_account"
+              ]
+            },
+            "DeleteSshPublicKey": {
+              "methods": [
+                "delete_ssh_public_key"
+              ]
+            },
+            "GetLoginProfile": {
+              "methods": [
+                "get_login_profile"
+              ]
+            },
+            "GetSshPublicKey": {
+              "methods": [
+                "get_ssh_public_key"
+              ]
+            },
+            "ImportSshPublicKey": {
+              "methods": [
+                "import_ssh_public_key"
+              ]
+            },
+            "UpdateSshPublicKey": {
+              "methods": [
+                "update_ssh_public_key"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-os_login-v1/google-cloud-os_login-v1.gemspec
+++ b/google-cloud-os_login-v1/google-cloud-os_login-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-os_login-v1beta/gapic_metadata.json
+++ b/google-cloud-os_login-v1beta/gapic_metadata.json
@@ -9,25 +9,37 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::OsLogin::V1beta::OsLoginService::Client",
-          "methods": {
-            "DeletePosixAccount": [
-              "delete_posix_account"
-            ],
-            "DeleteSshPublicKey": [
-              "delete_ssh_public_key"
-            ],
-            "GetLoginProfile": [
-              "get_login_profile"
-            ],
-            "GetSshPublicKey": [
-              "get_ssh_public_key"
-            ],
-            "ImportSshPublicKey": [
-              "import_ssh_public_key"
-            ],
-            "UpdateSshPublicKey": [
-              "update_ssh_public_key"
-            ]
+          "rpcs": {
+            "DeletePosixAccount": {
+              "methods": [
+                "delete_posix_account"
+              ]
+            },
+            "DeleteSshPublicKey": {
+              "methods": [
+                "delete_ssh_public_key"
+              ]
+            },
+            "GetLoginProfile": {
+              "methods": [
+                "get_login_profile"
+              ]
+            },
+            "GetSshPublicKey": {
+              "methods": [
+                "get_ssh_public_key"
+              ]
+            },
+            "ImportSshPublicKey": {
+              "methods": [
+                "import_ssh_public_key"
+              ]
+            },
+            "UpdateSshPublicKey": {
+              "methods": [
+                "update_ssh_public_key"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-os_login-v1beta/google-cloud-os_login-v1beta.gemspec
+++ b/google-cloud-os_login-v1beta/google-cloud-os_login-v1beta.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-phishing_protection-v1beta1/gapic_metadata.json
+++ b/google-cloud-phishing_protection-v1beta1/gapic_metadata.json
@@ -9,10 +9,12 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::PhishingProtection::V1beta1::PhishingProtectionService::Client",
-          "methods": {
-            "ReportPhishing": [
-              "report_phishing"
-            ]
+          "rpcs": {
+            "ReportPhishing": {
+              "methods": [
+                "report_phishing"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-phishing_protection-v1beta1/google-cloud-phishing_protection-v1beta1.gemspec
+++ b/google-cloud-phishing_protection-v1beta1/google-cloud-phishing_protection-v1beta1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-policy_troubleshooter-v1/gapic_metadata.json
+++ b/google-cloud-policy_troubleshooter-v1/gapic_metadata.json
@@ -9,10 +9,12 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::PolicyTroubleshooter::V1::IamChecker::Client",
-          "methods": {
-            "TroubleshootIamPolicy": [
-              "troubleshoot_iam_policy"
-            ]
+          "rpcs": {
+            "TroubleshootIamPolicy": {
+              "methods": [
+                "troubleshoot_iam_policy"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-policy_troubleshooter-v1/google-cloud-policy_troubleshooter-v1.gemspec
+++ b/google-cloud-policy_troubleshooter-v1/google-cloud-policy_troubleshooter-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
   gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.0"
 

--- a/google-cloud-profiler-v2/gapic_metadata.json
+++ b/google-cloud-profiler-v2/gapic_metadata.json
@@ -9,16 +9,22 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Profiler::V2::ProfilerService::Client",
-          "methods": {
-            "CreateProfile": [
-              "create_profile"
-            ],
-            "CreateOfflineProfile": [
-              "create_offline_profile"
-            ],
-            "UpdateProfile": [
-              "update_profile"
-            ]
+          "rpcs": {
+            "CreateProfile": {
+              "methods": [
+                "create_profile"
+              ]
+            },
+            "CreateOfflineProfile": {
+              "methods": [
+                "create_offline_profile"
+              ]
+            },
+            "UpdateProfile": {
+              "methods": [
+                "update_profile"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-profiler-v2/google-cloud-profiler-v2.gemspec
+++ b/google-cloud-profiler-v2/google-cloud-profiler-v2.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-pubsub-v1/gapic_metadata.json
+++ b/google-cloud-pubsub-v1/gapic_metadata.json
@@ -9,25 +9,37 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::PubSub::V1::SchemaService::Client",
-          "methods": {
-            "CreateSchema": [
-              "create_schema"
-            ],
-            "GetSchema": [
-              "get_schema"
-            ],
-            "ListSchemas": [
-              "list_schemas"
-            ],
-            "DeleteSchema": [
-              "delete_schema"
-            ],
-            "ValidateSchema": [
-              "validate_schema"
-            ],
-            "ValidateMessage": [
-              "validate_message"
-            ]
+          "rpcs": {
+            "CreateSchema": {
+              "methods": [
+                "create_schema"
+              ]
+            },
+            "GetSchema": {
+              "methods": [
+                "get_schema"
+              ]
+            },
+            "ListSchemas": {
+              "methods": [
+                "list_schemas"
+              ]
+            },
+            "DeleteSchema": {
+              "methods": [
+                "delete_schema"
+              ]
+            },
+            "ValidateSchema": {
+              "methods": [
+                "validate_schema"
+              ]
+            },
+            "ValidateMessage": {
+              "methods": [
+                "validate_message"
+              ]
+            }
           }
         }
       }
@@ -36,34 +48,52 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::PubSub::V1::Publisher::Client",
-          "methods": {
-            "CreateTopic": [
-              "create_topic"
-            ],
-            "UpdateTopic": [
-              "update_topic"
-            ],
-            "Publish": [
-              "publish"
-            ],
-            "GetTopic": [
-              "get_topic"
-            ],
-            "ListTopics": [
-              "list_topics"
-            ],
-            "ListTopicSubscriptions": [
-              "list_topic_subscriptions"
-            ],
-            "ListTopicSnapshots": [
-              "list_topic_snapshots"
-            ],
-            "DeleteTopic": [
-              "delete_topic"
-            ],
-            "DetachSubscription": [
-              "detach_subscription"
-            ]
+          "rpcs": {
+            "CreateTopic": {
+              "methods": [
+                "create_topic"
+              ]
+            },
+            "UpdateTopic": {
+              "methods": [
+                "update_topic"
+              ]
+            },
+            "Publish": {
+              "methods": [
+                "publish"
+              ]
+            },
+            "GetTopic": {
+              "methods": [
+                "get_topic"
+              ]
+            },
+            "ListTopics": {
+              "methods": [
+                "list_topics"
+              ]
+            },
+            "ListTopicSubscriptions": {
+              "methods": [
+                "list_topic_subscriptions"
+              ]
+            },
+            "ListTopicSnapshots": {
+              "methods": [
+                "list_topic_snapshots"
+              ]
+            },
+            "DeleteTopic": {
+              "methods": [
+                "delete_topic"
+              ]
+            },
+            "DetachSubscription": {
+              "methods": [
+                "detach_subscription"
+              ]
+            }
           }
         }
       }
@@ -72,55 +102,87 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::PubSub::V1::Subscriber::Client",
-          "methods": {
-            "CreateSubscription": [
-              "create_subscription"
-            ],
-            "GetSubscription": [
-              "get_subscription"
-            ],
-            "UpdateSubscription": [
-              "update_subscription"
-            ],
-            "ListSubscriptions": [
-              "list_subscriptions"
-            ],
-            "DeleteSubscription": [
-              "delete_subscription"
-            ],
-            "ModifyAckDeadline": [
-              "modify_ack_deadline"
-            ],
-            "Acknowledge": [
-              "acknowledge"
-            ],
-            "Pull": [
-              "pull"
-            ],
-            "StreamingPull": [
-              "streaming_pull"
-            ],
-            "ModifyPushConfig": [
-              "modify_push_config"
-            ],
-            "GetSnapshot": [
-              "get_snapshot"
-            ],
-            "ListSnapshots": [
-              "list_snapshots"
-            ],
-            "CreateSnapshot": [
-              "create_snapshot"
-            ],
-            "UpdateSnapshot": [
-              "update_snapshot"
-            ],
-            "DeleteSnapshot": [
-              "delete_snapshot"
-            ],
-            "Seek": [
-              "seek"
-            ]
+          "rpcs": {
+            "CreateSubscription": {
+              "methods": [
+                "create_subscription"
+              ]
+            },
+            "GetSubscription": {
+              "methods": [
+                "get_subscription"
+              ]
+            },
+            "UpdateSubscription": {
+              "methods": [
+                "update_subscription"
+              ]
+            },
+            "ListSubscriptions": {
+              "methods": [
+                "list_subscriptions"
+              ]
+            },
+            "DeleteSubscription": {
+              "methods": [
+                "delete_subscription"
+              ]
+            },
+            "ModifyAckDeadline": {
+              "methods": [
+                "modify_ack_deadline"
+              ]
+            },
+            "Acknowledge": {
+              "methods": [
+                "acknowledge"
+              ]
+            },
+            "Pull": {
+              "methods": [
+                "pull"
+              ]
+            },
+            "StreamingPull": {
+              "methods": [
+                "streaming_pull"
+              ]
+            },
+            "ModifyPushConfig": {
+              "methods": [
+                "modify_push_config"
+              ]
+            },
+            "GetSnapshot": {
+              "methods": [
+                "get_snapshot"
+              ]
+            },
+            "ListSnapshots": {
+              "methods": [
+                "list_snapshots"
+              ]
+            },
+            "CreateSnapshot": {
+              "methods": [
+                "create_snapshot"
+              ]
+            },
+            "UpdateSnapshot": {
+              "methods": [
+                "update_snapshot"
+              ]
+            },
+            "DeleteSnapshot": {
+              "methods": [
+                "delete_snapshot"
+              ]
+            },
+            "Seek": {
+              "methods": [
+                "seek"
+              ]
+            }
           }
         }
       }
@@ -129,16 +191,22 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::PubSub::V1::IAMPolicy::Client",
-          "methods": {
-            "SetIamPolicy": [
-              "set_iam_policy"
-            ],
-            "GetIamPolicy": [
-              "get_iam_policy"
-            ],
-            "TestIamPermissions": [
-              "test_iam_permissions"
-            ]
+          "rpcs": {
+            "SetIamPolicy": {
+              "methods": [
+                "set_iam_policy"
+              ]
+            },
+            "GetIamPolicy": {
+              "methods": [
+                "get_iam_policy"
+              ]
+            },
+            "TestIamPermissions": {
+              "methods": [
+                "test_iam_permissions"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-pubsub-v1/google-cloud-pubsub-v1.gemspec
+++ b/google-cloud-pubsub-v1/google-cloud-pubsub-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
   gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.0"
 

--- a/google-cloud-recaptcha_enterprise-v1/gapic_metadata.json
+++ b/google-cloud-recaptcha_enterprise-v1/gapic_metadata.json
@@ -9,28 +9,42 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::RecaptchaEnterprise::V1::RecaptchaEnterpriseService::Client",
-          "methods": {
-            "CreateAssessment": [
-              "create_assessment"
-            ],
-            "AnnotateAssessment": [
-              "annotate_assessment"
-            ],
-            "CreateKey": [
-              "create_key"
-            ],
-            "ListKeys": [
-              "list_keys"
-            ],
-            "GetKey": [
-              "get_key"
-            ],
-            "UpdateKey": [
-              "update_key"
-            ],
-            "DeleteKey": [
-              "delete_key"
-            ]
+          "rpcs": {
+            "CreateAssessment": {
+              "methods": [
+                "create_assessment"
+              ]
+            },
+            "AnnotateAssessment": {
+              "methods": [
+                "annotate_assessment"
+              ]
+            },
+            "CreateKey": {
+              "methods": [
+                "create_key"
+              ]
+            },
+            "ListKeys": {
+              "methods": [
+                "list_keys"
+              ]
+            },
+            "GetKey": {
+              "methods": [
+                "get_key"
+              ]
+            },
+            "UpdateKey": {
+              "methods": [
+                "update_key"
+              ]
+            },
+            "DeleteKey": {
+              "methods": [
+                "delete_key"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-recaptcha_enterprise-v1/google-cloud-recaptcha_enterprise-v1.gemspec
+++ b/google-cloud-recaptcha_enterprise-v1/google-cloud-recaptcha_enterprise-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-recaptcha_enterprise-v1beta1/gapic_metadata.json
+++ b/google-cloud-recaptcha_enterprise-v1beta1/gapic_metadata.json
@@ -9,28 +9,42 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::RecaptchaEnterprise::V1beta1::RecaptchaEnterpriseService::Client",
-          "methods": {
-            "CreateAssessment": [
-              "create_assessment"
-            ],
-            "AnnotateAssessment": [
-              "annotate_assessment"
-            ],
-            "CreateKey": [
-              "create_key"
-            ],
-            "ListKeys": [
-              "list_keys"
-            ],
-            "GetKey": [
-              "get_key"
-            ],
-            "UpdateKey": [
-              "update_key"
-            ],
-            "DeleteKey": [
-              "delete_key"
-            ]
+          "rpcs": {
+            "CreateAssessment": {
+              "methods": [
+                "create_assessment"
+              ]
+            },
+            "AnnotateAssessment": {
+              "methods": [
+                "annotate_assessment"
+              ]
+            },
+            "CreateKey": {
+              "methods": [
+                "create_key"
+              ]
+            },
+            "ListKeys": {
+              "methods": [
+                "list_keys"
+              ]
+            },
+            "GetKey": {
+              "methods": [
+                "get_key"
+              ]
+            },
+            "UpdateKey": {
+              "methods": [
+                "update_key"
+              ]
+            },
+            "DeleteKey": {
+              "methods": [
+                "delete_key"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-recaptcha_enterprise-v1beta1/google-cloud-recaptcha_enterprise-v1beta1.gemspec
+++ b/google-cloud-recaptcha_enterprise-v1beta1/google-cloud-recaptcha_enterprise-v1beta1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-recommendation_engine-v1beta1/gapic_metadata.json
+++ b/google-cloud-recommendation_engine-v1beta1/gapic_metadata.json
@@ -9,25 +9,37 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::RecommendationEngine::V1beta1::CatalogService::Client",
-          "methods": {
-            "CreateCatalogItem": [
-              "create_catalog_item"
-            ],
-            "GetCatalogItem": [
-              "get_catalog_item"
-            ],
-            "ListCatalogItems": [
-              "list_catalog_items"
-            ],
-            "UpdateCatalogItem": [
-              "update_catalog_item"
-            ],
-            "DeleteCatalogItem": [
-              "delete_catalog_item"
-            ],
-            "ImportCatalogItems": [
-              "import_catalog_items"
-            ]
+          "rpcs": {
+            "CreateCatalogItem": {
+              "methods": [
+                "create_catalog_item"
+              ]
+            },
+            "GetCatalogItem": {
+              "methods": [
+                "get_catalog_item"
+              ]
+            },
+            "ListCatalogItems": {
+              "methods": [
+                "list_catalog_items"
+              ]
+            },
+            "UpdateCatalogItem": {
+              "methods": [
+                "update_catalog_item"
+              ]
+            },
+            "DeleteCatalogItem": {
+              "methods": [
+                "delete_catalog_item"
+              ]
+            },
+            "ImportCatalogItems": {
+              "methods": [
+                "import_catalog_items"
+              ]
+            }
           }
         }
       }
@@ -36,16 +48,22 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::RecommendationEngine::V1beta1::PredictionApiKeyRegistry::Client",
-          "methods": {
-            "CreatePredictionApiKeyRegistration": [
-              "create_prediction_api_key_registration"
-            ],
-            "ListPredictionApiKeyRegistrations": [
-              "list_prediction_api_key_registrations"
-            ],
-            "DeletePredictionApiKeyRegistration": [
-              "delete_prediction_api_key_registration"
-            ]
+          "rpcs": {
+            "CreatePredictionApiKeyRegistration": {
+              "methods": [
+                "create_prediction_api_key_registration"
+              ]
+            },
+            "ListPredictionApiKeyRegistrations": {
+              "methods": [
+                "list_prediction_api_key_registrations"
+              ]
+            },
+            "DeletePredictionApiKeyRegistration": {
+              "methods": [
+                "delete_prediction_api_key_registration"
+              ]
+            }
           }
         }
       }
@@ -54,10 +72,12 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::RecommendationEngine::V1beta1::PredictionService::Client",
-          "methods": {
-            "Predict": [
-              "predict"
-            ]
+          "rpcs": {
+            "Predict": {
+              "methods": [
+                "predict"
+              ]
+            }
           }
         }
       }
@@ -66,22 +86,32 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::RecommendationEngine::V1beta1::UserEventService::Client",
-          "methods": {
-            "WriteUserEvent": [
-              "write_user_event"
-            ],
-            "CollectUserEvent": [
-              "collect_user_event"
-            ],
-            "ListUserEvents": [
-              "list_user_events"
-            ],
-            "PurgeUserEvents": [
-              "purge_user_events"
-            ],
-            "ImportUserEvents": [
-              "import_user_events"
-            ]
+          "rpcs": {
+            "WriteUserEvent": {
+              "methods": [
+                "write_user_event"
+              ]
+            },
+            "CollectUserEvent": {
+              "methods": [
+                "collect_user_event"
+              ]
+            },
+            "ListUserEvents": {
+              "methods": [
+                "list_user_events"
+              ]
+            },
+            "PurgeUserEvents": {
+              "methods": [
+                "purge_user_events"
+              ]
+            },
+            "ImportUserEvents": {
+              "methods": [
+                "import_user_events"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-recommendation_engine-v1beta1/google-cloud-recommendation_engine-v1beta1.gemspec
+++ b/google-cloud-recommendation_engine-v1beta1/google-cloud-recommendation_engine-v1beta1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-recommender-v1/gapic_metadata.json
+++ b/google-cloud-recommender-v1/gapic_metadata.json
@@ -9,31 +9,47 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Recommender::V1::Recommender::Client",
-          "methods": {
-            "ListInsights": [
-              "list_insights"
-            ],
-            "GetInsight": [
-              "get_insight"
-            ],
-            "MarkInsightAccepted": [
-              "mark_insight_accepted"
-            ],
-            "ListRecommendations": [
-              "list_recommendations"
-            ],
-            "GetRecommendation": [
-              "get_recommendation"
-            ],
-            "MarkRecommendationClaimed": [
-              "mark_recommendation_claimed"
-            ],
-            "MarkRecommendationSucceeded": [
-              "mark_recommendation_succeeded"
-            ],
-            "MarkRecommendationFailed": [
-              "mark_recommendation_failed"
-            ]
+          "rpcs": {
+            "ListInsights": {
+              "methods": [
+                "list_insights"
+              ]
+            },
+            "GetInsight": {
+              "methods": [
+                "get_insight"
+              ]
+            },
+            "MarkInsightAccepted": {
+              "methods": [
+                "mark_insight_accepted"
+              ]
+            },
+            "ListRecommendations": {
+              "methods": [
+                "list_recommendations"
+              ]
+            },
+            "GetRecommendation": {
+              "methods": [
+                "get_recommendation"
+              ]
+            },
+            "MarkRecommendationClaimed": {
+              "methods": [
+                "mark_recommendation_claimed"
+              ]
+            },
+            "MarkRecommendationSucceeded": {
+              "methods": [
+                "mark_recommendation_succeeded"
+              ]
+            },
+            "MarkRecommendationFailed": {
+              "methods": [
+                "mark_recommendation_failed"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-recommender-v1/google-cloud-recommender-v1.gemspec
+++ b/google-cloud-recommender-v1/google-cloud-recommender-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-redis-v1/gapic_metadata.json
+++ b/google-cloud-redis-v1/gapic_metadata.json
@@ -9,34 +9,52 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Redis::V1::CloudRedis::Client",
-          "methods": {
-            "ListInstances": [
-              "list_instances"
-            ],
-            "GetInstance": [
-              "get_instance"
-            ],
-            "CreateInstance": [
-              "create_instance"
-            ],
-            "UpdateInstance": [
-              "update_instance"
-            ],
-            "UpgradeInstance": [
-              "upgrade_instance"
-            ],
-            "ImportInstance": [
-              "import_instance"
-            ],
-            "ExportInstance": [
-              "export_instance"
-            ],
-            "FailoverInstance": [
-              "failover_instance"
-            ],
-            "DeleteInstance": [
-              "delete_instance"
-            ]
+          "rpcs": {
+            "ListInstances": {
+              "methods": [
+                "list_instances"
+              ]
+            },
+            "GetInstance": {
+              "methods": [
+                "get_instance"
+              ]
+            },
+            "CreateInstance": {
+              "methods": [
+                "create_instance"
+              ]
+            },
+            "UpdateInstance": {
+              "methods": [
+                "update_instance"
+              ]
+            },
+            "UpgradeInstance": {
+              "methods": [
+                "upgrade_instance"
+              ]
+            },
+            "ImportInstance": {
+              "methods": [
+                "import_instance"
+              ]
+            },
+            "ExportInstance": {
+              "methods": [
+                "export_instance"
+              ]
+            },
+            "FailoverInstance": {
+              "methods": [
+                "failover_instance"
+              ]
+            },
+            "DeleteInstance": {
+              "methods": [
+                "delete_instance"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-redis-v1/google-cloud-redis-v1.gemspec
+++ b/google-cloud-redis-v1/google-cloud-redis-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-redis-v1beta1/gapic_metadata.json
+++ b/google-cloud-redis-v1beta1/gapic_metadata.json
@@ -9,34 +9,52 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Redis::V1beta1::CloudRedis::Client",
-          "methods": {
-            "ListInstances": [
-              "list_instances"
-            ],
-            "GetInstance": [
-              "get_instance"
-            ],
-            "CreateInstance": [
-              "create_instance"
-            ],
-            "UpdateInstance": [
-              "update_instance"
-            ],
-            "UpgradeInstance": [
-              "upgrade_instance"
-            ],
-            "ImportInstance": [
-              "import_instance"
-            ],
-            "ExportInstance": [
-              "export_instance"
-            ],
-            "FailoverInstance": [
-              "failover_instance"
-            ],
-            "DeleteInstance": [
-              "delete_instance"
-            ]
+          "rpcs": {
+            "ListInstances": {
+              "methods": [
+                "list_instances"
+              ]
+            },
+            "GetInstance": {
+              "methods": [
+                "get_instance"
+              ]
+            },
+            "CreateInstance": {
+              "methods": [
+                "create_instance"
+              ]
+            },
+            "UpdateInstance": {
+              "methods": [
+                "update_instance"
+              ]
+            },
+            "UpgradeInstance": {
+              "methods": [
+                "upgrade_instance"
+              ]
+            },
+            "ImportInstance": {
+              "methods": [
+                "import_instance"
+              ]
+            },
+            "ExportInstance": {
+              "methods": [
+                "export_instance"
+              ]
+            },
+            "FailoverInstance": {
+              "methods": [
+                "failover_instance"
+              ]
+            },
+            "DeleteInstance": {
+              "methods": [
+                "delete_instance"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-redis-v1beta1/google-cloud-redis-v1beta1.gemspec
+++ b/google-cloud-redis-v1beta1/google-cloud-redis-v1beta1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-retail-v2/gapic_metadata.json
+++ b/google-cloud-retail-v2/gapic_metadata.json
@@ -9,13 +9,17 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Retail::V2::CatalogService::Client",
-          "methods": {
-            "ListCatalogs": [
-              "list_catalogs"
-            ],
-            "UpdateCatalog": [
-              "update_catalog"
-            ]
+          "rpcs": {
+            "ListCatalogs": {
+              "methods": [
+                "list_catalogs"
+              ]
+            },
+            "UpdateCatalog": {
+              "methods": [
+                "update_catalog"
+              ]
+            }
           }
         }
       }
@@ -24,10 +28,12 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Retail::V2::PredictionService::Client",
-          "methods": {
-            "Predict": [
-              "predict"
-            ]
+          "rpcs": {
+            "Predict": {
+              "methods": [
+                "predict"
+              ]
+            }
           }
         }
       }
@@ -36,22 +42,32 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Retail::V2::ProductService::Client",
-          "methods": {
-            "CreateProduct": [
-              "create_product"
-            ],
-            "GetProduct": [
-              "get_product"
-            ],
-            "UpdateProduct": [
-              "update_product"
-            ],
-            "DeleteProduct": [
-              "delete_product"
-            ],
-            "ImportProducts": [
-              "import_products"
-            ]
+          "rpcs": {
+            "CreateProduct": {
+              "methods": [
+                "create_product"
+              ]
+            },
+            "GetProduct": {
+              "methods": [
+                "get_product"
+              ]
+            },
+            "UpdateProduct": {
+              "methods": [
+                "update_product"
+              ]
+            },
+            "DeleteProduct": {
+              "methods": [
+                "delete_product"
+              ]
+            },
+            "ImportProducts": {
+              "methods": [
+                "import_products"
+              ]
+            }
           }
         }
       }
@@ -60,22 +76,32 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Retail::V2::UserEventService::Client",
-          "methods": {
-            "WriteUserEvent": [
-              "write_user_event"
-            ],
-            "CollectUserEvent": [
-              "collect_user_event"
-            ],
-            "PurgeUserEvents": [
-              "purge_user_events"
-            ],
-            "ImportUserEvents": [
-              "import_user_events"
-            ],
-            "RejoinUserEvents": [
-              "rejoin_user_events"
-            ]
+          "rpcs": {
+            "WriteUserEvent": {
+              "methods": [
+                "write_user_event"
+              ]
+            },
+            "CollectUserEvent": {
+              "methods": [
+                "collect_user_event"
+              ]
+            },
+            "PurgeUserEvents": {
+              "methods": [
+                "purge_user_events"
+              ]
+            },
+            "ImportUserEvents": {
+              "methods": [
+                "import_user_events"
+              ]
+            },
+            "RejoinUserEvents": {
+              "methods": [
+                "rejoin_user_events"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-retail-v2/google-cloud-retail-v2.gemspec
+++ b/google-cloud-retail-v2/google-cloud-retail-v2.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-scheduler-v1/gapic_metadata.json
+++ b/google-cloud-scheduler-v1/gapic_metadata.json
@@ -9,31 +9,47 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Scheduler::V1::CloudScheduler::Client",
-          "methods": {
-            "ListJobs": [
-              "list_jobs"
-            ],
-            "GetJob": [
-              "get_job"
-            ],
-            "CreateJob": [
-              "create_job"
-            ],
-            "UpdateJob": [
-              "update_job"
-            ],
-            "DeleteJob": [
-              "delete_job"
-            ],
-            "PauseJob": [
-              "pause_job"
-            ],
-            "ResumeJob": [
-              "resume_job"
-            ],
-            "RunJob": [
-              "run_job"
-            ]
+          "rpcs": {
+            "ListJobs": {
+              "methods": [
+                "list_jobs"
+              ]
+            },
+            "GetJob": {
+              "methods": [
+                "get_job"
+              ]
+            },
+            "CreateJob": {
+              "methods": [
+                "create_job"
+              ]
+            },
+            "UpdateJob": {
+              "methods": [
+                "update_job"
+              ]
+            },
+            "DeleteJob": {
+              "methods": [
+                "delete_job"
+              ]
+            },
+            "PauseJob": {
+              "methods": [
+                "pause_job"
+              ]
+            },
+            "ResumeJob": {
+              "methods": [
+                "resume_job"
+              ]
+            },
+            "RunJob": {
+              "methods": [
+                "run_job"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-scheduler-v1/google-cloud-scheduler-v1.gemspec
+++ b/google-cloud-scheduler-v1/google-cloud-scheduler-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-scheduler-v1beta1/gapic_metadata.json
+++ b/google-cloud-scheduler-v1beta1/gapic_metadata.json
@@ -9,31 +9,47 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Scheduler::V1beta1::CloudScheduler::Client",
-          "methods": {
-            "ListJobs": [
-              "list_jobs"
-            ],
-            "GetJob": [
-              "get_job"
-            ],
-            "CreateJob": [
-              "create_job"
-            ],
-            "UpdateJob": [
-              "update_job"
-            ],
-            "DeleteJob": [
-              "delete_job"
-            ],
-            "PauseJob": [
-              "pause_job"
-            ],
-            "ResumeJob": [
-              "resume_job"
-            ],
-            "RunJob": [
-              "run_job"
-            ]
+          "rpcs": {
+            "ListJobs": {
+              "methods": [
+                "list_jobs"
+              ]
+            },
+            "GetJob": {
+              "methods": [
+                "get_job"
+              ]
+            },
+            "CreateJob": {
+              "methods": [
+                "create_job"
+              ]
+            },
+            "UpdateJob": {
+              "methods": [
+                "update_job"
+              ]
+            },
+            "DeleteJob": {
+              "methods": [
+                "delete_job"
+              ]
+            },
+            "PauseJob": {
+              "methods": [
+                "pause_job"
+              ]
+            },
+            "ResumeJob": {
+              "methods": [
+                "resume_job"
+              ]
+            },
+            "RunJob": {
+              "methods": [
+                "run_job"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-scheduler-v1beta1/google-cloud-scheduler-v1beta1.gemspec
+++ b/google-cloud-scheduler-v1beta1/google-cloud-scheduler-v1beta1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-secret_manager-v1/gapic_metadata.json
+++ b/google-cloud-secret_manager-v1/gapic_metadata.json
@@ -9,52 +9,82 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::SecretManager::V1::SecretManagerService::Client",
-          "methods": {
-            "ListSecrets": [
-              "list_secrets"
-            ],
-            "CreateSecret": [
-              "create_secret"
-            ],
-            "AddSecretVersion": [
-              "add_secret_version"
-            ],
-            "GetSecret": [
-              "get_secret"
-            ],
-            "UpdateSecret": [
-              "update_secret"
-            ],
-            "DeleteSecret": [
-              "delete_secret"
-            ],
-            "ListSecretVersions": [
-              "list_secret_versions"
-            ],
-            "GetSecretVersion": [
-              "get_secret_version"
-            ],
-            "AccessSecretVersion": [
-              "access_secret_version"
-            ],
-            "DisableSecretVersion": [
-              "disable_secret_version"
-            ],
-            "EnableSecretVersion": [
-              "enable_secret_version"
-            ],
-            "DestroySecretVersion": [
-              "destroy_secret_version"
-            ],
-            "SetIamPolicy": [
-              "set_iam_policy"
-            ],
-            "GetIamPolicy": [
-              "get_iam_policy"
-            ],
-            "TestIamPermissions": [
-              "test_iam_permissions"
-            ]
+          "rpcs": {
+            "ListSecrets": {
+              "methods": [
+                "list_secrets"
+              ]
+            },
+            "CreateSecret": {
+              "methods": [
+                "create_secret"
+              ]
+            },
+            "AddSecretVersion": {
+              "methods": [
+                "add_secret_version"
+              ]
+            },
+            "GetSecret": {
+              "methods": [
+                "get_secret"
+              ]
+            },
+            "UpdateSecret": {
+              "methods": [
+                "update_secret"
+              ]
+            },
+            "DeleteSecret": {
+              "methods": [
+                "delete_secret"
+              ]
+            },
+            "ListSecretVersions": {
+              "methods": [
+                "list_secret_versions"
+              ]
+            },
+            "GetSecretVersion": {
+              "methods": [
+                "get_secret_version"
+              ]
+            },
+            "AccessSecretVersion": {
+              "methods": [
+                "access_secret_version"
+              ]
+            },
+            "DisableSecretVersion": {
+              "methods": [
+                "disable_secret_version"
+              ]
+            },
+            "EnableSecretVersion": {
+              "methods": [
+                "enable_secret_version"
+              ]
+            },
+            "DestroySecretVersion": {
+              "methods": [
+                "destroy_secret_version"
+              ]
+            },
+            "SetIamPolicy": {
+              "methods": [
+                "set_iam_policy"
+              ]
+            },
+            "GetIamPolicy": {
+              "methods": [
+                "get_iam_policy"
+              ]
+            },
+            "TestIamPermissions": {
+              "methods": [
+                "test_iam_permissions"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-secret_manager-v1/google-cloud-secret_manager-v1.gemspec
+++ b/google-cloud-secret_manager-v1/google-cloud-secret_manager-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
   gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.0"
 

--- a/google-cloud-secret_manager-v1beta1/gapic_metadata.json
+++ b/google-cloud-secret_manager-v1beta1/gapic_metadata.json
@@ -9,52 +9,82 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::SecretManager::V1beta1::SecretManagerService::Client",
-          "methods": {
-            "ListSecrets": [
-              "list_secrets"
-            ],
-            "CreateSecret": [
-              "create_secret"
-            ],
-            "AddSecretVersion": [
-              "add_secret_version"
-            ],
-            "GetSecret": [
-              "get_secret"
-            ],
-            "UpdateSecret": [
-              "update_secret"
-            ],
-            "DeleteSecret": [
-              "delete_secret"
-            ],
-            "ListSecretVersions": [
-              "list_secret_versions"
-            ],
-            "GetSecretVersion": [
-              "get_secret_version"
-            ],
-            "AccessSecretVersion": [
-              "access_secret_version"
-            ],
-            "DisableSecretVersion": [
-              "disable_secret_version"
-            ],
-            "EnableSecretVersion": [
-              "enable_secret_version"
-            ],
-            "DestroySecretVersion": [
-              "destroy_secret_version"
-            ],
-            "SetIamPolicy": [
-              "set_iam_policy"
-            ],
-            "GetIamPolicy": [
-              "get_iam_policy"
-            ],
-            "TestIamPermissions": [
-              "test_iam_permissions"
-            ]
+          "rpcs": {
+            "ListSecrets": {
+              "methods": [
+                "list_secrets"
+              ]
+            },
+            "CreateSecret": {
+              "methods": [
+                "create_secret"
+              ]
+            },
+            "AddSecretVersion": {
+              "methods": [
+                "add_secret_version"
+              ]
+            },
+            "GetSecret": {
+              "methods": [
+                "get_secret"
+              ]
+            },
+            "UpdateSecret": {
+              "methods": [
+                "update_secret"
+              ]
+            },
+            "DeleteSecret": {
+              "methods": [
+                "delete_secret"
+              ]
+            },
+            "ListSecretVersions": {
+              "methods": [
+                "list_secret_versions"
+              ]
+            },
+            "GetSecretVersion": {
+              "methods": [
+                "get_secret_version"
+              ]
+            },
+            "AccessSecretVersion": {
+              "methods": [
+                "access_secret_version"
+              ]
+            },
+            "DisableSecretVersion": {
+              "methods": [
+                "disable_secret_version"
+              ]
+            },
+            "EnableSecretVersion": {
+              "methods": [
+                "enable_secret_version"
+              ]
+            },
+            "DestroySecretVersion": {
+              "methods": [
+                "destroy_secret_version"
+              ]
+            },
+            "SetIamPolicy": {
+              "methods": [
+                "set_iam_policy"
+              ]
+            },
+            "GetIamPolicy": {
+              "methods": [
+                "get_iam_policy"
+              ]
+            },
+            "TestIamPermissions": {
+              "methods": [
+                "test_iam_permissions"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-secret_manager-v1beta1/google-cloud-secret_manager-v1beta1.gemspec
+++ b/google-cloud-secret_manager-v1beta1/google-cloud-secret_manager-v1beta1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
   gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.0"
 

--- a/google-cloud-security-private_ca-v1beta1/gapic_metadata.json
+++ b/google-cloud-security-private_ca-v1beta1/gapic_metadata.json
@@ -9,67 +9,107 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Security::PrivateCA::V1beta1::CertificateAuthorityService::Client",
-          "methods": {
-            "CreateCertificate": [
-              "create_certificate"
-            ],
-            "GetCertificate": [
-              "get_certificate"
-            ],
-            "ListCertificates": [
-              "list_certificates"
-            ],
-            "RevokeCertificate": [
-              "revoke_certificate"
-            ],
-            "UpdateCertificate": [
-              "update_certificate"
-            ],
-            "ActivateCertificateAuthority": [
-              "activate_certificate_authority"
-            ],
-            "CreateCertificateAuthority": [
-              "create_certificate_authority"
-            ],
-            "DisableCertificateAuthority": [
-              "disable_certificate_authority"
-            ],
-            "EnableCertificateAuthority": [
-              "enable_certificate_authority"
-            ],
-            "FetchCertificateAuthorityCsr": [
-              "fetch_certificate_authority_csr"
-            ],
-            "GetCertificateAuthority": [
-              "get_certificate_authority"
-            ],
-            "ListCertificateAuthorities": [
-              "list_certificate_authorities"
-            ],
-            "RestoreCertificateAuthority": [
-              "restore_certificate_authority"
-            ],
-            "ScheduleDeleteCertificateAuthority": [
-              "schedule_delete_certificate_authority"
-            ],
-            "UpdateCertificateAuthority": [
-              "update_certificate_authority"
-            ],
-            "GetCertificateRevocationList": [
-              "get_certificate_revocation_list"
-            ],
-            "ListCertificateRevocationLists": [
-              "list_certificate_revocation_lists"
-            ],
-            "UpdateCertificateRevocationList": [
-              "update_certificate_revocation_list"
-            ],
-            "GetReusableConfig": [
-              "get_reusable_config"
-            ],
-            "ListReusableConfigs": [
-              "list_reusable_configs"
-            ]
+          "rpcs": {
+            "CreateCertificate": {
+              "methods": [
+                "create_certificate"
+              ]
+            },
+            "GetCertificate": {
+              "methods": [
+                "get_certificate"
+              ]
+            },
+            "ListCertificates": {
+              "methods": [
+                "list_certificates"
+              ]
+            },
+            "RevokeCertificate": {
+              "methods": [
+                "revoke_certificate"
+              ]
+            },
+            "UpdateCertificate": {
+              "methods": [
+                "update_certificate"
+              ]
+            },
+            "ActivateCertificateAuthority": {
+              "methods": [
+                "activate_certificate_authority"
+              ]
+            },
+            "CreateCertificateAuthority": {
+              "methods": [
+                "create_certificate_authority"
+              ]
+            },
+            "DisableCertificateAuthority": {
+              "methods": [
+                "disable_certificate_authority"
+              ]
+            },
+            "EnableCertificateAuthority": {
+              "methods": [
+                "enable_certificate_authority"
+              ]
+            },
+            "FetchCertificateAuthorityCsr": {
+              "methods": [
+                "fetch_certificate_authority_csr"
+              ]
+            },
+            "GetCertificateAuthority": {
+              "methods": [
+                "get_certificate_authority"
+              ]
+            },
+            "ListCertificateAuthorities": {
+              "methods": [
+                "list_certificate_authorities"
+              ]
+            },
+            "RestoreCertificateAuthority": {
+              "methods": [
+                "restore_certificate_authority"
+              ]
+            },
+            "ScheduleDeleteCertificateAuthority": {
+              "methods": [
+                "schedule_delete_certificate_authority"
+              ]
+            },
+            "UpdateCertificateAuthority": {
+              "methods": [
+                "update_certificate_authority"
+              ]
+            },
+            "GetCertificateRevocationList": {
+              "methods": [
+                "get_certificate_revocation_list"
+              ]
+            },
+            "ListCertificateRevocationLists": {
+              "methods": [
+                "list_certificate_revocation_lists"
+              ]
+            },
+            "UpdateCertificateRevocationList": {
+              "methods": [
+                "update_certificate_revocation_list"
+              ]
+            },
+            "GetReusableConfig": {
+              "methods": [
+                "get_reusable_config"
+              ]
+            },
+            "ListReusableConfigs": {
+              "methods": [
+                "list_reusable_configs"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-security-private_ca-v1beta1/google-cloud-security-private_ca-v1beta1.gemspec
+++ b/google-cloud-security-private_ca-v1beta1/google-cloud-security-private_ca-v1beta1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-security_center-v1/gapic_metadata.json
+++ b/google-cloud-security_center-v1/gapic_metadata.json
@@ -9,76 +9,122 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::SecurityCenter::V1::SecurityCenter::Client",
-          "methods": {
-            "CreateSource": [
-              "create_source"
-            ],
-            "CreateFinding": [
-              "create_finding"
-            ],
-            "CreateNotificationConfig": [
-              "create_notification_config"
-            ],
-            "DeleteNotificationConfig": [
-              "delete_notification_config"
-            ],
-            "GetIamPolicy": [
-              "get_iam_policy"
-            ],
-            "GetNotificationConfig": [
-              "get_notification_config"
-            ],
-            "GetOrganizationSettings": [
-              "get_organization_settings"
-            ],
-            "GetSource": [
-              "get_source"
-            ],
-            "GroupAssets": [
-              "group_assets"
-            ],
-            "GroupFindings": [
-              "group_findings"
-            ],
-            "ListAssets": [
-              "list_assets"
-            ],
-            "ListFindings": [
-              "list_findings"
-            ],
-            "ListNotificationConfigs": [
-              "list_notification_configs"
-            ],
-            "ListSources": [
-              "list_sources"
-            ],
-            "RunAssetDiscovery": [
-              "run_asset_discovery"
-            ],
-            "SetFindingState": [
-              "set_finding_state"
-            ],
-            "SetIamPolicy": [
-              "set_iam_policy"
-            ],
-            "TestIamPermissions": [
-              "test_iam_permissions"
-            ],
-            "UpdateFinding": [
-              "update_finding"
-            ],
-            "UpdateNotificationConfig": [
-              "update_notification_config"
-            ],
-            "UpdateOrganizationSettings": [
-              "update_organization_settings"
-            ],
-            "UpdateSource": [
-              "update_source"
-            ],
-            "UpdateSecurityMarks": [
-              "update_security_marks"
-            ]
+          "rpcs": {
+            "CreateSource": {
+              "methods": [
+                "create_source"
+              ]
+            },
+            "CreateFinding": {
+              "methods": [
+                "create_finding"
+              ]
+            },
+            "CreateNotificationConfig": {
+              "methods": [
+                "create_notification_config"
+              ]
+            },
+            "DeleteNotificationConfig": {
+              "methods": [
+                "delete_notification_config"
+              ]
+            },
+            "GetIamPolicy": {
+              "methods": [
+                "get_iam_policy"
+              ]
+            },
+            "GetNotificationConfig": {
+              "methods": [
+                "get_notification_config"
+              ]
+            },
+            "GetOrganizationSettings": {
+              "methods": [
+                "get_organization_settings"
+              ]
+            },
+            "GetSource": {
+              "methods": [
+                "get_source"
+              ]
+            },
+            "GroupAssets": {
+              "methods": [
+                "group_assets"
+              ]
+            },
+            "GroupFindings": {
+              "methods": [
+                "group_findings"
+              ]
+            },
+            "ListAssets": {
+              "methods": [
+                "list_assets"
+              ]
+            },
+            "ListFindings": {
+              "methods": [
+                "list_findings"
+              ]
+            },
+            "ListNotificationConfigs": {
+              "methods": [
+                "list_notification_configs"
+              ]
+            },
+            "ListSources": {
+              "methods": [
+                "list_sources"
+              ]
+            },
+            "RunAssetDiscovery": {
+              "methods": [
+                "run_asset_discovery"
+              ]
+            },
+            "SetFindingState": {
+              "methods": [
+                "set_finding_state"
+              ]
+            },
+            "SetIamPolicy": {
+              "methods": [
+                "set_iam_policy"
+              ]
+            },
+            "TestIamPermissions": {
+              "methods": [
+                "test_iam_permissions"
+              ]
+            },
+            "UpdateFinding": {
+              "methods": [
+                "update_finding"
+              ]
+            },
+            "UpdateNotificationConfig": {
+              "methods": [
+                "update_notification_config"
+              ]
+            },
+            "UpdateOrganizationSettings": {
+              "methods": [
+                "update_organization_settings"
+              ]
+            },
+            "UpdateSource": {
+              "methods": [
+                "update_source"
+              ]
+            },
+            "UpdateSecurityMarks": {
+              "methods": [
+                "update_security_marks"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-security_center-v1/google-cloud-security_center-v1.gemspec
+++ b/google-cloud-security_center-v1/google-cloud-security_center-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
   gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.0"
 

--- a/google-cloud-security_center-v1p1beta1/gapic_metadata.json
+++ b/google-cloud-security_center-v1p1beta1/gapic_metadata.json
@@ -9,76 +9,122 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::SecurityCenter::V1p1beta1::SecurityCenter::Client",
-          "methods": {
-            "CreateSource": [
-              "create_source"
-            ],
-            "CreateFinding": [
-              "create_finding"
-            ],
-            "CreateNotificationConfig": [
-              "create_notification_config"
-            ],
-            "DeleteNotificationConfig": [
-              "delete_notification_config"
-            ],
-            "GetIamPolicy": [
-              "get_iam_policy"
-            ],
-            "GetNotificationConfig": [
-              "get_notification_config"
-            ],
-            "GetOrganizationSettings": [
-              "get_organization_settings"
-            ],
-            "GetSource": [
-              "get_source"
-            ],
-            "GroupAssets": [
-              "group_assets"
-            ],
-            "GroupFindings": [
-              "group_findings"
-            ],
-            "ListAssets": [
-              "list_assets"
-            ],
-            "ListFindings": [
-              "list_findings"
-            ],
-            "ListNotificationConfigs": [
-              "list_notification_configs"
-            ],
-            "ListSources": [
-              "list_sources"
-            ],
-            "RunAssetDiscovery": [
-              "run_asset_discovery"
-            ],
-            "SetFindingState": [
-              "set_finding_state"
-            ],
-            "SetIamPolicy": [
-              "set_iam_policy"
-            ],
-            "TestIamPermissions": [
-              "test_iam_permissions"
-            ],
-            "UpdateFinding": [
-              "update_finding"
-            ],
-            "UpdateNotificationConfig": [
-              "update_notification_config"
-            ],
-            "UpdateOrganizationSettings": [
-              "update_organization_settings"
-            ],
-            "UpdateSource": [
-              "update_source"
-            ],
-            "UpdateSecurityMarks": [
-              "update_security_marks"
-            ]
+          "rpcs": {
+            "CreateSource": {
+              "methods": [
+                "create_source"
+              ]
+            },
+            "CreateFinding": {
+              "methods": [
+                "create_finding"
+              ]
+            },
+            "CreateNotificationConfig": {
+              "methods": [
+                "create_notification_config"
+              ]
+            },
+            "DeleteNotificationConfig": {
+              "methods": [
+                "delete_notification_config"
+              ]
+            },
+            "GetIamPolicy": {
+              "methods": [
+                "get_iam_policy"
+              ]
+            },
+            "GetNotificationConfig": {
+              "methods": [
+                "get_notification_config"
+              ]
+            },
+            "GetOrganizationSettings": {
+              "methods": [
+                "get_organization_settings"
+              ]
+            },
+            "GetSource": {
+              "methods": [
+                "get_source"
+              ]
+            },
+            "GroupAssets": {
+              "methods": [
+                "group_assets"
+              ]
+            },
+            "GroupFindings": {
+              "methods": [
+                "group_findings"
+              ]
+            },
+            "ListAssets": {
+              "methods": [
+                "list_assets"
+              ]
+            },
+            "ListFindings": {
+              "methods": [
+                "list_findings"
+              ]
+            },
+            "ListNotificationConfigs": {
+              "methods": [
+                "list_notification_configs"
+              ]
+            },
+            "ListSources": {
+              "methods": [
+                "list_sources"
+              ]
+            },
+            "RunAssetDiscovery": {
+              "methods": [
+                "run_asset_discovery"
+              ]
+            },
+            "SetFindingState": {
+              "methods": [
+                "set_finding_state"
+              ]
+            },
+            "SetIamPolicy": {
+              "methods": [
+                "set_iam_policy"
+              ]
+            },
+            "TestIamPermissions": {
+              "methods": [
+                "test_iam_permissions"
+              ]
+            },
+            "UpdateFinding": {
+              "methods": [
+                "update_finding"
+              ]
+            },
+            "UpdateNotificationConfig": {
+              "methods": [
+                "update_notification_config"
+              ]
+            },
+            "UpdateOrganizationSettings": {
+              "methods": [
+                "update_organization_settings"
+              ]
+            },
+            "UpdateSource": {
+              "methods": [
+                "update_source"
+              ]
+            },
+            "UpdateSecurityMarks": {
+              "methods": [
+                "update_security_marks"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-security_center-v1p1beta1/google-cloud-security_center-v1p1beta1.gemspec
+++ b/google-cloud-security_center-v1p1beta1/google-cloud-security_center-v1p1beta1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
   gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.0"
 

--- a/google-cloud-service_control-v1/gapic_metadata.json
+++ b/google-cloud-service_control-v1/gapic_metadata.json
@@ -9,10 +9,12 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::ServiceControl::V1::QuotaController::Client",
-          "methods": {
-            "AllocateQuota": [
-              "allocate_quota"
-            ]
+          "rpcs": {
+            "AllocateQuota": {
+              "methods": [
+                "allocate_quota"
+              ]
+            }
           }
         }
       }
@@ -21,13 +23,17 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::ServiceControl::V1::ServiceController::Client",
-          "methods": {
-            "Check": [
-              "check"
-            ],
-            "Report": [
-              "report"
-            ]
+          "rpcs": {
+            "Check": {
+              "methods": [
+                "check"
+              ]
+            },
+            "Report": {
+              "methods": [
+                "report"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-service_control-v1/google-cloud-service_control-v1.gemspec
+++ b/google-cloud-service_control-v1/google-cloud-service_control-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-service_directory-v1/gapic_metadata.json
+++ b/google-cloud-service_directory-v1/gapic_metadata.json
@@ -9,10 +9,12 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::ServiceDirectory::V1::LookupService::Client",
-          "methods": {
-            "ResolveService": [
-              "resolve_service"
-            ]
+          "rpcs": {
+            "ResolveService": {
+              "methods": [
+                "resolve_service"
+              ]
+            }
           }
         }
       }
@@ -21,61 +23,97 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::ServiceDirectory::V1::RegistrationService::Client",
-          "methods": {
-            "CreateNamespace": [
-              "create_namespace"
-            ],
-            "ListNamespaces": [
-              "list_namespaces"
-            ],
-            "GetNamespace": [
-              "get_namespace"
-            ],
-            "UpdateNamespace": [
-              "update_namespace"
-            ],
-            "DeleteNamespace": [
-              "delete_namespace"
-            ],
-            "CreateService": [
-              "create_service"
-            ],
-            "ListServices": [
-              "list_services"
-            ],
-            "GetService": [
-              "get_service"
-            ],
-            "UpdateService": [
-              "update_service"
-            ],
-            "DeleteService": [
-              "delete_service"
-            ],
-            "CreateEndpoint": [
-              "create_endpoint"
-            ],
-            "ListEndpoints": [
-              "list_endpoints"
-            ],
-            "GetEndpoint": [
-              "get_endpoint"
-            ],
-            "UpdateEndpoint": [
-              "update_endpoint"
-            ],
-            "DeleteEndpoint": [
-              "delete_endpoint"
-            ],
-            "GetIamPolicy": [
-              "get_iam_policy"
-            ],
-            "SetIamPolicy": [
-              "set_iam_policy"
-            ],
-            "TestIamPermissions": [
-              "test_iam_permissions"
-            ]
+          "rpcs": {
+            "CreateNamespace": {
+              "methods": [
+                "create_namespace"
+              ]
+            },
+            "ListNamespaces": {
+              "methods": [
+                "list_namespaces"
+              ]
+            },
+            "GetNamespace": {
+              "methods": [
+                "get_namespace"
+              ]
+            },
+            "UpdateNamespace": {
+              "methods": [
+                "update_namespace"
+              ]
+            },
+            "DeleteNamespace": {
+              "methods": [
+                "delete_namespace"
+              ]
+            },
+            "CreateService": {
+              "methods": [
+                "create_service"
+              ]
+            },
+            "ListServices": {
+              "methods": [
+                "list_services"
+              ]
+            },
+            "GetService": {
+              "methods": [
+                "get_service"
+              ]
+            },
+            "UpdateService": {
+              "methods": [
+                "update_service"
+              ]
+            },
+            "DeleteService": {
+              "methods": [
+                "delete_service"
+              ]
+            },
+            "CreateEndpoint": {
+              "methods": [
+                "create_endpoint"
+              ]
+            },
+            "ListEndpoints": {
+              "methods": [
+                "list_endpoints"
+              ]
+            },
+            "GetEndpoint": {
+              "methods": [
+                "get_endpoint"
+              ]
+            },
+            "UpdateEndpoint": {
+              "methods": [
+                "update_endpoint"
+              ]
+            },
+            "DeleteEndpoint": {
+              "methods": [
+                "delete_endpoint"
+              ]
+            },
+            "GetIamPolicy": {
+              "methods": [
+                "get_iam_policy"
+              ]
+            },
+            "SetIamPolicy": {
+              "methods": [
+                "set_iam_policy"
+              ]
+            },
+            "TestIamPermissions": {
+              "methods": [
+                "test_iam_permissions"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-service_directory-v1/google-cloud-service_directory-v1.gemspec
+++ b/google-cloud-service_directory-v1/google-cloud-service_directory-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
   gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.0"
 

--- a/google-cloud-service_directory-v1beta1/gapic_metadata.json
+++ b/google-cloud-service_directory-v1beta1/gapic_metadata.json
@@ -9,10 +9,12 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::ServiceDirectory::V1beta1::LookupService::Client",
-          "methods": {
-            "ResolveService": [
-              "resolve_service"
-            ]
+          "rpcs": {
+            "ResolveService": {
+              "methods": [
+                "resolve_service"
+              ]
+            }
           }
         }
       }
@@ -21,61 +23,97 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::ServiceDirectory::V1beta1::RegistrationService::Client",
-          "methods": {
-            "CreateNamespace": [
-              "create_namespace"
-            ],
-            "ListNamespaces": [
-              "list_namespaces"
-            ],
-            "GetNamespace": [
-              "get_namespace"
-            ],
-            "UpdateNamespace": [
-              "update_namespace"
-            ],
-            "DeleteNamespace": [
-              "delete_namespace"
-            ],
-            "CreateService": [
-              "create_service"
-            ],
-            "ListServices": [
-              "list_services"
-            ],
-            "GetService": [
-              "get_service"
-            ],
-            "UpdateService": [
-              "update_service"
-            ],
-            "DeleteService": [
-              "delete_service"
-            ],
-            "CreateEndpoint": [
-              "create_endpoint"
-            ],
-            "ListEndpoints": [
-              "list_endpoints"
-            ],
-            "GetEndpoint": [
-              "get_endpoint"
-            ],
-            "UpdateEndpoint": [
-              "update_endpoint"
-            ],
-            "DeleteEndpoint": [
-              "delete_endpoint"
-            ],
-            "GetIamPolicy": [
-              "get_iam_policy"
-            ],
-            "SetIamPolicy": [
-              "set_iam_policy"
-            ],
-            "TestIamPermissions": [
-              "test_iam_permissions"
-            ]
+          "rpcs": {
+            "CreateNamespace": {
+              "methods": [
+                "create_namespace"
+              ]
+            },
+            "ListNamespaces": {
+              "methods": [
+                "list_namespaces"
+              ]
+            },
+            "GetNamespace": {
+              "methods": [
+                "get_namespace"
+              ]
+            },
+            "UpdateNamespace": {
+              "methods": [
+                "update_namespace"
+              ]
+            },
+            "DeleteNamespace": {
+              "methods": [
+                "delete_namespace"
+              ]
+            },
+            "CreateService": {
+              "methods": [
+                "create_service"
+              ]
+            },
+            "ListServices": {
+              "methods": [
+                "list_services"
+              ]
+            },
+            "GetService": {
+              "methods": [
+                "get_service"
+              ]
+            },
+            "UpdateService": {
+              "methods": [
+                "update_service"
+              ]
+            },
+            "DeleteService": {
+              "methods": [
+                "delete_service"
+              ]
+            },
+            "CreateEndpoint": {
+              "methods": [
+                "create_endpoint"
+              ]
+            },
+            "ListEndpoints": {
+              "methods": [
+                "list_endpoints"
+              ]
+            },
+            "GetEndpoint": {
+              "methods": [
+                "get_endpoint"
+              ]
+            },
+            "UpdateEndpoint": {
+              "methods": [
+                "update_endpoint"
+              ]
+            },
+            "DeleteEndpoint": {
+              "methods": [
+                "delete_endpoint"
+              ]
+            },
+            "GetIamPolicy": {
+              "methods": [
+                "get_iam_policy"
+              ]
+            },
+            "SetIamPolicy": {
+              "methods": [
+                "set_iam_policy"
+              ]
+            },
+            "TestIamPermissions": {
+              "methods": [
+                "test_iam_permissions"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-service_directory-v1beta1/google-cloud-service_directory-v1beta1.gemspec
+++ b/google-cloud-service_directory-v1beta1/google-cloud-service_directory-v1beta1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
   gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.0"
 

--- a/google-cloud-service_management-v1/gapic_metadata.json
+++ b/google-cloud-service_management-v1/gapic_metadata.json
@@ -9,52 +9,82 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::ServiceManagement::V1::ServiceManager::Client",
-          "methods": {
-            "ListServices": [
-              "list_services"
-            ],
-            "GetService": [
-              "get_service"
-            ],
-            "CreateService": [
-              "create_service"
-            ],
-            "DeleteService": [
-              "delete_service"
-            ],
-            "UndeleteService": [
-              "undelete_service"
-            ],
-            "ListServiceConfigs": [
-              "list_service_configs"
-            ],
-            "GetServiceConfig": [
-              "get_service_config"
-            ],
-            "CreateServiceConfig": [
-              "create_service_config"
-            ],
-            "SubmitConfigSource": [
-              "submit_config_source"
-            ],
-            "ListServiceRollouts": [
-              "list_service_rollouts"
-            ],
-            "GetServiceRollout": [
-              "get_service_rollout"
-            ],
-            "CreateServiceRollout": [
-              "create_service_rollout"
-            ],
-            "GenerateConfigReport": [
-              "generate_config_report"
-            ],
-            "EnableService": [
-              "enable_service"
-            ],
-            "DisableService": [
-              "disable_service"
-            ]
+          "rpcs": {
+            "ListServices": {
+              "methods": [
+                "list_services"
+              ]
+            },
+            "GetService": {
+              "methods": [
+                "get_service"
+              ]
+            },
+            "CreateService": {
+              "methods": [
+                "create_service"
+              ]
+            },
+            "DeleteService": {
+              "methods": [
+                "delete_service"
+              ]
+            },
+            "UndeleteService": {
+              "methods": [
+                "undelete_service"
+              ]
+            },
+            "ListServiceConfigs": {
+              "methods": [
+                "list_service_configs"
+              ]
+            },
+            "GetServiceConfig": {
+              "methods": [
+                "get_service_config"
+              ]
+            },
+            "CreateServiceConfig": {
+              "methods": [
+                "create_service_config"
+              ]
+            },
+            "SubmitConfigSource": {
+              "methods": [
+                "submit_config_source"
+              ]
+            },
+            "ListServiceRollouts": {
+              "methods": [
+                "list_service_rollouts"
+              ]
+            },
+            "GetServiceRollout": {
+              "methods": [
+                "get_service_rollout"
+              ]
+            },
+            "CreateServiceRollout": {
+              "methods": [
+                "create_service_rollout"
+              ]
+            },
+            "GenerateConfigReport": {
+              "methods": [
+                "generate_config_report"
+              ]
+            },
+            "EnableService": {
+              "methods": [
+                "enable_service"
+              ]
+            },
+            "DisableService": {
+              "methods": [
+                "disable_service"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-service_management-v1/google-cloud-service_management-v1.gemspec
+++ b/google-cloud-service_management-v1/google-cloud-service_management-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-spanner-admin-database-v1/gapic_metadata.json
+++ b/google-cloud-spanner-admin-database-v1/gapic_metadata.json
@@ -9,58 +9,92 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdmin::Client",
-          "methods": {
-            "ListDatabases": [
-              "list_databases"
-            ],
-            "CreateDatabase": [
-              "create_database"
-            ],
-            "GetDatabase": [
-              "get_database"
-            ],
-            "UpdateDatabaseDdl": [
-              "update_database_ddl"
-            ],
-            "DropDatabase": [
-              "drop_database"
-            ],
-            "GetDatabaseDdl": [
-              "get_database_ddl"
-            ],
-            "SetIamPolicy": [
-              "set_iam_policy"
-            ],
-            "GetIamPolicy": [
-              "get_iam_policy"
-            ],
-            "TestIamPermissions": [
-              "test_iam_permissions"
-            ],
-            "CreateBackup": [
-              "create_backup"
-            ],
-            "GetBackup": [
-              "get_backup"
-            ],
-            "UpdateBackup": [
-              "update_backup"
-            ],
-            "DeleteBackup": [
-              "delete_backup"
-            ],
-            "ListBackups": [
-              "list_backups"
-            ],
-            "RestoreDatabase": [
-              "restore_database"
-            ],
-            "ListDatabaseOperations": [
-              "list_database_operations"
-            ],
-            "ListBackupOperations": [
-              "list_backup_operations"
-            ]
+          "rpcs": {
+            "ListDatabases": {
+              "methods": [
+                "list_databases"
+              ]
+            },
+            "CreateDatabase": {
+              "methods": [
+                "create_database"
+              ]
+            },
+            "GetDatabase": {
+              "methods": [
+                "get_database"
+              ]
+            },
+            "UpdateDatabaseDdl": {
+              "methods": [
+                "update_database_ddl"
+              ]
+            },
+            "DropDatabase": {
+              "methods": [
+                "drop_database"
+              ]
+            },
+            "GetDatabaseDdl": {
+              "methods": [
+                "get_database_ddl"
+              ]
+            },
+            "SetIamPolicy": {
+              "methods": [
+                "set_iam_policy"
+              ]
+            },
+            "GetIamPolicy": {
+              "methods": [
+                "get_iam_policy"
+              ]
+            },
+            "TestIamPermissions": {
+              "methods": [
+                "test_iam_permissions"
+              ]
+            },
+            "CreateBackup": {
+              "methods": [
+                "create_backup"
+              ]
+            },
+            "GetBackup": {
+              "methods": [
+                "get_backup"
+              ]
+            },
+            "UpdateBackup": {
+              "methods": [
+                "update_backup"
+              ]
+            },
+            "DeleteBackup": {
+              "methods": [
+                "delete_backup"
+              ]
+            },
+            "ListBackups": {
+              "methods": [
+                "list_backups"
+              ]
+            },
+            "RestoreDatabase": {
+              "methods": [
+                "restore_database"
+              ]
+            },
+            "ListDatabaseOperations": {
+              "methods": [
+                "list_database_operations"
+              ]
+            },
+            "ListBackupOperations": {
+              "methods": [
+                "list_backup_operations"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-spanner-admin-database-v1/google-cloud-spanner-admin-database-v1.gemspec
+++ b/google-cloud-spanner-admin-database-v1/google-cloud-spanner-admin-database-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
   gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.0"
 

--- a/google-cloud-spanner-admin-instance-v1/gapic_metadata.json
+++ b/google-cloud-spanner-admin-instance-v1/gapic_metadata.json
@@ -9,37 +9,57 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdmin::Client",
-          "methods": {
-            "ListInstanceConfigs": [
-              "list_instance_configs"
-            ],
-            "GetInstanceConfig": [
-              "get_instance_config"
-            ],
-            "ListInstances": [
-              "list_instances"
-            ],
-            "GetInstance": [
-              "get_instance"
-            ],
-            "CreateInstance": [
-              "create_instance"
-            ],
-            "UpdateInstance": [
-              "update_instance"
-            ],
-            "DeleteInstance": [
-              "delete_instance"
-            ],
-            "SetIamPolicy": [
-              "set_iam_policy"
-            ],
-            "GetIamPolicy": [
-              "get_iam_policy"
-            ],
-            "TestIamPermissions": [
-              "test_iam_permissions"
-            ]
+          "rpcs": {
+            "ListInstanceConfigs": {
+              "methods": [
+                "list_instance_configs"
+              ]
+            },
+            "GetInstanceConfig": {
+              "methods": [
+                "get_instance_config"
+              ]
+            },
+            "ListInstances": {
+              "methods": [
+                "list_instances"
+              ]
+            },
+            "GetInstance": {
+              "methods": [
+                "get_instance"
+              ]
+            },
+            "CreateInstance": {
+              "methods": [
+                "create_instance"
+              ]
+            },
+            "UpdateInstance": {
+              "methods": [
+                "update_instance"
+              ]
+            },
+            "DeleteInstance": {
+              "methods": [
+                "delete_instance"
+              ]
+            },
+            "SetIamPolicy": {
+              "methods": [
+                "set_iam_policy"
+              ]
+            },
+            "GetIamPolicy": {
+              "methods": [
+                "get_iam_policy"
+              ]
+            },
+            "TestIamPermissions": {
+              "methods": [
+                "test_iam_permissions"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-spanner-admin-instance-v1/google-cloud-spanner-admin-instance-v1.gemspec
+++ b/google-cloud-spanner-admin-instance-v1/google-cloud-spanner-admin-instance-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
   gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.0"
 

--- a/google-cloud-spanner-v1/gapic_metadata.json
+++ b/google-cloud-spanner-v1/gapic_metadata.json
@@ -9,52 +9,82 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Spanner::V1::Spanner::Client",
-          "methods": {
-            "CreateSession": [
-              "create_session"
-            ],
-            "BatchCreateSessions": [
-              "batch_create_sessions"
-            ],
-            "GetSession": [
-              "get_session"
-            ],
-            "ListSessions": [
-              "list_sessions"
-            ],
-            "DeleteSession": [
-              "delete_session"
-            ],
-            "ExecuteSql": [
-              "execute_sql"
-            ],
-            "ExecuteStreamingSql": [
-              "execute_streaming_sql"
-            ],
-            "ExecuteBatchDml": [
-              "execute_batch_dml"
-            ],
-            "Read": [
-              "read"
-            ],
-            "StreamingRead": [
-              "streaming_read"
-            ],
-            "BeginTransaction": [
-              "begin_transaction"
-            ],
-            "Commit": [
-              "commit"
-            ],
-            "Rollback": [
-              "rollback"
-            ],
-            "PartitionQuery": [
-              "partition_query"
-            ],
-            "PartitionRead": [
-              "partition_read"
-            ]
+          "rpcs": {
+            "CreateSession": {
+              "methods": [
+                "create_session"
+              ]
+            },
+            "BatchCreateSessions": {
+              "methods": [
+                "batch_create_sessions"
+              ]
+            },
+            "GetSession": {
+              "methods": [
+                "get_session"
+              ]
+            },
+            "ListSessions": {
+              "methods": [
+                "list_sessions"
+              ]
+            },
+            "DeleteSession": {
+              "methods": [
+                "delete_session"
+              ]
+            },
+            "ExecuteSql": {
+              "methods": [
+                "execute_sql"
+              ]
+            },
+            "ExecuteStreamingSql": {
+              "methods": [
+                "execute_streaming_sql"
+              ]
+            },
+            "ExecuteBatchDml": {
+              "methods": [
+                "execute_batch_dml"
+              ]
+            },
+            "Read": {
+              "methods": [
+                "read"
+              ]
+            },
+            "StreamingRead": {
+              "methods": [
+                "streaming_read"
+              ]
+            },
+            "BeginTransaction": {
+              "methods": [
+                "begin_transaction"
+              ]
+            },
+            "Commit": {
+              "methods": [
+                "commit"
+              ]
+            },
+            "Rollback": {
+              "methods": [
+                "rollback"
+              ]
+            },
+            "PartitionQuery": {
+              "methods": [
+                "partition_query"
+              ]
+            },
+            "PartitionRead": {
+              "methods": [
+                "partition_read"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-spanner-v1/google-cloud-spanner-v1.gemspec
+++ b/google-cloud-spanner-v1/google-cloud-spanner-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-speech-v1/gapic_metadata.json
+++ b/google-cloud-speech-v1/gapic_metadata.json
@@ -9,16 +9,22 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Speech::V1::Speech::Client",
-          "methods": {
-            "Recognize": [
-              "recognize"
-            ],
-            "LongRunningRecognize": [
-              "long_running_recognize"
-            ],
-            "StreamingRecognize": [
-              "streaming_recognize"
-            ]
+          "rpcs": {
+            "Recognize": {
+              "methods": [
+                "recognize"
+              ]
+            },
+            "LongRunningRecognize": {
+              "methods": [
+                "long_running_recognize"
+              ]
+            },
+            "StreamingRecognize": {
+              "methods": [
+                "streaming_recognize"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-speech-v1/google-cloud-speech-v1.gemspec
+++ b/google-cloud-speech-v1/google-cloud-speech-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-speech-v1p1beta1/gapic_metadata.json
+++ b/google-cloud-speech-v1p1beta1/gapic_metadata.json
@@ -9,16 +9,22 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Speech::V1p1beta1::Speech::Client",
-          "methods": {
-            "Recognize": [
-              "recognize"
-            ],
-            "LongRunningRecognize": [
-              "long_running_recognize"
-            ],
-            "StreamingRecognize": [
-              "streaming_recognize"
-            ]
+          "rpcs": {
+            "Recognize": {
+              "methods": [
+                "recognize"
+              ]
+            },
+            "LongRunningRecognize": {
+              "methods": [
+                "long_running_recognize"
+              ]
+            },
+            "StreamingRecognize": {
+              "methods": [
+                "streaming_recognize"
+              ]
+            }
           }
         }
       }
@@ -27,37 +33,57 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Speech::V1p1beta1::Adaptation::Client",
-          "methods": {
-            "CreatePhraseSet": [
-              "create_phrase_set"
-            ],
-            "GetPhraseSet": [
-              "get_phrase_set"
-            ],
-            "ListPhraseSet": [
-              "list_phrase_set"
-            ],
-            "UpdatePhraseSet": [
-              "update_phrase_set"
-            ],
-            "DeletePhraseSet": [
-              "delete_phrase_set"
-            ],
-            "CreateCustomClass": [
-              "create_custom_class"
-            ],
-            "GetCustomClass": [
-              "get_custom_class"
-            ],
-            "ListCustomClasses": [
-              "list_custom_classes"
-            ],
-            "UpdateCustomClass": [
-              "update_custom_class"
-            ],
-            "DeleteCustomClass": [
-              "delete_custom_class"
-            ]
+          "rpcs": {
+            "CreatePhraseSet": {
+              "methods": [
+                "create_phrase_set"
+              ]
+            },
+            "GetPhraseSet": {
+              "methods": [
+                "get_phrase_set"
+              ]
+            },
+            "ListPhraseSet": {
+              "methods": [
+                "list_phrase_set"
+              ]
+            },
+            "UpdatePhraseSet": {
+              "methods": [
+                "update_phrase_set"
+              ]
+            },
+            "DeletePhraseSet": {
+              "methods": [
+                "delete_phrase_set"
+              ]
+            },
+            "CreateCustomClass": {
+              "methods": [
+                "create_custom_class"
+              ]
+            },
+            "GetCustomClass": {
+              "methods": [
+                "get_custom_class"
+              ]
+            },
+            "ListCustomClasses": {
+              "methods": [
+                "list_custom_classes"
+              ]
+            },
+            "UpdateCustomClass": {
+              "methods": [
+                "update_custom_class"
+              ]
+            },
+            "DeleteCustomClass": {
+              "methods": [
+                "delete_custom_class"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-speech-v1p1beta1/google-cloud-speech-v1p1beta1.gemspec
+++ b/google-cloud-speech-v1p1beta1/google-cloud-speech-v1p1beta1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-talent-v4/gapic_metadata.json
+++ b/google-cloud-talent-v4/gapic_metadata.json
@@ -9,22 +9,32 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Talent::V4::CompanyService::Client",
-          "methods": {
-            "CreateCompany": [
-              "create_company"
-            ],
-            "GetCompany": [
-              "get_company"
-            ],
-            "UpdateCompany": [
-              "update_company"
-            ],
-            "DeleteCompany": [
-              "delete_company"
-            ],
-            "ListCompanies": [
-              "list_companies"
-            ]
+          "rpcs": {
+            "CreateCompany": {
+              "methods": [
+                "create_company"
+              ]
+            },
+            "GetCompany": {
+              "methods": [
+                "get_company"
+              ]
+            },
+            "UpdateCompany": {
+              "methods": [
+                "update_company"
+              ]
+            },
+            "DeleteCompany": {
+              "methods": [
+                "delete_company"
+              ]
+            },
+            "ListCompanies": {
+              "methods": [
+                "list_companies"
+              ]
+            }
           }
         }
       }
@@ -33,10 +43,12 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Talent::V4::Completion::Client",
-          "methods": {
-            "CompleteQuery": [
-              "complete_query"
-            ]
+          "rpcs": {
+            "CompleteQuery": {
+              "methods": [
+                "complete_query"
+              ]
+            }
           }
         }
       }
@@ -45,10 +57,12 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Talent::V4::EventService::Client",
-          "methods": {
-            "CreateClientEvent": [
-              "create_client_event"
-            ]
+          "rpcs": {
+            "CreateClientEvent": {
+              "methods": [
+                "create_client_event"
+              ]
+            }
           }
         }
       }
@@ -57,37 +71,57 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Talent::V4::JobService::Client",
-          "methods": {
-            "CreateJob": [
-              "create_job"
-            ],
-            "BatchCreateJobs": [
-              "batch_create_jobs"
-            ],
-            "GetJob": [
-              "get_job"
-            ],
-            "UpdateJob": [
-              "update_job"
-            ],
-            "BatchUpdateJobs": [
-              "batch_update_jobs"
-            ],
-            "DeleteJob": [
-              "delete_job"
-            ],
-            "BatchDeleteJobs": [
-              "batch_delete_jobs"
-            ],
-            "ListJobs": [
-              "list_jobs"
-            ],
-            "SearchJobs": [
-              "search_jobs"
-            ],
-            "SearchJobsForAlert": [
-              "search_jobs_for_alert"
-            ]
+          "rpcs": {
+            "CreateJob": {
+              "methods": [
+                "create_job"
+              ]
+            },
+            "BatchCreateJobs": {
+              "methods": [
+                "batch_create_jobs"
+              ]
+            },
+            "GetJob": {
+              "methods": [
+                "get_job"
+              ]
+            },
+            "UpdateJob": {
+              "methods": [
+                "update_job"
+              ]
+            },
+            "BatchUpdateJobs": {
+              "methods": [
+                "batch_update_jobs"
+              ]
+            },
+            "DeleteJob": {
+              "methods": [
+                "delete_job"
+              ]
+            },
+            "BatchDeleteJobs": {
+              "methods": [
+                "batch_delete_jobs"
+              ]
+            },
+            "ListJobs": {
+              "methods": [
+                "list_jobs"
+              ]
+            },
+            "SearchJobs": {
+              "methods": [
+                "search_jobs"
+              ]
+            },
+            "SearchJobsForAlert": {
+              "methods": [
+                "search_jobs_for_alert"
+              ]
+            }
           }
         }
       }
@@ -96,22 +130,32 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Talent::V4::TenantService::Client",
-          "methods": {
-            "CreateTenant": [
-              "create_tenant"
-            ],
-            "GetTenant": [
-              "get_tenant"
-            ],
-            "UpdateTenant": [
-              "update_tenant"
-            ],
-            "DeleteTenant": [
-              "delete_tenant"
-            ],
-            "ListTenants": [
-              "list_tenants"
-            ]
+          "rpcs": {
+            "CreateTenant": {
+              "methods": [
+                "create_tenant"
+              ]
+            },
+            "GetTenant": {
+              "methods": [
+                "get_tenant"
+              ]
+            },
+            "UpdateTenant": {
+              "methods": [
+                "update_tenant"
+              ]
+            },
+            "DeleteTenant": {
+              "methods": [
+                "delete_tenant"
+              ]
+            },
+            "ListTenants": {
+              "methods": [
+                "list_tenants"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-talent-v4/google-cloud-talent-v4.gemspec
+++ b/google-cloud-talent-v4/google-cloud-talent-v4.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-talent-v4beta1/gapic_metadata.json
+++ b/google-cloud-talent-v4beta1/gapic_metadata.json
@@ -9,22 +9,32 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Talent::V4beta1::ApplicationService::Client",
-          "methods": {
-            "CreateApplication": [
-              "create_application"
-            ],
-            "GetApplication": [
-              "get_application"
-            ],
-            "UpdateApplication": [
-              "update_application"
-            ],
-            "DeleteApplication": [
-              "delete_application"
-            ],
-            "ListApplications": [
-              "list_applications"
-            ]
+          "rpcs": {
+            "CreateApplication": {
+              "methods": [
+                "create_application"
+              ]
+            },
+            "GetApplication": {
+              "methods": [
+                "get_application"
+              ]
+            },
+            "UpdateApplication": {
+              "methods": [
+                "update_application"
+              ]
+            },
+            "DeleteApplication": {
+              "methods": [
+                "delete_application"
+              ]
+            },
+            "ListApplications": {
+              "methods": [
+                "list_applications"
+              ]
+            }
           }
         }
       }
@@ -33,22 +43,32 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Talent::V4beta1::CompanyService::Client",
-          "methods": {
-            "CreateCompany": [
-              "create_company"
-            ],
-            "GetCompany": [
-              "get_company"
-            ],
-            "UpdateCompany": [
-              "update_company"
-            ],
-            "DeleteCompany": [
-              "delete_company"
-            ],
-            "ListCompanies": [
-              "list_companies"
-            ]
+          "rpcs": {
+            "CreateCompany": {
+              "methods": [
+                "create_company"
+              ]
+            },
+            "GetCompany": {
+              "methods": [
+                "get_company"
+              ]
+            },
+            "UpdateCompany": {
+              "methods": [
+                "update_company"
+              ]
+            },
+            "DeleteCompany": {
+              "methods": [
+                "delete_company"
+              ]
+            },
+            "ListCompanies": {
+              "methods": [
+                "list_companies"
+              ]
+            }
           }
         }
       }
@@ -57,10 +77,12 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Talent::V4beta1::Completion::Client",
-          "methods": {
-            "CompleteQuery": [
-              "complete_query"
-            ]
+          "rpcs": {
+            "CompleteQuery": {
+              "methods": [
+                "complete_query"
+              ]
+            }
           }
         }
       }
@@ -69,10 +91,12 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Talent::V4beta1::EventService::Client",
-          "methods": {
-            "CreateClientEvent": [
-              "create_client_event"
-            ]
+          "rpcs": {
+            "CreateClientEvent": {
+              "methods": [
+                "create_client_event"
+              ]
+            }
           }
         }
       }
@@ -81,37 +105,57 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Talent::V4beta1::JobService::Client",
-          "methods": {
-            "CreateJob": [
-              "create_job"
-            ],
-            "BatchCreateJobs": [
-              "batch_create_jobs"
-            ],
-            "GetJob": [
-              "get_job"
-            ],
-            "UpdateJob": [
-              "update_job"
-            ],
-            "BatchUpdateJobs": [
-              "batch_update_jobs"
-            ],
-            "DeleteJob": [
-              "delete_job"
-            ],
-            "BatchDeleteJobs": [
-              "batch_delete_jobs"
-            ],
-            "ListJobs": [
-              "list_jobs"
-            ],
-            "SearchJobs": [
-              "search_jobs"
-            ],
-            "SearchJobsForAlert": [
-              "search_jobs_for_alert"
-            ]
+          "rpcs": {
+            "CreateJob": {
+              "methods": [
+                "create_job"
+              ]
+            },
+            "BatchCreateJobs": {
+              "methods": [
+                "batch_create_jobs"
+              ]
+            },
+            "GetJob": {
+              "methods": [
+                "get_job"
+              ]
+            },
+            "UpdateJob": {
+              "methods": [
+                "update_job"
+              ]
+            },
+            "BatchUpdateJobs": {
+              "methods": [
+                "batch_update_jobs"
+              ]
+            },
+            "DeleteJob": {
+              "methods": [
+                "delete_job"
+              ]
+            },
+            "BatchDeleteJobs": {
+              "methods": [
+                "batch_delete_jobs"
+              ]
+            },
+            "ListJobs": {
+              "methods": [
+                "list_jobs"
+              ]
+            },
+            "SearchJobs": {
+              "methods": [
+                "search_jobs"
+              ]
+            },
+            "SearchJobsForAlert": {
+              "methods": [
+                "search_jobs_for_alert"
+              ]
+            }
           }
         }
       }
@@ -120,25 +164,37 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Talent::V4beta1::ProfileService::Client",
-          "methods": {
-            "ListProfiles": [
-              "list_profiles"
-            ],
-            "CreateProfile": [
-              "create_profile"
-            ],
-            "GetProfile": [
-              "get_profile"
-            ],
-            "UpdateProfile": [
-              "update_profile"
-            ],
-            "DeleteProfile": [
-              "delete_profile"
-            ],
-            "SearchProfiles": [
-              "search_profiles"
-            ]
+          "rpcs": {
+            "ListProfiles": {
+              "methods": [
+                "list_profiles"
+              ]
+            },
+            "CreateProfile": {
+              "methods": [
+                "create_profile"
+              ]
+            },
+            "GetProfile": {
+              "methods": [
+                "get_profile"
+              ]
+            },
+            "UpdateProfile": {
+              "methods": [
+                "update_profile"
+              ]
+            },
+            "DeleteProfile": {
+              "methods": [
+                "delete_profile"
+              ]
+            },
+            "SearchProfiles": {
+              "methods": [
+                "search_profiles"
+              ]
+            }
           }
         }
       }
@@ -147,22 +203,32 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Talent::V4beta1::TenantService::Client",
-          "methods": {
-            "CreateTenant": [
-              "create_tenant"
-            ],
-            "GetTenant": [
-              "get_tenant"
-            ],
-            "UpdateTenant": [
-              "update_tenant"
-            ],
-            "DeleteTenant": [
-              "delete_tenant"
-            ],
-            "ListTenants": [
-              "list_tenants"
-            ]
+          "rpcs": {
+            "CreateTenant": {
+              "methods": [
+                "create_tenant"
+              ]
+            },
+            "GetTenant": {
+              "methods": [
+                "get_tenant"
+              ]
+            },
+            "UpdateTenant": {
+              "methods": [
+                "update_tenant"
+              ]
+            },
+            "DeleteTenant": {
+              "methods": [
+                "delete_tenant"
+              ]
+            },
+            "ListTenants": {
+              "methods": [
+                "list_tenants"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-talent-v4beta1/google-cloud-talent-v4beta1.gemspec
+++ b/google-cloud-talent-v4beta1/google-cloud-talent-v4beta1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-tasks-v2/gapic_metadata.json
+++ b/google-cloud-tasks-v2/gapic_metadata.json
@@ -9,55 +9,87 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Tasks::V2::CloudTasks::Client",
-          "methods": {
-            "ListQueues": [
-              "list_queues"
-            ],
-            "GetQueue": [
-              "get_queue"
-            ],
-            "CreateQueue": [
-              "create_queue"
-            ],
-            "UpdateQueue": [
-              "update_queue"
-            ],
-            "DeleteQueue": [
-              "delete_queue"
-            ],
-            "PurgeQueue": [
-              "purge_queue"
-            ],
-            "PauseQueue": [
-              "pause_queue"
-            ],
-            "ResumeQueue": [
-              "resume_queue"
-            ],
-            "GetIamPolicy": [
-              "get_iam_policy"
-            ],
-            "SetIamPolicy": [
-              "set_iam_policy"
-            ],
-            "TestIamPermissions": [
-              "test_iam_permissions"
-            ],
-            "ListTasks": [
-              "list_tasks"
-            ],
-            "GetTask": [
-              "get_task"
-            ],
-            "CreateTask": [
-              "create_task"
-            ],
-            "DeleteTask": [
-              "delete_task"
-            ],
-            "RunTask": [
-              "run_task"
-            ]
+          "rpcs": {
+            "ListQueues": {
+              "methods": [
+                "list_queues"
+              ]
+            },
+            "GetQueue": {
+              "methods": [
+                "get_queue"
+              ]
+            },
+            "CreateQueue": {
+              "methods": [
+                "create_queue"
+              ]
+            },
+            "UpdateQueue": {
+              "methods": [
+                "update_queue"
+              ]
+            },
+            "DeleteQueue": {
+              "methods": [
+                "delete_queue"
+              ]
+            },
+            "PurgeQueue": {
+              "methods": [
+                "purge_queue"
+              ]
+            },
+            "PauseQueue": {
+              "methods": [
+                "pause_queue"
+              ]
+            },
+            "ResumeQueue": {
+              "methods": [
+                "resume_queue"
+              ]
+            },
+            "GetIamPolicy": {
+              "methods": [
+                "get_iam_policy"
+              ]
+            },
+            "SetIamPolicy": {
+              "methods": [
+                "set_iam_policy"
+              ]
+            },
+            "TestIamPermissions": {
+              "methods": [
+                "test_iam_permissions"
+              ]
+            },
+            "ListTasks": {
+              "methods": [
+                "list_tasks"
+              ]
+            },
+            "GetTask": {
+              "methods": [
+                "get_task"
+              ]
+            },
+            "CreateTask": {
+              "methods": [
+                "create_task"
+              ]
+            },
+            "DeleteTask": {
+              "methods": [
+                "delete_task"
+              ]
+            },
+            "RunTask": {
+              "methods": [
+                "run_task"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-tasks-v2/google-cloud-tasks-v2.gemspec
+++ b/google-cloud-tasks-v2/google-cloud-tasks-v2.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
   gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.0"
 

--- a/google-cloud-tasks-v2beta2/gapic_metadata.json
+++ b/google-cloud-tasks-v2beta2/gapic_metadata.json
@@ -9,67 +9,107 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Tasks::V2beta2::CloudTasks::Client",
-          "methods": {
-            "ListQueues": [
-              "list_queues"
-            ],
-            "GetQueue": [
-              "get_queue"
-            ],
-            "CreateQueue": [
-              "create_queue"
-            ],
-            "UpdateQueue": [
-              "update_queue"
-            ],
-            "DeleteQueue": [
-              "delete_queue"
-            ],
-            "PurgeQueue": [
-              "purge_queue"
-            ],
-            "PauseQueue": [
-              "pause_queue"
-            ],
-            "ResumeQueue": [
-              "resume_queue"
-            ],
-            "GetIamPolicy": [
-              "get_iam_policy"
-            ],
-            "SetIamPolicy": [
-              "set_iam_policy"
-            ],
-            "TestIamPermissions": [
-              "test_iam_permissions"
-            ],
-            "ListTasks": [
-              "list_tasks"
-            ],
-            "GetTask": [
-              "get_task"
-            ],
-            "CreateTask": [
-              "create_task"
-            ],
-            "DeleteTask": [
-              "delete_task"
-            ],
-            "LeaseTasks": [
-              "lease_tasks"
-            ],
-            "AcknowledgeTask": [
-              "acknowledge_task"
-            ],
-            "RenewLease": [
-              "renew_lease"
-            ],
-            "CancelLease": [
-              "cancel_lease"
-            ],
-            "RunTask": [
-              "run_task"
-            ]
+          "rpcs": {
+            "ListQueues": {
+              "methods": [
+                "list_queues"
+              ]
+            },
+            "GetQueue": {
+              "methods": [
+                "get_queue"
+              ]
+            },
+            "CreateQueue": {
+              "methods": [
+                "create_queue"
+              ]
+            },
+            "UpdateQueue": {
+              "methods": [
+                "update_queue"
+              ]
+            },
+            "DeleteQueue": {
+              "methods": [
+                "delete_queue"
+              ]
+            },
+            "PurgeQueue": {
+              "methods": [
+                "purge_queue"
+              ]
+            },
+            "PauseQueue": {
+              "methods": [
+                "pause_queue"
+              ]
+            },
+            "ResumeQueue": {
+              "methods": [
+                "resume_queue"
+              ]
+            },
+            "GetIamPolicy": {
+              "methods": [
+                "get_iam_policy"
+              ]
+            },
+            "SetIamPolicy": {
+              "methods": [
+                "set_iam_policy"
+              ]
+            },
+            "TestIamPermissions": {
+              "methods": [
+                "test_iam_permissions"
+              ]
+            },
+            "ListTasks": {
+              "methods": [
+                "list_tasks"
+              ]
+            },
+            "GetTask": {
+              "methods": [
+                "get_task"
+              ]
+            },
+            "CreateTask": {
+              "methods": [
+                "create_task"
+              ]
+            },
+            "DeleteTask": {
+              "methods": [
+                "delete_task"
+              ]
+            },
+            "LeaseTasks": {
+              "methods": [
+                "lease_tasks"
+              ]
+            },
+            "AcknowledgeTask": {
+              "methods": [
+                "acknowledge_task"
+              ]
+            },
+            "RenewLease": {
+              "methods": [
+                "renew_lease"
+              ]
+            },
+            "CancelLease": {
+              "methods": [
+                "cancel_lease"
+              ]
+            },
+            "RunTask": {
+              "methods": [
+                "run_task"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-tasks-v2beta2/google-cloud-tasks-v2beta2.gemspec
+++ b/google-cloud-tasks-v2beta2/google-cloud-tasks-v2beta2.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
   gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.0"
 

--- a/google-cloud-tasks-v2beta3/gapic_metadata.json
+++ b/google-cloud-tasks-v2beta3/gapic_metadata.json
@@ -9,55 +9,87 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Tasks::V2beta3::CloudTasks::Client",
-          "methods": {
-            "ListQueues": [
-              "list_queues"
-            ],
-            "GetQueue": [
-              "get_queue"
-            ],
-            "CreateQueue": [
-              "create_queue"
-            ],
-            "UpdateQueue": [
-              "update_queue"
-            ],
-            "DeleteQueue": [
-              "delete_queue"
-            ],
-            "PurgeQueue": [
-              "purge_queue"
-            ],
-            "PauseQueue": [
-              "pause_queue"
-            ],
-            "ResumeQueue": [
-              "resume_queue"
-            ],
-            "GetIamPolicy": [
-              "get_iam_policy"
-            ],
-            "SetIamPolicy": [
-              "set_iam_policy"
-            ],
-            "TestIamPermissions": [
-              "test_iam_permissions"
-            ],
-            "ListTasks": [
-              "list_tasks"
-            ],
-            "GetTask": [
-              "get_task"
-            ],
-            "CreateTask": [
-              "create_task"
-            ],
-            "DeleteTask": [
-              "delete_task"
-            ],
-            "RunTask": [
-              "run_task"
-            ]
+          "rpcs": {
+            "ListQueues": {
+              "methods": [
+                "list_queues"
+              ]
+            },
+            "GetQueue": {
+              "methods": [
+                "get_queue"
+              ]
+            },
+            "CreateQueue": {
+              "methods": [
+                "create_queue"
+              ]
+            },
+            "UpdateQueue": {
+              "methods": [
+                "update_queue"
+              ]
+            },
+            "DeleteQueue": {
+              "methods": [
+                "delete_queue"
+              ]
+            },
+            "PurgeQueue": {
+              "methods": [
+                "purge_queue"
+              ]
+            },
+            "PauseQueue": {
+              "methods": [
+                "pause_queue"
+              ]
+            },
+            "ResumeQueue": {
+              "methods": [
+                "resume_queue"
+              ]
+            },
+            "GetIamPolicy": {
+              "methods": [
+                "get_iam_policy"
+              ]
+            },
+            "SetIamPolicy": {
+              "methods": [
+                "set_iam_policy"
+              ]
+            },
+            "TestIamPermissions": {
+              "methods": [
+                "test_iam_permissions"
+              ]
+            },
+            "ListTasks": {
+              "methods": [
+                "list_tasks"
+              ]
+            },
+            "GetTask": {
+              "methods": [
+                "get_task"
+              ]
+            },
+            "CreateTask": {
+              "methods": [
+                "create_task"
+              ]
+            },
+            "DeleteTask": {
+              "methods": [
+                "delete_task"
+              ]
+            },
+            "RunTask": {
+              "methods": [
+                "run_task"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-tasks-v2beta3/google-cloud-tasks-v2beta3.gemspec
+++ b/google-cloud-tasks-v2beta3/google-cloud-tasks-v2beta3.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
   gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.0"
 

--- a/google-cloud-text_to_speech-v1/gapic_metadata.json
+++ b/google-cloud-text_to_speech-v1/gapic_metadata.json
@@ -9,13 +9,17 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::TextToSpeech::V1::TextToSpeech::Client",
-          "methods": {
-            "ListVoices": [
-              "list_voices"
-            ],
-            "SynthesizeSpeech": [
-              "synthesize_speech"
-            ]
+          "rpcs": {
+            "ListVoices": {
+              "methods": [
+                "list_voices"
+              ]
+            },
+            "SynthesizeSpeech": {
+              "methods": [
+                "synthesize_speech"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-text_to_speech-v1/google-cloud-text_to_speech-v1.gemspec
+++ b/google-cloud-text_to_speech-v1/google-cloud-text_to_speech-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-text_to_speech-v1beta1/gapic_metadata.json
+++ b/google-cloud-text_to_speech-v1beta1/gapic_metadata.json
@@ -9,13 +9,17 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::TextToSpeech::V1beta1::TextToSpeech::Client",
-          "methods": {
-            "ListVoices": [
-              "list_voices"
-            ],
-            "SynthesizeSpeech": [
-              "synthesize_speech"
-            ]
+          "rpcs": {
+            "ListVoices": {
+              "methods": [
+                "list_voices"
+              ]
+            },
+            "SynthesizeSpeech": {
+              "methods": [
+                "synthesize_speech"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-text_to_speech-v1beta1/google-cloud-text_to_speech-v1beta1.gemspec
+++ b/google-cloud-text_to_speech-v1beta1/google-cloud-text_to_speech-v1beta1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-trace-v1/gapic_metadata.json
+++ b/google-cloud-trace-v1/gapic_metadata.json
@@ -9,16 +9,22 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Trace::V1::TraceService::Client",
-          "methods": {
-            "ListTraces": [
-              "list_traces"
-            ],
-            "GetTrace": [
-              "get_trace"
-            ],
-            "PatchTraces": [
-              "patch_traces"
-            ]
+          "rpcs": {
+            "ListTraces": {
+              "methods": [
+                "list_traces"
+              ]
+            },
+            "GetTrace": {
+              "methods": [
+                "get_trace"
+              ]
+            },
+            "PatchTraces": {
+              "methods": [
+                "patch_traces"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-trace-v1/google-cloud-trace-v1.gemspec
+++ b/google-cloud-trace-v1/google-cloud-trace-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-trace-v2/gapic_metadata.json
+++ b/google-cloud-trace-v2/gapic_metadata.json
@@ -9,13 +9,17 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Trace::V2::TraceService::Client",
-          "methods": {
-            "BatchWriteSpans": [
-              "batch_write_spans"
-            ],
-            "CreateSpan": [
-              "create_span"
-            ]
+          "rpcs": {
+            "BatchWriteSpans": {
+              "methods": [
+                "batch_write_spans"
+              ]
+            },
+            "CreateSpan": {
+              "methods": [
+                "create_span"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-trace-v2/google-cloud-trace-v2.gemspec
+++ b/google-cloud-trace-v2/google-cloud-trace-v2.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-translate-v3/gapic_metadata.json
+++ b/google-cloud-translate-v3/gapic_metadata.json
@@ -9,31 +9,47 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Translate::V3::TranslationService::Client",
-          "methods": {
-            "TranslateText": [
-              "translate_text"
-            ],
-            "DetectLanguage": [
-              "detect_language"
-            ],
-            "GetSupportedLanguages": [
-              "get_supported_languages"
-            ],
-            "BatchTranslateText": [
-              "batch_translate_text"
-            ],
-            "CreateGlossary": [
-              "create_glossary"
-            ],
-            "ListGlossaries": [
-              "list_glossaries"
-            ],
-            "GetGlossary": [
-              "get_glossary"
-            ],
-            "DeleteGlossary": [
-              "delete_glossary"
-            ]
+          "rpcs": {
+            "TranslateText": {
+              "methods": [
+                "translate_text"
+              ]
+            },
+            "DetectLanguage": {
+              "methods": [
+                "detect_language"
+              ]
+            },
+            "GetSupportedLanguages": {
+              "methods": [
+                "get_supported_languages"
+              ]
+            },
+            "BatchTranslateText": {
+              "methods": [
+                "batch_translate_text"
+              ]
+            },
+            "CreateGlossary": {
+              "methods": [
+                "create_glossary"
+              ]
+            },
+            "ListGlossaries": {
+              "methods": [
+                "list_glossaries"
+              ]
+            },
+            "GetGlossary": {
+              "methods": [
+                "get_glossary"
+              ]
+            },
+            "DeleteGlossary": {
+              "methods": [
+                "delete_glossary"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-translate-v3/google-cloud-translate-v3.gemspec
+++ b/google-cloud-translate-v3/google-cloud-translate-v3.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-video-transcoder-v1beta1/gapic_metadata.json
+++ b/google-cloud-video-transcoder-v1beta1/gapic_metadata.json
@@ -9,31 +9,47 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Video::Transcoder::V1beta1::TranscoderService::Client",
-          "methods": {
-            "CreateJob": [
-              "create_job"
-            ],
-            "ListJobs": [
-              "list_jobs"
-            ],
-            "GetJob": [
-              "get_job"
-            ],
-            "DeleteJob": [
-              "delete_job"
-            ],
-            "CreateJobTemplate": [
-              "create_job_template"
-            ],
-            "ListJobTemplates": [
-              "list_job_templates"
-            ],
-            "GetJobTemplate": [
-              "get_job_template"
-            ],
-            "DeleteJobTemplate": [
-              "delete_job_template"
-            ]
+          "rpcs": {
+            "CreateJob": {
+              "methods": [
+                "create_job"
+              ]
+            },
+            "ListJobs": {
+              "methods": [
+                "list_jobs"
+              ]
+            },
+            "GetJob": {
+              "methods": [
+                "get_job"
+              ]
+            },
+            "DeleteJob": {
+              "methods": [
+                "delete_job"
+              ]
+            },
+            "CreateJobTemplate": {
+              "methods": [
+                "create_job_template"
+              ]
+            },
+            "ListJobTemplates": {
+              "methods": [
+                "list_job_templates"
+              ]
+            },
+            "GetJobTemplate": {
+              "methods": [
+                "get_job_template"
+              ]
+            },
+            "DeleteJobTemplate": {
+              "methods": [
+                "delete_job_template"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-video-transcoder-v1beta1/google-cloud-video-transcoder-v1beta1.gemspec
+++ b/google-cloud-video-transcoder-v1beta1/google-cloud-video-transcoder-v1beta1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-video_intelligence-v1/gapic_metadata.json
+++ b/google-cloud-video_intelligence-v1/gapic_metadata.json
@@ -9,10 +9,12 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::VideoIntelligence::V1::VideoIntelligenceService::Client",
-          "methods": {
-            "AnnotateVideo": [
-              "annotate_video"
-            ]
+          "rpcs": {
+            "AnnotateVideo": {
+              "methods": [
+                "annotate_video"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-video_intelligence-v1/google-cloud-video_intelligence-v1.gemspec
+++ b/google-cloud-video_intelligence-v1/google-cloud-video_intelligence-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-video_intelligence-v1beta2/gapic_metadata.json
+++ b/google-cloud-video_intelligence-v1beta2/gapic_metadata.json
@@ -9,10 +9,12 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::VideoIntelligence::V1beta2::VideoIntelligenceService::Client",
-          "methods": {
-            "AnnotateVideo": [
-              "annotate_video"
-            ]
+          "rpcs": {
+            "AnnotateVideo": {
+              "methods": [
+                "annotate_video"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-video_intelligence-v1beta2/google-cloud-video_intelligence-v1beta2.gemspec
+++ b/google-cloud-video_intelligence-v1beta2/google-cloud-video_intelligence-v1beta2.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-video_intelligence-v1p1beta1/gapic_metadata.json
+++ b/google-cloud-video_intelligence-v1p1beta1/gapic_metadata.json
@@ -9,10 +9,12 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::VideoIntelligence::V1p1beta1::VideoIntelligenceService::Client",
-          "methods": {
-            "AnnotateVideo": [
-              "annotate_video"
-            ]
+          "rpcs": {
+            "AnnotateVideo": {
+              "methods": [
+                "annotate_video"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-video_intelligence-v1p1beta1/google-cloud-video_intelligence-v1p1beta1.gemspec
+++ b/google-cloud-video_intelligence-v1p1beta1/google-cloud-video_intelligence-v1p1beta1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-video_intelligence-v1p2beta1/gapic_metadata.json
+++ b/google-cloud-video_intelligence-v1p2beta1/gapic_metadata.json
@@ -9,10 +9,12 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::VideoIntelligence::V1p2beta1::VideoIntelligenceService::Client",
-          "methods": {
-            "AnnotateVideo": [
-              "annotate_video"
-            ]
+          "rpcs": {
+            "AnnotateVideo": {
+              "methods": [
+                "annotate_video"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-video_intelligence-v1p2beta1/google-cloud-video_intelligence-v1p2beta1.gemspec
+++ b/google-cloud-video_intelligence-v1p2beta1/google-cloud-video_intelligence-v1p2beta1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-vision-v1/gapic_metadata.json
+++ b/google-cloud-vision-v1/gapic_metadata.json
@@ -9,64 +9,102 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Vision::V1::ProductSearch::Client",
-          "methods": {
-            "CreateProductSet": [
-              "create_product_set"
-            ],
-            "ListProductSets": [
-              "list_product_sets"
-            ],
-            "GetProductSet": [
-              "get_product_set"
-            ],
-            "UpdateProductSet": [
-              "update_product_set"
-            ],
-            "DeleteProductSet": [
-              "delete_product_set"
-            ],
-            "CreateProduct": [
-              "create_product"
-            ],
-            "ListProducts": [
-              "list_products"
-            ],
-            "GetProduct": [
-              "get_product"
-            ],
-            "UpdateProduct": [
-              "update_product"
-            ],
-            "DeleteProduct": [
-              "delete_product"
-            ],
-            "CreateReferenceImage": [
-              "create_reference_image"
-            ],
-            "DeleteReferenceImage": [
-              "delete_reference_image"
-            ],
-            "ListReferenceImages": [
-              "list_reference_images"
-            ],
-            "GetReferenceImage": [
-              "get_reference_image"
-            ],
-            "AddProductToProductSet": [
-              "add_product_to_product_set"
-            ],
-            "RemoveProductFromProductSet": [
-              "remove_product_from_product_set"
-            ],
-            "ListProductsInProductSet": [
-              "list_products_in_product_set"
-            ],
-            "ImportProductSets": [
-              "import_product_sets"
-            ],
-            "PurgeProducts": [
-              "purge_products"
-            ]
+          "rpcs": {
+            "CreateProductSet": {
+              "methods": [
+                "create_product_set"
+              ]
+            },
+            "ListProductSets": {
+              "methods": [
+                "list_product_sets"
+              ]
+            },
+            "GetProductSet": {
+              "methods": [
+                "get_product_set"
+              ]
+            },
+            "UpdateProductSet": {
+              "methods": [
+                "update_product_set"
+              ]
+            },
+            "DeleteProductSet": {
+              "methods": [
+                "delete_product_set"
+              ]
+            },
+            "CreateProduct": {
+              "methods": [
+                "create_product"
+              ]
+            },
+            "ListProducts": {
+              "methods": [
+                "list_products"
+              ]
+            },
+            "GetProduct": {
+              "methods": [
+                "get_product"
+              ]
+            },
+            "UpdateProduct": {
+              "methods": [
+                "update_product"
+              ]
+            },
+            "DeleteProduct": {
+              "methods": [
+                "delete_product"
+              ]
+            },
+            "CreateReferenceImage": {
+              "methods": [
+                "create_reference_image"
+              ]
+            },
+            "DeleteReferenceImage": {
+              "methods": [
+                "delete_reference_image"
+              ]
+            },
+            "ListReferenceImages": {
+              "methods": [
+                "list_reference_images"
+              ]
+            },
+            "GetReferenceImage": {
+              "methods": [
+                "get_reference_image"
+              ]
+            },
+            "AddProductToProductSet": {
+              "methods": [
+                "add_product_to_product_set"
+              ]
+            },
+            "RemoveProductFromProductSet": {
+              "methods": [
+                "remove_product_from_product_set"
+              ]
+            },
+            "ListProductsInProductSet": {
+              "methods": [
+                "list_products_in_product_set"
+              ]
+            },
+            "ImportProductSets": {
+              "methods": [
+                "import_product_sets"
+              ]
+            },
+            "PurgeProducts": {
+              "methods": [
+                "purge_products"
+              ]
+            }
           }
         }
       }
@@ -75,19 +113,27 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Vision::V1::ImageAnnotator::Client",
-          "methods": {
-            "BatchAnnotateImages": [
-              "batch_annotate_images"
-            ],
-            "BatchAnnotateFiles": [
-              "batch_annotate_files"
-            ],
-            "AsyncBatchAnnotateImages": [
-              "async_batch_annotate_images"
-            ],
-            "AsyncBatchAnnotateFiles": [
-              "async_batch_annotate_files"
-            ]
+          "rpcs": {
+            "BatchAnnotateImages": {
+              "methods": [
+                "batch_annotate_images"
+              ]
+            },
+            "BatchAnnotateFiles": {
+              "methods": [
+                "batch_annotate_files"
+              ]
+            },
+            "AsyncBatchAnnotateImages": {
+              "methods": [
+                "async_batch_annotate_images"
+              ]
+            },
+            "AsyncBatchAnnotateFiles": {
+              "methods": [
+                "async_batch_annotate_files"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-vision-v1/google-cloud-vision-v1.gemspec
+++ b/google-cloud-vision-v1/google-cloud-vision-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-vision-v1p3beta1/gapic_metadata.json
+++ b/google-cloud-vision-v1p3beta1/gapic_metadata.json
@@ -9,61 +9,97 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Vision::V1p3beta1::ProductSearch::Client",
-          "methods": {
-            "CreateProductSet": [
-              "create_product_set"
-            ],
-            "ListProductSets": [
-              "list_product_sets"
-            ],
-            "GetProductSet": [
-              "get_product_set"
-            ],
-            "UpdateProductSet": [
-              "update_product_set"
-            ],
-            "DeleteProductSet": [
-              "delete_product_set"
-            ],
-            "CreateProduct": [
-              "create_product"
-            ],
-            "ListProducts": [
-              "list_products"
-            ],
-            "GetProduct": [
-              "get_product"
-            ],
-            "UpdateProduct": [
-              "update_product"
-            ],
-            "DeleteProduct": [
-              "delete_product"
-            ],
-            "CreateReferenceImage": [
-              "create_reference_image"
-            ],
-            "DeleteReferenceImage": [
-              "delete_reference_image"
-            ],
-            "ListReferenceImages": [
-              "list_reference_images"
-            ],
-            "GetReferenceImage": [
-              "get_reference_image"
-            ],
-            "AddProductToProductSet": [
-              "add_product_to_product_set"
-            ],
-            "RemoveProductFromProductSet": [
-              "remove_product_from_product_set"
-            ],
-            "ListProductsInProductSet": [
-              "list_products_in_product_set"
-            ],
-            "ImportProductSets": [
-              "import_product_sets"
-            ]
+          "rpcs": {
+            "CreateProductSet": {
+              "methods": [
+                "create_product_set"
+              ]
+            },
+            "ListProductSets": {
+              "methods": [
+                "list_product_sets"
+              ]
+            },
+            "GetProductSet": {
+              "methods": [
+                "get_product_set"
+              ]
+            },
+            "UpdateProductSet": {
+              "methods": [
+                "update_product_set"
+              ]
+            },
+            "DeleteProductSet": {
+              "methods": [
+                "delete_product_set"
+              ]
+            },
+            "CreateProduct": {
+              "methods": [
+                "create_product"
+              ]
+            },
+            "ListProducts": {
+              "methods": [
+                "list_products"
+              ]
+            },
+            "GetProduct": {
+              "methods": [
+                "get_product"
+              ]
+            },
+            "UpdateProduct": {
+              "methods": [
+                "update_product"
+              ]
+            },
+            "DeleteProduct": {
+              "methods": [
+                "delete_product"
+              ]
+            },
+            "CreateReferenceImage": {
+              "methods": [
+                "create_reference_image"
+              ]
+            },
+            "DeleteReferenceImage": {
+              "methods": [
+                "delete_reference_image"
+              ]
+            },
+            "ListReferenceImages": {
+              "methods": [
+                "list_reference_images"
+              ]
+            },
+            "GetReferenceImage": {
+              "methods": [
+                "get_reference_image"
+              ]
+            },
+            "AddProductToProductSet": {
+              "methods": [
+                "add_product_to_product_set"
+              ]
+            },
+            "RemoveProductFromProductSet": {
+              "methods": [
+                "remove_product_from_product_set"
+              ]
+            },
+            "ListProductsInProductSet": {
+              "methods": [
+                "list_products_in_product_set"
+              ]
+            },
+            "ImportProductSets": {
+              "methods": [
+                "import_product_sets"
+              ]
+            }
           }
         }
       }
@@ -72,13 +108,17 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Vision::V1p3beta1::ImageAnnotator::Client",
-          "methods": {
-            "BatchAnnotateImages": [
-              "batch_annotate_images"
-            ],
-            "AsyncBatchAnnotateFiles": [
-              "async_batch_annotate_files"
-            ]
+          "rpcs": {
+            "BatchAnnotateImages": {
+              "methods": [
+                "batch_annotate_images"
+              ]
+            },
+            "AsyncBatchAnnotateFiles": {
+              "methods": [
+                "async_batch_annotate_files"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-vision-v1p3beta1/google-cloud-vision-v1p3beta1.gemspec
+++ b/google-cloud-vision-v1p3beta1/google-cloud-vision-v1p3beta1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-web_risk-v1/gapic_metadata.json
+++ b/google-cloud-web_risk-v1/gapic_metadata.json
@@ -9,19 +9,27 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::WebRisk::V1::WebRiskService::Client",
-          "methods": {
-            "ComputeThreatListDiff": [
-              "compute_threat_list_diff"
-            ],
-            "SearchUris": [
-              "search_uris"
-            ],
-            "SearchHashes": [
-              "search_hashes"
-            ],
-            "CreateSubmission": [
-              "create_submission"
-            ]
+          "rpcs": {
+            "ComputeThreatListDiff": {
+              "methods": [
+                "compute_threat_list_diff"
+              ]
+            },
+            "SearchUris": {
+              "methods": [
+                "search_uris"
+              ]
+            },
+            "SearchHashes": {
+              "methods": [
+                "search_hashes"
+              ]
+            },
+            "CreateSubmission": {
+              "methods": [
+                "create_submission"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-web_risk-v1/google-cloud-web_risk-v1.gemspec
+++ b/google-cloud-web_risk-v1/google-cloud-web_risk-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-web_risk-v1beta1/gapic_metadata.json
+++ b/google-cloud-web_risk-v1beta1/gapic_metadata.json
@@ -9,16 +9,22 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::WebRisk::V1beta1::WebRiskService::Client",
-          "methods": {
-            "ComputeThreatListDiff": [
-              "compute_threat_list_diff"
-            ],
-            "SearchUris": [
-              "search_uris"
-            ],
-            "SearchHashes": [
-              "search_hashes"
-            ]
+          "rpcs": {
+            "ComputeThreatListDiff": {
+              "methods": [
+                "compute_threat_list_diff"
+              ]
+            },
+            "SearchUris": {
+              "methods": [
+                "search_uris"
+              ]
+            },
+            "SearchHashes": {
+              "methods": [
+                "search_hashes"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-web_risk-v1beta1/google-cloud-web_risk-v1beta1.gemspec
+++ b/google-cloud-web_risk-v1beta1/google-cloud-web_risk-v1beta1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-web_security_scanner-v1/gapic_metadata.json
+++ b/google-cloud-web_security_scanner-v1/gapic_metadata.json
@@ -9,46 +9,72 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::WebSecurityScanner::V1::WebSecurityScanner::Client",
-          "methods": {
-            "CreateScanConfig": [
-              "create_scan_config"
-            ],
-            "DeleteScanConfig": [
-              "delete_scan_config"
-            ],
-            "GetScanConfig": [
-              "get_scan_config"
-            ],
-            "ListScanConfigs": [
-              "list_scan_configs"
-            ],
-            "UpdateScanConfig": [
-              "update_scan_config"
-            ],
-            "StartScanRun": [
-              "start_scan_run"
-            ],
-            "GetScanRun": [
-              "get_scan_run"
-            ],
-            "ListScanRuns": [
-              "list_scan_runs"
-            ],
-            "StopScanRun": [
-              "stop_scan_run"
-            ],
-            "ListCrawledUrls": [
-              "list_crawled_urls"
-            ],
-            "GetFinding": [
-              "get_finding"
-            ],
-            "ListFindings": [
-              "list_findings"
-            ],
-            "ListFindingTypeStats": [
-              "list_finding_type_stats"
-            ]
+          "rpcs": {
+            "CreateScanConfig": {
+              "methods": [
+                "create_scan_config"
+              ]
+            },
+            "DeleteScanConfig": {
+              "methods": [
+                "delete_scan_config"
+              ]
+            },
+            "GetScanConfig": {
+              "methods": [
+                "get_scan_config"
+              ]
+            },
+            "ListScanConfigs": {
+              "methods": [
+                "list_scan_configs"
+              ]
+            },
+            "UpdateScanConfig": {
+              "methods": [
+                "update_scan_config"
+              ]
+            },
+            "StartScanRun": {
+              "methods": [
+                "start_scan_run"
+              ]
+            },
+            "GetScanRun": {
+              "methods": [
+                "get_scan_run"
+              ]
+            },
+            "ListScanRuns": {
+              "methods": [
+                "list_scan_runs"
+              ]
+            },
+            "StopScanRun": {
+              "methods": [
+                "stop_scan_run"
+              ]
+            },
+            "ListCrawledUrls": {
+              "methods": [
+                "list_crawled_urls"
+              ]
+            },
+            "GetFinding": {
+              "methods": [
+                "get_finding"
+              ]
+            },
+            "ListFindings": {
+              "methods": [
+                "list_findings"
+              ]
+            },
+            "ListFindingTypeStats": {
+              "methods": [
+                "list_finding_type_stats"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-web_security_scanner-v1/google-cloud-web_security_scanner-v1.gemspec
+++ b/google-cloud-web_security_scanner-v1/google-cloud-web_security_scanner-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-web_security_scanner-v1beta/gapic_metadata.json
+++ b/google-cloud-web_security_scanner-v1beta/gapic_metadata.json
@@ -9,46 +9,72 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::WebSecurityScanner::V1beta::WebSecurityScanner::Client",
-          "methods": {
-            "CreateScanConfig": [
-              "create_scan_config"
-            ],
-            "DeleteScanConfig": [
-              "delete_scan_config"
-            ],
-            "GetScanConfig": [
-              "get_scan_config"
-            ],
-            "ListScanConfigs": [
-              "list_scan_configs"
-            ],
-            "UpdateScanConfig": [
-              "update_scan_config"
-            ],
-            "StartScanRun": [
-              "start_scan_run"
-            ],
-            "GetScanRun": [
-              "get_scan_run"
-            ],
-            "ListScanRuns": [
-              "list_scan_runs"
-            ],
-            "StopScanRun": [
-              "stop_scan_run"
-            ],
-            "ListCrawledUrls": [
-              "list_crawled_urls"
-            ],
-            "GetFinding": [
-              "get_finding"
-            ],
-            "ListFindings": [
-              "list_findings"
-            ],
-            "ListFindingTypeStats": [
-              "list_finding_type_stats"
-            ]
+          "rpcs": {
+            "CreateScanConfig": {
+              "methods": [
+                "create_scan_config"
+              ]
+            },
+            "DeleteScanConfig": {
+              "methods": [
+                "delete_scan_config"
+              ]
+            },
+            "GetScanConfig": {
+              "methods": [
+                "get_scan_config"
+              ]
+            },
+            "ListScanConfigs": {
+              "methods": [
+                "list_scan_configs"
+              ]
+            },
+            "UpdateScanConfig": {
+              "methods": [
+                "update_scan_config"
+              ]
+            },
+            "StartScanRun": {
+              "methods": [
+                "start_scan_run"
+              ]
+            },
+            "GetScanRun": {
+              "methods": [
+                "get_scan_run"
+              ]
+            },
+            "ListScanRuns": {
+              "methods": [
+                "list_scan_runs"
+              ]
+            },
+            "StopScanRun": {
+              "methods": [
+                "stop_scan_run"
+              ]
+            },
+            "ListCrawledUrls": {
+              "methods": [
+                "list_crawled_urls"
+              ]
+            },
+            "GetFinding": {
+              "methods": [
+                "get_finding"
+              ]
+            },
+            "ListFindings": {
+              "methods": [
+                "list_findings"
+              ]
+            },
+            "ListFindingTypeStats": {
+              "methods": [
+                "list_finding_type_stats"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-web_security_scanner-v1beta/google-cloud-web_security_scanner-v1beta.gemspec
+++ b/google-cloud-web_security_scanner-v1beta/google-cloud-web_security_scanner-v1beta.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-workflows-executions-v1beta/gapic_metadata.json
+++ b/google-cloud-workflows-executions-v1beta/gapic_metadata.json
@@ -9,19 +9,27 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Workflows::Executions::V1beta::Executions::Client",
-          "methods": {
-            "ListExecutions": [
-              "list_executions"
-            ],
-            "CreateExecution": [
-              "create_execution"
-            ],
-            "GetExecution": [
-              "get_execution"
-            ],
-            "CancelExecution": [
-              "cancel_execution"
-            ]
+          "rpcs": {
+            "ListExecutions": {
+              "methods": [
+                "list_executions"
+              ]
+            },
+            "CreateExecution": {
+              "methods": [
+                "create_execution"
+              ]
+            },
+            "GetExecution": {
+              "methods": [
+                "get_execution"
+              ]
+            },
+            "CancelExecution": {
+              "methods": [
+                "cancel_execution"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-workflows-executions-v1beta/google-cloud-workflows-executions-v1beta.gemspec
+++ b/google-cloud-workflows-executions-v1beta/google-cloud-workflows-executions-v1beta.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-workflows-v1beta/gapic_metadata.json
+++ b/google-cloud-workflows-v1beta/gapic_metadata.json
@@ -9,22 +9,32 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Cloud::Workflows::V1beta::Workflows::Client",
-          "methods": {
-            "ListWorkflows": [
-              "list_workflows"
-            ],
-            "GetWorkflow": [
-              "get_workflow"
-            ],
-            "CreateWorkflow": [
-              "create_workflow"
-            ],
-            "DeleteWorkflow": [
-              "delete_workflow"
-            ],
-            "UpdateWorkflow": [
-              "update_workflow"
-            ]
+          "rpcs": {
+            "ListWorkflows": {
+              "methods": [
+                "list_workflows"
+              ]
+            },
+            "GetWorkflow": {
+              "methods": [
+                "get_workflow"
+              ]
+            },
+            "CreateWorkflow": {
+              "methods": [
+                "create_workflow"
+              ]
+            },
+            "DeleteWorkflow": {
+              "methods": [
+                "delete_workflow"
+              ]
+            },
+            "UpdateWorkflow": {
+              "methods": [
+                "update_workflow"
+              ]
+            }
           }
         }
       }

--- a/google-cloud-workflows-v1beta/google-cloud-workflows-v1beta.gemspec
+++ b/google-cloud-workflows-v1beta/google-cloud-workflows-v1beta.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-iam-credentials-v1/gapic_metadata.json
+++ b/google-iam-credentials-v1/gapic_metadata.json
@@ -9,19 +9,27 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Iam::Credentials::V1::IAMCredentials::Client",
-          "methods": {
-            "GenerateAccessToken": [
-              "generate_access_token"
-            ],
-            "GenerateIdToken": [
-              "generate_id_token"
-            ],
-            "SignBlob": [
-              "sign_blob"
-            ],
-            "SignJwt": [
-              "sign_jwt"
-            ]
+          "rpcs": {
+            "GenerateAccessToken": {
+              "methods": [
+                "generate_access_token"
+              ]
+            },
+            "GenerateIdToken": {
+              "methods": [
+                "generate_id_token"
+              ]
+            },
+            "SignBlob": {
+              "methods": [
+                "sign_blob"
+              ]
+            },
+            "SignJwt": {
+              "methods": [
+                "sign_jwt"
+              ]
+            }
           }
         }
       }

--- a/google-iam-credentials-v1/google-iam-credentials-v1.gemspec
+++ b/google-iam-credentials-v1/google-iam-credentials-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-iam-v1beta/gapic_metadata.json
+++ b/google-iam-v1beta/gapic_metadata.json
@@ -9,43 +9,67 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Google::Iam::V1beta::WorkloadIdentityPools::Client",
-          "methods": {
-            "ListWorkloadIdentityPools": [
-              "list_workload_identity_pools"
-            ],
-            "GetWorkloadIdentityPool": [
-              "get_workload_identity_pool"
-            ],
-            "CreateWorkloadIdentityPool": [
-              "create_workload_identity_pool"
-            ],
-            "UpdateWorkloadIdentityPool": [
-              "update_workload_identity_pool"
-            ],
-            "DeleteWorkloadIdentityPool": [
-              "delete_workload_identity_pool"
-            ],
-            "UndeleteWorkloadIdentityPool": [
-              "undelete_workload_identity_pool"
-            ],
-            "ListWorkloadIdentityPoolProviders": [
-              "list_workload_identity_pool_providers"
-            ],
-            "GetWorkloadIdentityPoolProvider": [
-              "get_workload_identity_pool_provider"
-            ],
-            "CreateWorkloadIdentityPoolProvider": [
-              "create_workload_identity_pool_provider"
-            ],
-            "UpdateWorkloadIdentityPoolProvider": [
-              "update_workload_identity_pool_provider"
-            ],
-            "DeleteWorkloadIdentityPoolProvider": [
-              "delete_workload_identity_pool_provider"
-            ],
-            "UndeleteWorkloadIdentityPoolProvider": [
-              "undelete_workload_identity_pool_provider"
-            ]
+          "rpcs": {
+            "ListWorkloadIdentityPools": {
+              "methods": [
+                "list_workload_identity_pools"
+              ]
+            },
+            "GetWorkloadIdentityPool": {
+              "methods": [
+                "get_workload_identity_pool"
+              ]
+            },
+            "CreateWorkloadIdentityPool": {
+              "methods": [
+                "create_workload_identity_pool"
+              ]
+            },
+            "UpdateWorkloadIdentityPool": {
+              "methods": [
+                "update_workload_identity_pool"
+              ]
+            },
+            "DeleteWorkloadIdentityPool": {
+              "methods": [
+                "delete_workload_identity_pool"
+              ]
+            },
+            "UndeleteWorkloadIdentityPool": {
+              "methods": [
+                "undelete_workload_identity_pool"
+              ]
+            },
+            "ListWorkloadIdentityPoolProviders": {
+              "methods": [
+                "list_workload_identity_pool_providers"
+              ]
+            },
+            "GetWorkloadIdentityPoolProvider": {
+              "methods": [
+                "get_workload_identity_pool_provider"
+              ]
+            },
+            "CreateWorkloadIdentityPoolProvider": {
+              "methods": [
+                "create_workload_identity_pool_provider"
+              ]
+            },
+            "UpdateWorkloadIdentityPoolProvider": {
+              "methods": [
+                "update_workload_identity_pool_provider"
+              ]
+            },
+            "DeleteWorkloadIdentityPoolProvider": {
+              "methods": [
+                "delete_workload_identity_pool_provider"
+              ]
+            },
+            "UndeleteWorkloadIdentityPoolProvider": {
+              "methods": [
+                "undelete_workload_identity_pool_provider"
+              ]
+            }
           }
         }
       }

--- a/google-iam-v1beta/google-iam-v1beta.gemspec
+++ b/google-iam-v1beta/google-iam-v1beta.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/grafeas-v1/gapic_metadata.json
+++ b/grafeas-v1/gapic_metadata.json
@@ -9,49 +9,77 @@
       "clients": {
         "grpc": {
           "libraryClient": "::Grafeas::V1::Grafeas::Client",
-          "methods": {
-            "GetOccurrence": [
-              "get_occurrence"
-            ],
-            "ListOccurrences": [
-              "list_occurrences"
-            ],
-            "DeleteOccurrence": [
-              "delete_occurrence"
-            ],
-            "CreateOccurrence": [
-              "create_occurrence"
-            ],
-            "BatchCreateOccurrences": [
-              "batch_create_occurrences"
-            ],
-            "UpdateOccurrence": [
-              "update_occurrence"
-            ],
-            "GetOccurrenceNote": [
-              "get_occurrence_note"
-            ],
-            "GetNote": [
-              "get_note"
-            ],
-            "ListNotes": [
-              "list_notes"
-            ],
-            "DeleteNote": [
-              "delete_note"
-            ],
-            "CreateNote": [
-              "create_note"
-            ],
-            "BatchCreateNotes": [
-              "batch_create_notes"
-            ],
-            "UpdateNote": [
-              "update_note"
-            ],
-            "ListNoteOccurrences": [
-              "list_note_occurrences"
-            ]
+          "rpcs": {
+            "GetOccurrence": {
+              "methods": [
+                "get_occurrence"
+              ]
+            },
+            "ListOccurrences": {
+              "methods": [
+                "list_occurrences"
+              ]
+            },
+            "DeleteOccurrence": {
+              "methods": [
+                "delete_occurrence"
+              ]
+            },
+            "CreateOccurrence": {
+              "methods": [
+                "create_occurrence"
+              ]
+            },
+            "BatchCreateOccurrences": {
+              "methods": [
+                "batch_create_occurrences"
+              ]
+            },
+            "UpdateOccurrence": {
+              "methods": [
+                "update_occurrence"
+              ]
+            },
+            "GetOccurrenceNote": {
+              "methods": [
+                "get_occurrence_note"
+              ]
+            },
+            "GetNote": {
+              "methods": [
+                "get_note"
+              ]
+            },
+            "ListNotes": {
+              "methods": [
+                "list_notes"
+              ]
+            },
+            "DeleteNote": {
+              "methods": [
+                "delete_note"
+              ]
+            },
+            "CreateNote": {
+              "methods": [
+                "create_note"
+              ]
+            },
+            "BatchCreateNotes": {
+              "methods": [
+                "batch_create_notes"
+              ]
+            },
+            "UpdateNote": {
+              "methods": [
+                "update_note"
+              ]
+            },
+            "ListNoteOccurrences": {
+              "methods": [
+                "list_note_occurrences"
+              ]
+            }
           }
         }
       }

--- a/grafeas-v1/grafeas-v1.gemspec
+++ b/grafeas-v1/grafeas-v1.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "gapic-common", "~> 0.3"
+  gem.add_dependency "gapic-common", "~> 0.4"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"


### PR DESCRIPTION
This is the result of running synth on all gems with the 0.7.3 release of the ruby microgenerator.

For each versioned gem, this updates:
* The `gapic_metadata.json` file with fixes.
* The gemspec to update the `gapic-common` dependency from `~> 0.3` to `~> 0.4`.

The latter is technically a real change, so I'm a bit concerned. We might want to consider committing this as a "fix" instead of a "chore" so it shows up in release notes, although that will trigger releases of all versioned gems.