### PR TITLE
Release google-cloud-web_security_scanner 1.0.0

### DIFF
--- a/google-cloud-web_security_scanner/CHANGELOG.md
+++ b/google-cloud-web_security_scanner/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 1.0.0 / 2021-03-30
+
+* Bump client version to 1.0 to reflect GA status
+
 ### 0.2.0 / 2021-03-08
 
 #### Features

--- a/google-cloud-web_security_scanner/google-cloud-web_security_scanner.gemspec
+++ b/google-cloud-web_security_scanner/google-cloud-web_security_scanner.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.5"
 
   gem.add_dependency "google-cloud-core", "~> 1.5"
-  gem.add_dependency "google-cloud-web_security_scanner-v1", "~> 0.0"
-  gem.add_dependency "google-cloud-web_security_scanner-v1beta", "~> 0.0"
+  gem.add_dependency "google-cloud-web_security_scanner-v1", "~> 0.3"
+  gem.add_dependency "google-cloud-web_security_scanner-v1beta", "~> 0.3"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"

--- a/google-cloud-web_security_scanner/lib/google/cloud/web_security_scanner/version.rb
+++ b/google-cloud-web_security_scanner/lib/google/cloud/web_security_scanner/version.rb
@@ -20,7 +20,7 @@
 module Google
   module Cloud
     module WebSecurityScanner
-      VERSION = "0.2.0"
+      VERSION = "1.0.0"
     end
   end
 end

--- a/google-cloud-web_security_scanner/synth.py
+++ b/google-cloud-web_security_scanner/synth.py
@@ -29,7 +29,7 @@ library = gapic.ruby_library(
         "ruby-cloud-title": "Web Security Scanner",
         "ruby-cloud-description": "Web Security Scanner scans your Compute and App Engine apps for common web vulnerabilities.",
         "ruby-cloud-env-prefix": "WEB_SECURITY_SCANNER",
-        "ruby-cloud-wrapper-of": "v1:0.0;v1beta:0.0",
+        "ruby-cloud-wrapper-of": "v1:0.3;v1beta:0.3",
         "ruby-cloud-product-url": "https://cloud.google.com/security-command-center/docs/concepts-web-security-scanner-overview/",
         "ruby-cloud-api-id": "websecurityscanner.googleapis.com",
         "ruby-cloud-api-shortname": "websecurityscanner",


### PR DESCRIPTION
* Bump client version to 1.0 to reflect GA status

<details><summary>Commits since previous release</summary><pre><code></code></pre></details>

This pull request was generated using releasetool.