### PR TITLE
fix(bigtable): Update internal management of view states in Table

### DIFF
--- a/google-cloud-bigtable/acceptance/bigtable/table_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/table_test.rb
@@ -109,25 +109,22 @@ describe "Instance Tables", :bigtable do
     let(:table) { bigtable_read_table }
 
     it "Project#table loads NAME_ONLY by default" do
-      _(table.view).must_equal :NAME_ONLY
-      _(table.loaded_views).must_be :nil?
+      _(table.loaded_views).must_equal Set[:NAME_ONLY]
 
       _(table.name).wont_be :nil?
 
-      _(table.view).must_equal :NAME_ONLY
-      _(table.loaded_views).must_be :nil?
+      _(table.loaded_views).must_equal Set[:NAME_ONLY]
 
       _(table.grpc.name).wont_be :nil?
-      _(table.grpc.cluster_states.count).must_equal 0 # Google::Protobuf::Map
-      _(table.grpc.column_families.count).must_equal 0 # Google::Protobuf::Map
+      _(table.grpc.cluster_states.count).must_equal 0 # Google::Protobuf::Map does not have #empty?
+      _(table.grpc.column_families.count).must_equal 0 # Google::Protobuf::Map does not have #empty?
       _(table.grpc.granularity).must_equal :TIMESTAMP_GRANULARITY_UNSPECIFIED
     end
 
     it "column_families and granularity loads SCHEMA_VIEW" do
-      _(table.column_families).wont_be :empty?
+      _(table.column_families).wont_be :empty? # RPC
       _(table.granularity).must_equal :MILLIS
 
-      _(table.view).must_equal :NAME_ONLY
       _(table.loaded_views).must_equal Set[:NAME_ONLY, :SCHEMA_VIEW]
 
       _(table.grpc.name).wont_be :nil?
@@ -137,9 +134,8 @@ describe "Instance Tables", :bigtable do
     end
 
     it "cluster_states loads REPLICATION_VIEW" do
-      _(table.cluster_states).wont_be :empty?
+      _(table.cluster_states).wont_be :empty? # RPC
 
-      _(table.view).must_equal :NAME_ONLY
       _(table.loaded_views).must_equal Set[:NAME_ONLY, :REPLICATION_VIEW]
 
       _(table.grpc.name).wont_be :nil?
@@ -149,11 +145,10 @@ describe "Instance Tables", :bigtable do
     end
 
     it "column_families, granularity and cluster_states loads SCHEMA_VIEW, REPLICATION_VIEW" do
-      _(table.column_families).wont_be :empty?
+      _(table.column_families).wont_be :empty? # RPC
       _(table.granularity).must_equal :MILLIS
-      _(table.cluster_states).wont_be :empty?
+      _(table.cluster_states).wont_be :empty? # RPC
 
-      _(table.view).must_equal :NAME_ONLY
       _(table.loaded_views).must_equal Set[:NAME_ONLY, :SCHEMA_VIEW, :REPLICATION_VIEW]
 
       _(table.grpc.name).wont_be :nil?
@@ -163,13 +158,9 @@ describe "Instance Tables", :bigtable do
     end
 
     it "reloads without view option" do
-      _(table.view).must_equal :NAME_ONLY
-      _(table.loaded_views).must_be :nil?
-
       table.reload!
 
-      _(table.view).must_equal :SCHEMA_VIEW
-      _(table.loaded_views).must_be :nil?
+      _(table.loaded_views).must_equal Set[:SCHEMA_VIEW]
 
       _(table.grpc.name).wont_be :nil?
       _(table.grpc.cluster_states.count).must_equal 0
@@ -178,13 +169,9 @@ describe "Instance Tables", :bigtable do
     end
 
     it "reloads with view option NAME_ONLY" do
-      _(table.view).must_equal :NAME_ONLY
-      _(table.loaded_views).must_be :nil?
-
       table.reload! view: :NAME_ONLY
 
-      _(table.view).must_equal :NAME_ONLY
-      _(table.loaded_views).must_be :nil?
+      _(table.loaded_views).must_equal Set[:NAME_ONLY]
 
       _(table.grpc.name).wont_be :nil?
       _(table.grpc.cluster_states.count).must_equal 0
@@ -193,13 +180,9 @@ describe "Instance Tables", :bigtable do
     end
 
     it "reloads with view option SCHEMA_VIEW" do
-      _(table.view).must_equal :NAME_ONLY
-      _(table.loaded_views).must_be :nil?
-
       table.reload! view: :SCHEMA_VIEW
 
