### PR TITLE
chore: change broken YARD-links to github friendly md links in handwritten libraries 

### DIFF
--- a/google-cloud-asset-v1beta1/README.md
+++ b/google-cloud-asset-v1beta1/README.md
@@ -19,7 +19,7 @@ In order to use this library, you first need to go through the following steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 1. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 1. [Enable the API.](https://console.cloud.google.com/apis/library/cloudasset.googleapis.com)
-1. {file:AUTHENTICATION.md Set up authentication.}
+2. [Set up authentication.](AUTHENTICATION.md)
 
 ## Quick Start
 

--- a/google-cloud-asset-v1beta1/README.md
+++ b/google-cloud-asset-v1beta1/README.md
@@ -19,7 +19,7 @@ In order to use this library, you first need to go through the following steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 1. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 1. [Enable the API.](https://console.cloud.google.com/apis/library/cloudasset.googleapis.com)
-2. [Set up authentication.](AUTHENTICATION.md)
+1. {file:AUTHENTICATION.md Set up authentication.}
 
 ## Quick Start
 

--- a/google-cloud-bigquery/AUTHENTICATION.md
+++ b/google-cloud-bigquery/AUTHENTICATION.md
@@ -155,4 +155,4 @@ Developers service account.
 ## Troubleshooting
 
 If you're having trouble authenticating you can ask for help by following the
-{file:TROUBLESHOOTING.md Troubleshooting Guide}.
+[Troubleshooting Guide](TROUBLESHOOTING.md).

--- a/google-cloud-bigquery/CONTRIBUTING.md
+++ b/google-cloud-bigquery/CONTRIBUTING.md
@@ -53,7 +53,7 @@ there is a small amount of setup:
 In order to run code interactively, you can automatically load
 google-cloud-bigquery and its dependencies in IRB. This requires that your
 developer environment has already been configured by following the steps
-described in the {file:AUTHENTICATION.md Authentication Guide}. An IRB console
+described in the [Authentication Guide](AUTHENTICATION.md). An IRB console
 can be created with:
 
 ```sh
@@ -119,15 +119,14 @@ If you alter an example's title, you may encounter breaking tests.
 ### BigQuery Acceptance Tests
 
 The BigQuery acceptance tests interact with the live service API. Follow the
-instructions in the {file:AUTHENTICATION.md Authentication guide} for enabling
+instructions in the [Authentication Guide](AUTHENTICATION.md) for enabling
 the BigQuery API. Occasionally, some API features may not yet be generally
 available, making it difficult for some contributors to successfully run the
 entire acceptance test suite. However, please ensure that you do successfully
 run acceptance tests for any code areas covered by your pull request.
 
 To run the acceptance tests, first create and configure a project in the Google
-Developers Console, as described in the {file:AUTHENTICATION.md Authentication
-guide}. Be sure to download the JSON KEY file. Make note of the PROJECT_ID and
+Developers Console, as described in the [Authentication Guide](AUTHENTICATION.md). Be sure to download the JSON KEY file. Make note of the PROJECT_ID and
 the KEYFILE location on your system.
 
 Before you can run the BigQuery acceptance tests, you must first create indexes
@@ -185,4 +184,4 @@ $ bundle exec rake rubocop
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See
-{file:CODE_OF_CONDUCT.md Code of Conduct} for more information.
+[Code of Conduct](CODE_OF_CONDUCT.md) for more information.

--- a/google-cloud-bigtable/AUTHENTICATION.md
+++ b/google-cloud-bigtable/AUTHENTICATION.md
@@ -174,4 +174,4 @@ Developers service account.
 ## Troubleshooting
 
 If you're having trouble authenticating you can ask for help by following the
-{file:TROUBLESHOOTING.md Troubleshooting Guide}.
+[Troubleshooting Guide](TROUBLESHOOTING.md).

--- a/google-cloud-bigtable/CONTRIBUTING.md
+++ b/google-cloud-bigtable/CONTRIBUTING.md
@@ -53,7 +53,7 @@ there is a small amount of setup:
 In order to run code interactively, you can automatically load
 google-cloud-bigtable and its dependencies in IRB. This requires that your
 developer environment has already been configured by following the steps
-described in the {file:AUTHENTICATION.md Authentication Guide}. An IRB console
+described in the [Authentication Guide](AUTHENTICATION.md). An IRB console
 can be created with:
 
 ```sh
@@ -119,15 +119,14 @@ If you alter an example's title, you may encounter breaking tests.
 ### Bigtable Acceptance Tests
 
 The Bigtable acceptance tests interact with the live service API. Follow the
-instructions in the {file:AUTHENTICATION.md Authentication guide} for enabling
+instructions in the [Authentication Guide](AUTHENTICATION.md) for enabling
 the Bigtable API. Occasionally, some API features may not yet be generally
 available, making it difficult for some contributors to successfully run the
 entire acceptance test suite. However, please ensure that you do successfully
 run acceptance tests for any code areas covered by your pull request.
 
 To run the acceptance tests, first create and configure a project in the Google
-Developers Console, as described in the {file:AUTHENTICATION.md Authentication
-guide}. Be sure to download the JSON KEY file. Make note of the PROJECT_ID and
+Developers Console, as described in the [Authentication Guide](AUTHENTICATION.md). Be sure to download the JSON KEY file. Make note of the PROJECT_ID and
 the KEYFILE location on your system.
 
 Before you can run the Bigtable acceptance tests, you must first create indexes
@@ -185,4 +184,4 @@ $ bundle exec rake rubocop
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See
-{file:CODE_OF_CONDUCT.md Code of Conduct} for more information.
+[Code of Conduct](CODE_OF_CONDUCT.md) for more information.

--- a/google-cloud-bigtable/OVERVIEW.md
+++ b/google-cloud-bigtable/OVERVIEW.md
@@ -16,7 +16,7 @@ Platform (GCP), including Google Compute Engine (GCE), Google Kubernetes Engine
 (GKE), Google App Engine (GAE), Google Cloud Functions (GCF) and Cloud Run. In
 other environments you can configure authentication easily, either directly in
 your code or via environment variables. Read more about the options for
-connecting in the {file:AUTHENTICATION.md Authentication Guide}.
+connecting in the [Authentication Guide](AUTHENTICATION.md).
 
 ## Creating instances and clusters
 
@@ -396,5 +396,5 @@ instance.delete
 ## Additional information
 
 Google Bigtable can be configured to use an emulator or to enable gRPC's
-logging. To learn more, see the {file:EMULATOR.md Emulator guide} and
-{file:LOGGING.md Logging guide}.
+logging. To learn more, see the [Emulator guide}](EMULATOR.md) and
+[Logging guide](file:LOGGING.md).

--- a/google-cloud-bigtable/OVERVIEW.md
+++ b/google-cloud-bigtable/OVERVIEW.md
@@ -397,4 +397,4 @@ instance.delete
 
 Google Bigtable can be configured to use an emulator or to enable gRPC's
 logging. To learn more, see the [Emulator guide}](EMULATOR.md) and
