### PR TITLE
docs(firestore): remove dual-homed region tags

### DIFF
--- a/google-cloud-firestore/samples/add_data.rb
+++ b/google-cloud-firestore/samples/add_data.rb
@@ -21,7 +21,6 @@ def set_document project_id:, collection_path: "cities"
 
   firestore = Google::Cloud::Firestore.new project_id: project_id
   # [START firestore_data_set_from_map]
-  # [START fs_set_document]
   city_ref = firestore.doc "#{collection_path}/LA"
 
   data = {
@@ -31,7 +30,6 @@ def set_document project_id:, collection_path: "cities"
   }
 
   city_ref.set data
-  # [END fs_set_document]
   # [END firestore_data_set_from_map]
   puts "Set data for the LA document in the cities collection."
 end
@@ -42,10 +40,8 @@ def update_create_if_missing project_id:, collection_path: "cities"
 
   firestore = Google::Cloud::Firestore.new project_id: project_id
   # [START firestore_data_set_doc_upsert]
-  # [START fs_update_create_if_missing]
   city_ref = firestore.doc "#{collection_path}/LA"
   city_ref.set({ capital: false }, merge: true)
-  # [END fs_update_create_if_missing]
   # [END firestore_data_set_doc_upsert]
   puts "Merged data into the LA document in the cities collection."
 end
@@ -56,7 +52,6 @@ def set_document_data_types project_id:, collection_path: "data"
 
   firestore = Google::Cloud::Firestore.new project_id: project_id
   # [START firestore_data_set_from_map_nested]
-  # [START fs_set_document_data_types]
   doc_ref = firestore.doc "#{collection_path}/one"
 
   data = {
@@ -73,7 +68,6 @@ def set_document_data_types project_id:, collection_path: "data"
   }
 
   doc_ref.set data
-  # [END fs_set_document_data_types]
   # [END firestore_data_set_from_map_nested]
   puts "Set multiple data-type data for the one document in the data collection."
 end
@@ -89,10 +83,8 @@ def set_requires_id project_id:, collection_path: "cities"
     country: "Thailand"
   }
   # [START firestore_data_set_id_specified]
-  # [START fs_set_requires_id]
   city_ref = firestore.doc "#{collection_path}/new-city-id"
   city_ref.set data
-  # [END fs_set_requires_id]
   # [END firestore_data_set_id_specified]
   puts "Added document with ID: new-city-id."
 end
@@ -103,7 +95,6 @@ def add_doc_data_with_auto_id project_id:, collection_path: "cities"
 
   firestore = Google::Cloud::Firestore.new project_id: project_id
   # [START firestore_data_set_id_random_collection]
-  # [START fs_add_doc_data_with_auto_id]
   data = {
     name:    "Tokyo",
     country: "Japan"
@@ -113,7 +104,6 @@ def add_doc_data_with_auto_id project_id:, collection_path: "cities"
 
   added_doc_ref = cities_ref.add data
   puts "Added document with ID: #{added_doc_ref.document_id}."
-  # [END fs_add_doc_data_with_auto_id]
   # [END firestore_data_set_id_random_collection]
 end
 
@@ -128,14 +118,12 @@ def add_doc_data_after_auto_id project_id:, collection_path: "cities"
     country: "Russia"
   }
   # [START firestore_data_set_id_random_document_ref]
-  # [START fs_add_doc_data_after_auto_id]
   cities_ref = firestore.col collection_path
 
   added_doc_ref = cities_ref.doc
   puts "Added document with ID: #{added_doc_ref.document_id}."
 
   added_doc_ref.set data
-  # [END fs_add_doc_data_after_auto_id]
   # [END firestore_data_set_id_random_document_ref]
   puts "Added data to the #{added_doc_ref.document_id} document in the cities collection."
 end
@@ -154,10 +142,8 @@ def update_doc project_id:, collection_path: "cities"
   }
   doc_ref.set data
   # [START firestore_data_set_field]
-  # [START fs_update_doc]
   city_ref = firestore.doc "#{collection_path}/DC"
   city_ref.update({ capital: true })
-  # [END fs_update_doc]
   # [END firestore_data_set_field]
   puts "Updated the capital field of the DC document in the cities collection."
 end
@@ -168,7 +154,6 @@ def update_nested_fields project_id:, collection_path: "users"
 
   firestore = Google::Cloud::Firestore.new project_id: project_id
   # [START firestore_data_set_nested_fields]
-  # [START fs_update_nested_fields]
   # Create an initial document to update
   frank_ref = firestore.doc "#{collection_path}/frank"
   frank_ref.set(
@@ -185,7 +170,6 @@ def update_nested_fields project_id:, collection_path: "users"
 
   # Update age and favorite color
   frank_ref.update({ age: 13, "favorites.color": "Red" })
-  # [END fs_update_nested_fields]
   # [END firestore_data_set_nested_fields]
   puts "Updated the age and favorite color fields of the frank document in the users collection."
 end
@@ -205,10 +189,8 @@ def update_server_timestamp project_id:, collection_path: "cities"
     }
   )
   # [START firestore_data_set_server_timestamp]