-      _(table.view).must_equal :SCHEMA_VIEW
-      _(table.loaded_views).must_be :nil?
+      _(table.loaded_views).must_equal Set[:SCHEMA_VIEW]
 
       _(table.grpc.name).wont_be :nil?
       _(table.grpc.cluster_states.count).must_equal 0
@@ -208,13 +191,9 @@ describe "Instance Tables", :bigtable do
     end
 
     it "reloads with view option REPLICATION_VIEW" do
-      _(table.view).must_equal :NAME_ONLY
-      _(table.loaded_views).must_be :nil?
-
       table.reload! view: :REPLICATION_VIEW
 
-      _(table.view).must_equal :REPLICATION_VIEW
-      _(table.loaded_views).must_be :nil?
+      _(table.loaded_views).must_equal Set[:REPLICATION_VIEW]
 
       _(table.grpc.name).wont_be :nil?
       _(table.grpc.cluster_states.count).must_be :>, 0
@@ -223,13 +202,9 @@ describe "Instance Tables", :bigtable do
     end
 
     it "reloads with view option FULL" do
-      _(table.view).must_equal :NAME_ONLY
-      _(table.loaded_views).must_be :nil?
-
       table.reload! view: :FULL
 
-      _(table.view).must_equal :FULL
-      _(table.loaded_views).must_be :nil?
+      _(table.loaded_views).must_equal Set[:FULL]
 
       _(table.grpc.name).wont_be :nil?
       _(table.grpc.cluster_states.count).must_be :>, 0

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/instance.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/instance.rb
@@ -520,6 +520,7 @@ module Google
         def table table_id, view: nil, perform_lookup: nil, app_profile_id: nil
           ensure_service!
 
+          view ||= :SCHEMA_VIEW
           table = if perform_lookup
                     grpc = service.get_table instance_id, table_id, view: view
                     Table.from_grpc grpc, service, view: view

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/project.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/project.rb
@@ -316,18 +316,18 @@ module Google
         #
         #   table = bigtable.table("my-instance", "my-table")
         #
-        # @example Get a table with schema-only view.
+        # @example Retrieve a table with a schema-only view.
         #   require "google/cloud/bigtable"
         #
         #   bigtable = Google::Cloud::Bigtable.new
         #
-        #   table = bigtable.table("my-instance", "my-table", perform_lookup: true, view: :SCHEMA_VIEW)
+        #   table = bigtable.table("my-instance", "my-table", perform_lookup: true)
         #   if table
         #     puts table.name
         #     puts table.column_families
         #   end
         #
-        # @example Get a table with all fields, cluster states, and column families.
+        # @example Retrieve a table with all fields, cluster states, and column families.
         #   require "google/cloud/bigtable"
         #
         #   bigtable = Google::Cloud::Bigtable.new
@@ -342,6 +342,7 @@ module Google
         def table instance_id, table_id, view: nil, perform_lookup: nil, app_profile_id: nil
           ensure_service!
 
+          view ||= :SCHEMA_VIEW
           table = if perform_lookup
                     grpc = service.get_table instance_id, table_id, view: view
                     Table.from_grpc grpc, service, view: view

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/table.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/table.rb
@@ -56,6 +56,18 @@ module Google
         # The gRPC Service object.
         attr_accessor :service
 
+        # @private
+        # The current gRPC resource, for testing only.
+        attr_accessor :grpc
+
+        # @private
+        # The current view, for testing only. See #check_view_and_load, below.
+        attr_reader :view
+
+        # @private
+        # The current loaded_views, for testing only. See #check_view_and_load, below.
+        attr_reader :loaded_views
+
         ##
         # @return [String] App profile ID for request routing.
         #

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/table.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/table.rb
@@ -72,10 +72,11 @@ module Google
         # @private
         #
         # Creates a new Table instance.
-        def initialize grpc, service, view: nil
+        def initialize grpc, service, view:
           @grpc = grpc
           @service = service
-          @loaded_views = Set[view || :SCHEMA_VIEW]
+          raise ArgumentError, "view must not be nil" if view.nil?
+          @loaded_views = Set[view]
         end
 
         ##
@@ -457,7 +458,7 @@ module Google
           }.delete_if { |_, v| v.nil? })
 
           grpc = service.create_table instance_id, table_id, table, initial_splits: initial_splits
-          from_grpc grpc, service
+          from_grpc grpc, service, view: :SCHEMA_VIEW
         end
 
         ##
@@ -643,7 +644,7 @@ module Google
         # @param view [Symbol] View type.
         # @return [Google::Cloud::Bigtable::Table]
         #
