### PR TITLE
Release google-cloud-managed_identities 1.0.0

### DIFF
--- a/google-cloud-managed_identities/CHANGELOG.md
+++ b/google-cloud-managed_identities/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 1.0.0 / 2021-03-30
+
+* Bump client version to 1.0 to reflect GA status
+
 ### 0.2.0 / 2021-03-08
 
 #### Features

--- a/google-cloud-managed_identities/google-cloud-managed_identities.gemspec
+++ b/google-cloud-managed_identities/google-cloud-managed_identities.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.5"
 
   gem.add_dependency "google-cloud-core", "~> 1.5"
-  gem.add_dependency "google-cloud-managed_identities-v1", "~> 0.0"
+  gem.add_dependency "google-cloud-managed_identities-v1", "~> 0.3"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"

--- a/google-cloud-managed_identities/lib/google/cloud/managed_identities/version.rb
+++ b/google-cloud-managed_identities/lib/google/cloud/managed_identities/version.rb
@@ -20,7 +20,7 @@
 module Google
   module Cloud
     module ManagedIdentities
-      VERSION = "0.2.0"
+      VERSION = "1.0.0"
     end
   end
 end

--- a/google-cloud-managed_identities/synth.py
+++ b/google-cloud-managed_identities/synth.py
@@ -29,7 +29,7 @@ library = gapic.ruby_library(
         "ruby-cloud-title": "Managed Service for Microsoft Active Directory API",
         "ruby-cloud-description": "The Managed Service for Microsoft Active Directory API is used for managing a highly available, hardened service running Microsoft Active Directory.",
         "ruby-cloud-env-prefix": "MANAGED_IDENTITIES",
-        "ruby-cloud-wrapper-of": "v1:0.0",
+        "ruby-cloud-wrapper-of": "v1:0.3,
         "ruby-cloud-product-url": "https://cloud.google.com/managed-microsoft-ad/",
         "ruby-cloud-api-id": "managedidentities.googleapis.com",
         "ruby-cloud-api-shortname": "managedidentities",


### PR DESCRIPTION
* Bump client version to 1.0 to reflect GA status

<details><summary>Commits since previous release</summary><pre><code>commit 122d72df42f82d28c795b4507436aad98232eac9
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Tue Mar 16 21:31:00 2021 -0700

    chore(managed_identities): Remove titles in service descriptions
    
    PiperOrigin-RevId: 362943541
    
    Source-Author: Google APIs <noreply@google.com>
    Source-Date: Mon Mar 15 08:17:12 2021 -0700
    Source-Repo: googleapis/googleapis
    Source-Sha: cb631dd3ffe0d6f77f7b01c5168e357771c74b51
    Source-Link: https://github.com/googleapis/googleapis/commit/cb631dd3ffe0d6f77f7b01c5168e357771c74b51
</code></pre></details>

This pull request was generated using releasetool.