-  # [START fs_update_server_timestamp]
   city_ref = firestore.doc "#{collection_path}/new-city-id"
   city_ref.update({ timestamp: firestore.field_server_time })
-  # [END fs_update_server_timestamp]
   # [END firestore_data_set_server_timestamp]
   puts "Updated the timestamp field of the new-city-id document in the cities collection."
 end
@@ -228,10 +210,8 @@ def update_document_increment project_id:, collection_path: "cities"
     }
   )
   # [START firestore_data_set_numeric_increment]
-  # [START fs_update_document_increment]
   city_ref = firestore.doc "#{collection_path}/DC"
   city_ref.update({ population: firestore.field_increment(50) })
-  # [END fs_update_document_increment]
   # [END firestore_data_set_numeric_increment]
   puts "Updated the population of the DC document in the cities collection."
 end

--- a/google-cloud-firestore/samples/data_model.rb
+++ b/google-cloud-firestore/samples/data_model.rb
@@ -19,9 +19,7 @@ def document_ref project_id:
 
   firestore = Google::Cloud::Firestore.new project_id: project_id
   # [START firestore_data_reference_document]
-  # [START fs_document_ref]
   document_ref = firestore.col("users").doc("alovelace")
-  # [END fs_document_ref]
   # [END firestore_data_reference_document]
 end
 
@@ -30,9 +28,7 @@ def collection_ref project_id:
 
   firestore = Google::Cloud::Firestore.new project_id: project_id
   # [START firestore_data_reference_collection]
-  # [START fs_collection_ref]
   collection_ref = firestore.col "users"
-  # [END fs_collection_ref]
   # [END firestore_data_reference_collection]
 end
 
@@ -41,9 +37,7 @@ def document_path_ref project_id:
 
   firestore = Google::Cloud::Firestore.new project_id: project_id
   # [START firestore_data_reference_document_path]
-  # [START fs_document_path_ref]
   document_path_ref = firestore.doc "users/alovelace"
-  # [END fs_document_path_ref]
   # [END firestore_data_reference_document_path]
 end
 
@@ -52,9 +46,7 @@ def subcollection_ref project_id:
 
   firestore = Google::Cloud::Firestore.new project_id: project_id
   # [START firestore_data_reference_subcollection]
-  # [START fs_subcollection_ref]
   message_ref = firestore.col("rooms").doc("roomA").col("messages").doc("message1")
-  # [END fs_subcollection_ref]
   # [END firestore_data_reference_subcollection]
 end
 

--- a/google-cloud-firestore/samples/delete_data.rb
+++ b/google-cloud-firestore/samples/delete_data.rb
@@ -21,10 +21,8 @@ def delete_doc project_id:, collection_path: "cities"
 
   firestore = Google::Cloud::Firestore.new project_id: project_id
   # [START firestore_data_delete_doc]
-  # [START fs_delete_doc]
   city_ref = firestore.doc "#{collection_path}/DC"
   city_ref.delete
-  # [END fs_delete_doc]
   # [END firestore_data_delete_doc]
   puts "Deleted the DC document in the cities collection."
 end
@@ -35,10 +33,8 @@ def delete_field project_id:, collection_path: "cities"
 
   firestore = Google::Cloud::Firestore.new project_id: project_id
   # [START firestore_data_delete_field]
-  # [START fs_delete_field]
   city_ref = firestore.doc "#{collection_path}/BJ"
   city_ref.update({ capital: firestore.field_delete })
-  # [END fs_delete_field]
   # [END firestore_data_delete_field]
   puts "Deleted the capital field from the BJ document in the cities collection."
 end
@@ -49,7 +45,6 @@ def delete_collection project_id:, collection_path: "cities"
 
   firestore = Google::Cloud::Firestore.new project_id: project_id
   # [START firestore_data_delete_collection]
-  # [START fs_delete_collection]
   cities_ref = firestore.col collection_path
   query      = cities_ref
 
@@ -58,7 +53,6 @@ def delete_collection project_id:, collection_path: "cities"
     document_ref = document_snapshot.ref
     document_ref.delete
   end
-  # [END fs_delete_collection]
   # [END firestore_data_delete_collection]
   puts "Finished deleting all documents from the collection."
 end

--- a/google-cloud-firestore/samples/distributed_counters.rb
+++ b/google-cloud-firestore/samples/distributed_counters.rb
@@ -15,7 +15,6 @@
 
 def create_counter project_id:, num_shards:, collection_path: "shards"
   # [START firestore_solution_sharded_counter_create]
-  # [START fs_create_counter]
   # project_id = "Your Google Cloud Project ID"
   # num_shards = "Number of shards for distributed counter"
   # collection_path = "shards"