-        def self.from_grpc grpc, service, view: nil
+        def self.from_grpc grpc, service, view:
           new grpc, service, view: view
         end
 

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/table/restore_job.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/table/restore_job.rb
@@ -108,7 +108,7 @@ module Google
           #   end
           #
           def table
-            Table.from_grpc results, service if results
+            Table.from_grpc results, service, view: :NAME_ONLY if results
           end
         end
       end

--- a/google-cloud-bigtable/support/doctest_helper.rb
+++ b/google-cloud-bigtable/support/doctest_helper.rb
@@ -352,7 +352,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Bigtable::ColumnFamilyMap" do
     mock_bigtable do |mock, mocked_instances, mocked_tables, mocked_job|
-      mocked_tables.expect :get_table, table_resp, [name: "projects/my-project/instances/my-instance/tables/my-table", view: nil]
+      mocked_tables.expect :get_table, table_resp, [name: "projects/my-project/instances/my-instance/tables/my-table", view: :SCHEMA_VIEW]
       mocked_tables.expect :create_table, table_resp, [Hash]
       mocked_tables.expect :modify_column_families, table_resp, [Hash]
     end
@@ -472,7 +472,7 @@ YARD::Doctest.configure do |doctest|
   doctest.before "Google::Cloud::Bigtable::Instance#table" do
     mock_bigtable do |mock, mocked_instances, mocked_tables, mocked_job|
       mocked_instances.expect :get_instance, instance_resp, [name: "projects/my-project/instances/my-instance"]
-      mocked_tables.expect :get_table, table_resp, [name: "projects/my-project/instances/my-instance/tables/my-table", view: nil]
+      mocked_tables.expect :get_table, table_resp, [name: "projects/my-project/instances/my-instance/tables/my-table", view: :SCHEMA_VIEW]
       mocked_tables.expect :get_table, table_resp, [name: "projects/my-project/instances/my-instance/tables/my-table", view: :NAME_ONLY]
       mock.expect :mutate_row, mutate_row_resp, [Hash]
     end
@@ -627,7 +627,15 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Bigtable::Project#table" do
     mock_bigtable do |mock, mocked_instances, mocked_tables, mocked_job|
-      mocked_tables.expect :get_table, table_resp, [Hash]
+      mocked_tables.expect :get_table, table_resp, [name: "projects/my-project/instances/my-instance/tables/my-table", view: :SCHEMA_VIEW]
+      mock.expect :mutate_row, nil, [Hash]
+      mock.expect :read_rows, [], [Hash]
+    end
+  end
+
+  doctest.before "Google::Cloud::Bigtable::Project#table@Retrieve a table with all fields, cluster states, and column families." do
+    mock_bigtable do |mock, mocked_instances, mocked_tables, mocked_job|
+      mocked_tables.expect :get_table, table_resp, [name: "projects/my-project/instances/my-instance/tables/my-table", view: :FULL]
       mock.expect :mutate_row, nil, [Hash]
       mock.expect :read_rows, [], [Hash]
     end
@@ -644,14 +652,14 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Bigtable::ReadOperations" do
     mock_bigtable do |mock, mocked_instances, mocked_tables, mocked_job|
-      mocked_tables.expect :get_table, table_resp, [name: "projects/my-project/instances/my-instance/tables/my-table", view: nil]
+      mocked_tables.expect :get_table, table_resp, [name: "projects/my-project/instances/my-instance/tables/my-table", view: :SCHEMA_VIEW]
       mock.expect :read_rows, [], [Hash]
     end
   end
 
   doctest.before "Google::Cloud::Bigtable::ReadOperations#sample_row_keys" do
     mock_bigtable do |mock, mocked_instances, mocked_tables, mocked_job|
-      mocked_tables.expect :get_table, table_resp, [name: "projects/my-project/instances/my-instance/tables/my-table", view: nil]
+      mocked_tables.expect :get_table, table_resp, [name: "projects/my-project/instances/my-instance/tables/my-table", view: :SCHEMA_VIEW]
       mock.expect :sample_row_keys, [], [Hash]
     end
   end
@@ -665,7 +673,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Bigtable::SampleRowKey" do
     mock_bigtable do |mock, mocked_instances, mocked_tables, mocked_job|
-      mocked_tables.expect :get_table, table_resp, [name: "projects/my-project/instances/my-instance/tables/my-table", view: nil]
+      mocked_tables.expect :get_table, table_resp, [name: "projects/my-project/instances/my-instance/tables/my-table", view: :SCHEMA_VIEW]
       mock.expect :sample_row_keys, [], [Hash]
     end
   end
