### PR TITLE
chore: Update kokoro release job

### DIFF
--- a/.kokoro/populate-secrets.sh
+++ b/.kokoro/populate-secrets.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Copyright 2020 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file is called in the early stage of `trampoline_v2.sh` to
+# populate secrets needed for the CI builds.
+
+set -eo pipefail
+
+function now { date +"%Y-%m-%d %H:%M:%S" | tr -d '\n' ;}
+function msg { println "$*" >&2 ;}
+function println { printf '%s\n' "$(now) $*" ;}
+
+# Populates requested secrets set in SECRET_MANAGER_KEYS
+
+# In Kokoro CI builds, we use the service account attached to the
+# Kokoro VM. This means we need to setup auth on other CI systems.
+# For local run, we just use the gcloud command for retrieving the
+# secrets.
+
+if [[ "${RUNNING_IN_CI:-}" == "true" ]]; then
+    GCLOUD_COMMANDS=(
+        "docker"
+        "run"
+        "--entrypoint=gcloud"
+        "--volume=${KOKORO_GFILE_DIR}:${KOKORO_GFILE_DIR}"
+        "gcr.io/google.com/cloudsdktool/cloud-sdk"
+    )
+    if [[ "${TRAMPOLINE_CI:-}" == "kokoro" ]]; then
+        SECRET_LOCATION="${KOKORO_GFILE_DIR}/secret_manager"
+    else
+        echo "Authentication for this CI system is not implemented yet."
+        exit 2
+        # TODO: Determine appropriate SECRET_LOCATION and the GCLOUD_COMMANDS.
+    fi
+else
+    # For local run, use /dev/shm or temporary directory for
+    # KOKORO_GFILE_DIR.
+    if [[ -d "/dev/shm" ]]; then
+        export KOKORO_GFILE_DIR=/dev/shm
+    else
+        export KOKORO_GFILE_DIR=$(mktemp -d -t ci-XXXXXXXX)
+    fi
+    SECRET_LOCATION="${KOKORO_GFILE_DIR}/secret_manager"
+    GCLOUD_COMMANDS=("gcloud")
+fi
+
+msg "Creating folder on disk for secrets: ${SECRET_LOCATION}"
+mkdir -p ${SECRET_LOCATION}
+
+for key in $(echo ${SECRET_MANAGER_KEYS} | sed "s/,/ /g")
+do
+    msg "Retrieving secret ${key}"
+    "${GCLOUD_COMMANDS[@]}" \
+        secrets versions access latest \
+        --project cloud-devrel-kokoro-resources \
+        --secret $key > \
+        "$SECRET_LOCATION/$key"
+    if [[ $? == 0 ]]; then
+        msg "Secret written to ${SECRET_LOCATION}/${key}"
+    else
+        msg "Error retrieving secret ${key}"
+        exit 2
+    fi
+done

--- a/.kokoro/release.cfg
+++ b/.kokoro/release.cfg
@@ -1,0 +1,42 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Build logs will be here
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.xml"
+  }
+}
+
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "docuploader_service_account"
+    }
+  }
+}
+
+# Download resources for system tests (service account key, etc.)
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/google-cloud-ruby"
+
+# Download trampoline resources.
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
+
+# Use the trampoline script to run in docker.
+build_file: "google-cloud-ruby/.kokoro/trampoline_v2.sh"
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+  key: "TRAMPOLINE_IMAGE"
+  value: "gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/release"
+}
+
+env_vars: {
+  key: "TRAMPOLINE_BUILD_FILE"
+  value: ".kokoro/release.sh"
+}
+
+env_vars: {
+  key: "SECRET_MANAGER_KEYS"
+  value: "releasetool-publish-reporter-app,releasetool-publish-reporter-googleapis-installation,releasetool-publish-reporter-pem"
+}

--- a/.kokoro/release.sh
+++ b/.kokoro/release.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -eo pipefail
+
+# Install gems in the user directory because the default install directory
+# is in a read-only location.
+export GEM_HOME=$HOME/.gem
+export PATH=$GEM_HOME/bin:$PATH
+
+python3 -m pip install git+https://github.com/googleapis/releasetool
+python3 -m pip install gcp-docuploader
+gem install --no-document toys
+
+python3 -m releasetool publish-reporter-script > /tmp/publisher-script; source /tmp/publisher-script
+toys kokoro release < /dev/null