@@ -32,13 +31,11 @@ def create_counter project_id:, num_shards:, collection_path: "shards"
   end
 
   puts "Distributed counter shards collection created."
-  # [END fs_create_counter]
   # [END firestore_solution_sharded_counter_create]
 end
 
 def increment_counter project_id:, num_shards:, collection_path: "shards"
   # [START firestore_solution_sharded_counter_increment]
-  # [START fs_increment_counter]
   # project_id = "Your Google Cloud Project ID"
   # num_shards = "Number of shards for distributed counter"
   # collection_path = "shards"
@@ -55,13 +52,11 @@ def increment_counter project_id:, num_shards:, collection_path: "shards"
   shard_ref.update({ count: firestore.field_increment(1) })
 
   puts "Counter incremented."
-  # [END fs_increment_counter]
   # [END firestore_solution_sharded_counter_increment]
 end
 
 def get_count project_id:, collection_path: "shards"
   # [START firestore_solution_sharded_counter_get]
-  # [START fs_get_count]
   # project_id = "Your Google Cloud Project ID"
   # collection_path = "shards"
 
@@ -77,7 +72,6 @@ def get_count project_id:, collection_path: "shards"
   end
 
   puts "Count value is #{count}."
-  # [END fs_get_count]
   # [END firestore_solution_sharded_counter_get]
 end
 

--- a/google-cloud-firestore/samples/get_data.rb
+++ b/google-cloud-firestore/samples/get_data.rb
@@ -20,7 +20,6 @@ def retrieve_create_examples project_id:, collection_path: "cities"
 
   firestore = Google::Cloud::Firestore.new project_id: project_id
   # [START firestore_data_get_dataset]
-  # [START fs_retrieve_create_examples]
   cities_ref = firestore.col collection_path
   cities_ref.doc("SF").set(
     {
@@ -67,7 +66,6 @@ def retrieve_create_examples project_id:, collection_path: "cities"
       population: 21_500_000
     }
   )
-  # [END fs_retrieve_create_examples]
   # [END firestore_data_get_dataset]
   puts "Added example cities data to the cities collection."
 end
@@ -79,7 +77,6 @@ def get_document project_id:, collection_path: "cities"
   firestore = Google::Cloud::Firestore.new project_id: project_id
 
   # [START firestore_data_get_as_map]
-  # [START fs_get_document]
   doc_ref  = firestore.doc "#{collection_path}/SF"
   snapshot = doc_ref.get
   if snapshot.exists?
@@ -87,7 +84,6 @@ def get_document project_id:, collection_path: "cities"
   else
     puts "Document #{snapshot.document_id} does not exist!"
   end
-  # [END fs_get_document]
   # [END firestore_data_get_as_map]
 end
 
@@ -97,7 +93,6 @@ def get_multiple_docs project_id:, collection_path: "cities"
 
   firestore = Google::Cloud::Firestore.new project_id: project_id
   # [START firestore_data_query]
-  # [START fs_get_multiple_docs]
   cities_ref = firestore.col collection_path
 
   query = cities_ref.where "capital", "=", true
@@ -105,7 +100,6 @@ def get_multiple_docs project_id:, collection_path: "cities"
   query.get do |city|
     puts "#{city.document_id} data: #{city.data}."
   end
-  # [END fs_get_multiple_docs]
   # [END firestore_data_query]
 end
 
@@ -115,12 +109,10 @@ def get_all_docs project_id:, collection_path: "cities"
 
   firestore = Google::Cloud::Firestore.new project_id: project_id
   # [START firestore_data_get_all_documents]
-  # [START fs_get_all_docs]
   cities_ref = firestore.col collection_path
   cities_ref.get do |city|
     puts "#{city.document_id} data: #{city.data}."
   end
-  # [END fs_get_all_docs]
   # [END firestore_data_get_all_documents]
 end
 
@@ -129,14 +121,12 @@ def add_subcollection project_id:, collection_path: "cities"
   # collection_path = "cities"
 
   firestore = Google::Cloud::Firestore.new project_id: project_id
-  # [START fs_add_subcollection]
   city_ref = firestore.doc "#{collection_path}/SF"
 
   subcollection_ref = city_ref.col "neighborhoods"
 
   added_doc_ref = subcollection_ref.add name: "Marina"
   puts "Added document with ID: #{added_doc_ref.document_id}."
-  # [END fs_add_subcollection]
 end
 
 def list_subcollections project_id:, collection_path: "cities"
@@ -145,12 +135,10 @@ def list_subcollections project_id:, collection_path: "cities"
 
   firestore = Google::Cloud::Firestore.new project_id: project_id
   # [START firestore_data_get_sub_collections]
-  # [START fs_list_subcollections]
   city_ref = firestore.doc "#{collection_path}/SF"
   city_ref.cols do |col|
     puts col.collection_id
   end
-  # [END fs_list_subcollections]
   # [END firestore_data_get_sub_collections]
 end
 