@@ -692,7 +700,7 @@ YARD::Doctest.configure do |doctest|
   doctest.before "Google::Cloud::Bigtable::Table#check_consistency" do
     mock_bigtable do |mock, mocked_instances, mocked_tables, mocked_job|
       mocked_instances.expect :get_instance, instance_resp, [name: "projects/my-project/instances/my-instance"]
-      mocked_tables.expect :get_table, table_resp, [name: "projects/my-project/instances/my-instance/tables/my-table", view: nil]
+      mocked_tables.expect :get_table, table_resp, [name: "projects/my-project/instances/my-instance/tables/my-table", view: :SCHEMA_VIEW]
       mocked_tables.expect :check_consistency, OpenStruct.new(consistent: true), [Hash]
     end
   end
@@ -700,7 +708,7 @@ YARD::Doctest.configure do |doctest|
   doctest.before "Google::Cloud::Bigtable::Table#column_families" do
     mock_bigtable do |mock, mocked_instances, mocked_tables, mocked_job|
       mocked_instances.expect :get_instance, instance_resp, [name: "projects/my-project/instances/my-instance"]
-      mocked_tables.expect :get_table, table_resp, [name: "projects/my-project/instances/my-instance/tables/my-table", view: nil]
+      mocked_tables.expect :get_table, table_resp, [name: "projects/my-project/instances/my-instance/tables/my-table", view: :SCHEMA_VIEW]
       mocked_tables.expect :modify_column_families, table_resp, [Hash]
     end
   end
@@ -708,7 +716,7 @@ YARD::Doctest.configure do |doctest|
   doctest.before "Google::Cloud::Bigtable::Table#column_family" do
     mock_bigtable do |mock, mocked_instances, mocked_tables, mocked_job|
       mocked_instances.expect :get_instance, instance_resp, [name: "projects/my-project/instances/my-instance"]
-      mocked_tables.expect :get_table, table_resp, [name: "projects/my-project/instances/my-instance/tables/my-table", view: nil]
+      mocked_tables.expect :get_table, table_resp, [name: "projects/my-project/instances/my-instance/tables/my-table", view: :SCHEMA_VIEW]
       mocked_tables.expect :modify_column_families, table_resp, [Hash]
       mocked_tables.expect :modify_column_families, table_resp, [Hash]
     end
@@ -716,7 +724,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Bigtable::Table#delete" do
     mock_bigtable do |mock, mocked_instances, mocked_tables, mocked_job|
-      mocked_tables.expect :get_table, table_resp, [name: "projects/my-project/instances/my-instance/tables/my-table", view: nil]
+      mocked_tables.expect :get_table, table_resp, [name: "projects/my-project/instances/my-instance/tables/my-table", view: :SCHEMA_VIEW]
       mocked_tables.expect :delete_table, table_resp, [name: "projects/my-project/instances/my-instance/tables/my-table"]
     end
   end
@@ -724,7 +732,7 @@ YARD::Doctest.configure do |doctest|
   doctest.before "Google::Cloud::Bigtable::Table#delete_all_rows" do
     mock_bigtable do |mock, mocked_instances, mocked_tables, mocked_job|
       mocked_instances.expect :get_instance, instance_resp, [name: "projects/my-project/instances/my-instance"]
-      mocked_tables.expect :get_table, table_resp, [name: "projects/my-project/instances/my-instance/tables/my-table", view: nil]
+      mocked_tables.expect :get_table, table_resp, [name: "projects/my-project/instances/my-instance/tables/my-table", view: :SCHEMA_VIEW]
       mocked_tables.expect :drop_row_range, nil, [Hash, nil]
       mocked_tables.expect :drop_row_range, nil, [Hash, Gapic::CallOptions]
     end
@@ -732,7 +740,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Bigtable::Table#delete_rows_by_prefix" do
     mock_bigtable do |mock, mocked_instances, mocked_tables, mocked_job|
-      mocked_tables.expect :get_table, table_resp, [name: "projects/my-project/instances/my-instance/tables/my-table", view: nil]
+      mocked_tables.expect :get_table, table_resp, [name: "projects/my-project/instances/my-instance/tables/my-table", view: :SCHEMA_VIEW]
       mocked_tables.expect :drop_row_range, nil, [Hash, nil]
       mocked_tables.expect :drop_row_range, nil, [Hash, Gapic::CallOptions]
     end
@@ -740,7 +748,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Bigtable::Table#drop_row_range" do
     mock_bigtable do |mock, mocked_instances, mocked_tables, mocked_job|
