### PR TITLE
chore: Fix release-please tool to handle libraries with no existing releases

### DIFF
--- a/.toys/ci.rb
+++ b/.toys/ci.rb
@@ -100,6 +100,7 @@ def gem_dirs_from_changes
     puts "Gem directories changed:", :bold
     dirs.each { |dir| puts "  #{dir}" }
   end
+  dirs
 end
 
 def interpret_github_event

--- a/.toys/release-please.rb
+++ b/.toys/release-please.rb
@@ -37,19 +37,22 @@ end
 
 def release_please gem_name
   version = gem_version gem_name
-  puts "Running release-please for #{gem_name} from version #{version}", :bold
+  puts "Running release-please for #{gem_name} from version #{version.inspect}", :bold
   cmd = [
     "npx", "release-please", "release-pr",
     "--package-name", gem_name,
-    "--last-package-version", version,
     "--release-type", "ruby-yoshi",
     "--repo-url", "googleapis/google-cloud-ruby",
-    "--bump-minor-pre-major"
+    "--bump-minor-pre-major", "--debug"
   ]
+  cmd += ["--last-package-version", version] if version
   cmd += ["--token", github_token] if github_token
   log_cmd = cmd.inspect
   log_cmd.sub! github_token, "****" if github_token
-  exec cmd, log_cmd: log_cmd
+  result = exec cmd, log_cmd: log_cmd, e: false
+  unless result.success?
+    puts "Error running release-please for #{gem_name} from version #{version.inspect}", :bold, :red
+  end
 end
 
 def gem_version gem_name
@@ -59,5 +62,6 @@ def gem_version gem_name
       puts spec.version.to_s
     end
   end
-  capture_proc(func).strip
+  version = capture_proc(func).strip
+  version == "0.0.1alpha" ? nil : version
 end


### PR DESCRIPTION
This fixes the immediate issue where the nightly release-please job is terminating because compute-v1 fails (due to not having an existing release). The full fix will require two parts: one here in the Ruby code where we detect this case and properly inform release-please that the library indeed has no previous release; and the second being a separate fix in release-please itself where we need to generate a proper initial release. This PR by itself includes the Ruby-side fix, and also responds to the release-please error by logging the failure rather than aborting jobs for other gems.