--- a/google-cloud-firestore/samples/get_data.rb
+++ b/google-cloud-firestore/samples/get_data.rb
@@ -128,7 +128,7 @@ def add_subcollection project_id:, collection_path: "cities"
 
   added_doc_ref = subcollection_ref.add name: "Marina"
   puts "Added document with ID: #{added_doc_ref.document_id}."
-   # [END fs_add_subcollection]
+  # [END fs_add_subcollection]
 end
 
 def list_subcollections project_id:, collection_path: "cities"

--- a/google-cloud-firestore/samples/get_data.rb
+++ b/google-cloud-firestore/samples/get_data.rb
@@ -121,12 +121,14 @@ def add_subcollection project_id:, collection_path: "cities"
   # collection_path = "cities"
 
   firestore = Google::Cloud::Firestore.new project_id: project_id
+  # [START fs_add_subcollection]
   city_ref = firestore.doc "#{collection_path}/SF"
 
   subcollection_ref = city_ref.col "neighborhoods"
 
   added_doc_ref = subcollection_ref.add name: "Marina"
   puts "Added document with ID: #{added_doc_ref.document_id}."
+   # [END fs_add_subcollection]
 end
 
 def list_subcollections project_id:, collection_path: "cities"

--- a/google-cloud-firestore/samples/order_limit_data.rb
+++ b/google-cloud-firestore/samples/order_limit_data.rb
@@ -22,9 +22,7 @@ def order_by_name_limit_query project_id:, collection_path: "cities"
 
   cities_ref = firestore.col collection_path
   # [START firestore_query_order_limit]
-  # [START fs_order_by_name_limit_query]
   query = cities_ref.order("name").limit(3)
-  # [END fs_order_by_name_limit_query]
   # [END firestore_query_order_limit]
   query.get do |city|
     puts "Document #{city.document_id} returned by order by name with limit query."
@@ -39,9 +37,7 @@ def order_by_name_desc_limit_query project_id:, collection_path: "cities"
 
   cities_ref = firestore.col collection_path
   # [START firestore_query_order_desc_limit]
-  # [START fs_order_by_name_desc_limit_query]
   query = cities_ref.order("name", "desc").limit(3)
-  # [END fs_order_by_name_desc_limit_query]
   # [END firestore_query_order_desc_limit]
   query.get do |city|
     puts "Document #{city.document_id} returned by order by name descending with limit query."
@@ -56,9 +52,7 @@ def order_by_state_and_population_query project_id:, collection_path: "cities"
 
   cities_ref = firestore.col collection_path
   # [START firestore_query_order_multi]
-  # [START fs_order_by_state_and_population_query]
   query = cities_ref.order("state").order("population", "desc")
-  # [END fs_order_by_state_and_population_query]
   # [END firestore_query_order_multi]
   query.get do |city|
     puts "Document #{city.document_id} returned by order by state and descending population query."
@@ -73,9 +67,7 @@ def where_order_by_limit_query project_id:, collection_path: "cities"
 
   cities_ref = firestore.col collection_path
   # [START firestore_query_order_limit_field_valid]
-  # [START fs_where_order_by_limit_query]
   query = cities_ref.where("population", ">", 2_500_000).order("population").limit(2)
-  # [END fs_where_order_by_limit_query]
   # [END firestore_query_order_limit_field_valid]
   query.get do |city|
     puts "Document #{city.document_id} returned by where order by limit query."
@@ -90,9 +82,7 @@ def range_order_by_query project_id:, collection_path: "cities"
 
   cities_ref = firestore.col collection_path
   # [START firestore_query_order_with_filter]
-  # [START fs_range_order_by_query]
   query = cities_ref.where("population", ">", 2_500_000).order("population")
-  # [END fs_range_order_by_query]
   # [END firestore_query_order_with_filter]
   query.get do |city|
     puts "Document #{city.document_id} returned by range with order by query."
@@ -107,9 +97,7 @@ def invalid_range_order_by_query project_id:, collection_path: "cities"
 
   cities_ref = firestore.col collection_path
   # [START firestore_query_order_field_invalid]
-  # [START fs_invalid_range_order_by_query]
   query = cities_ref.where("population", ">", 2_500_000).order("country")
-  # [END fs_invalid_range_order_by_query]
   # [END firestore_query_order_field_invalid]
 end
 

--- a/google-cloud-firestore/samples/paginate_data.rb
+++ b/google-cloud-firestore/samples/paginate_data.rb
@@ -22,9 +22,7 @@ def start_at_field_query_cursor project_id:, collection_path: "cities"
 
   cities_ref = firestore.col collection_path
   # [START firestore_query_cursor_start_at_field_value_single]
-  # [START fs_start_at_field_query_cursor]
   query = cities_ref.order("population").start_at(1_000_000)
-  # [END fs_start_at_field_query_cursor]
   # [END firestore_query_cursor_start_at_field_value_single]
   query.get do |city|
     puts "Document #{city.document_id} returned by start at population 1000000 field query cursor."
