### PR TITLE
Release google-cloud-metastore 0.1.0

### DIFF
--- a/google-cloud-metastore/CHANGELOG.md
+++ b/google-cloud-metastore/CHANGELOG.md
@@ -1,2 +1,6 @@
 # Release History
 
+### 0.1.0 / 2021-03-30
+
+* Initial release
+

--- a/google-cloud-metastore/lib/google/cloud/metastore/version.rb
+++ b/google-cloud-metastore/lib/google/cloud/metastore/version.rb
@@ -20,7 +20,7 @@
 module Google
   module Cloud
     module Metastore
-      VERSION = "0.0.1"
+      VERSION = "0.1.0"
     end
   end
 end


### PR DESCRIPTION
* Initial release

<details><summary>Commits since previous release</summary><pre><code></code></pre></details>

This pull request was generated using releasetool.