-      mocked_tables.expect :get_table, table_resp, [name: "projects/my-project/instances/my-instance/tables/my-table", view: nil]
+      mocked_tables.expect :get_table, table_resp, [name: "projects/my-project/instances/my-instance/tables/my-table", view: :SCHEMA_VIEW]
       mocked_tables.expect :drop_row_range, nil, [Hash, nil]
       mocked_tables.expect :drop_row_range, nil, [Hash, Gapic::CallOptions]
     end
@@ -749,7 +757,7 @@ YARD::Doctest.configure do |doctest|
   doctest.before "Google::Cloud::Bigtable::Table#generate_consistency_token" do
     mock_bigtable do |mock, mocked_instances, mocked_tables, mocked_job|
       mocked_instances.expect :get_instance, instance_resp, [name: "projects/my-project/instances/my-instance"]
-      mocked_tables.expect :get_table, table_resp, [name: "projects/my-project/instances/my-instance/tables/my-table", view: nil]
+      mocked_tables.expect :get_table, table_resp, [name: "projects/my-project/instances/my-instance/tables/my-table", view: :SCHEMA_VIEW]
       mocked_tables.expect :generate_consistency_token, OpenStruct.new(consistency_token: ""), [name: "projects/my-project/instances/my-instance/tables/my-table"]
     end
   end
@@ -764,7 +772,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Bigtable::Table#policy" do
     mock_bigtable do |mock, mocked_instances, mocked_tables, mocked_job|
-      mocked_tables.expect :get_table, table_resp, [name: "projects/my-project/instances/my-instance/tables/my-table", view: nil]
+      mocked_tables.expect :get_table, table_resp, [name: "projects/my-project/instances/my-instance/tables/my-table", view: :SCHEMA_VIEW]
       mocked_tables.expect :get_iam_policy, policy_resp, [resource: "projects/my-project/instances/my-instance/tables/my-table"]
       mocked_tables.expect :set_iam_policy, policy_resp, [Hash]
     end
@@ -772,14 +780,14 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Bigtable::Table#test_iam_permissions" do
     mock_bigtable do |mock, mocked_instances, mocked_tables, mocked_job|
-      mocked_tables.expect :get_table, table_resp, [name: "projects/my-project/instances/my-instance/tables/my-table", view: nil]
+      mocked_tables.expect :get_table, table_resp, [name: "projects/my-project/instances/my-instance/tables/my-table", view: :SCHEMA_VIEW]
       mocked_tables.expect :test_iam_permissions, table_iam_permissions_resp, [Hash]
     end
   end
 
   doctest.before "Google::Cloud::Bigtable::Table#update_policy" do
     mock_bigtable do |mock, mocked_instances, mocked_tables, mocked_job|
-      mocked_tables.expect :get_table, table_resp, [name: "projects/my-project/instances/my-instance/tables/my-table", view: nil]
+      mocked_tables.expect :get_table, table_resp, [name: "projects/my-project/instances/my-instance/tables/my-table", view: :SCHEMA_VIEW]
       mocked_tables.expect :get_iam_policy, policy_resp, [resource: "projects/my-project/instances/my-instance/tables/my-table"]
       mocked_tables.expect :set_iam_policy, policy_resp, [Hash]
     end
@@ -787,7 +795,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Bigtable::Table#wait_for_replication" do
     mock_bigtable do |mock, mocked_instances, mocked_tables, mocked_job|
-      mocked_tables.expect :get_table, table_resp, [name: "projects/my-project/instances/my-instance/tables/my-table", view: nil]
+      mocked_tables.expect :get_table, table_resp, [name: "projects/my-project/instances/my-instance/tables/my-table", view: :SCHEMA_VIEW]
       mocked_tables.expect :generate_consistency_token, OpenStruct.new(consistency_token: "123"), [name: "projects/my-project/instances/my-instance/tables/my-table"]
       mocked_tables.expect :check_consistency, OpenStruct.new(consistent: true), [name: "projects/my-project/instances/my-instance/tables/my-table", consistency_token: "123"]
       mocked_tables.expect :generate_consistency_token, OpenStruct.new(consistency_token: "123"), [name: "projects/my-project/instances/my-instance/tables/my-table"]
@@ -797,7 +805,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::Bigtable::Table::List" do
     mock_bigtable do |mock, mocked_instances, mocked_tables, mocked_job|