-[Logging guide](file:LOGGING.md).
+[Logging guide](LOGGING.md).

--- a/google-cloud-compute-v1/README.md
+++ b/google-cloud-compute-v1/README.md
@@ -20,7 +20,7 @@ In order to use this library, you first need to go through the following steps:
 
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 1. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
-1. {file:AUTHENTICATION.md Set up authentication.}
+2. [Set up authentication.](AUTHENTICATION.md)
 
 ## Quick Start
 

--- a/google-cloud-compute-v1/README.md
+++ b/google-cloud-compute-v1/README.md
@@ -20,7 +20,7 @@ In order to use this library, you first need to go through the following steps:
 
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 1. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
-2. [Set up authentication.](AUTHENTICATION.md)
+1. [Set up authentication.](AUTHENTICATION.md)
 
 ## Quick Start
 

--- a/google-cloud-core/CONTRIBUTING.md
+++ b/google-cloud-core/CONTRIBUTING.md
@@ -53,7 +53,7 @@ there is a small amount of setup:
 In order to run code interactively, you can automatically load
 google-cloud and its dependencies in IRB. This requires that your
 developer environment has already been configured by following the steps
-described in the {file:AUTHENTICATION.md Authentication Guide}. An IRB console
+described in the [Authentication Guide](AUTHENTICATION.md). An IRB console
 can be created with:
 
 ```sh
@@ -138,4 +138,4 @@ $ bundle exec rake rubocop
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See
-{file:CODE_OF_CONDUCT.md Code of Conduct} for more information.
+[Code of Conduct](CODE_OF_CONDUCT.md) for more information.

--- a/google-cloud-datastore/AUTHENTICATION.md
+++ b/google-cloud-datastore/AUTHENTICATION.md
@@ -175,4 +175,4 @@ Developers service account.
 ## Troubleshooting
 
 If you're having trouble authenticating you can ask for help by following the
-{file:TROUBLESHOOTING.md Troubleshooting Guide}.
+[Troubleshooting Guide](TROUBLESHOOTING.md).

--- a/google-cloud-datastore/CONTRIBUTING.md
+++ b/google-cloud-datastore/CONTRIBUTING.md
@@ -53,7 +53,7 @@ there is a small amount of setup:
 In order to run code interactively, you can automatically load
 google-cloud-datastore and its dependencies in IRB. This requires that your
 developer environment has already been configured by following the steps
-described in the {file:AUTHENTICATION.md Authentication Guide}. An IRB console
+described in the [Authentication Guide](AUTHENTICATION.md). An IRB console
 can be created with:
 
 ```sh
@@ -119,7 +119,7 @@ If you alter an example's title, you may encounter breaking tests.
 ### Datastore Acceptance Tests
 
 The Datastore acceptance tests interact with the live service API. Follow the
-instructions in the {file:AUTHENTICATION.md Authentication guide} for enabling
+instructions in the [Authentication Guide](AUTHENTICATION.md) for enabling
 the Datastore API. Occasionally, some API features may not yet be generally
 available, making it difficult for some contributors to successfully run the
 entire acceptance test suite. However, please ensure that you do successfully
@@ -206,4 +206,4 @@ $ bundle exec rake rubocop
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See
-{file:CODE_OF_CONDUCT.md Code of Conduct} for more information.
+[Code of Conduct](CODE_OF_CONDUCT.md) for more information.

--- a/google-cloud-datastore/OVERVIEW.md
+++ b/google-cloud-datastore/OVERVIEW.md
@@ -11,7 +11,7 @@ Platform (GCP), including Google Compute Engine (GCE), Google Kubernetes Engine
 (GKE), Google App Engine (GAE), Google Cloud Functions (GCF) and Cloud Run. In
 other environments you can configure authentication easily, either directly in
 your code or via environment variables. Read more about the options for
-connecting in the {file:AUTHENTICATION.md Authentication Guide}.
+connecting in the [Authentication Guide](AUTHENTICATION.md).
 
 ```ruby
 require "google/cloud/datastore"
@@ -490,5 +490,5 @@ datastore = Google::Cloud::Datastore.new timeout: 120
 ## Additional information
 
 Google Cloud Datastore can be configured to use an emulator or to enable gRPC's
-logging. To learn more, see the {file:EMULATOR.md Emulator guide} and
-{file:LOGGING.md Logging guide}.
+logging. To learn more, see the [Emulator guide}](EMULATOR.md) and
+[Logging guide](file:LOGGING.md).

--- a/google-cloud-datastore/OVERVIEW.md
+++ b/google-cloud-datastore/OVERVIEW.md
@@ -491,4 +491,4 @@ datastore = Google::Cloud::Datastore.new timeout: 120
 
 Google Cloud Datastore can be configured to use an emulator or to enable gRPC's
 logging. To learn more, see the [Emulator guide}](EMULATOR.md) and
-[Logging guide](file:LOGGING.md).
+[Logging guide](LOGGING.md).

--- a/google-cloud-debugger/AUTHENTICATION.md
+++ b/google-cloud-debugger/AUTHENTICATION.md
@@ -175,4 +175,4 @@ Developers service account.
 ## Troubleshooting
 
 If you're having trouble authenticating you can ask for help by following the
-{file:TROUBLESHOOTING.md Troubleshooting Guide}.
+[Troubleshooting Guide](TROUBLESHOOTING.md).

--- a/google-cloud-debugger/CONTRIBUTING.md
+++ b/google-cloud-debugger/CONTRIBUTING.md
@@ -53,7 +53,7 @@ there is a small amount of setup:
 In order to run code interactively, you can automatically load
 google-cloud-debugger and its dependencies in IRB. This requires that your
 developer environment has already been configured by following the steps
-described in the {file:AUTHENTICATION.md Authentication Guide}. An IRB console
+described in the [Authentication Guide](AUTHENTICATION.md). An IRB console
 can be created with:
 
 ```sh
