### PR TITLE
Release google-cloud-org_policy 1.0.0

### DIFF
--- a/google-cloud-org_policy/CHANGELOG.md
+++ b/google-cloud-org_policy/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 1.0.0 / 2021-03-30
+
+* Bump client version to 1.0 to reflect GA status
+
 ### 0.2.0 / 2021-03-08
 
 #### Features

--- a/google-cloud-org_policy/google-cloud-org_policy.gemspec
+++ b/google-cloud-org_policy/google-cloud-org_policy.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.5"
 
   gem.add_dependency "google-cloud-core", "~> 1.5"
-  gem.add_dependency "google-cloud-org_policy-v2", "~> 0.0"
+  gem.add_dependency "google-cloud-org_policy-v2", "~> 0.2"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"

--- a/google-cloud-org_policy/lib/google/cloud/org_policy/version.rb
+++ b/google-cloud-org_policy/lib/google/cloud/org_policy/version.rb
@@ -20,7 +20,7 @@
 module Google
   module Cloud
     module OrgPolicy
-      VERSION = "0.2.0"
+      VERSION = "1.0.0"
     end
   end
 end

--- a/google-cloud-org_policy/synth.py
+++ b/google-cloud-org_policy/synth.py
@@ -29,7 +29,7 @@ library = gapic.ruby_library(
         "ruby-cloud-title": "Organization Policy",
         "ruby-cloud-description": "The Cloud Org Policy service provides a simple mechanism for organizations to restrict the allowed configurations across their entire Cloud Resource hierarchy.",
         "ruby-cloud-env-prefix": "ORG_POLICY",
-        "ruby-cloud-wrapper-of": "v2:0.0",
+        "ruby-cloud-wrapper-of": "v2:0.2",
         "ruby-cloud-product-url": "https://cloud.google.com/resource-manager/docs/organization-policy/overview",
         "ruby-cloud-api-id": "orgpolicy.googleapis.com",
         "ruby-cloud-api-shortname": "orgpolicy",


### PR DESCRIPTION
* Bump client version to 1.0 to reflect GA status

<details><summary>Commits since previous release</summary><pre><code></code></pre></details>

This pull request was generated using releasetool.