### PR TITLE
tests(text_to_speech): Create a simple smoke test

### DIFF
--- a/google-cloud-text_to_speech/acceptance/helper.rb
+++ b/google-cloud-text_to_speech/acceptance/helper.rb
@@ -1,0 +1,18 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "minitest/autorun"
+require "minitest/focus"
+require "minitest/rg"
+require "google/cloud/text_to_speech"

--- a/google-cloud-text_to_speech/acceptance/tts_smoke_test.rb
+++ b/google-cloud-text_to_speech/acceptance/tts_smoke_test.rb
@@ -1,0 +1,33 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "helper"
+
+describe "smoke test" do
+  it "generates hello world speech" do
+    client = Google::Cloud::TextToSpeech.text_to_speech
+    synthesis_input = { text: "Hello, World!" }
+    voice = {
+      language_code: "en-US",
+      ssml_gender:   "NEUTRAL"
+    }
+    audio_config = { audio_encoding: "MP3" }
+    response = client.synthesize_speech(
+      input:        synthesis_input,
+      voice:        voice,
+      audio_config: audio_config
+    )
+    assert response.audio_content.length.positive?
+  end
+end


### PR DESCRIPTION
This pulls the quickstart code into a smoke test before the samples get deleted in #10910.