### PR TITLE
chore: Open actions-based release-please PRs from a fork

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -28,4 +28,4 @@ jobs:
       - name: Install tools
         run: "gem install --no-document toys && npm install release-please"
       - name: execute
-        run: "toys release-please ${{ github.event.inputs.gem }}"
+        run: "toys release-please --fork ${{ github.event.inputs.gem }}"

--- a/.toys/release-please.rb
+++ b/.toys/release-please.rb
@@ -18,6 +18,7 @@ desc "Runs release-please."
 
 flag :github_token, "--github-token=TOKEN", default: ENV["GITHUB_TOKEN"]
 flag :install
+flag :use_fork, "--fork"
 remaining_args :gems, desc: "Release the specified gems. If no specific gem is provided, all gems are checked."
 
 include :exec, e: true
@@ -45,6 +46,7 @@ def release_please gem_name
     "--repo-url", "googleapis/google-cloud-ruby",
     "--bump-minor-pre-major", "--debug"
   ]
+  cmd += ["--fork"] if use_fork
   cmd += ["--last-package-version", version] if version
   cmd += ["--token", github_token] if github_token
   log_cmd = cmd.inspect


### PR DESCRIPTION
Release-please is currently failing due to the actions-based yoshi code bot not having write access to the repo. Configure the action to use a repo fork.