-      mocked_tables.expect :get_table, table_resp, [name: "projects/my-project/instances/my-instance/tables/my-table", view: nil]
+      mocked_tables.expect :get_table, table_resp, [name: "projects/my-project/instances/my-instance/tables/my-table", view: :SCHEMA_VIEW]
       mocked_tables.expect :list_tables, tables_resp, [parent: "projects/my-project/instances/my-instance", view: nil]
     end
   end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/backup_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/backup_test.rb
@@ -25,7 +25,7 @@ describe Google::Cloud::Bigtable::Backup, :mock_bigtable do
   let :source_table_grpc do
     Google::Cloud::Bigtable::Admin::V2::Table.new table_hash(name: table_path(instance_id, source_table_id))
   end
-  let(:source_table) { Google::Cloud::Bigtable::Table.from_grpc source_table_grpc, bigtable.service }
+  let(:source_table) { Google::Cloud::Bigtable::Table.from_grpc source_table_grpc, bigtable.service, view: :NAME_ONLY }
   let(:target_table_id) { "test-table-target" }
   let :target_table_grpc do
     Google::Cloud::Bigtable::Admin::V2::Table.new table_hash(name: table_path(instance_id, target_table_id))

--- a/google-cloud-bigtable/test/google/cloud/bigtable/cluster/create_backup_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/cluster/create_backup_test.rb
@@ -48,7 +48,7 @@ describe Google::Cloud::Bigtable::Cluster, :create_backup, :mock_bigtable do
   let :source_table_grpc do
     Google::Cloud::Bigtable::Admin::V2::Table.new table_hash(name: table_path(instance_id, source_table_id))
   end
-  let(:source_table) { Google::Cloud::Bigtable::Table.from_grpc source_table_grpc, bigtable.service }
+  let(:source_table) { Google::Cloud::Bigtable::Table.from_grpc source_table_grpc, bigtable.service, view: :NAME_ONLY }
   let(:expire_time) { Time.now.round(0) + 60 * 60 * 7 }
   let :backup_grpc do
     Google::Cloud::Bigtable::Admin::V2::Backup.new source_table: table_path(instance_id, source_table_id),

--- a/google-cloud-bigtable/test/google/cloud/bigtable/column_family/modifications_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/column_family/modifications_test.rb
@@ -27,7 +27,7 @@ describe Google::Cloud::Bigtable::ColumnFamily, :create, :mock_bigtable do
     )
   end
   let(:table) do
-    Google::Cloud::Bigtable::Table.from_grpc(table_grpc, bigtable.service)
+    Google::Cloud::Bigtable::Table.from_grpc(table_grpc, bigtable.service, view: :SCHEMA_VIEW)
   end
   let(:gc_rule) {
     Google::Cloud::Bigtable::GcRule.max_versions(3)

--- a/google-cloud-bigtable/test/google/cloud/bigtable/project/table_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/project/table_test.rb
@@ -72,34 +72,6 @@ describe Google::Cloud::Bigtable::Project, :table, :mock_bigtable do
     _(table).must_be :nil?
   end
 
-  it "load schema view on access schema fields" do
-    table_id = "test-table"
-    get_res = Google::Cloud::Bigtable::Admin::V2::Table.new(
-      name: table_path(instance_id, table_id),
-      cluster_states: clusters_state_grpc,
-      column_families: column_families_grpc,
-      granularity: :MILLIS
-    )
-
-    mock = Minitest::Mock.new
-    mock.expect :get_table, get_res, [name: table_path(instance_id, table_id), view: :SCHEMA_VIEW]
-    mock.expect :get_table, get_res, [name: table_path(instance_id, table_id), view: :REPLICATION_VIEW]
-    bigtable.service.mocked_tables = mock
-
-    table = Google::Cloud::Bigtable::Table.from_grpc(
-      Google::Cloud::Bigtable::Admin::V2::Table.new(name: table_path(instance_id, table_id)),
-      bigtable.service,
-      view: :NAME_ONLY
-    )
-
-    2.times do
-      _(table.column_families).wont_be :empty?
-      _(table.granularity).must_equal :MILLIS
-      _(table.cluster_states).wont_be :empty?
-    end
-    mock.verify
-  end
-
   it "get table object without fetching table" do
     table_id = "my-table"
     app_profile_id = "my-app-profile"

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/column_families_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/column_families_test.rb
@@ -31,7 +31,7 @@ describe Google::Cloud::Bigtable::Table, :column_families, :mock_bigtable do
     )
   end
   let(:table) do
