### PR TITLE
Release google-cloud-retail 1.0.0

### DIFF
--- a/google-cloud-retail/CHANGELOG.md
+++ b/google-cloud-retail/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 1.0.0 / 2021-03-30
+
+* Bump client version to 1.0 to reflect GA status
+
 ### 0.2.0 / 2021-03-08
 
 #### Features

--- a/google-cloud-retail/google-cloud-retail.gemspec
+++ b/google-cloud-retail/google-cloud-retail.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.5"
 
   gem.add_dependency "google-cloud-core", "~> 1.5"
-  gem.add_dependency "google-cloud-retail-v2", "~> 0.0"
+  gem.add_dependency "google-cloud-retail-v2", "~> 0.3"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"

--- a/google-cloud-retail/lib/google/cloud/retail/version.rb
+++ b/google-cloud-retail/lib/google/cloud/retail/version.rb
@@ -20,7 +20,7 @@
 module Google
   module Cloud
     module Retail
-      VERSION = "0.2.0"
+      VERSION = "1.0.0"
     end
   end
 end

--- a/google-cloud-retail/synth.py
+++ b/google-cloud-retail/synth.py
@@ -29,7 +29,7 @@ library = gapic.ruby_library(
         "ruby-cloud-title": "Retail",
         "ruby-cloud-description": "Retail enables you to build an end-to-end personalized recommendation system based on state-of-the-art deep learning ML models, without a need for expertise in ML or recommendation systems.",
         "ruby-cloud-env-prefix": "RETAIL",
-        "ruby-cloud-wrapper-of": "v2:0.0",
+        "ruby-cloud-wrapper-of": "v2:0.3",
         "ruby-cloud-product-url": "https://cloud.google.com/retail/docs/apis",
         "ruby-cloud-api-id": "retail.googleapis.com",
         "ruby-cloud-api-shortname": "retail",


### PR DESCRIPTION
* Bump client version to 1.0 to reflect GA status

<details><summary>Commits since previous release</summary><pre><code></code></pre></details>

This pull request was generated using releasetool.