### PR TITLE
Release google-cloud-iot 1.0.0

### DIFF
--- a/google-cloud-iot/CHANGELOG.md
+++ b/google-cloud-iot/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 1.0.0 / 2021-03-30
+
+* Bump client version to 1.0 to reflect GA status
+
 ### 0.2.0 / 2021-03-08
 
 #### Features

--- a/google-cloud-iot/google-cloud-iot.gemspec
+++ b/google-cloud-iot/google-cloud-iot.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.5"
 
   gem.add_dependency "google-cloud-core", "~> 1.5"
-  gem.add_dependency "google-cloud-iot-v1", "~> 0.0"
+  gem.add_dependency "google-cloud-iot-v1", "~> 0.3"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"

--- a/google-cloud-iot/lib/google/cloud/iot/version.rb
+++ b/google-cloud-iot/lib/google/cloud/iot/version.rb
@@ -20,7 +20,7 @@
 module Google
   module Cloud
     module Iot
-      VERSION = "0.2.0"
+      VERSION = "1.0.0"
     end
   end
 end

--- a/google-cloud-iot/synth.py
+++ b/google-cloud-iot/synth.py
@@ -29,7 +29,7 @@ library = gapic.ruby_library(
         "ruby-cloud-title": "Cloud IoT",
         "ruby-cloud-description": "Registers and manages IoT (Internet of Things) devices that connect to the Google Cloud Platform.",
         "ruby-cloud-env-prefix": "IOT",
-        "ruby-cloud-wrapper-of": "v1:0.0",
+        "ruby-cloud-wrapper-of": "v1:0.3",
         "ruby-cloud-product-url": "https://cloud.google.com/iot",
         "ruby-cloud-api-id": "cloudiot.googleapis.com",
         "ruby-cloud-api-shortname": "cloudiot",


### PR DESCRIPTION
* Bump client version to 1.0 to reflect GA status

<details><summary>Commits since previous release</summary><pre><code></code></pre></details>

This pull request was generated using releasetool.