-    Google::Cloud::Bigtable::Table.from_grpc(table_grpc, bigtable.service)
+    Google::Cloud::Bigtable::Table.from_grpc(table_grpc, bigtable.service, view: :FULL)
   end
 
   it "modifies column families in the table" do

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/delete_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/delete_test.rb
@@ -31,7 +31,7 @@ describe Google::Cloud::Bigtable::Table, :delete, :mock_bigtable do
     )
   }
   let(:table) {
-    Google::Cloud::Bigtable::Table.from_grpc(table_grpc, bigtable.service)
+    Google::Cloud::Bigtable::Table.from_grpc(table_grpc, bigtable.service, view: :FULL)
   }
 
   it "can delete itself" do

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/drop_row_range_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/drop_row_range_test.rb
@@ -33,7 +33,7 @@ describe Google::Cloud::Bigtable::Table, :drop_rows, :mock_bigtable do
     )
   end
   let(:table) do
-    Google::Cloud::Bigtable::Table.from_grpc(table_grpc, bigtable.service)
+    Google::Cloud::Bigtable::Table.from_grpc(table_grpc, bigtable.service, view: :FULL)
   end
 
   describe "drop_row_range" do

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/iam_policy_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/iam_policy_test.rb
@@ -29,7 +29,7 @@ describe Google::Cloud::Bigtable::Table, :iam_policy, :mock_bigtable do
     )
   }
   let(:table) do
-    Google::Cloud::Bigtable::Table.from_grpc(table_grpc, bigtable.service)
+    Google::Cloud::Bigtable::Table.from_grpc(table_grpc, bigtable.service, view: :SCHEMA_VIEW)
   end
   let(:viewer_policy_json) do
     {

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/replication_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/replication_test.rb
@@ -33,7 +33,7 @@ describe Google::Cloud::Bigtable::Table, :replication, :mock_bigtable do
     )
   end
   let(:table) do
-    Google::Cloud::Bigtable::Table.from_grpc(table_grpc, bigtable.service)
+    Google::Cloud::Bigtable::Table.from_grpc(table_grpc, bigtable.service, view: :FULL)
   end
 
   let(:token) { "l947XelENinaxJQP0nnrZJjHnAF7YrwW8HCJLotwrF" }

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table_test.rb
@@ -102,24 +102,95 @@ describe Google::Cloud::Bigtable::Table, :mock_bigtable do
 
   it "reloads its state" do
     mock = Minitest::Mock.new
-    mock.expect :get_table, table_grpc, [name: table_path(instance_id, table_id), view: nil]
+    mock.expect :get_table, table_grpc, [name: table_path(instance_id, table_id), view: :SCHEMA_VIEW]
     table.service.mocked_tables = mock
 
     table.reload!
 
     mock.verify
+  end
 
-    _(table.project_id).must_equal project_id
-    _(table.instance_id).must_equal instance_id
-    _(table.name).must_equal table_id
-    _(table.path).must_equal table_path(instance_id, table_id)
-    _(table.granularity).must_equal :MILLIS
+  it "reloads its state with view option" do
+    mock = Minitest::Mock.new
+    mock.expect :get_table, table_grpc, [name: table_path(instance_id, table_id), view: :REPLICATION_VIEW]
+    table.service.mocked_tables = mock
 
