### PR TITLE
Release google-cloud-gke_hub-v1beta1 0.1.0

### DIFF
--- a/google-cloud-gke_hub-v1beta1/CHANGELOG.md
+++ b/google-cloud-gke_hub-v1beta1/CHANGELOG.md
@@ -1,2 +1,6 @@
 # Release History
 
+### 0.1.0 / 2021-03-30
+
+* Initial release
+

--- a/google-cloud-gke_hub-v1beta1/lib/google/cloud/gke_hub/v1beta1/version.rb
+++ b/google-cloud-gke_hub-v1beta1/lib/google/cloud/gke_hub/v1beta1/version.rb
@@ -21,7 +21,7 @@ module Google
   module Cloud
     module GkeHub
       module V1beta1
-        VERSION = "0.0.1"
+        VERSION = "0.1.0"
       end
     end
   end


### PR DESCRIPTION
* Initial release

<details><summary>Commits since previous release</summary><pre><code></code></pre></details>

This pull request was generated using releasetool.