@@ -39,9 +37,7 @@ def end_at_field_query_cursor project_id:, collection_path: "cities"
 
   cities_ref = firestore.col collection_path
   # [START firestore_query_cursor_end_at_field_value_single]
-  # [START fs_end_at_field_query_cursor]
   query = cities_ref.order("population").end_at(1_000_000)
-  # [END fs_end_at_field_query_cursor]
   # [END firestore_query_cursor_end_at_field_value_single]
   query.get do |city|
     puts "Document #{city.document_id} returned by end at population 1000000 field query cursor."
@@ -55,7 +51,6 @@ def paginated_query_cursor project_id:, collection_path: "cities"
   firestore = Google::Cloud::Firestore.new project_id: project_id
 
   # [START firestore_query_cursor_pagination]
-  # [START fs_paginated_query_cursor]
   cities_ref  = firestore.col collection_path
   first_query = cities_ref.order("population").limit(3)
 
@@ -71,7 +66,6 @@ def paginated_query_cursor project_id:, collection_path: "cities"
   second_query.get do |city|
     puts "Document #{city.document_id} returned by paginated query cursor."
   end
-  # [END fs_paginated_query_cursor]
   # [END firestore_query_cursor_pagination]
 end
 
@@ -83,13 +77,11 @@ def multiple_cursor_conditions project_id:, collection_path: "cities"
 
   cities_ref = firestore.col collection_path
   # [START firestore_query_cursor_start_at_field_value_multi]
-  # [START fs_multiple_cursor_conditions]
   # Will return all Springfields
   query1 = firestore.col(collection_path).order("name").order("state").start_at("Springfield")
 
   # Will return "Springfield, Missouri" and "Springfield, Wisconsin"
   query2 = firestore.col(collection_path).order("name").order("state").start_at(["Springfield", "Missouri"])
-  # [END fs_multiple_cursor_conditions]
   # [END firestore_query_cursor_start_at_field_value_multi]
   query1.get do |city|
     puts "Document #{city.document_id} returned by start at Springfield query."
@@ -107,11 +99,9 @@ def start_at_snapshot_query_cursor project_id:, collection_path: "cities"
 
   cities_ref = firestore.col collection_path
   # [START firestore_query_cursor_start_at_document]
-  # [START fs_start_at_snapshot_query_cursor]
   doc_ref = firestore.doc "#{collection_path}/SF"
   snapshot = doc_ref.get
   query = cities_ref.order("population").start_at(snapshot)
-  # [END fs_start_at_snapshot_query_cursor]
   # [END firestore_query_cursor_start_at_document]
   query.get do |city|
     puts "Document #{city.document_id} returned by start at document snapshot query cursor."

--- a/google-cloud-firestore/samples/query_data.rb
+++ b/google-cloud-firestore/samples/query_data.rb
@@ -20,7 +20,6 @@ def query_create_examples project_id:, collection_path: "cities"
 
   firestore = Google::Cloud::Firestore.new project_id: project_id
   # [START firestore_query_filter_dataset]
-  # [START fs_query_create_examples]
   cities_ref = firestore.col collection_path
   cities_ref.doc("SF").set(
     {
@@ -72,7 +71,6 @@ def query_create_examples project_id:, collection_path: "cities"
       regions:    ["jingjinji", "hebei"]
     }
   )
-  # [END fs_query_create_examples]
   # [END firestore_query_filter_dataset]
   puts "Added example cities data to the cities collection."
 end
@@ -83,7 +81,6 @@ def create_query_state project_id:, collection_path: "cities"
 
   firestore = Google::Cloud::Firestore.new project_id: project_id
   # [START firestore_query_filter_eq_string]
-  # [START fs_create_query_state]
   cities_ref = firestore.col collection_path
 
   query = cities_ref.where "state", "=", "CA"
@@ -91,7 +88,6 @@ def create_query_state project_id:, collection_path: "cities"
   query.get do |city|
     puts "Document #{city.document_id} returned by query state=CA."
   end
-  # [END fs_create_query_state]
   # [END firestore_query_filter_eq_string]
 end
 
@@ -101,7 +97,6 @@ def create_query_capital project_id:, collection_path: "cities"
 
   firestore = Google::Cloud::Firestore.new project_id: project_id
   # [START firestore_query_filter_eq_boolean]
-  # [START fs_create_query_capital]
   cities_ref = firestore.col collection_path
 
   query = cities_ref.where "capital", "=", true
@@ -109,7 +104,6 @@ def create_query_capital project_id:, collection_path: "cities"
   query.get do |city|
     puts "Document #{city.document_id} returned by query capital=true."
   end
-  # [END fs_create_query_capital]
   # [END firestore_query_filter_eq_boolean]
 end
 
@@ -121,11 +115,9 @@ def simple_queries project_id:, collection_path: "cities"
   cities_ref = firestore.col collection_path
 
   # [START firestore_query_filter_single_examples]
