### PR TITLE
Release google-cloud-profiler 1.0.0

### DIFF
--- a/google-cloud-profiler/CHANGELOG.md
+++ b/google-cloud-profiler/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 1.0.0 / 2021-03-30
+
+* Bump client version to 1.0 to reflect GA status
+
 ### 0.2.0 / 2021-03-08
 
 #### Features

--- a/google-cloud-profiler/google-cloud-profiler.gemspec
+++ b/google-cloud-profiler/google-cloud-profiler.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.5"
 
   gem.add_dependency "google-cloud-core", "~> 1.5"
-  gem.add_dependency "google-cloud-profiler-v2", "~> 0.0"
+  gem.add_dependency "google-cloud-profiler-v2", "~> 0.2"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"

--- a/google-cloud-profiler/lib/google/cloud/profiler/version.rb
+++ b/google-cloud-profiler/lib/google/cloud/profiler/version.rb
@@ -20,7 +20,7 @@
 module Google
   module Cloud
     module Profiler
-      VERSION = "0.2.0"
+      VERSION = "1.0.0"
     end
   end
 end

--- a/google-cloud-profiler/synth.py
+++ b/google-cloud-profiler/synth.py
@@ -30,7 +30,7 @@ library = gapic.ruby_library(
         "ruby-cloud-title": "Cloud Profiler",
         "ruby-cloud-description": "Cloud Profiler is a statistical, low-overhead profiler that continuously gathers CPU usage and memory-allocation information from your production applications. It attributes that information to the application's source code, helping you identify the parts of the application consuming the most resources, and otherwise illuminating the performance characteristics of the code.",
         "ruby-cloud-env-prefix": "PROFILER",
-        "ruby-cloud-wrapper-of": "v2:0.0",
+        "ruby-cloud-wrapper-of": "v2:0.2",
         "ruby-cloud-product-url": "https://cloud.google.com/profiler/",
         "ruby-cloud-api-id": "cloudprofiler.googleapis.com",
         "ruby-cloud-api-shortname": "cloudprofiler",


### PR DESCRIPTION
* Bump client version to 1.0 to reflect GA status

<details><summary>Commits since previous release</summary><pre><code></code></pre></details>

This pull request was generated using releasetool.