### PR TITLE
Release google-cloud-app_engine 1.0.0

### DIFF
--- a/google-cloud-app_engine/CHANGELOG.md
+++ b/google-cloud-app_engine/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 1.0.0 / 2021-03-30
+
+* Bump client version to 1.0 to reflect GA status
+
 ### 0.2.0 / 2021-03-08
 
 #### Features

--- a/google-cloud-app_engine/google-cloud-app_engine.gemspec
+++ b/google-cloud-app_engine/google-cloud-app_engine.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "google-cloud-app_engine-v1", "~> 0.0"
+  gem.add_dependency "google-cloud-app_engine-v1", "~> 0.3"
   gem.add_dependency "google-cloud-core", "~> 1.5"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-app_engine/lib/google/cloud/app_engine/version.rb
+++ b/google-cloud-app_engine/lib/google/cloud/app_engine/version.rb
@@ -20,7 +20,7 @@
 module Google
   module Cloud
     module AppEngine
-      VERSION = "0.2.0"
+      VERSION = "1.0.0"
     end
   end
 end

--- a/google-cloud-app_engine/synth.py
+++ b/google-cloud-app_engine/synth.py
@@ -30,7 +30,7 @@ library = gapic.ruby_library(
         "ruby-cloud-title": "App Engine Admin",
         "ruby-cloud-description": "The App Engine Admin API provisions and manages your App Engine applications.",
         "ruby-cloud-env-prefix": "APP_ENGINE",
-        "ruby-cloud-wrapper-of": "v1:0.0",
+        "ruby-cloud-wrapper-of": "v1:0.3",
         "ruby-cloud-product-url": "https://cloud.google.com/appengine/docs/admin-api/",
         "ruby-cloud-api-id": "appengine.googleapis.com",
         "ruby-cloud-api-shortname": "appengine",


### PR DESCRIPTION
* Bump client version to 1.0 to reflect GA status

<details><summary>Commits since previous release</summary><pre><code></code></pre></details>

This pull request was generated using releasetool.