### PR TITLE
docs(stackdriver): Remove Debugger description from stackdriver gem

### DIFF
--- a/stackdriver/INSTRUMENTATION_CONFIGURATION.md
+++ b/stackdriver/INSTRUMENTATION_CONFIGURATION.md
@@ -42,13 +42,6 @@ Google::Cloud::ErrorReporting.configure do |config|
   config.service_name = "my-service"
 end
 
-# Debugger specific configurations
-Google::Cloud::Debugger.configure do |config|
-  config.project_id = "debugger-project"
-  config.service_name = "my-service"
-  config.allow_mutating_methods = true
-end
-
 # Logging specific configurations
 Google::Cloud::Logging.configure do |config|
   config.project_id = "error-reporting-project"
@@ -73,7 +66,6 @@ end
 * `project_id`: [`String`] Shared Google Cloud Platform Project identifier. Self discovered on GCP.
 * `credentials`: [`String`] Path to shared service account JSON keyfile. Self discovered on GCP.
 * `use_error_reporting`: [`Boolean`] Explicitly enable or disable Error Reporting features. Default: `Rails.env.production?`
-* `use_debugger`: [`Boolean`] Explicitly enable or disable Debugger features. Default: `Rails.env.production?`
 * `use_logging`: [`Boolean`] Explicitly enable or disable Logging middleware. Default: `Rails.env.production?`
 * `use_trace`: [`Boolean`] Explicitly enable or disable Trace features. Default: `Rails.env.production?`
 
@@ -84,16 +76,6 @@ end
 * `error_reporting.service_name`: [`String`] Identifier to running service. Self discovered on GCP. Default: `"ruby"`
 * `error_reporting.service_version`: [`String`] Version identifier to running service. Self discovered on GCP.
 * `error_reporting.ignore_classes`: [`Array`] An Array of Exception classes to ignore. Default: `[]`
-
-#### Debugger
-
-* `debugger.project_id`: [`String`] Google Cloud Platform Project identifier just for Debugger. Self discovered on GCP.
-* `debugger.credentials`: [`String`] Path to service account JSON keyfile. Self discovered on GCP.
-* `debugger.service_name`: [`String`] Identifier to running service. Self discovered on GCP. Default: `"ruby-app"`
-* `debugger.service_version`: [`String`] Version identifier to running service. Self discovered on GCP.
-* `debugger.root`: [`String`] The root directory of the debuggee application in absolute file path form. Default: `Rack::Directory#root` if the application framework is rack-based,i.e. Ruby on Rails, Sinatra. Otherwise use current working directory.
-* `debugger.allow_mutating_methods`: [`boolean`] Whether to allow expressions to call methods that could mutate program state. Default is `false`.
-* `debugger.evaluation_time_limit`: [`Numeric`] The time limit in seconds for evaluating expressions. Default is `0.05`.
 
 #### Logging
 

--- a/stackdriver/README.md
+++ b/stackdriver/README.md
@@ -8,8 +8,6 @@ application.
 Specifically, this gem is a convenience package that loads and automatically
 activates the instrumentation features of the following gems:
 
-*   [google-cloud-debugger](https://googleapis.dev/ruby/google-cloud-debugger/latest) which enables remote
-    debugging using [Stackdriver Debugger](https://cloud.google.com/debugger/)
 *   [google-cloud-error_reporting](https://googleapis.dev/ruby/google-cloud-error_reporting/latest) which
     reports unhandled exceptions and other errors to
     [Stackdriver Error Reporting](https://cloud.google.com/error-reporting/)
@@ -57,7 +55,6 @@ require "stackdriver"
 use Google::Cloud::Logging::Middleware
 use Google::Cloud::ErrorReporting::Middleware
 use Google::Cloud::Trace::Middleware
-use Google::Cloud::Debugger::Middleware
 ```
 
 #### Advanced instrumentation


### PR DESCRIPTION
Now that the stackdriver gem no longer depends on Debugger(google-cloud-debugger), it looks like we can remove the description of Debugger from the documentation. So I removed the description of the Debugger from the stackdriver gem documentation.

- Here are the commits related to the removal of the Debugger: 
  - googleapis@bf17920#diff-ae0c347001fcba09f798bd5e12b1e6041afca5ce18fe1187a86f213a687fdb0e
  - googleapis@00c40db#diff-ae0c347001fcba09f798bd5e12b1e6041afca5ce18fe1187a86f213a687fdb0e

---

- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-ruby/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea.
- [x] Follow the instructions in [CONTRIBUTING](CONTRIBUTING.md). Most importantly, ensure the tests and linter pass by running `bundle exec rake ci` in the gem subdirectory.
- [x] Update code documentation if necessary.

closes: #11223