-    _(table.column_families).must_be_instance_of Google::Cloud::Bigtable::ColumnFamilyMap
-    _(table.column_families).must_be :frozen?
-    _(table.column_families.names.sort).must_equal column_families.keys
-    table.column_families.each do |name, cf|
-      _(cf.gc_rule.to_grpc).must_equal column_families[cf.name].gc_rule
+    table.reload! view: :REPLICATION_VIEW
+
+    mock.verify
+  end
+
+  describe "views" do
+    let(:table_grpc) { Google::Cloud::Bigtable::Admin::V2::Table.new(name: table_path(instance_id, table_id)) }
+    let(:table) { Google::Cloud::Bigtable::Table.from_grpc(table_grpc, bigtable.service, view: :NAME_ONLY) }
+
+    it "loads SCHEMA_VIEW on access to column_families" do
+      get_res = Google::Cloud::Bigtable::Admin::V2::Table.new(
+        name: table_path(instance_id, table_id),
+        column_families: column_families_grpc,
+        granularity: :MILLIS
+      )
+
+      mock = Minitest::Mock.new
+      mock.expect :get_table, get_res, [name: table_path(instance_id, table_id), view: :SCHEMA_VIEW]
+      table.service.mocked_tables = mock
+
+      _(table.column_families).wont_be :empty?
+
+      mock.verify
+    end
+
+    it "loads SCHEMA_VIEW on access to granularity" do
+      get_res = Google::Cloud::Bigtable::Admin::V2::Table.new(
+        name: table_path(instance_id, table_id),
+        column_families: column_families_grpc,
+        granularity: :MILLIS
+      )
+
+      mock = Minitest::Mock.new
+      mock.expect :get_table, get_res, [name: table_path(instance_id, table_id), view: :SCHEMA_VIEW]
+      table.service.mocked_tables = mock
+
+      _(table.granularity).must_equal :MILLIS
+
+      mock.verify
+    end
+
+    it "loads REPLICATION_VIEW on access to cluster_states" do
+      get_res = Google::Cloud::Bigtable::Admin::V2::Table.new(
+        name: table_path(instance_id, table_id),
+        cluster_states: cluster_states
+      )
+
+      mock = Minitest::Mock.new
+      mock.expect :get_table, get_res, [name: table_path(instance_id, table_id), view: :REPLICATION_VIEW]
+      table.service.mocked_tables = mock
+
+      _(table.cluster_states).wont_be :empty?
+
+      mock.verify
+    end
+
+    it "loads SCHEMA_VIEW and REPLICATION_VIEW on access to column_families and cluster_states" do
+      get_res_schema = Google::Cloud::Bigtable::Admin::V2::Table.new(
+        name: table_path(instance_id, table_id),
+        column_families: column_families_grpc,
+        granularity: :MILLIS
+      )
+      get_res_replication = Google::Cloud::Bigtable::Admin::V2::Table.new(
+        name: table_path(instance_id, table_id),
+        cluster_states: cluster_states
+      )
+
+      mock = Minitest::Mock.new
+      mock.expect :get_table, get_res_schema, [name: table_path(instance_id, table_id), view: :SCHEMA_VIEW]
+      mock.expect :get_table, get_res_replication, [name: table_path(instance_id, table_id), view: :REPLICATION_VIEW]
+      table.service.mocked_tables = mock
+
+      _(table.column_families).wont_be :empty?
+      _(table.cluster_states).wont_be :empty?
+
+      mock.verify
     end
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table_test.rb
@@ -136,6 +136,7 @@ describe Google::Cloud::Bigtable::Table, :mock_bigtable do
       table.service.mocked_tables = mock
 
       _(table.column_families).wont_be :empty?
+      _(table.column_families).wont_be :empty? # No RPC on subsequent access
 
       mock.verify
     end
@@ -152,6 +153,7 @@ describe Google::Cloud::Bigtable::Table, :mock_bigtable do
       table.service.mocked_tables = mock
 
       _(table.granularity).must_equal :MILLIS
+      _(table.granularity).must_equal :MILLIS # No RPC on subsequent access
 
       mock.verify
     end
@@ -167,6 +169,7 @@ describe Google::Cloud::Bigtable::Table, :mock_bigtable do
       table.service.mocked_tables = mock
 
       _(table.cluster_states).wont_be :empty?
+      _(table.cluster_states).wont_be :empty? # No RPC on subsequent access
 
       mock.verify
     end
@@ -189,6 +192,8 @@ describe Google::Cloud::Bigtable::Table, :mock_bigtable do
 
       _(table.column_families).wont_be :empty?
       _(table.cluster_states).wont_be :empty?
+      _(table.column_families).wont_be :empty? # No RPC on subsequent access
+      _(table.cluster_states).wont_be :empty? # No RPC on subsequent access
 
       mock.verify
     end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table_test.rb
@@ -61,7 +61,7 @@ describe Google::Cloud::Bigtable::Table, :mock_bigtable do
 
   describe "#helpers" do
     let(:table) do
-      Google::Cloud::Bigtable::Table.new(Object.new, Object.new)
+      Google::Cloud::Bigtable::Table.new(Object.new, Object.new, view: :NAME_ONLY)
     end
 
     it "create mutation entry instance" do
@@ -71,7 +71,6 @@ describe Google::Cloud::Bigtable::Table, :mock_bigtable do
     end
 
     it "create read modify write row rule instance" do
-      table = Google::Cloud::Bigtable::Table.new(Object.new, Object.new)
       rule = table.new_read_modify_write_rule("cf", "field1")
       _(rule).must_be_kind_of Google::Cloud::Bigtable::ReadModifyWriteRule
       _(rule.to_grpc.family_name).must_equal "cf"


### PR DESCRIPTION
The internals of view state management in `Table` have some quirks. For example, calling `Table#reload!` on a table that was initially loaded from `Project#table` will change its current view from `NAME_ONLY` to `SCHEMA_VIEW `.

Pending analysis and discussion of potential bugs, this PR currently just exposes some internal state for testing purposes, and adds missing tests.