@@ -119,7 +119,7 @@ If you alter an example's title, you may encounter breaking tests.
 ### Debugger Acceptance Tests
 
 The Debugger acceptance tests interact with the live service API. Follow the
-instructions in the {file:AUTHENTICATION.md Authentication guide} for enabling
+instructions in the [Authentication Guide](AUTHENTICATION.md) for enabling
 the Debugger API. Occasionally, some API features may not yet be generally
 available, making it difficult for some contributors to successfully run the
 entire acceptance test suite. However, please ensure that you do successfully
@@ -184,5 +184,4 @@ $ bundle exec rake rubocop
 ## Code of Conduct
 
 Please note that this project is released with a Contributor Code of Conduct. By
-participating in this project you agree to abide by its terms. See
-{file:CODE_OF_CONDUCT.md Code of Conduct} for more information.
+participating in this project you agree to abide by its terms. See [Code of Conduct](CODE_OF_CONDUCT.md) for more information.

--- a/google-cloud-debugger/OVERVIEW.md
+++ b/google-cloud-debugger/OVERVIEW.md
@@ -263,4 +263,4 @@ response = debugger_client.list_debuggees(
 ## Additional information
 
 Stackdriver Debugger can be configured to use gRPC's logging. To learn more, see
-the [Logging guide](file:LOGGING.md).
+the [Logging guide](LOGGING.md).

--- a/google-cloud-debugger/OVERVIEW.md
+++ b/google-cloud-debugger/OVERVIEW.md
@@ -263,4 +263,4 @@ response = debugger_client.list_debuggees(
 ## Additional information
 
 Stackdriver Debugger can be configured to use gRPC's logging. To learn more, see
-the {file:LOGGING.md Logging guide}.
+the [Logging guide](file:LOGGING.md).

--- a/google-cloud-dns/AUTHENTICATION.md
+++ b/google-cloud-dns/AUTHENTICATION.md
@@ -157,4 +157,4 @@ Developers service account.
 ## Troubleshooting
 
 If you're having trouble authenticating you can ask for help by following the
-{file:TROUBLESHOOTING.md Troubleshooting Guide}.
+[Troubleshooting Guide](TROUBLESHOOTING.md).

--- a/google-cloud-dns/CONTRIBUTING.md
+++ b/google-cloud-dns/CONTRIBUTING.md
@@ -53,7 +53,7 @@ there is a small amount of setup:
 In order to run code interactively, you can automatically load
 google-cloud-dns and its dependencies in IRB. This requires that your
 developer environment has already been configured by following the steps
-described in the {file:AUTHENTICATION.md Authentication Guide}. An IRB console
+described in the [Authentication Guide](AUTHENTICATION.md). An IRB console
 can be created with:
 
 ```sh
@@ -126,8 +126,7 @@ entire acceptance test suite. However, please ensure that you do successfully
 run acceptance tests for any code areas covered by your pull request.
 
 To run the acceptance tests, first create and configure a project in the Google
-Developers Console, as described in the {file:AUTHENTICATION.md Authentication
-guide}. Be sure to download the JSON KEY file. Make note of the PROJECT_ID and
+Developers Console, as described in the [Authentication Guide](AUTHENTICATION.md). Be sure to download the JSON KEY file. Make note of the PROJECT_ID and
 the KEYFILE location on your system.
 
 Before you can run the DNS acceptance tests, you must first create indexes
@@ -185,4 +184,4 @@ $ bundle exec rake rubocop
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See
-{file:CODE_OF_CONDUCT.md Code of Conduct} for more information.
+[Code of Conduct](CODE_OF_CONDUCT.md) for more information.

--- a/google-cloud-dns/OVERVIEW.md
+++ b/google-cloud-dns/OVERVIEW.md
@@ -250,4 +250,4 @@ dns = Google::Cloud::Dns.new retries: 10, timeout: 120
 
 ## Additional information
 
-Google Cloud DNS can be configured to use logging. To learn more, see the [Logging guide](file:LOGGING.md).
+Google Cloud DNS can be configured to use logging. To learn more, see the [Logging guide](LOGGING.md).

--- a/google-cloud-dns/OVERVIEW.md
+++ b/google-cloud-dns/OVERVIEW.md
@@ -13,7 +13,7 @@ Platform (GCP), including Google Compute Engine (GCE), Google Kubernetes Engine
 (GKE), Google App Engine (GAE), Google Cloud Functions (GCF) and Cloud Run. In
 other environments you can configure authentication easily, either directly in
 your code or via environment variables. Read more about the options for
-connecting in the {file:AUTHENTICATION.md Authentication Guide}.
+connecting in the [Authentication Guide](AUTHENTICATION.md).
 
 ## Creating Zones
 
@@ -250,5 +250,4 @@ dns = Google::Cloud::Dns.new retries: 10, timeout: 120
 
 ## Additional information
 
-Google Cloud DNS can be configured to use logging. To learn more, see the
-{file:LOGGING.md Logging guide}.
+Google Cloud DNS can be configured to use logging. To learn more, see the [Logging guide](file:LOGGING.md).

--- a/google-cloud-env/CONTRIBUTING.md
+++ b/google-cloud-env/CONTRIBUTING.md
@@ -106,5 +106,4 @@ If you alter an example's title, you may encounter breaking tests.
 ## Code of Conduct
 
 Please note that this project is released with a Contributor Code of Conduct. By
-participating in this project you agree to abide by its terms. See
-{file:CODE_OF_CONDUCT.md Code of Conduct} for more information.
+participating in this project you agree to abide by its terms. See [Code of Conduct](CODE_OF_CONDUCT.md) for more information.

--- a/google-cloud-error_reporting/AUTHENTICATION.md
+++ b/google-cloud-error_reporting/AUTHENTICATION.md
@@ -175,4 +175,4 @@ Developers service account.
 ## Troubleshooting
 
 If you're having trouble authenticating you can ask for help by following the
-{file:TROUBLESHOOTING.md Troubleshooting Guide}.
+[Troubleshooting Guide](TROUBLESHOOTING.md).

--- a/google-cloud-error_reporting/CONTRIBUTING.md
+++ b/google-cloud-error_reporting/CONTRIBUTING.md
@@ -53,7 +53,7 @@ tests, there is a small amount of setup:
 In order to run code interactively, you can automatically load
 google-cloud-error_reporting and its dependencies in IRB. This requires that
 your developer environment has already been configured by following the steps
-described in the {file:AUTHENTICATION.md Authentication Guide}. An IRB console
+described in the [Authentication Guide](AUTHENTICATION.md). An IRB console
 can be created with:
 
 ```sh
@@ -126,9 +126,7 @@ run the entire acceptance test suite. However, please ensure that you do
 successfully run acceptance tests for any code areas covered by your pull
 request.
 
-To run the acceptance tests, first create and configure a project in the Google
-Developers Console, as described in the {file:AUTHENTICATION.md Authentication
-guide}. Be sure to download the JSON KEY file. Make note of the PROJECT_ID and
+To run the acceptance tests, first creat[Authentication Guide](AUTHENTICATION.md). Be sure to download the JSON KEY file. Make note of the PROJECT_ID and
 the KEYFILE location on your system.
 
 Before you can run the Error Reporting acceptance tests, you must first create
@@ -185,5 +183,4 @@ $ bundle exec rake rubocop
 ## Code of Conduct
 
 Please note that this project is released with a Contributor Code of Conduct. By
-participating in this project you agree to abide by its terms. See
-{file:CODE_OF_CONDUCT.md Code of Conduct} for more information.
+participating in this project you agree to abide by its terms. See [Code of Conduct](CODE_OF_CONDUCT.md) for more information.

--- a/google-cloud-error_reporting/OVERVIEW.md
+++ b/google-cloud-error_reporting/OVERVIEW.md
@@ -13,7 +13,7 @@ Platform (GCP), including Google Compute Engine (GCE), Google Kubernetes Engine
 (GKE), Google App Engine (GAE), Google Cloud Functions (GCF) and Cloud Run. In
 other environments you can configure authentication easily, either directly in
 your code or via environment variables. Read more about the options for
-connecting in the {file:AUTHENTICATION.md Authentication Guide}.
+connecting in the [Authentication Guide](AUTHENTICATION.md).
 
 ## How to report errors
 
@@ -40,9 +40,8 @@ rescue => exception
 end
 ```
 
-See the {file:INSTRUMENTATION.md Instrumentation Guide} for more examples.
+See the [Instrumentation Guide](INSTRUMENTATION.md) for more examples.
 
 ## Additional information
 
-Stackdriver Error Reporting can be configured to use gRPC's logging. To learn more, see the
-{file:LOGGING.md Logging guide}.
+Stackdriver Error Reporting can be configured to use gRPC's logging. To learn more, see the[Logging guide](file:LOGGING.md).

--- a/google-cloud-error_reporting/OVERVIEW.md
+++ b/google-cloud-error_reporting/OVERVIEW.md
@@ -44,4 +44,4 @@ See the [Instrumentation Guide](INSTRUMENTATION.md) for more examples.
 
 ## Additional information
 
-Stackdriver Error Reporting can be configured to use gRPC's logging. To learn more, see the[Logging guide](file:LOGGING.md).
+Stackdriver Error Reporting can be configured to use gRPC's logging. To learn more, see the[Logging guide](LOGGING.md).

--- a/google-cloud-errors/CONTRIBUTING.md
+++ b/google-cloud-errors/CONTRIBUTING.md
@@ -124,5 +124,4 @@ $ bundle exec rake rubocop
 ## Code of Conduct
 
 Please note that this project is released with a Contributor Code of Conduct. By
-participating in this project you agree to abide by its terms. See
-{file:CODE_OF_CONDUCT.md Code of Conduct} for more information.
+participating in this project you agree to abide by its terms. See [Code of Conduct](CODE_OF_CONDUCT.md) for more information.

--- a/google-cloud-firestore/AUTHENTICATION.md
+++ b/google-cloud-firestore/AUTHENTICATION.md
@@ -174,4 +174,4 @@ Developers service account.
 ## Troubleshooting
 
 If you're having trouble authenticating you can ask for help by following the
-{file:TROUBLESHOOTING.md Troubleshooting Guide}.
+[Troubleshooting Guide](TROUBLESHOOTING.md).

--- a/google-cloud-firestore/CONTRIBUTING.md
+++ b/google-cloud-firestore/CONTRIBUTING.md
@@ -53,7 +53,7 @@ there is a small amount of setup:
 In order to run code interactively, you can automatically load
 google-cloud-firestore and its dependencies in IRB. This requires that your
 developer environment has already been configured by following the steps
-described in the {file:AUTHENTICATION.md Authentication Guide}. An IRB console
+described in the [Authentication Guide](AUTHENTICATION.md). An IRB console
 can be created with:
 
 ```sh
@@ -119,15 +119,14 @@ If you alter an example's title, you may encounter breaking tests.
 ### Firestore Acceptance Tests
 
 The Firestore acceptance tests interact with the live service API. Follow the
-instructions in the {file:AUTHENTICATION.md Authentication guide} for enabling
+instructions in the [Authentication Guide](AUTHENTICATION.md) for enabling
 the Firestore API. Occasionally, some API features may not yet be generally
 available, making it difficult for some contributors to successfully run the
 entire acceptance test suite. However, please ensure that you do successfully
 run acceptance tests for any code areas covered by your pull request.
 
 To run the acceptance tests, first create and configure a project in the Google
-Developers Console, as described in the {file:AUTHENTICATION.md Authentication
-guide}. Be sure to download the JSON KEY file. Make note of the PROJECT_ID and
+Developers Console, as described in the [Authentication Guide](AUTHENTICATION.md). Be sure to download the JSON KEY file. Make note of the PROJECT_ID and
 the KEYFILE location on your system.
 
 Before you can run the Firestore acceptance tests, you must first create indexes
@@ -185,4 +184,4 @@ $ bundle exec rake rubocop
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See
-{file:CODE_OF_CONDUCT.md Code of Conduct} for more information.
+[Code of Conduct](CODE_OF_CONDUCT.md) for more information.

--- a/google-cloud-firestore/OVERVIEW.md
+++ b/google-cloud-firestore/OVERVIEW.md
@@ -16,7 +16,7 @@ Firestore service, or if you are running on Google Cloud Platform (GCP),
 including Google Compute Engine (GCE), Google Kubernetes Engine (GKE), Google
 App Engine (GAE), Google Cloud Functions (GCF) and Cloud Run this configuration
 is taken care of for you. You can read more about the options for connecting in
-the {file:AUTHENTICATION.md Authentication Guide}.
+the [Authentication Guide](AUTHENTICATION.md).
 
 ## Adding data
 
@@ -490,4 +490,4 @@ the entire collection or sub-collection.
 ## Additional information
 
 Google Firestore can be configured to use gRPC's logging. To learn more, see the
-{file:LOGGING.md Logging guide}.
+[Logging guide](file:LOGGING.md).

--- a/google-cloud-firestore/OVERVIEW.md
+++ b/google-cloud-firestore/OVERVIEW.md
@@ -490,4 +490,4 @@ the entire collection or sub-collection.
 ## Additional information
 
 Google Firestore can be configured to use gRPC's logging. To learn more, see the
-[Logging guide](file:LOGGING.md).
+[Logging guide](LOGGING.md).

--- a/google-cloud-logging/AUTHENTICATION.md
+++ b/google-cloud-logging/AUTHENTICATION.md
@@ -175,4 +175,4 @@ Developers service account.
 ## Troubleshooting
 
 If you're having trouble authenticating you can ask for help by following the
-{file:TROUBLESHOOTING.md Troubleshooting Guide}.
+[Troubleshooting Guide](TROUBLESHOOTING.md).

--- a/google-cloud-logging/CONTRIBUTING.md
+++ b/google-cloud-logging/CONTRIBUTING.md
@@ -53,7 +53,7 @@ there is a small amount of setup:
 In order to run code interactively, you can automatically load
 google-cloud-logging and its dependencies in IRB. This requires that your
 developer environment has already been configured by following the steps
-described in the {file:AUTHENTICATION.md Authentication Guide}. An IRB console
+described in the [Authentication Guide](AUTHENTICATION.md). An IRB console
 can be created with:
 
 ```sh
@@ -119,15 +119,14 @@ If you alter an example's title, you may encounter breaking tests.
 ### Logging Acceptance Tests
 
 The Logging acceptance tests interact with the live service API. Follow the
-instructions in the {file:AUTHENTICATION.md Authentication guide} for enabling
+instructions in the [Authentication Guide](AUTHENTICATION.md) for enabling
 the Logging API. Occasionally, some API features may not yet be generally
 available, making it difficult for some contributors to successfully run the
 entire acceptance test suite. However, please ensure that you do successfully
 run acceptance tests for any code areas covered by your pull request.
 
 To run the acceptance tests, first create and configure a project in the Google
-Developers Console, as described in the {file:AUTHENTICATION.md Authentication
-guide}. Be sure to download the JSON KEY file. Make note of the PROJECT_ID and
+Developers Console, as described in the [Authentication Guide](AUTHENTICATION.md). Be sure to download the JSON KEY file. Make note of the PROJECT_ID and
 the KEYFILE location on your system.
 
 Before you can run the Logging acceptance tests, you must first create indexes
@@ -185,4 +184,4 @@ $ bundle exec rake rubocop
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See
-{file:CODE_OF_CONDUCT.md Code of Conduct} for more information.
+[Code of Conduct](CODE_OF_CONDUCT.md) for more information.

--- a/google-cloud-logging/OVERVIEW.md
+++ b/google-cloud-logging/OVERVIEW.md
@@ -317,4 +317,4 @@ logging = Google::Cloud::Logging.new timeout: 120
 ## Additional information
 
 Stackdriver Logging can be configured to be used in Rack applications or to use
-gRPC's logging. To learn more, see the [Instrumentation Guide](INSTRUMENTATION.md) and [Logging guide](file:LOGGING.md).
+gRPC's logging. To learn more, see the [Instrumentation Guide](INSTRUMENTATION.md) and [Logging guide](LOGGING.md).

--- a/google-cloud-logging/OVERVIEW.md
+++ b/google-cloud-logging/OVERVIEW.md
@@ -20,7 +20,7 @@ Platform (GCP), including Google Compute Engine (GCE), Google Kubernetes Engine
 (GKE), Google App Engine (GAE), Google Cloud Functions (GCF) and Cloud Run. In
 other environments you can configure authentication easily, either directly in
 your code or via environment variables. Read more about the options for
-connecting in the {file:AUTHENTICATION.md Authentication Guide}.
+connecting in the [Authentication Guide](AUTHENTICATION.md).
 
 ## Listing log entries
 
@@ -317,5 +317,4 @@ logging = Google::Cloud::Logging.new timeout: 120
 ## Additional information
 
 Stackdriver Logging can be configured to be used in Rack applications or to use
-gRPC's logging. To learn more, see the {file:INSTRUMENTATION.md Instrumentation
-Guide} and {file:LOGGING.md Logging guide}.
+gRPC's logging. To learn more, see the [Instrumentation Guide](INSTRUMENTATION.md) and [Logging guide](file:LOGGING.md).

--- a/google-cloud-pubsub/AUTHENTICATION.md
+++ b/google-cloud-pubsub/AUTHENTICATION.md
@@ -175,4 +175,4 @@ Developers service account.
 ## Troubleshooting
 
 If you're having trouble authenticating you can ask for help by following the
-{file:TROUBLESHOOTING.md Troubleshooting Guide}.
+[Troubleshooting Guide](TROUBLESHOOTING.md).

--- a/google-cloud-pubsub/CONTRIBUTING.md
+++ b/google-cloud-pubsub/CONTRIBUTING.md
@@ -53,7 +53,7 @@ there is a small amount of setup:
 In order to run code interactively, you can automatically load
 google-cloud-pubsub and its dependencies in IRB. This requires that your
 developer environment has already been configured by following the steps
-described in the {file:AUTHENTICATION.md Authentication Guide}. An IRB console
+described in the [Authentication Guide](AUTHENTICATION.md). An IRB console
 can be created with:
 
 ```sh
@@ -119,15 +119,14 @@ If you alter an example's title, you may encounter breaking tests.
 ### Pub/Sub Acceptance Tests
 
 The Pub/Sub acceptance tests interact with the live service API. Follow the
-instructions in the {file:AUTHENTICATION.md Authentication guide} for enabling
+instructions in the [Authentication Guide](AUTHENTICATION.md) for enabling
 the Pub/Sub API. Occasionally, some API features may not yet be generally
 available, making it difficult for some contributors to successfully run the
 entire acceptance test suite. However, please ensure that you do successfully
 run acceptance tests for any code areas covered by your pull request.
 
 To run the acceptance tests, first create and configure a project in the Google
-Developers Console, as described in the {file:AUTHENTICATION.md Authentication
-guide}. Be sure to download the JSON KEY file. Make note of the PROJECT_ID and
+Developers Console, as described in the [Authentication Guide](AUTHENTICATION.md). Be sure to download the JSON KEY file. Make note of the PROJECT_ID and
 the KEYFILE location on your system.
 
 Before you can run the Pub/Sub acceptance tests, you must first create indexes
@@ -185,4 +184,4 @@ $ bundle exec rake rubocop
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See
-{file:CODE_OF_CONDUCT.md Code of Conduct} for more information.
+[Code of Conduct](CODE_OF_CONDUCT.md) for more information.

--- a/google-cloud-pubsub/OVERVIEW.md
+++ b/google-cloud-pubsub/OVERVIEW.md
@@ -522,4 +522,4 @@ sub.topic.name #=> "projects/other-project-id/topics/other-topic"
 
 Google Cloud Pub/Sub can be configured to use an emulator or to enable gRPC's
 logging. To learn more, see the [Emulator guide}](EMULATOR.md) and
-[Logging guide](file:LOGGING.md).
+[Logging guide](LOGGING.md).

--- a/google-cloud-pubsub/OVERVIEW.md
+++ b/google-cloud-pubsub/OVERVIEW.md
@@ -12,7 +12,7 @@ Platform (GCP), including Google Compute Engine (GCE), Google Kubernetes Engine
 (GKE), Google App Engine (GAE), Google Cloud Functions (GCF) and Cloud Run. In
 other environments you can configure authentication easily, either directly in
 your code or via environment variables. Read more about the options for
-connecting in the {file:AUTHENTICATION.md Authentication Guide}.
+connecting in the [Authentication Guide](AUTHENTICATION.md).
 
 ```ruby
 require "google/cloud/pubsub"
@@ -521,5 +521,5 @@ sub.topic.name #=> "projects/other-project-id/topics/other-topic"
 ## Additional information
 
 Google Cloud Pub/Sub can be configured to use an emulator or to enable gRPC's
-logging. To learn more, see the {file:EMULATOR.md Emulator guide} and
-{file:LOGGING.md Logging guide}.
+logging. To learn more, see the [Emulator guide}](EMULATOR.md) and
+[Logging guide](file:LOGGING.md).

--- a/google-cloud-resource_manager/AUTHENTICATION.md
+++ b/google-cloud-resource_manager/AUTHENTICATION.md
@@ -178,4 +178,4 @@ Developers service account.
 ## Troubleshooting
 
 If you're having trouble authenticating you can ask for help by following the
-{file:TROUBLESHOOTING.md Troubleshooting Guide}.
+[Troubleshooting Guide](TROUBLESHOOTING.md).

--- a/google-cloud-resource_manager/CONTRIBUTING.md
+++ b/google-cloud-resource_manager/CONTRIBUTING.md
@@ -53,7 +53,7 @@ tests, there is a small amount of setup:
 In order to run code interactively, you can automatically load
 google-cloud-resource_manager and its dependencies in IRB. This requires that
 your developer environment has already been configured by following the steps
-described in the {file:AUTHENTICATION.md Authentication Guide}. An IRB console
+described in the [Authentication Guide](AUTHENTICATION.md). An IRB console
 can be created with:
 
 ```sh
@@ -120,7 +120,7 @@ If you alter an example's title, you may encounter breaking tests.
 ### Resource Manager Acceptance Tests
 
 The Resource Manager acceptance tests interact with the live service API. Follow
-the instructions in the {file:AUTHENTICATION.md Authentication guide} for
+the instructions in the [Authentication Guide](AUTHENTICATION.md) for
 enabling the Resource Manager API. Occasionally, some API features may not yet
 be generally available, making it difficult for some contributors to
 successfully run the entire acceptance test suite. However, please ensure that
@@ -128,8 +128,7 @@ you do successfully run acceptance tests for any code areas covered by your pull
 request.
 
 To run the acceptance tests, first create and configure a project in the Google
-Developers Console, as described in the {file:AUTHENTICATION.md Authentication
-guide}. Be sure to download the JSON KEY file. Make note of the PROJECT_ID and
+Developers Console, as described in the [Authentication Guide](AUTHENTICATION.md). Be sure to download the JSON KEY file. Make note of the PROJECT_ID and
 the KEYFILE location on your system.
 
 Before you can run the Resource Manager acceptance tests, you must first create
@@ -187,4 +186,4 @@ $ bundle exec rake rubocop
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See
-{file:CODE_OF_CONDUCT.md Code of Conduct} for more information.
+[Code of Conduct](CODE_OF_CONDUCT.md) for more information.

--- a/google-cloud-resource_manager/OVERVIEW.md
+++ b/google-cloud-resource_manager/OVERVIEW.md
@@ -185,4 +185,4 @@ Policies](https://cloud.google.com/iam/docs/managing-policies).
 ## Additional information
 
 Resource Manager can be configured to use logging. To learn more, see the
-[Logging guide](file:LOGGING.md).
+[Logging guide](LOGGING.md).

--- a/google-cloud-resource_manager/OVERVIEW.md
+++ b/google-cloud-resource_manager/OVERVIEW.md
@@ -18,7 +18,7 @@ Platform (GCP), including Google Compute Engine (GCE), Google Kubernetes Engine
 (GKE), Google App Engine (GAE), Google Cloud Functions (GCF) and Cloud Run. In
 other environments you can configure authentication easily, either directly in
 your code or via environment variables. Read more about the options for
-connecting in the {file:AUTHENTICATION.md Authentication Guide}.
+connecting in the [Authentication Guide](AUTHENTICATION.md).
 
 ## Listing Projects
 
@@ -185,4 +185,4 @@ Policies](https://cloud.google.com/iam/docs/managing-policies).
 ## Additional information
 
 Resource Manager can be configured to use logging. To learn more, see the
-{file:LOGGING.md Logging guide}.
+[Logging guide](file:LOGGING.md).

--- a/google-cloud-spanner/AUTHENTICATION.md
+++ b/google-cloud-spanner/AUTHENTICATION.md
@@ -174,4 +174,4 @@ Developers service account.
 ## Troubleshooting
 
 If you're having trouble authenticating you can ask for help by following the
-{file:TROUBLESHOOTING.md Troubleshooting Guide}.
+[Troubleshooting Guide](TROUBLESHOOTING.md).

--- a/google-cloud-spanner/CONTRIBUTING.md
+++ b/google-cloud-spanner/CONTRIBUTING.md
@@ -53,7 +53,7 @@ there is a small amount of setup:
 In order to run code interactively, you can automatically load
 google-cloud-spanner and its dependencies in IRB. This requires that your
 developer environment has already been configured by following the steps
-described in the {file:AUTHENTICATION.md Authentication Guide}. An IRB console
+described in the [Authentication Guide](AUTHENTICATION.md). An IRB console
 can be created with:
 
 ```sh
@@ -119,7 +119,7 @@ If you alter an example's title, you may encounter breaking tests.
 ### Spanner Acceptance Tests
 
 The Spanner acceptance tests interact with the live service API. Follow the
-instructions in the {file:AUTHENTICATION.md Authentication Guide} for enabling
+instructions in the [Authentication Guide](AUTHENTICATION.md) for enabling
 the Spanner API. Occasionally, some API features may not yet be generally
 available, making it difficult for some contributors to successfully run the
 entire acceptance test suite. However, please ensure that you do successfully
@@ -127,7 +127,7 @@ run acceptance tests for any code areas covered by your pull request.
 
 To run the acceptance tests, first create and configure a project in the Google
 Developers Console, as described in the
-{file:AUTHENTICATION.md Authentication Guide}. Be sure to download the JSON KEY
+[Authentication Guide](AUTHENTICATION.md). Be sure to download the JSON KEY
 file. Make note of the PROJECT_ID and the KEYFILE location on your system.
 
 Before you can run the Spanner acceptance tests, you must first create indexes
@@ -185,4 +185,4 @@ $ bundle exec rake rubocop
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See the
-{file:CODE_OF_CONDUCT.md Code of Conduct} for more information.
+[Code of Conduct](CODE_OF_CONDUCT.md) for more information.

--- a/google-cloud-spanner/OVERVIEW.md
+++ b/google-cloud-spanner/OVERVIEW.md
@@ -13,7 +13,7 @@ Platform (GCP), including Google Compute Engine (GCE), Google Kubernetes Engine
 (GKE), Google App Engine (GAE), Google Cloud Functions (GCF) and Cloud Run. In
 other environments you can configure authentication easily, either directly in
 your code or via environment variables. Read more about the options for
-connecting in the {file:AUTHENTICATION.md Authentication Guide}.
+connecting in the [Authentication Guide](AUTHENTICATION.md).
 
 ## Creating instances
 
@@ -316,9 +316,9 @@ spanner = Google::Cloud::Spanner.new
 instance = spanner.instance "my-instance"
 
 instance.delete
-````
+```
 
 ## Additional information
 
 Cloud Spanner can be configured to use gRPC's logging. To learn more, see the
-{file:LOGGING.md Logging guide}.
+[Logging guide](file:LOGGING.md).

--- a/google-cloud-spanner/OVERVIEW.md
+++ b/google-cloud-spanner/OVERVIEW.md
@@ -321,4 +321,4 @@ instance.delete
 ## Additional information
 
 Cloud Spanner can be configured to use gRPC's logging. To learn more, see the
-[Logging guide](file:LOGGING.md).
+[Logging guide](LOGGING.md).

--- a/google-cloud-storage/AUTHENTICATION.md
+++ b/google-cloud-storage/AUTHENTICATION.md
@@ -161,4 +161,4 @@ Developers service account.
 ## Troubleshooting
 
 If you're having trouble authenticating you can ask for help by following the
-{file:TROUBLESHOOTING.md Troubleshooting Guide}.
+[Troubleshooting Guide](TROUBLESHOOTING.md).

--- a/google-cloud-storage/CONTRIBUTING.md
+++ b/google-cloud-storage/CONTRIBUTING.md
@@ -53,7 +53,7 @@ there is a small amount of setup:
 In order to run code interactively, you can automatically load
 google-cloud-storage and its dependencies in IRB. This requires that your
 developer environment has already been configured by following the steps
-described in the {file:AUTHENTICATION.md Authentication Guide}. An IRB console
+described in the [Authentication Guide](AUTHENTICATION.md). An IRB console
 can be created with:
 
 ```sh
@@ -119,15 +119,14 @@ If you alter an example's title, you may encounter breaking tests.
 ### Storage Acceptance Tests
 
 The Storage acceptance tests interact with the live service API. Follow the
-instructions in the {file:AUTHENTICATION.md Authentication guide} for enabling
+instructions in the [Authentication Guide](AUTHENTICATION.md) for enabling
 the Storage API. Occasionally, some API features may not yet be generally
 available, making it difficult for some contributors to successfully run the
 entire acceptance test suite. However, please ensure that you do successfully
 run acceptance tests for any code areas covered by your pull request.
 
 To run the acceptance tests, first create and configure a project in the Google
-Developers Console, as described in the {file:AUTHENTICATION.md Authentication
-guide}. Be sure to download the JSON KEY file. Make note of the PROJECT_ID and
+Developers Console, as described in the [Authentication Guide](AUTHENTICATION.md). Be sure to download the JSON KEY file. Make note of the PROJECT_ID and
 the KEYFILE location on your system.
 
 Before you can run the Storage acceptance tests, you must first create indexes
@@ -185,4 +184,4 @@ $ bundle exec rake rubocop
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See
-{file:CODE_OF_CONDUCT.md Code of Conduct} for more information.
+[Code of Conduct](CODE_OF_CONDUCT.md) for more information.

--- a/google-cloud-storage/OVERVIEW.md
+++ b/google-cloud-storage/OVERVIEW.md
@@ -11,7 +11,7 @@ Platform (GCP), including Google Compute Engine (GCE), Google Kubernetes Engine
 (GKE), Google App Engine (GAE), Google Cloud Functions (GCF) and Cloud Run. In
 other environments you can configure authentication easily, either directly in
 your code or via environment variables. Read more about the options for
-connecting in the {file:AUTHENTICATION.md Authentication Guide}.
+connecting in the [Authentication Guide](AUTHENTICATION.md).
 
 ```ruby
 require "google/cloud/storage"
@@ -570,4 +570,4 @@ for a list of error conditions.
 ## Additional information
 
 Google Cloud Storage can be configured to use logging. To learn more, see the
-{file:LOGGING.md Logging guide}.
+[Logging guide](file:LOGGING.md).

--- a/google-cloud-storage/OVERVIEW.md
+++ b/google-cloud-storage/OVERVIEW.md
@@ -570,4 +570,4 @@ for a list of error conditions.
 ## Additional information
 
 Google Cloud Storage can be configured to use logging. To learn more, see the
-[Logging guide](file:LOGGING.md).
+[Logging guide](LOGGING.md).

--- a/google-cloud-trace/AUTHENTICATION.md
+++ b/google-cloud-trace/AUTHENTICATION.md
@@ -174,4 +174,4 @@ Developers service account.
 ## Troubleshooting
 
 If you're having trouble authenticating you can ask for help by following the
-{file:TROUBLESHOOTING.md Troubleshooting Guide}.
+[Troubleshooting Guide](TROUBLESHOOTING.md).

--- a/google-cloud-trace/CONTRIBUTING.md
+++ b/google-cloud-trace/CONTRIBUTING.md
@@ -53,7 +53,7 @@ there is a small amount of setup:
 In order to run code interactively, you can automatically load
 google-cloud-trace and its dependencies in IRB. This requires that your
 developer environment has already been configured by following the steps
-described in the {file:AUTHENTICATION.md Authentication Guide}. An IRB console
+described in the [Authentication Guide](AUTHENTICATION.md). An IRB console
 can be created with:
 
 ```sh
@@ -119,15 +119,14 @@ If you alter an example's title, you may encounter breaking tests.
 ### Trace Acceptance Tests
 
 The Trace acceptance tests interact with the live service API. Follow the
-instructions in the {file:AUTHENTICATION.md Authentication guide} for enabling
+instructions in the [Authentication Guide](AUTHENTICATION.md) for enabling
 the Trace API. Occasionally, some API features may not yet be generally
 available, making it difficult for some contributors to successfully run the
 entire acceptance test suite. However, please ensure that you do successfully
 run acceptance tests for any code areas covered by your pull request.
 
 To run the acceptance tests, first create and configure a project in the Google
-Developers Console, as described in the {file:AUTHENTICATION.md Authentication
-guide}. Be sure to download the JSON KEY file. Make note of the PROJECT_ID and
+Developers Console, as described in the [Authentication Guide](AUTHENTICATION.md). Be sure to download the JSON KEY file. Make note of the PROJECT_ID and
 the KEYFILE location on your system.
 
 Before you can run the Trace acceptance tests, you must first create indexes
@@ -185,4 +184,4 @@ $ bundle exec rake rubocop
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See
-{file:CODE_OF_CONDUCT.md Code of Conduct} for more information.
+[Code of Conduct](CODE_OF_CONDUCT.md) for more information.

--- a/google-cloud-trace/OVERVIEW.md
+++ b/google-cloud-trace/OVERVIEW.md
@@ -157,5 +157,4 @@ trace_client.patch_traces trace
 ## Additional information
 
 Stackdriver Trace can be configured to be used in Rack applications or to use
-gRPC's logging. To learn more, see the {file:INSTRUMENTATION.md Instrumentation
-Guide} and {file:LOGGING.md Logging guide}.
+gRPC's logging. To learn more, see the [Instrumentation Guide](INSTRUMENTATION.md) and [Logging guide](file:LOGGING.md).

--- a/google-cloud-trace/OVERVIEW.md
+++ b/google-cloud-trace/OVERVIEW.md
@@ -157,4 +157,4 @@ trace_client.patch_traces trace
 ## Additional information
 
 Stackdriver Trace can be configured to be used in Rack applications or to use
-gRPC's logging. To learn more, see the [Instrumentation Guide](INSTRUMENTATION.md) and [Logging guide](file:LOGGING.md).
+gRPC's logging. To learn more, see the [Instrumentation Guide](INSTRUMENTATION.md) and [Logging guide](LOGGING.md).

--- a/google-cloud-translate-v2/README.md
+++ b/google-cloud-translate-v2/README.md
@@ -18,7 +18,7 @@ In order to use this library, you first need to go through the following steps:
 
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 1. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
-1. {file:AUTHENTICATION.md Set up authentication.}
+1. [Set up authentication.](AUTHENTICATION.md)
 
 ## Quick Start
 

--- a/google-cloud/CONTRIBUTING.md
+++ b/google-cloud/CONTRIBUTING.md
@@ -53,7 +53,7 @@ there is a small amount of setup:
 In order to run code interactively, you can automatically load
 google-cloud and its dependencies in IRB. This requires that your
 developer environment has already been configured by following the steps
-described in the {file:AUTHENTICATION.md Authentication Guide}. An IRB console
+described in the [Authentication Guide](AUTHENTICATION.md). An IRB console
 can be created with:
 
 ```sh
@@ -138,4 +138,4 @@ $ bundle exec rake rubocop
 
 Please note that this project is released with a Contributor Code of Conduct. By
 participating in this project you agree to abide by its terms. See
-{file:CODE_OF_CONDUCT.md Code of Conduct} for more information.
+[Code of Conduct](CODE_OF_CONDUCT.md) for more information.


### PR DESCRIPTION
Follow up PR to change broken YARD-links in the markdown files to github-friendly md links 