### PR TITLE
chore(dialogflow-v2): Undo version 0.6.5 changelog

### DIFF
--- a/google-cloud-dialogflow-v2/CHANGELOG.md
+++ b/google-cloud-dialogflow-v2/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Release History
 
-### 0.6.5 / 2020-08-06
-
-#### Bug Fixes
-
-* Fix retry logic by checking the correct numeric error codes
-
 ### 0.6.4 / 2020-06-25
 
 #### Bug Fixes

--- a/google-cloud-dialogflow-v2/lib/google/cloud/dialogflow/v2/version.rb
+++ b/google-cloud-dialogflow-v2/lib/google/cloud/dialogflow/v2/version.rb
@@ -21,7 +21,7 @@ module Google
   module Cloud
     module Dialogflow
       module V2
-        VERSION = "0.6.5"
+        VERSION = "0.6.4"
       end
     end
   end


### PR DESCRIPTION
The 0.6.5 release was never completed (see #7247), leaving the release scripts in a bad state where the library's version number is 0.6.5 but there isn't a tag for the 0.6.5 release. This has prevented any further releases from successfully triggering since Aug 2020. To unblock this, I'm rolling back the version number and changelog for the aborted release.