### PR TITLE
Release google-cloud-compute-v1 0.1.0

### DIFF
--- a/google-cloud-compute-v1/CHANGELOG.md
+++ b/google-cloud-compute-v1/CHANGELOG.md
@@ -2,3 +2,7 @@
 
 0.0.1alpha / 2021-03-08
 Initial release.
+### 0.1.0 / 2021-05-10
+
+* Initial alpha release
+

--- a/google-cloud-compute-v1/CHANGELOG.md
+++ b/google-cloud-compute-v1/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Release History
 
-0.0.1alpha / 2021-03-08
-Initial release.
 ### 0.1.0 / 2021-05-10
 
 * Initial alpha release

--- a/google-cloud-compute-v1/lib/google/cloud/compute/v1/version.rb
+++ b/google-cloud-compute-v1/lib/google/cloud/compute/v1/version.rb
@@ -21,7 +21,7 @@ module Google
   module Cloud
     module Compute
       module V1
-        VERSION = "0.0.1"
+        VERSION = "0.1.0"
       end
     end
   end


### PR DESCRIPTION
* Initial alpha release

<details><summary>Commits since previous release</summary><pre><code></code></pre></details>

This pull request was generated using releasetool.