-  # [START fs_simple_queries]
   state_query      = cities_ref.where "state", "=", "CA"
   population_query = cities_ref.where "population", ">", 1_000_000
   name_query       = cities_ref.where "name", ">=", "San Francisco"
-  # [END fs_simple_queries]
   # [END firestore_query_filter_single_examples]
   state_query.get do |city|
     puts "Document #{city.document_id} returned by query state=CA."
@@ -145,9 +137,7 @@ def chained_query project_id:, collection_path: "cities"
   firestore  = Google::Cloud::Firestore.new project_id: project_id
   cities_ref = firestore.col collection_path
   # [START firestore_query_filter_compound_multi_eq]
-  # [START fs_chained_query]
   chained_query = cities_ref.where("state", "=", "CA").where("name", "=", "San Francisco")
-  # [END fs_chained_query]
   # [END firestore_query_filter_compound_multi_eq]
   chained_query.get do |city|
     puts "Document #{city.document_id} returned by query state=CA and name=San Francisco."
@@ -161,9 +151,7 @@ def composite_index_chained_query project_id:, collection_path: "cities"
   firestore  = Google::Cloud::Firestore.new project_id: project_id
   cities_ref = firestore.col collection_path
   # [START firestore_query_filter_compound_multi_eq_lt]
-  # [START fs_composite_index_chained_query]
   chained_query = cities_ref.where("state", "=", "CA").where("population", "<", 1_000_000)
-  # [END fs_composite_index_chained_query]
   # [END firestore_query_filter_compound_multi_eq_lt]
   chained_query.get do |city|
     puts "Document #{city.document_id} returned by query state=CA and population<1000000."
@@ -177,9 +165,7 @@ def range_query project_id:, collection_path: "cities"
   firestore  = Google::Cloud::Firestore.new project_id: project_id
   cities_ref = firestore.col collection_path
   # [START firestore_query_filter_range_valid]
-  # [START fs_range_query]
   range_query = cities_ref.where("state", ">=", "CA").where("state", "<=", "IN")
-  # [END fs_range_query]
   # [END firestore_query_filter_range_valid]
   range_query.get do |city|
     puts "Document #{city.document_id} returned by query CA<=state<=IN."
@@ -193,9 +179,7 @@ def invalid_range_query project_id:, collection_path: "cities"
   firestore  = Google::Cloud::Firestore.new project_id: project_id
   cities_ref = firestore.col collection_path
   # [START firestore_query_filter_range_invalid]
-  # [START fs_invalid_range_query]
   invalid_range_query = cities_ref.where("state", ">=", "CA").where("population", ">", 1_000_000)
-  # [END fs_invalid_range_query]
   # [END firestore_query_filter_range_invalid]
 end
 
@@ -205,10 +189,8 @@ def in_query_without_array project_id:, collection_path: "cities"
 
   firestore = Google::Cloud::Firestore.new project_id: project_id
   # [START firestore_query_filter_in]
-  # [START fs_query_filter_in]
   cities_ref = firestore.col collection_path
   usr_or_japan = cities_ref.where "country", "in", ["USA", "Japan"]
-  # [END fs_query_filter_in]
   # [END firestore_query_filter_in]
   usr_or_japan.get do |city|
     puts "Document #{city.document_id} returned by query in ['USA','Japan']."
@@ -221,10 +203,8 @@ def in_query_with_array project_id:, collection_path: "cities"
 
   firestore = Google::Cloud::Firestore.new project_id: project_id
   # [START firestore_query_filter_in_with_array]
-  # [START fs_query_filter_in_with_array]
   cities_ref = firestore.col collection_path
   exactly_one_cost = cities_ref.where "regions", "in", [["west_coast"], ["east_coast"]]
-  # [END fs_query_filter_in_with_array]
   # [END firestore_query_filter_in_with_array]
   exactly_one_cost.get do |city|
     puts "Document #{city.document_id} returned by query in [['west_coast'], ['east_coast']]."
@@ -237,10 +217,8 @@ def query_not_equals project_id:, collection_path: "cities"
 
   firestore = Google::Cloud::Firestore.new project_id: project_id
   # [START firestore_query_filter_not_eq]
-  # [START fs_query_not_equals]
   cities_ref = firestore.col collection_path
   query = cities_ref.where "capital", "!=", false
-  # [END fs_query_not_equals]
   # [END firestore_query_filter_not_eq]
   query.get do |city|
     puts "Document #{city.document_id} returned by query capital!=false."
@@ -253,10 +231,8 @@ def filter_not_in project_id:, collection_path: "cities"
 
   firestore = Google::Cloud::Firestore.new project_id: project_id
   # [START firestore_query_filter_not_in]
-  # [START fs_filter_not_in]
   cities_ref = firestore.col collection_path
   usr_or_japan = cities_ref.where "country", "not_in", ["USA", "Japan"]
-  # [END fs_filter_not_in]
   # [END firestore_query_filter_not_in]
   usr_or_japan.get do |city|
     puts "Document #{city.document_id} returned by query not_in ['USA','Japan']."