--- a/.kokoro/trampoline_v2.sh
+++ b/.kokoro/trampoline_v2.sh
@@ -1,0 +1,489 @@
+#!/usr/bin/env bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# trampoline_v2.sh
+#
+# If you want to make a change to this file, consider doing so at:
+# https://github.com/googlecloudplatform/docker-ci-helper
+#
+# This script is for running CI builds. For Kokoro builds, we
+# set this script to `build_file` field in the Kokoro configuration.
+
+# This script does 3 things.
+#
+# 1. Prepare the Docker image for the test
+# 2. Run the Docker with appropriate flags to run the test
+# 3. Upload the newly built Docker image
+#
+# in a way that is somewhat compatible with trampoline_v1.
+#
+# These environment variables are required:
+# TRAMPOLINE_IMAGE: The docker image to use.
+# TRAMPOLINE_DOCKERFILE: The location of the Dockerfile.
+#
+# You can optionally change these environment variables:
+# TRAMPOLINE_IMAGE_UPLOAD:
+#     (true|false): Whether to upload the Docker image after the
+#                   successful builds.
+# TRAMPOLINE_BUILD_FILE: The script to run in the docker container.
+# TRAMPOLINE_WORKSPACE: The workspace path in the docker container.
+#                       Defaults to /workspace.
+# Potentially there are some repo specific envvars in .trampolinerc in
+# the project root.
+#
+# Here is an example for running this script.
+#   TRAMPOLINE_IMAGE=gcr.io/cloud-devrel-kokoro-resources/node:10-user \
+#     TRAMPOLINE_BUILD_FILE=.kokoro/system-test.sh \
+#     .kokoro/trampoline_v2.sh
+
+set -euo pipefail
+
+TRAMPOLINE_VERSION="2.0.10"
+
+if command -v tput >/dev/null && [[ -n "${TERM:-}" ]]; then
+  readonly IO_COLOR_RED="$(tput setaf 1)"
+  readonly IO_COLOR_GREEN="$(tput setaf 2)"
+  readonly IO_COLOR_YELLOW="$(tput setaf 3)"
+  readonly IO_COLOR_RESET="$(tput sgr0)"
+else
+  readonly IO_COLOR_RED=""
+  readonly IO_COLOR_GREEN=""
+  readonly IO_COLOR_YELLOW=""
+  readonly IO_COLOR_RESET=""
+fi
+
+function function_exists {
+    [ $(LC_ALL=C type -t $1)"" == "function" ]
+}
+
+# Logs a message using the given color. The first argument must be one
+# of the IO_COLOR_* variables defined above, such as
+# "${IO_COLOR_YELLOW}". The remaining arguments will be logged in the
+# given color. The log message will also have an RFC-3339 timestamp
+# prepended (in UTC). You can disable the color output by setting
+# TERM=vt100.
+function log_impl() {
+    local color="$1"
+    shift
+    local timestamp="$(date -u "+%Y-%m-%dT%H:%M:%SZ")"
+    echo "================================================================"
+    echo "${color}${timestamp}:" "$@" "${IO_COLOR_RESET}"
+    echo "================================================================"
+}
+
+# Logs the given message with normal coloring and a timestamp.
+function log() {
+  log_impl "${IO_COLOR_RESET}" "$@"
+}
+
+# Logs the given message in green with a timestamp.
+function log_green() {
+  log_impl "${IO_COLOR_GREEN}" "$@"
+}
+
+# Logs the given message in yellow with a timestamp.
+function log_yellow() {
+  log_impl "${IO_COLOR_YELLOW}" "$@"
+}
+
+# Logs the given message in red with a timestamp.
+function log_red() {
+  log_impl "${IO_COLOR_RED}" "$@"
+}
+
+readonly tmpdir=$(mktemp -d -t ci-XXXXXXXX)
+readonly tmphome="${tmpdir}/h"
+mkdir -p "${tmphome}"
+
+function cleanup() {
+    rm -rf "${tmpdir}"
+}
+trap cleanup EXIT
+
+RUNNING_IN_CI="${RUNNING_IN_CI:-false}"
+
+# The workspace in the container, defaults to /workspace.
+TRAMPOLINE_WORKSPACE="${TRAMPOLINE_WORKSPACE:-/workspace}"
+
+pass_down_envvars=(
+    # TRAMPOLINE_V2 variables.
+    # Tells scripts whether they are running as part of CI or not.
+    "RUNNING_IN_CI"
+    # Indicates which CI system we're in.
+    "TRAMPOLINE_CI"
+    # Indicates the version of the script.
+    "TRAMPOLINE_VERSION"
+)
+
+log_yellow "Building with Trampoline ${TRAMPOLINE_VERSION}"
+
+# Detect which CI systems we're in. If we're in any of the CI systems
+# we support, `RUNNING_IN_CI` will be true and `TRAMPOLINE_CI` will be
+# the name of the CI system. Both envvars will be passing down to the
+# container for telling which CI system we're in.
+if [[ -n "${KOKORO_BUILD_ID:-}" ]]; then
+    # descriptive env var for indicating it's on CI.
+    RUNNING_IN_CI="true"
+    TRAMPOLINE_CI="kokoro"
+    if [[ "${TRAMPOLINE_USE_LEGACY_SERVICE_ACCOUNT:-}" == "true" ]]; then
+	if [[ ! -f "${KOKORO_GFILE_DIR}/kokoro-trampoline.service-account.json" ]]; then
+	    log_red "${KOKORO_GFILE_DIR}/kokoro-trampoline.service-account.json does not exist. Did you forget to mount cloud-devrel-kokoro-resources/trampoline? Aborting."
+	    exit 1
+	fi
+	# This service account will be activated later.
+	TRAMPOLINE_SERVICE_ACCOUNT="${KOKORO_GFILE_DIR}/kokoro-trampoline.service-account.json"
+    else
+	if [[ "${TRAMPOLINE_VERBOSE:-}" == "true" ]]; then
+	    gcloud auth list
+	fi
+	log_yellow "Configuring Container Registry access"
+	gcloud auth configure-docker --quiet
+    fi
+    pass_down_envvars+=(
+	# KOKORO dynamic variables.
+	"KOKORO_BUILD_NUMBER"
+	"KOKORO_BUILD_ID"
+	"KOKORO_JOB_NAME"
+	"KOKORO_GIT_COMMIT"
+	"KOKORO_GITHUB_COMMIT"
+	"KOKORO_GITHUB_PULL_REQUEST_NUMBER"
+	"KOKORO_GITHUB_PULL_REQUEST_COMMIT"
+	# For Flaky Bot
+	"KOKORO_GITHUB_COMMIT_URL"
+	"KOKORO_GITHUB_PULL_REQUEST_URL"
+	"KOKORO_BUILD_ARTIFACTS_SUBDIR"
+    )
+elif [[ "${TRAVIS:-}" == "true" ]]; then
+    RUNNING_IN_CI="true"
+    TRAMPOLINE_CI="travis"
+    pass_down_envvars+=(
+	"TRAVIS_BRANCH"
+	"TRAVIS_BUILD_ID"
+	"TRAVIS_BUILD_NUMBER"
+	"TRAVIS_BUILD_WEB_URL"
+	"TRAVIS_COMMIT"
+	"TRAVIS_COMMIT_MESSAGE"
+	"TRAVIS_COMMIT_RANGE"
+	"TRAVIS_JOB_NAME"
+	"TRAVIS_JOB_NUMBER"
+	"TRAVIS_JOB_WEB_URL"
+	"TRAVIS_PULL_REQUEST"
+	"TRAVIS_PULL_REQUEST_BRANCH"
+	"TRAVIS_PULL_REQUEST_SHA"
+	"TRAVIS_PULL_REQUEST_SLUG"
+	"TRAVIS_REPO_SLUG"
+	"TRAVIS_SECURE_ENV_VARS"
+	"TRAVIS_TAG"
+    )
+elif [[ -n "${GITHUB_RUN_ID:-}" ]]; then
+    RUNNING_IN_CI="true"
+    TRAMPOLINE_CI="github-workflow"
+    pass_down_envvars+=(
+	"GITHUB_WORKFLOW"
+	"GITHUB_RUN_ID"
+	"GITHUB_RUN_NUMBER"
+	"GITHUB_ACTION"
+	"GITHUB_ACTIONS"
+	"GITHUB_ACTOR"
+	"GITHUB_REPOSITORY"
+	"GITHUB_EVENT_NAME"
+	"GITHUB_EVENT_PATH"
+	"GITHUB_SHA"
+	"GITHUB_REF"
+	"GITHUB_HEAD_REF"
+	"GITHUB_BASE_REF"
+    )
+elif [[ "${CIRCLECI:-}" == "true" ]]; then
+    RUNNING_IN_CI="true"
+    TRAMPOLINE_CI="circleci"
+    pass_down_envvars+=(
+	"CIRCLE_BRANCH"
+	"CIRCLE_BUILD_NUM"
+	"CIRCLE_BUILD_URL"
+	"CIRCLE_COMPARE_URL"
+	"CIRCLE_JOB"
+	"CIRCLE_NODE_INDEX"
+	"CIRCLE_NODE_TOTAL"
+	"CIRCLE_PREVIOUS_BUILD_NUM"
+	"CIRCLE_PROJECT_REPONAME"
+	"CIRCLE_PROJECT_USERNAME"
+	"CIRCLE_REPOSITORY_URL"
+	"CIRCLE_SHA1"
+	"CIRCLE_STAGE"
+	"CIRCLE_USERNAME"
+	"CIRCLE_WORKFLOW_ID"
+	"CIRCLE_WORKFLOW_JOB_ID"
+	"CIRCLE_WORKFLOW_UPSTREAM_JOB_IDS"
+	"CIRCLE_WORKFLOW_WORKSPACE_ID"
+    )
+fi
+
+# Configure the service account for pulling the docker image.
+function repo_root() {
+    local dir="$1"
+    while [[ ! -d "${dir}/.git" ]]; do
+	dir="$(dirname "$dir")"
+    done
+    echo "${dir}"
+}
+
+# Detect the project root. In CI builds, we assume the script is in
+# the git tree and traverse from there, otherwise, traverse from `pwd`
+# to find `.git` directory.
+if [[ "${RUNNING_IN_CI:-}" == "true" ]]; then
+    PROGRAM_PATH="$(realpath "$0")"
+    PROGRAM_DIR="$(dirname "${PROGRAM_PATH}")"
+    PROJECT_ROOT="$(repo_root "${PROGRAM_DIR}")"
+else
+    PROJECT_ROOT="$(repo_root $(pwd))"
+fi
+
+log_yellow "Changing to the project root: ${PROJECT_ROOT}."
+cd "${PROJECT_ROOT}"
+
+# To support relative path for `TRAMPOLINE_SERVICE_ACCOUNT`, we need
+# to use this environment variable in `PROJECT_ROOT`.
+if [[ -n "${TRAMPOLINE_SERVICE_ACCOUNT:-}" ]]; then
+
+    mkdir -p "${tmpdir}/gcloud"
+    gcloud_config_dir="${tmpdir}/gcloud"
+
+    log_yellow "Using isolated gcloud config: ${gcloud_config_dir}."
+    export CLOUDSDK_CONFIG="${gcloud_config_dir}"
+
+    log_yellow "Using ${TRAMPOLINE_SERVICE_ACCOUNT} for authentication."
+    gcloud auth activate-service-account \
+	   --key-file "${TRAMPOLINE_SERVICE_ACCOUNT}"
+    log_yellow "Configuring Container Registry access"
+    gcloud auth configure-docker --quiet
+fi
+
+required_envvars=(
+    # The basic trampoline configurations.
+    "TRAMPOLINE_IMAGE"
+    "TRAMPOLINE_BUILD_FILE"
+)
+
+if [[ -f "${PROJECT_ROOT}/.trampolinerc" ]]; then
+    source "${PROJECT_ROOT}/.trampolinerc"
+fi
+
+log_yellow "Checking environment variables."
+for e in "${required_envvars[@]}"
+do
+    if [[ -z "${!e:-}" ]]; then
+	log "Missing ${e} env var. Aborting."
+	exit 1
+    fi
+done
+
+# We want to support legacy style TRAMPOLINE_BUILD_FILE used with V1
+# script: e.g. "github/repo-name/.kokoro/run_tests.sh"
+TRAMPOLINE_BUILD_FILE="${TRAMPOLINE_BUILD_FILE#github/*/}"
+log_yellow "Using TRAMPOLINE_BUILD_FILE: ${TRAMPOLINE_BUILD_FILE}"
+
+# ignore error on docker operations and test execution
+set +e
+
+log_yellow "Preparing Docker image."
+# We only download the docker image in CI builds.
+if [[ "${RUNNING_IN_CI:-}" == "true" ]]; then
+    # Download the docker image specified by `TRAMPOLINE_IMAGE`
+
+    # We may want to add --max-concurrent-downloads flag.
+
+    log_yellow "Start pulling the Docker image: ${TRAMPOLINE_IMAGE}."
+    if docker pull "${TRAMPOLINE_IMAGE}"; then
+	log_green "Finished pulling the Docker image: ${TRAMPOLINE_IMAGE}."
+	has_image="true"
+    else
+	log_red "Failed pulling the Docker image: ${TRAMPOLINE_IMAGE}."
+	has_image="false"
+    fi
+else
+    # For local run, check if we have the image.
+    if docker images "${TRAMPOLINE_IMAGE}" | grep "${TRAMPOLINE_IMAGE%:*}"; then
+	has_image="true"
+    else
+	has_image="false"
+    fi
+fi
+
+
+# The default user for a Docker container has uid 0 (root). To avoid
+# creating root-owned files in the build directory we tell docker to
+# use the current user ID.
+user_uid="$(id -u)"
+user_gid="$(id -g)"
+user_name="$(id -un)"
+
+# To allow docker in docker, we add the user to the docker group in
+# the host os.
+docker_gid=$(cut -d: -f3 < <(getent group docker))
+
+update_cache="false"
+if [[ "${TRAMPOLINE_DOCKERFILE:-none}" != "none" ]]; then
+    # Build the Docker image from the source.
+    context_dir=$(dirname "${TRAMPOLINE_DOCKERFILE}")
+    docker_build_flags=(
+	"-f" "${TRAMPOLINE_DOCKERFILE}"
+	"-t" "${TRAMPOLINE_IMAGE}"
+	"--build-arg" "UID=${user_uid}"
+	"--build-arg" "USERNAME=${user_name}"
+    )
+    if [[ "${has_image}" == "true" ]]; then
+	docker_build_flags+=("--cache-from" "${TRAMPOLINE_IMAGE}")
+    fi
+
+    log_yellow "Start building the docker image."
+    if [[ "${TRAMPOLINE_VERBOSE:-false}" == "true" ]]; then
+	echo "docker build" "${docker_build_flags[@]}" "${context_dir}"
+    fi
+
+    # ON CI systems, we want to suppress docker build logs, only
+    # output the logs when it fails.
+    if [[ "${RUNNING_IN_CI:-}" == "true" ]]; then
+	if docker build "${docker_build_flags[@]}" "${context_dir}" \
+		  > "${tmpdir}/docker_build.log" 2>&1; then
+	    if [[ "${TRAMPOLINE_VERBOSE:-}" == "true" ]]; then
+		cat "${tmpdir}/docker_build.log"
+	    fi
+
+	    log_green "Finished building the docker image."
+	    update_cache="true"
+	else
+	    log_red "Failed to build the Docker image, aborting."
+	    log_yellow "Dumping the build logs:"
+	    cat "${tmpdir}/docker_build.log"
+	    exit 1
+	fi
+    else
+	if docker build "${docker_build_flags[@]}" "${context_dir}"; then
+	    log_green "Finished building the docker image."
+	    update_cache="true"
+	else
+	    log_red "Failed to build the Docker image, aborting."
+	    exit 1
+	fi
+    fi
+else
+    if [[ "${has_image}" != "true" ]]; then
+	log_red "We do not have ${TRAMPOLINE_IMAGE} locally, aborting."
+	exit 1
+    fi
+fi
+
+# We use an array for the flags so they are easier to document.
+docker_flags=(
+    # Remove the container after it exists.
+    "--rm"
+
+    # Use the host network.
+    "--network=host"
+
+    # Run in priviledged mode. We are not using docker for sandboxing or
+    # isolation, just for packaging our dev tools.
+    "--privileged"
+
+    # Run the docker script with the user id. Because the docker image gets to
+    # write in ${PWD} you typically want this to be your user id.
+    # To allow docker in docker, we need to use docker gid on the host.
+    "--user" "${user_uid}:${docker_gid}"
+
+    # Pass down the USER.
+    "--env" "USER=${user_name}"
+
+    # Mount the project directory inside the Docker container.
+    "--volume" "${PROJECT_ROOT}:${TRAMPOLINE_WORKSPACE}"
+    "--workdir" "${TRAMPOLINE_WORKSPACE}"
+    "--env" "PROJECT_ROOT=${TRAMPOLINE_WORKSPACE}"
+
+    # Mount the temporary home directory.
+    "--volume" "${tmphome}:/h"
+    "--env" "HOME=/h"
+
+    # Allow docker in docker.
+    "--volume" "/var/run/docker.sock:/var/run/docker.sock"
+
+    # Mount the /tmp so that docker in docker can mount the files
+    # there correctly.
+    "--volume" "/tmp:/tmp"
+    # Pass down the KOKORO_GFILE_DIR and KOKORO_KEYSTORE_DIR
+    # TODO(tmatsuo): This part is not portable.
+    "--env" "TRAMPOLINE_SECRET_DIR=/secrets"
+    "--volume" "${KOKORO_GFILE_DIR:-/dev/shm}:/secrets/gfile"
+    "--env" "KOKORO_GFILE_DIR=/secrets/gfile"
+    "--volume" "${KOKORO_KEYSTORE_DIR:-/dev/shm}:/secrets/keystore"
+    "--env" "KOKORO_KEYSTORE_DIR=/secrets/keystore"
+)
+
+# Add an option for nicer output if the build gets a tty.
+if [[ -t 0 ]]; then
+    docker_flags+=("-it")
+fi
+
+# Passing down env vars
+for e in "${pass_down_envvars[@]}"
+do
+    if [[ -n "${!e:-}" ]]; then
+	docker_flags+=("--env" "${e}=${!e}")
+    fi
+done
+
+# If arguments are given, all arguments will become the commands run
+# in the container, otherwise run TRAMPOLINE_BUILD_FILE.
+if [[ $# -ge 1 ]]; then
+    log_yellow "Running the given commands '" "${@:1}" "' in the container."
+    readonly commands=("${@:1}")
+    if [[ "${TRAMPOLINE_VERBOSE:-}" == "true" ]]; then
+	echo docker run "${docker_flags[@]}" "${TRAMPOLINE_IMAGE}" "${commands[@]}"
+    fi
+    docker run "${docker_flags[@]}" "${TRAMPOLINE_IMAGE}" "${commands[@]}"
+else
+    log_yellow "Running the tests in a Docker container."
+    docker_flags+=("--entrypoint=${TRAMPOLINE_BUILD_FILE}")
+    if [[ "${TRAMPOLINE_VERBOSE:-}" == "true" ]]; then
+	echo docker run "${docker_flags[@]}" "${TRAMPOLINE_IMAGE}"
+    fi
+    docker run "${docker_flags[@]}" "${TRAMPOLINE_IMAGE}"
+fi
+
+
+test_retval=$?
+
+if [[ ${test_retval} -eq 0 ]]; then
+    log_green "Build finished with ${test_retval}"
+else
+    log_red "Build finished with ${test_retval}"
+fi
+
+# Only upload it when the test passes.
+if [[ "${update_cache}" == "true" ]] && \
+       [[ $test_retval == 0 ]] && \
+       [[ "${TRAMPOLINE_IMAGE_UPLOAD:-false}" == "true" ]]; then
+    log_yellow "Uploading the Docker image."
+    if docker push "${TRAMPOLINE_IMAGE}"; then
+	log_green "Finished uploading the Docker image."
+    else
+	log_red "Failed uploading the Docker image."
+    fi
+    # Call trampoline_after_upload_hook if it's defined.
+    if function_exists trampoline_after_upload_hook; then
+	trampoline_after_upload_hook
+    fi
+
+fi
+
+exit "${test_retval}"

--- a/.toys/kokoro/.lib/releaser.rb
+++ b/.toys/kokoro/.lib/releaser.rb
@@ -1,0 +1,232 @@
+require "fileutils"
+require "gems"
+require "rubygems"
+require "toys/utils/exec"
+
+class Releaser
+  @loaded_env = false
+
+  def self.load_env
+    return if @loaded_env
+
+    if ::ENV["KOKORO_GFILE_DIR"]
+      service_account = "#{::ENV['KOKORO_GFILE_DIR']}/service-account.json"
+      raise "#{service_account} is not a file" unless ::File.file? service_account
+      ::ENV["GOOGLE_APPLICATION_CREDENTIALS"] = service_account
+
+      filename = "#{::ENV['KOKORO_GFILE_DIR']}/ruby_env_vars.json"
+      raise "#{filename} is not a file" unless ::File.file? filename
+      env_vars = ::JSON.parse ::File.read filename
+      env_vars.each { |k, v| ::ENV[k] ||= v }
+    end
+
+    if ::ENV["KOKORO_KEYSTORE_DIR"]
+      ::ENV["DOCS_CREDENTIALS"] ||= "#{::ENV['KOKORO_KEYSTORE_DIR']}/73713_docuploader_service_account"
+      ::ENV["GITHUB_TOKEN"] ||= "#{::ENV['KOKORO_KEYSTORE_DIR']}/73713_yoshi-automation-github-key"
+    end
+
+    @loaded_env = true
+  end
+
+  def self.lookup_current_versions regex
+    versions = {}
+    lines = `gem search '^#{regex}'`.split("\n")
+    lines.each do |line|
+      if line =~ /^(#{regex}) \(([\d.]+)\)/
+        versions[Regexp.last_match[1]] = Regexp.last_match[2]
+      end
+    end
+    raise "Something went wrong getting all current gem versions" if versions.empty?
+    versions
+  end
+
+  def self.package_from_context
+    return ::ENV["RELEASE_PACKAGE"] if ::ENV["RELEASE_PACKAGE"]
+    tags = Array(::ENV["KOKORO_GIT_COMMIT"])
+    executor = Toys::Utils::Exec.new
+    tags += executor.capture(["git", "describe", "--exact-match", "--tags"], err: :null).strip.split
+    tags.each do |tag|
+      if tag =~ %r{^([^/]+)/v\d+\.\d+\.\d+$}
+        return Regexp.last_match[1]
+      end
+    end
+    nil
+  end
+
+  def initialize gem_name, gem_dir,
+                 rubygems_api_token: nil,
+                 docs_staging_bucket: nil,
+                 docuploader_credentials: nil,
+                 dry_run: false,
+                 current_versions: nil,
+                 logger: nil
+    raise "Gem name unknown" unless gem_name
+    @gem_name = gem_name
+    @gem_dir = File.expand_path gem_dir
+    @rubygems_api_token = rubygems_api_token || ENV["RUBYGEMS_API_TOKEN"]
+    @docs_staging_bucket = docs_staging_bucket || ENV["STAGING_BUCKET"] || "docs-staging"
+    @docuploader_credentials = docuploader_credentials
+    if ENV["KOKORO_KEYSTORE_DIR"]
+      @docuploader_credentials ||= File.join(ENV["KOKORO_KEYSTORE_DIR"], "73713_docuploader_service_account")
+    end
+    @dry_run = dry_run ? true : false
+    @current_rubygems_version = current_versions[gem_name] if current_versions
+    @bundle_updated = false
+    result_callback = proc { |result| raise "Command failed" unless result.success? }
+    @executor = Toys::Utils::Exec.new logger: logger, result_callback: result_callback
+  end
+
+  attr_reader :gem_name
+  attr_reader :gem_dir
+  attr_reader :rubygems_api_token
+  attr_reader :docs_staging_bucket
+  attr_reader :docuploader_credentials
+
+  def dry_run?
+    @dry_run
+  end
+
+  def needs_gem_publish?
+    Gem::Version.new(gem_version) > Gem::Version.new(current_rubygems_version)
+  end
+
+  def publish_gem
+    puts "**** Starting publish_gem for #{gem_name}"
+    Dir.chdir gem_dir do
+      FileUtils.rm_rf "pkg"
+      isolate_bundle do
+        @executor.exec ["bundle", "exec", "rake", "build"]
+      end
+      built_gem_path = "pkg/#{gem_name}-#{gem_version}.gem"
+      raise "Failed to build #{built_gem_path}" unless File.file? built_gem_path
+      if dry_run?
+        puts "**** In dry run mode. Skipping gem publish of #{gem_name}"
+        return
+      end
+      response = gems_client.push File.new built_gem_path
+      puts response
+      raise "Failed to publish gem" unless response.include? "Successfully registered gem:"
+    end
+  end
+
+  def publish_docs
+    puts "**** Starting publish_docs for #{gem_name}"
+    Dir.chdir gem_dir do
+      FileUtils.rm_rf "doc"
+      FileUtils.rm_rf ".yardoc"
+      isolate_bundle do
+        @executor.exec ["bundle", "exec", "rake", "yard"]
+      end
+      Dir.chdir "doc" do
+        @executor.exec [
+          "python3", "-m", "docuploader", "create-metadata",
+          "--name", gem_name,
+          "--distribution-name", gem_name,
+          "--language", "ruby",
+          "--version", "v#{gem_version}",
+        ]
+        unless docuploader_credentials
+          puts "**** No credentials available. Skipping doc upload of #{gem_name}"
+          return
+        end
+        if dry_run?
+          puts "**** In dry run mode. Skipping doc upload of #{gem_name}"
+          return
+        end
+        @executor.exec [
+          "python3", "-m", "docuploader", "upload", ".",
+          "--credentials", docuploader_credentials,
+          "--staging-bucket", docs_staging_bucket,
+          "--metadata-file", "./docs.metadata",
+        ]
+      end
+    end
+  end
+
+  def publish_rad
+    puts "**** Starting publish_rad for #{gem_name}"
+    Dir.chdir gem_dir do
+      unless File.file? ".yardopts-cloudrad"
+        puts "**** No .yardopts-cloudrad file present. Skipping rad upload of #{gem_name}"
+        return
+      end
+      FileUtils.rm_rf "doc"
+      FileUtils.rm_rf ".yardoc"
+      isolate_bundle do
+        @executor.exec ["bundle", "exec", "rake", "cloudrad"]
+      end
+      Dir.chdir "doc" do
+        @executor.exec [
+          "python3", "-m", "docuploader", "create-metadata",
+          "--name", gem_name,
+          "--distribution-name", gem_name,
+          "--language", "ruby",
+          "--version", "v#{gem_version}",
+        ]
+        unless docuploader_credentials
+          puts "**** No credentials available. Skipping rad upload of #{gem_name}"
+          return
+        end
+        if dry_run?
+          puts "**** In dry run mode. Skipping doc upload of #{gem_name}"
+          return
+        end
+        @executor.exec [
+          "python3", "-m", "docuploader", "upload", ".",
+          "--credentials", docuploader_credentials,
+          "--staging-bucket", docs_staging_bucket,
+          "--metadata-file", "./docs.metadata",
+        ]
+      end
+    end
+  end
+
+  def current_rubygems_version
+    @current_rubygems_version ||= begin
+      gems_client.info(gem_name)["version"]
+    rescue Gems::NotFound
+      "0.0.0"
+    end
+  end
+
+  def gem_version
+    @gem_version ||= begin
+      func = proc do
+        Dir.chdir gem_dir do
+          spec = Gem::Specification.load "#{gem_name}.gemspec"
+          puts spec.version
+        end
+      end
+      @executor.capture_proc(func).strip
+    end
+  end
+
+  def gems_client
+    @gems_client ||= begin
+      if rubygems_api_token
+        Gems.configure do |config|
+          config.key = rubygems_api_token
+        end
+        puts "Configured rubygems api token of length #{rubygems_api_token.length}"
+      end
+      Gems::Client.new
+    end
+  end
+
+  def isolate_bundle
+    block = proc do
+      @executor.exec ["bundle", "update"] unless @bundle_updated
+      @bundle_updated = true
+      yield
+    end
+    if defined?(Bundler)
+      if Bundler.respond_to? :with_unbundled_env
+        Bundler.with_unbundled_env(&block)
+      else
+        Bundler.with_clean_env(&block)
+      end
+    else
+      block.call
+    end
+  end
+end

--- a/.toys/kokoro/.lib/releaser.rb
+++ b/.toys/kokoro/.lib/releaser.rb
@@ -43,8 +43,10 @@ class Releaser
   def self.package_from_context
     return ::ENV["RELEASE_PACKAGE"] if ::ENV["RELEASE_PACKAGE"]
     tags = Array(::ENV["KOKORO_GIT_COMMIT"])
+    puts "Got #{tags.inspect} from KOKORO_GIT_COMMIT"
     executor = Toys::Utils::Exec.new
     tags += executor.capture(["git", "describe", "--exact-match", "--tags"], err: :null).strip.split
+    puts "All tags: #{tags.inspect}"
     tags.each do |tag|
       if tag =~ %r{^([^/]+)/v\d+\.\d+\.\d+$}
         return Regexp.last_match[1]

--- a/.toys/kokoro/.lib/releaser.rb
+++ b/.toys/kokoro/.lib/releaser.rb
@@ -56,6 +56,7 @@ class Releaser
   def initialize gem_name, gem_dir,
                  rubygems_api_token: nil,
                  docs_staging_bucket: nil,
+                 docs_staging_bucket_v2: nil,
                  docuploader_credentials: nil,
                  dry_run: false,
                  current_versions: nil,
@@ -65,6 +66,7 @@ class Releaser
     @gem_dir = File.expand_path gem_dir
     @rubygems_api_token = rubygems_api_token || ENV["RUBYGEMS_API_TOKEN"]
     @docs_staging_bucket = docs_staging_bucket || ENV["STAGING_BUCKET"] || "docs-staging"
+    @docs_staging_bucket_v2 = docs_staging_bucket_v2 || ENV["V2_STAGING_BUCKET"] || "docs-staging-v2-dev"
     @docuploader_credentials = docuploader_credentials
     if ENV["KOKORO_KEYSTORE_DIR"]
       @docuploader_credentials ||= File.join(ENV["KOKORO_KEYSTORE_DIR"], "73713_docuploader_service_account")
@@ -80,6 +82,7 @@ class Releaser
   attr_reader :gem_dir
   attr_reader :rubygems_api_token
   attr_reader :docs_staging_bucket
+  attr_reader :docs_staging_bucket_v2
   attr_reader :docuploader_credentials
 
   def dry_run?
@@ -174,8 +177,9 @@ class Releaser
         @executor.exec [
           "python3", "-m", "docuploader", "upload", ".",
           "--credentials", docuploader_credentials,
-          "--staging-bucket", docs_staging_bucket,
+          "--staging-bucket", docs_staging_bucket_v2,
           "--metadata-file", "./docs.metadata",
+          "--destination-prefix", "docfx",
         ]
       end
     end

--- a/.toys/kokoro/release.rb
+++ b/.toys/kokoro/release.rb
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include :exec, e: true
-include :gems
-
 optional_arg :package
 flag :dry_run, default: ::ENV["RELEASE_DRY_RUN"] == "true"
+
+include :exec, e: true
+include :gems
 
 def run
   gem "gems", "~> 1.2"
@@ -24,7 +24,9 @@ def run
   require "releaser"
   Releaser.load_env
   set :package, Releaser.package_from_context unless package
+  raise "Unable to determine package" unless package
 
+  # TODO: Move link transformer into Toys lib directory.
   require File.join(Dir.getwd, "rakelib", "link_transformer")
   Dir.chdir package do
     yard_link_transformer = LinkTransformer.new

--- a/.toys/kokoro/release.rb
+++ b/.toys/kokoro/release.rb
@@ -1,0 +1,39 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include :exec, e: true
+include :gems
+
+optional_arg :package
+flag :dry_run, default: ::ENV["RELEASE_DRY_RUN"] == "true"
+
+def run
+  gem "gems", "~> 1.2"
+  Dir.chdir context_directory
+  require "releaser"
+  Releaser.load_env
+  set :package, Releaser.package_from_context unless package
+
+  require File.join(Dir.getwd, "rakelib", "link_transformer")
+  Dir.chdir package do
+    yard_link_transformer = LinkTransformer.new
+    files = yard_link_transformer.find_markdown_files
+    yard_link_transformer.transform_links_in_files files
+  end
+
+  releaser = Releaser.new package, package, dry_run: dry_run, logger: logger
+  releaser.publish_gem if releaser.needs_gem_publish?
+  releaser.publish_docs
+  releaser.publish_rad
+end

--- a/.toys/release-please.rb
+++ b/.toys/release-please.rb
@@ -52,8 +52,11 @@ def release_please gem_name
   log_cmd = cmd.inspect
   log_cmd.sub! github_token, "****" if github_token
   result = exec cmd, log_cmd: log_cmd, e: false
-  unless result.success?
+  if result.success?
+    sleep 1
+  else
     puts "Error running release-please for #{gem_name} from version #{version.inspect}", :bold, :red
+    sleep 2
   end
 end
 

--- a/.trampolinerc
+++ b/.trampolinerc
@@ -1,0 +1,48 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Add required env vars here.
+required_envvars+=(
+)
+
+# Add env vars which are passed down into the container here.
+pass_down_envvars+=(
+    "AUTORELEASE_PR" "RELEASE_DRY_RUN" "RELEASE_PACKAGE" "KOKORO_GIT_COMMIT"
+)
+
+# Prevent unintentional override on the default image.
+if [[ "${TRAMPOLINE_IMAGE_UPLOAD:-false}" == "true" ]] && [[ -z "${TRAMPOLINE_IMAGE:-}" ]]; then
+    echo "Please set TRAMPOLINE_IMAGE if you want to upload the Docker image."
+    exit 1
+fi
+
+# Define the default value if it makes sense.
+if [[ -z "${TRAMPOLINE_IMAGE_UPLOAD:-}" ]]; then
+    TRAMPOLINE_IMAGE_UPLOAD=""
+fi
+
+if [[ -z "${TRAMPOLINE_IMAGE:-}" ]]; then
+    TRAMPOLINE_IMAGE=""
+fi
+
+if [[ -z "${TRAMPOLINE_DOCKERFILE:-}" ]]; then
+    TRAMPOLINE_DOCKERFILE=""
+fi
+
+if [[ -z "${TRAMPOLINE_BUILD_FILE:-}" ]]; then
+    TRAMPOLINE_BUILD_FILE=""
+fi
+
+# Secret Manager secrets.
+source ${PROJECT_ROOT}/.kokoro/populate-secrets.sh


### PR DESCRIPTION
Rework the kokoro release job to bring it up to date. The new job will live in parallel with the old for the moment. This has the following goals:

* Update the job to use the latest infrastructure: Trampoline V2 and Secret Manager.
* Re-enable the publish reporter (i.e. updating the release PR), which has been broken for a very long time.
* Have a single release job rather than separate jobs per library. (Ultimately, we want to eliminate _all_ per-library jobs so that we don't have to add kokoro configs every time we create a new library.)
* Continue moving scripts from Rake to Toys to make them easier to maintain and test.

Details:

* Much of the code was copied and adapted from earlier work on google-api-ruby-client.
* Copied the Releaser class from google-api-ruby-client to `.toys/kokoro/.lib/releaser.rb`, with a few changes:
    * Support for Cloud RAD.
    * Eliminated a few places where it assumed it was being used for google-api-ruby-client.
    * Added a utility method to determine the package to release based on git tags.
* Copied the "front end" Toys script (`.toys/kokoro/release.rb`) from google-api-ruby-client. Updated it to call the above utility method to determine the package to release, and to call Tram's LinkTransformer.
    * Note: for now, I'm leaving LinkTransformer in the `rakelib` directory, but will eventually move it into `.toys/kokoro/.lib`.
* Copied and adapted the trampoline invocation script (`.kokoro/release.sh`) from google-api-ruby-client. 
* Copied and adapted `.trampolinerc` from google-api-ruby-client. Updated it to pass additional environment variables.
* Copied Trampoline V2 (`.kokoro/trampoline_v2.sh`), and the populate secrets script we originally stole from Node's repos (`.kokoro/trampoline_v2.sh`), verbatim from google-api-ruby-client.
* Wrote `.kokoro/release.cfg`. Note this job will live in parallel with the older release jobs (in `.kokoro/release/*/*.cfg`) until we are confident of its stability.

Notes:

* This needs to go in tandem with internal cl/368948263 to create the corresponding internal kokoro config.
* [Releasetool](https://github.com/googleapis/releasetool/blob/master/releasetool/commands/tag/ruby.py#L143) controls which job is run (the old per-library job or this new global job).