### PR TITLE
Release google-iam-credentials 1.0.0

### DIFF
--- a/google-iam-credentials/CHANGELOG.md
+++ b/google-iam-credentials/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 1.0.0 / 2021-03-30
+
+* Bump client version to 1.0 to reflect GA status
+
 ### 0.2.0 / 2021-03-08
 
 #### Features

--- a/google-iam-credentials/google-iam-credentials.gemspec
+++ b/google-iam-credentials/google-iam-credentials.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.5"
 
   gem.add_dependency "google-cloud-core", "~> 1.5"
-  gem.add_dependency "google-iam-credentials-v1", "~> 0.0"
+  gem.add_dependency "google-iam-credentials-v1", "~> 0.3"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"

--- a/google-iam-credentials/lib/google/iam/credentials/version.rb
+++ b/google-iam-credentials/lib/google/iam/credentials/version.rb
@@ -20,7 +20,7 @@
 module Google
   module Iam
     module Credentials
-      VERSION = "0.2.0"
+      VERSION = "1.0.0"
     end
   end
 end

--- a/google-iam-credentials/synth.py
+++ b/google-iam-credentials/synth.py
@@ -30,7 +30,7 @@ library = gapic.ruby_library(
         "ruby-cloud-title": "IAM Service Account Credentials",
         "ruby-cloud-description": "The Service Account Credentials API creates short-lived credentials for Identity and Access Management (IAM) service accounts. You can also use this API to sign JSON Web Tokens (JWTs), as well as blobs of binary data that contain other types of tokens.",
         "ruby-cloud-env-prefix": "IAM_CREDENTIALS",
-        "ruby-cloud-wrapper-of": "v1:0.0",
+        "ruby-cloud-wrapper-of": "v1:0.3",
         "ruby-cloud-product-url": "https://cloud.google.com/iam",
         "ruby-cloud-api-id": "iamcredentials.googleapis.com",
         "ruby-cloud-api-shortname": "iamcredentials",


### PR DESCRIPTION
* Bump client version to 1.0 to reflect GA status

<details><summary>Commits since previous release</summary><pre><code></code></pre></details>

This pull request was generated using releasetool.