@@ -269,10 +245,8 @@ def array_contains_any_queries project_id:, collection_path: "cities"
 
   firestore = Google::Cloud::Firestore.new project_id: project_id
   # [START firestore_query_filter_array_contains_any]
-  # [START fs_query_filter_array_contains_any]
   cities_ref = firestore.col collection_path
   costal_cities = cities_ref.where "regions", "array-contains-any", ["west_coast", "east_coast"]
-  # [END fs_query_filter_array_contains_any]
   # [END firestore_query_filter_array_contains_any]
   costal_cities.get do |city|
     puts "Document #{city.document_id} returned by query array-contains-any ['west_coast', 'east_coast']."
@@ -285,10 +259,8 @@ def array_contains_filter project_id:, collection_path: "cities"
 
   firestore = Google::Cloud::Firestore.new project_id: project_id
   # [START firestore_query_filter_array_contains]
-  # [START fs_array_contains_filter]
   cities_ref = firestore.col collection_path
   cities = cities_ref.where "regions", "array-contains", "west_coast"
-  # [END fs_array_contains_filter]
   # [END firestore_query_filter_array_contains]
   cities.get do |city|
     puts "Document #{city.document_id} returned by query array-contains 'west_coast'."
@@ -301,7 +273,6 @@ def collection_group_query project_id:, collection_path: "cities"
 
   firestore = Google::Cloud::Firestore.new project_id: project_id
   # [START firestore_query_collection_group_dataset]
-  # [START fs_collection_group_query_data_setup]
   cities_ref = firestore.col collection_path
 
   sf_landmarks = cities_ref.document("SF").collection("landmarks")
@@ -373,16 +344,13 @@ def collection_group_query project_id:, collection_path: "cities"
       type: "museum"
     }
   )
-  # [END fs_collection_group_query_data_setup]
   # [END firestore_query_collection_group_dataset]
 
   # [START firestore_query_collection_group_filter_eq]
-  # [START fs_collection_group_query]
   museums = firestore.collection_group("landmarks").where("type", "==", "museum")
   museums.get do |museum|
     puts "#{museum[:type]} name is #{museum[:name]}."
   end
-  # [END fs_collection_group_query]
   # [END firestore_query_collection_group_filter_eq]
 end
 

--- a/google-cloud-firestore/samples/query_watch.rb
+++ b/google-cloud-firestore/samples/query_watch.rb
@@ -21,7 +21,6 @@ def listen_document project_id:, collection_path: "cities", document_path: "SF"
 
   firestore = Google::Cloud::Firestore.new project_id: project_id
   # [START firestore_listen_document]
-  # [START fs_listen_document]
   doc_ref = firestore.col(collection_path).doc document_path
   snapshots = []
 
@@ -30,7 +29,6 @@ def listen_document project_id:, collection_path: "cities", document_path: "SF"
     puts "Received document snapshot: #{snapshot.document_id}"
     snapshots << snapshot
   end
-  # [END fs_listen_document]
   # [END firestore_listen_document]
 
   # Create the document.
@@ -48,9 +46,7 @@ def listen_document project_id:, collection_path: "cities", document_path: "SF"
   wait_until { !snapshots.empty? }
 
   # [START firestore_listen_detach]
-  # [START fs_detach_listener]
   listener.stop
-  # [END fs_detach_listener]
   # [END firestore_listen_detach]
 end
 
@@ -60,7 +56,6 @@ def listen_changes project_id:, collection_path: "cities"
 
   firestore = Google::Cloud::Firestore.new project_id: project_id
   # [START firestore_listen_query_changes]
-  # [START fs_listen_changes]
   query = firestore.col(collection_path).where :state, :==, "CA"
   added = []
   modified = []
@@ -83,7 +78,6 @@ def listen_changes project_id:, collection_path: "cities"
       end
     end
   end
-  # [END fs_listen_changes]
   # [END firestore_listen_query_changes]
 
   mtv_doc = firestore.col(collection_path).doc("MTV")
@@ -128,7 +122,6 @@ def listen_errors project_id:, collection_path: "cities"
 
   firestore = Google::Cloud::Firestore.new project_id: project_id
   # [START firestore_listen_handle_error]
-  # [START fs_listen_errors]
   listener = firestore.col(collection_path).listen do |snapshot|
     snapshot.changes.each do |change|
       puts "New city: #{change.doc.document_id}" if change.added?
@@ -139,7 +132,6 @@ def listen_errors project_id:, collection_path: "cities"
   listener.on_error do |error|
     puts "Listen failed: #{error.message}"
   end
-  # [END fs_listen_errors]
   # [END firestore_listen_handle_error]
 
   listener.stop
@@ -151,7 +143,6 @@ def listen_multiple project_id:, collection_path: "cities"
 
   firestore = Google::Cloud::Firestore.new project_id: project_id
   # [START firestore_listen_query_snapshots]
