### PR TITLE
chore(memcache-v1beta2): Undo version 0.1.3 changelog

### DIFF
--- a/google-cloud-memcache-v1beta2/CHANGELOG.md
+++ b/google-cloud-memcache-v1beta2/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Release History
 
-### 0.1.3 / 2020-08-10
-
-#### Bug Fixes
-
-* Allow special symbolic credentials in client configs
-
 ### 0.1.2 / 2020-08-06
 
 #### Bug Fixes

--- a/google-cloud-memcache-v1beta2/lib/google/cloud/memcache/v1beta2/version.rb
+++ b/google-cloud-memcache-v1beta2/lib/google/cloud/memcache/v1beta2/version.rb
@@ -21,7 +21,7 @@ module Google
   module Cloud
     module Memcache
       module V1beta2
-        VERSION = "0.1.3"
+        VERSION = "0.1.2"
       end
     end
   end


### PR DESCRIPTION
The 0.1.3 release was never completed (see https://github.com/googleapis/google-cloud-ruby/pull/7394), leaving the release scripts in a bad state where the library's version number is 0.1.3 but there isn't a tag for the 0.1.3 release. This has prevented any further releases from successfully triggering since Aug 2020. To unblock this, I'm rolling back the version number and changelog for the aborted release.