### PR TITLE
chore: Try to get presubmit changed file detection to use the actual expected merge base

### DIFF
--- a/.toys/ci.rb
+++ b/.toys/ci.rb
@@ -109,7 +109,7 @@ def interpret_github_event
     case github_event_name
     when "pull_request"
       puts "Getting commits from pull_request event"
-      [payload["pull_request"]["base"]["sha"], nil]
+      [payload["pull_request"]["base"]["ref"], nil]
     when "push"
       puts "Getting commits from push event"
       [payload["before"], nil]


### PR DESCRIPTION
Looks like the "sha" field gives the sha of the branch point, not the head of the base branch. So it currently incorrectly includes changes made to master since the PR was originally branched. This should fix that.