### PR TITLE
Release google-cloud-service_management 1.0.0

### DIFF
--- a/google-cloud-service_management/CHANGELOG.md
+++ b/google-cloud-service_management/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 1.0.0 / 2021-03-30
+
+* Bump client version to 1.0 to reflect GA status
+
 ### 0.2.0 / 2021-03-08
 
 #### Features

--- a/google-cloud-service_management/google-cloud-service_management.gemspec
+++ b/google-cloud-service_management/google-cloud-service_management.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.5"
 
   gem.add_dependency "google-cloud-core", "~> 1.5"
-  gem.add_dependency "google-cloud-service_management-v1", "~> 0.0"
+  gem.add_dependency "google-cloud-service_management-v1", "~> 0.3"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"

--- a/google-cloud-service_management/lib/google/cloud/service_management/version.rb
+++ b/google-cloud-service_management/lib/google/cloud/service_management/version.rb
@@ -20,7 +20,7 @@
 module Google
   module Cloud
     module ServiceManagement
-      VERSION = "0.2.0"
+      VERSION = "1.0.0"
     end
   end
 end

--- a/google-cloud-service_management/synth.py
+++ b/google-cloud-service_management/synth.py
@@ -30,7 +30,7 @@ library = gapic.ruby_library(
         "ruby-cloud-title": "Service Management API",
         "ruby-cloud-description": "Google Service Management allows service producers to publish their services on Google Cloud Platform so that they can be discovered and used by service consumers.",
         "ruby-cloud-env-prefix": "SERVICE_MANAGEMENT",
-        "ruby-cloud-wrapper-of": "v1:0.0",
+        "ruby-cloud-wrapper-of": "v1:0.3",
         "ruby-cloud-product-url": "https://cloud.google.com/service-infrastructure/docs/overview/",
         "ruby-cloud-api-id": "servicemanagement.googleapis.com",
         "ruby-cloud-api-shortname": "servicemanagement",


### PR DESCRIPTION
* Bump client version to 1.0 to reflect GA status

<details><summary>Commits since previous release</summary><pre><code></code></pre></details>

This pull request was generated using releasetool.