### PR TITLE
docs(pubsub): Update Subscription#pull docs and samples to recommend return_immediately: false

### DIFF
--- a/google-cloud-pubsub/OVERVIEW.md
+++ b/google-cloud-pubsub/OVERVIEW.md
@@ -205,13 +205,16 @@ sleep
 Messages also can be pulled directly in a one-time operation. (See
 {Google::Cloud::PubSub::Subscription#pull Subscription#pull})
 
+The `immediate: false` option is now recommended to avoid adverse impacts on
+pull operations.
+
 ```ruby
 require "google/cloud/pubsub"
 
 pubsub = Google::Cloud::PubSub.new
 
 sub = pubsub.subscription "my-topic-sub"
-received_messages = sub.pull
+received_messages = sub.pull immediate: false
 ```
 
 A maximum number of messages to pull can be specified:
@@ -222,7 +225,7 @@ require "google/cloud/pubsub"
 pubsub = Google::Cloud::PubSub.new
 
 sub = pubsub.subscription "my-topic-sub"
-received_messages = sub.pull max: 10
+received_messages = sub.pull immediate: false, max: 10
 ```
 
 ## Acknowledging a Message
@@ -263,7 +266,7 @@ require "google/cloud/pubsub"
 pubsub = Google::Cloud::PubSub.new
 
 sub = pubsub.subscription "my-topic-sub"
-received_messages = sub.pull
+received_messages = sub.pull immediate: false
 sub.acknowledge received_messages
 ```
 
@@ -328,7 +331,7 @@ require "google/cloud/pubsub"
 pubsub = Google::Cloud::PubSub.new
 
 sub = pubsub.subscription "my-topic-sub"
-received_messages = sub.pull
+received_messages = sub.pull immediate: false
 sub.modify_ack_deadline 120, received_messages
 ```
 
@@ -474,7 +477,7 @@ sub = pubsub.subscription "my-topic-sub"
 
 snapshot = sub.create_snapshot
 
-received_messages = sub.pull
+received_messages = sub.pull immediate: false
 sub.acknowledge received_messages
 
 sub.seek snapshot

--- a/google-cloud-pubsub/acceptance/pubsub_helper.rb
+++ b/google-cloud-pubsub/acceptance/pubsub_helper.rb
@@ -64,7 +64,7 @@ module Acceptance
       received_messages = []
       retries = 0
       while retries <= 5 do
-        received_messages = sub.pull
+        received_messages = sub.pull immediate: false
         break if received_messages.any?
         retries += 1
         puts "the subscription does not have the message yet. sleeping for #{retries*retries} second(s) and retrying."

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -733,19 +733,27 @@ module Google
         end
 
         ##
-        # Pulls messages from the server. Returns an empty list if there are no
-        # messages available in the backlog. Raises an ApiError with status
-        # `UNAVAILABLE` if there are too many concurrent pull requests pending
-        # for the given subscription.
+        # Pulls messages from the server, blocking until messages are available
+        # when called with the `immediate: false` option, which is now recommended
+        # to avoid adverse impacts on pull operations. Raises an API error with
+        # status `UNAVAILABLE` if there are too many concurrent pull requests
+        # pending for the given subscription.
         #
         # See also {#listen} for the preferred way to process messages as they
         # become available.
         #
-        # @param [Boolean] immediate When `true` the system will respond
-        #   immediately even if it is not able to return messages. When `false`
-        #   the system is allowed to wait until it can return least one message.
-        #   No messages are returned when a request times out. The default value
-        #   is `true`.
+        # @param [Boolean] immediate Whether to return immediately or block until
+        #   messages are available.
+        #
+        #   **Warning:** The default value of this field is `true`. However, sending
+        #   `true` is discouraged because it adversely impacts the performance of
+        #   pull operations. We recommend that users always explicitly set this field
+        #   to `false`.
+        #
+        #   If this field set to `true`, the system will respond immediately
+        #   even if it there are no messages available to return in the pull
+        #   response. Otherwise, the system may wait (for a bounded amount of time)
+        #   until at least one message is available, rather than returning no messages.
         #
         #   See also {#listen} for the preferred way to process messages as they
         #   become available.
@@ -755,13 +763,16 @@ module Google
         #
         # @return [Array<Google::Cloud::PubSub::ReceivedMessage>]
         #
-        # @example
+        # @example The `immediate: false` option is now recommended to avoid adverse impacts on pull operations:
         #   require "google/cloud/pubsub"
         #
         #   pubsub = Google::Cloud::PubSub.new
         #
         #   sub = pubsub.subscription "my-topic-sub"
-        #   sub.pull.each { |received_message| received_message.acknowledge! }
+        #   received_messages = sub.pull immediate: false
+        #   received_messages.each do |received_message|
+        #     received_message.acknowledge!
+        #   end
         #
         # @example A maximum number of messages returned can also be specified:
         #   require "google/cloud/pubsub"
@@ -769,17 +780,7 @@ module Google
         #   pubsub = Google::Cloud::PubSub.new
         #
         #   sub = pubsub.subscription "my-topic-sub"
-        #   sub.pull(max: 10).each do |received_message|
-        #     received_message.acknowledge!
-        #   end
-        #
-        # @example The call can block until messages are available:
-        #   require "google/cloud/pubsub"
-        #
-        #   pubsub = Google::Cloud::PubSub.new
-        #
-        #   sub = pubsub.subscription "my-topic-sub"
-        #   received_messages = sub.pull immediate: false
+        #   received_messages = sub.pull immediate: false, max: 10
         #   received_messages.each do |received_message|
         #     received_message.acknowledge!
         #   end
@@ -1010,7 +1011,7 @@ module Google
         #   pubsub = Google::Cloud::PubSub.new
         #
         #   sub = pubsub.subscription "my-topic-sub"
-        #   received_messages = sub.pull
+        #   received_messages = sub.pull immediate: false
         #   sub.acknowledge received_messages
         #
         def acknowledge *messages
@@ -1045,7 +1046,7 @@ module Google
         #   pubsub = Google::Cloud::PubSub.new
         #
         #   sub = pubsub.subscription "my-topic-sub"
-        #   received_messages = sub.pull
+        #   received_messages = sub.pull immediate: false
         #   sub.modify_ack_deadline 120, received_messages
         #
         def modify_ack_deadline new_deadline, *messages
@@ -1143,7 +1144,7 @@ module Google
         #
         #   snapshot = sub.create_snapshot
         #
-        #   received_messages = sub.pull
+        #   received_messages = sub.pull immediate: false
         #   sub.acknowledge received_messages
         #
         #   sub.seek snapshot
@@ -1156,7 +1157,7 @@ module Google
         #
         #   time = Time.now
         #
-        #   received_messages = sub.pull
+        #   received_messages = sub.pull immediate: false
         #   sub.acknowledge received_messages
         #
         #   sub.seek time

--- a/google-cloud-pubsub/samples/acceptance/topics_test.rb
+++ b/google-cloud-pubsub/samples/acceptance/topics_test.rb
@@ -118,7 +118,7 @@ describe "topics" do
 
     messages = []
     expect_with_retry "pubsub_publish_with_ordering_keys" do
-      @subscription.pull(max: 20).each do |message|
+      @subscription.pull(immediate: false, max: 20).each do |message|
         messages << message
         message.acknowledge!
       end
@@ -141,7 +141,7 @@ describe "topics" do
 
     messages = []
     expect_with_retry "pubsub_resume_publish_with_ordering_keys" do
-      @subscription.pull(max: 20).each do |message|
+      @subscription.pull(immediate: false, max: 20).each do |message|
         messages << message
         message.acknowledge!
       end
@@ -238,7 +238,7 @@ describe "topics" do
 
     messages = []
     expect_with_retry "pubsub_publish" do
-      @subscription.pull(max: 1).each do |message|
+      @subscription.pull(immediate: false, max: 1).each do |message|
         messages << message
         message.acknowledge!
       end
@@ -259,7 +259,7 @@ describe "topics" do
 
     messages = []
     expect_with_retry "pubsub_publish_custom_attributes" do
-      @subscription.pull(max: 1).each do |message|
+      @subscription.pull(immediate: false, max: 1).each do |message|
         messages << message
         message.acknowledge!
       end
@@ -283,7 +283,7 @@ describe "topics" do
 
     messages = []
     expect_with_retry "pubsub_publisher_batch_settings" do
-      @subscription.pull(max: 20).each do |message|
+      @subscription.pull(immediate: false, max: 20).each do |message|
         messages << message
         message.acknowledge!
       end
@@ -308,7 +308,7 @@ describe "topics" do
 
     messages = []
     expect_with_retry "pubsub_publisher_concurrency_control" do
-      @subscription.pull(max: 1).each do |message|
+      @subscription.pull(immediate: false, max: 1).each do |message|
         messages << message
         message.acknowledge!
       end
@@ -329,7 +329,7 @@ describe "topics" do
 
     messages = []
     expect_with_retry "pubsub_publish" do
-      @subscription.pull(max: 1).each do |message|
+      @subscription.pull(immediate: false, max: 1).each do |message|
         messages << message
         message.acknowledge!
       end

--- a/google-cloud-pubsub/samples/subscriptions.rb
+++ b/google-cloud-pubsub/samples/subscriptions.rb
@@ -211,7 +211,7 @@ def pull_messages subscription_id:
   pubsub = Google::Cloud::Pubsub.new
 
   subscription = pubsub.subscription subscription_id
-  subscription.pull.each do |message|
+  subscription.pull(immediate: false).each do |message|
     puts "Message pulled: #{message.data}"
     message.acknowledge!
   end
@@ -303,7 +303,7 @@ def dead_letter_delivery_attempt subscription_id:
   pubsub = Google::Cloud::Pubsub.new
 
   subscription = pubsub.subscription subscription_id
-  subscription.pull.each do |message|
+  subscription.pull(immediate: false).each do |message|
     puts "Received message: #{message.data}"
     puts "Delivery Attempt: #{message.delivery_attempt}"
     message.acknowledge!
@@ -323,7 +323,7 @@ def subscriber_sync_pull_with_lease subscription_id:
   processed = false
 
   # The subscriber pulls a specified number of messages.
-  received_messages = subscription.pull max: 1
+  received_messages = subscription.pull immediate: false, max: 1
 
   # Obtain the first message.
   message = received_messages.first


### PR DESCRIPTION
Update `Subscription#pull` docs and samples to recommend `immediate: false` (sending `return_immediately: false`).

The default value sent when calling `Subscription#pull` without arguments will be `return_immediately: true`.

closes: #10924