### PR TITLE
Release google-cloud-metastore-v1beta 0.1.0

### DIFF
--- a/google-cloud-metastore-v1beta/CHANGELOG.md
+++ b/google-cloud-metastore-v1beta/CHANGELOG.md
@@ -1,2 +1,6 @@
 # Release History
 
+### 0.1.0 / 2021-03-30
+
+* Initial release
+

--- a/google-cloud-metastore-v1beta/lib/google/cloud/metastore/v1beta/version.rb
+++ b/google-cloud-metastore-v1beta/lib/google/cloud/metastore/v1beta/version.rb
@@ -21,7 +21,7 @@ module Google
   module Cloud
     module Metastore
       module V1beta
-        VERSION = "0.0.1"
+        VERSION = "0.1.0"
       end
     end
   end


### PR DESCRIPTION
* Initial release

<details><summary>Commits since previous release</summary><pre><code></code></pre></details>

This pull request was generated using releasetool.