### PR TITLE
fix: Expand googleauth dependency to support future 1.x versions

### DIFF
--- a/google-cloud-bigquery/google-cloud-bigquery.gemspec
+++ b/google-cloud-bigquery/google-cloud-bigquery.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "concurrent-ruby", "~> 1.0"
   gem.add_dependency "google-apis-bigquery_v2", "~> 0.1"
-  gem.add_dependency "googleauth", "~> 0.9"
-  gem.add_dependency "google-cloud-core", "~> 1.2"
+  gem.add_dependency "googleauth", ">= 0.16.2", "< 2.a"
+  gem.add_dependency "google-cloud-core", "~> 1.6"
   gem.add_dependency "mini_mime", "~> 1.0"
 
   gem.add_development_dependency "autotest-suffix", "~> 1.1"

--- a/google-cloud-dns/google-cloud-dns.gemspec
+++ b/google-cloud-dns/google-cloud-dns.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "google-cloud-core", "~> 1.2"
+  gem.add_dependency "google-cloud-core", "~> 1.6"
   gem.add_dependency "google-apis-dns_v1", "~> 0.1"
-  gem.add_dependency "googleauth", "~> 0.9"
+  gem.add_dependency "googleauth", ">= 0.16.2", "< 2.a"
   gem.add_dependency "zonefile", "~> 1.04"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"

--- a/google-cloud-resource_manager/google-cloud-resource_manager.gemspec
+++ b/google-cloud-resource_manager/google-cloud-resource_manager.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "google-cloud-core", "~> 1.2"
+  gem.add_dependency "google-cloud-core", "~> 1.6"
   gem.add_dependency "google-apis-cloudresourcemanager_v1", "~> 0.1"
-  gem.add_dependency "googleauth", "~> 0.9"
+  gem.add_dependency "googleauth", ">= 0.16.2", "< 2.a"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"

--- a/google-cloud-storage/google-cloud-storage.gemspec
+++ b/google-cloud-storage/google-cloud-storage.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "google-cloud-core", "~> 1.2"
+  gem.add_dependency "google-cloud-core", "~> 1.6"
   gem.add_dependency "google-apis-iamcredentials_v1", "~> 0.1"
   gem.add_dependency "google-apis-storage_v1", "~> 0.1"
-  gem.add_dependency "googleauth", "~> 0.9"
+  gem.add_dependency "googleauth", ">= 0.16.2", "< 2.a"
   gem.add_dependency "digest-crc", "~> 0.4"
   gem.add_dependency "addressable", "~> 2.5"
   gem.add_dependency "mini_mime", "~> 1.0"

--- a/google-cloud-translate-v2/google-cloud-translate-v2.gemspec
+++ b/google-cloud-translate-v2/google-cloud-translate-v2.gemspec
@@ -19,11 +19,11 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "faraday", ">= 0.17.3", "< 2.0"
-  gem.add_dependency "googleapis-common-protos", ">= 1.3.10", "< 2.0"
-  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.5", "< 2.0"
-  gem.add_dependency "googleauth", "~> 0.12"
-  gem.add_dependency "google-cloud-core", "~> 1.5"
+  gem.add_dependency "faraday", ">= 0.17.3", "< 2.a"
+  gem.add_dependency "googleapis-common-protos", ">= 1.3.10", "< 2.a"
+  gem.add_dependency "googleapis-common-protos-types", ">= 1.0.5", "< 2.a"
+  gem.add_dependency "googleauth", ">= 0.16.2", "< 2.a"
+  gem.add_dependency "google-cloud-core", "~> 1.6"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"


### PR DESCRIPTION
We've been asked to bump googleauth to 1.0. In preparation, we're expanding all googleauth dependencies to support both 0.x and 1.x.