### PR TITLE
Release google-cloud-service_control 1.0.0

### DIFF
--- a/google-cloud-service_control/CHANGELOG.md
+++ b/google-cloud-service_control/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+### 1.0.0 / 2021-03-30
+
+* Bump client version to 1.0 to reflect GA status
+* Fixed several broken links in the reference documentation
+
 ### 0.2.0 / 2021-03-08
 
 #### Features

--- a/google-cloud-service_control/google-cloud-service_control.gemspec
+++ b/google-cloud-service_control/google-cloud-service_control.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.5"
 
   gem.add_dependency "google-cloud-core", "~> 1.5"
-  gem.add_dependency "google-cloud-service_control-v1", "~> 0.0"
+  gem.add_dependency "google-cloud-service_control-v1", "~> 0.3"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"

--- a/google-cloud-service_control/lib/google/cloud/service_control/version.rb
+++ b/google-cloud-service_control/lib/google/cloud/service_control/version.rb
@@ -20,7 +20,7 @@
 module Google
   module Cloud
     module ServiceControl
-      VERSION = "0.2.0"
+      VERSION = "1.0.0"
     end
   end
 end

--- a/google-cloud-service_control/synth.py
+++ b/google-cloud-service_control/synth.py
@@ -30,7 +30,7 @@ library = gapic.ruby_library(
         "ruby-cloud-title": "Service Control API",
         "ruby-cloud-description": "The Service Control API provides control plane functionality to managed services, such as logging, monitoring, and status checks.",
         "ruby-cloud-env-prefix": "SERVICE_CONTROL",
-        "ruby-cloud-wrapper-of": "v1:0.0",
+        "ruby-cloud-wrapper-of": "v1:0.3",
         "ruby-cloud-product-url": "https://cloud.google.com/service-infrastructure/docs/overview/",
         "ruby-cloud-api-id": "servicecontrol.googleapis.com",
         "ruby-cloud-api-shortname": "servicecontrol",


### PR DESCRIPTION
* Bump client version to 1.0 to reflect GA status
* Fixed several broken links in the reference documentation

<details><summary>Commits since previous release</summary><pre><code>commit 7ada85da1cd0e006f772255ea1114bf7a07a2897
Author: Yoshi Automation Bot <yoshi-automation@google.com>
Date:   Wed Mar 24 14:51:45 2021 -0700

    docs(service_control): Fixed several broken links in the reference documentation
    
    PiperOrigin-RevId: 364666178
    
    Source-Author: Google APIs <noreply@google.com>
    Source-Date: Tue Mar 23 16:01:41 2021 -0700
    Source-Repo: googleapis/googleapis
    Source-Sha: 336d6f419fe9466e4540083bbfa46a57f67dc92e
    Source-Link: https://github.com/googleapis/googleapis/commit/336d6f419fe9466e4540083bbfa46a57f67dc92e
</code></pre></details>

This pull request was generated using releasetool.