-  # [START fs_listen_multiple]
   query = firestore.col(collection_path).where :state, :==, "CA"
   docs = []
 
@@ -164,7 +155,6 @@ def listen_multiple project_id:, collection_path: "cities"
       docs << doc
     end
   end
-  # [END fs_listen_multiple]
   # [END firestore_listen_query_snapshots]
 
   # Create the document.

--- a/google-cloud-firestore/samples/quickstart.rb
+++ b/google-cloud-firestore/samples/quickstart.rb
@@ -16,13 +16,11 @@ require "google/cloud/firestore"
 
 def initialize_firestore_client project_id:
   # [START firestore_setup_client_create]
-  # [START fs_initialize]
   require "google/cloud/firestore"
 
   firestore = Google::Cloud::Firestore.new project_id: project_id
 
   puts "Created Cloud Firestore client with given project ID."
-  # [END fs_initialize]
   # [END firestore_setup_client_create]
 end
 
@@ -32,7 +30,6 @@ def add_data_1 project_id:, collection_path: "users"
 
   firestore = Google::Cloud::Firestore.new project_id: project_id
   # [START firestore_setup_dataset_pt1]
-  # [START fs_add_data_1]
   doc_ref = firestore.doc "#{collection_path}/alovelace"
 
   doc_ref.set(
@@ -44,7 +41,6 @@ def add_data_1 project_id:, collection_path: "users"
   )
 
   puts "Added data to the alovelace document in the users collection."
-  # [END fs_add_data_1]
   # [END firestore_setup_dataset_pt1]
 end
 
@@ -54,7 +50,6 @@ def add_data_2 project_id:, collection_path: "users"
 
   firestore = Google::Cloud::Firestore.new project_id: project_id
   # [START firestore_setup_dataset_pt2]
-  # [START fs_add_data_2]
   doc_ref = firestore.doc "#{collection_path}/aturing"
 
   doc_ref.set(
@@ -67,7 +62,6 @@ def add_data_2 project_id:, collection_path: "users"
   )
 
   puts "Added data to the aturing document in the users collection."
-  # [END fs_add_data_2]
   # [END firestore_setup_dataset_pt2]
 end
 
@@ -77,12 +71,10 @@ def get_all project_id:, collection_path: "users"
 
   firestore = Google::Cloud::Firestore.new project_id: project_id
   # [START firestore_setup_dataset_read]
-  # [START fs_get_all]
   users_ref = firestore.col collection_path
   users_ref.get do |user|
     puts "#{user.document_id} data: #{user.data}."
   end
-  # [END fs_get_all]
   # [END firestore_setup_dataset_read]
 end
 

--- a/google-cloud-firestore/samples/transactions_and_batched_writes.rb
+++ b/google-cloud-firestore/samples/transactions_and_batched_writes.rb
@@ -20,7 +20,6 @@ def run_simple_transaction project_id:, collection_path: "cities"
 
   firestore = Google::Cloud::Firestore.new project_id: project_id
   # [START firestore_transaction_document_update]
-  # [START fs_run_simple_transaction]
   city_ref = firestore.doc "#{collection_path}/SF"
 
   firestore.transaction do |tx|
@@ -28,7 +27,6 @@ def run_simple_transaction project_id:, collection_path: "cities"
     puts "New population is #{new_population}."
     tx.update city_ref, { population: new_population }
   end
-  # [END fs_run_simple_transaction]
   # [END firestore_transaction_document_update]
   puts "Ran a simple transaction to update the population field in the SF document in the cities collection."
 end
@@ -39,7 +37,6 @@ def return_info_transaction project_id:, collection_path: "cities"
 
   firestore = Google::Cloud::Firestore.new project_id: project_id
   # [START firestore_transaction_document_update_conditional]
-  # [START fs_return_info_transaction]
   city_ref = firestore.doc "#{collection_path}/SF"
 
   updated = firestore.transaction do |tx|
@@ -55,7 +52,6 @@ def return_info_transaction project_id:, collection_path: "cities"
   else
     puts "Sorry! Population is too big."
   end
-  # [END fs_return_info_transaction]
   # [END firestore_transaction_document_update_conditional]
 end
 
@@ -65,7 +61,6 @@ def batch_write project_id:, collection_path: "cities"
 
   firestore = Google::Cloud::Firestore.new project_id: project_id
   # [START firestore_data_batch_writes]
-  # [START fs_batch_write]
   firestore.batch do |b|
     # Set the data for NYC
     b.set "#{collection_path}/NYC", { name: "New York City" }
@@ -76,7 +71,6 @@ def batch_write project_id:, collection_path: "cities"
     # Delete LA
     b.delete "#{collection_path}/LA"
   end
-  # [END fs_batch_write]
   # [END firestore_data_batch_writes]
   puts "Batch write successfully completed."
 end


### PR DESCRIPTION
Remove unnecessary+outdated region tags now that new ones have proliferated in docs.