### PR TITLE
chore: Disable CI runs on unsupported Ruby versions

### DIFF
--- a/google-cloud-debugger-v2/synth.py
+++ b/google-cloud-debugger-v2/synth.py
@@ -19,7 +19,6 @@ import synthtool.gcp as gcp
 import synthtool.languages.ruby as ruby
 import logging
 
-
 logging.basicConfig(level=logging.DEBUG)
 
 gapic = gcp.GAPICMicrogenerator()

--- a/google-cloud-debugger/README.md
+++ b/google-cloud-debugger/README.md
@@ -246,7 +246,7 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.5+. It is not currently supported on Ruby 3.
+This library is supported on Ruby 2.5+. It is _not_ currently supported on Ruby 3.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or in


### PR DESCRIPTION
Updates the CI script so it omits any libraries that are not compatible (according to their gemspec) with the current Ruby version. This PR includes trivial changes to debugger (which is incompatible with Ruby 3) and debugger-v2 (which is compatible) to test it.