### PR TITLE
docs(pubsub): The immediate: false option is recommended to avoid adverse impacts on the performance of pull operations

### DIFF
--- a/google-cloud-pubsub/OVERVIEW.md
+++ b/google-cloud-pubsub/OVERVIEW.md
@@ -205,8 +205,8 @@ sleep
 Messages also can be pulled directly in a one-time operation. (See
 {Google::Cloud::PubSub::Subscription#pull Subscription#pull})
 
-The `immediate: false` option is now recommended to avoid adverse impacts on
-pull operations.
+The `immediate: false` option is recommended to avoid adverse impacts on the
+performance of pull operations.
 
 ```ruby
 require "google/cloud/pubsub"

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -734,10 +734,11 @@ module Google
 
         ##
         # Pulls messages from the server, blocking until messages are available
-        # when called with the `immediate: false` option, which is now recommended
-        # to avoid adverse impacts on pull operations. Raises an API error with
-        # status `UNAVAILABLE` if there are too many concurrent pull requests
-        # pending for the given subscription.
+        # when called with the `immediate: false` option, which is recommended
+        # to avoid adverse impacts on the performance of pull operations.
+        #
+        # Raises an API error with status `UNAVAILABLE` if there are too many
+        # concurrent pull requests pending for the given subscription.
         #
         # See also {#listen} for the preferred way to process messages as they
         # become available.


### PR DESCRIPTION
refs: #11126