### PR TITLE
Release google-cloud-channel 1.0.0

### DIFF
--- a/google-cloud-channel/CHANGELOG.md
+++ b/google-cloud-channel/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 1.0.0 / 2021-03-30
+
+* Bump client version to 1.0 to reflect GA status
+
 ### 0.2.0 / 2021-03-08
 
 #### Features

--- a/google-cloud-channel/google-cloud-channel.gemspec
+++ b/google-cloud-channel/google-cloud-channel.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "google-cloud-channel-v1", "~> 0.0"
+  gem.add_dependency "google-cloud-channel-v1", "~> 0.5"
   gem.add_dependency "google-cloud-core", "~> 1.5"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-channel/lib/google/cloud/channel/version.rb
+++ b/google-cloud-channel/lib/google/cloud/channel/version.rb
@@ -20,7 +20,7 @@
 module Google
   module Cloud
     module Channel
-      VERSION = "0.2.0"
+      VERSION = "1.0.0"
     end
   end
 end

--- a/google-cloud-channel/synth.py
+++ b/google-cloud-channel/synth.py
@@ -29,7 +29,7 @@ library = gapic.ruby_library(
         "ruby-cloud-title": "Cloud Channel",
         "ruby-cloud-description": "You can use Channel Services to manage your relationships with your partners and your customers. Channel Services include a console and APIs to view and provision links between distributors and resellers, customers and entitlements.",
         "ruby-cloud-env-prefix": "CHANNEL",
-        "ruby-cloud-wrapper-of": "v1:0.0",
+        "ruby-cloud-wrapper-of": "v1:0.5",
         "ruby-cloud-product-url": "https://cloud.google.com/channel",
         "ruby-cloud-api-id": "cloudchannel.googleapis.com",
         "ruby-cloud-api-shortname": "cloudchannel",


### PR DESCRIPTION
* Bump client version to 1.0 to reflect GA status

<details><summary>Commits since previous release</summary><pre><code></code></pre></details>

This pull request was generated using releasetool.