### PR TITLE
fix(spanner): extract binary retry info from error

### DIFF
--- a/google-cloud-spanner/lib/google/cloud/spanner/client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/client.rb
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# frozen_string_literal: true
 
 
 require "google/cloud/spanner/errors"
@@ -1804,11 +1806,10 @@ module Google
         # GRPC::Aborted
         def delay_from_aborted err
           return nil if err.nil?
-          if err.respond_to?(:metadata) && err.metadata["retryDelay"]
-            # a correct metadata will look like this:
-            # "{\"retryDelay\":{\"seconds\":60}}"
-            seconds = err.metadata["retryDelay"]["seconds"].to_i
-            nanos = err.metadata["retryDelay"]["nanos"].to_i
+          if err.respond_to?(:metadata) && err.metadata["google.rpc.retryinfo-bin"]
+            retry_info = Google::Rpc::RetryInfo.decode(err.metadata["google.rpc.retryinfo-bin"])
+            seconds = retry_info["retry_delay"].seconds
+            nanos = retry_info["retry_delay"].nanos
             return seconds if nanos.zero?
             return seconds + (nanos / 1_000_000_000.0)
           end

--- a/google-cloud-spanner/lib/google/cloud/spanner/client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/client.rb
@@ -1805,7 +1805,7 @@ module Google
         def delay_from_aborted err
           return nil if err.nil?
           if err.respond_to?(:metadata) && err.metadata["google.rpc.retryinfo-bin"]
-            retry_info = Google::Rpc::RetryInfo.decode(err.metadata["google.rpc.retryinfo-bin"])
+            retry_info = Google::Rpc::RetryInfo.decode err.metadata["google.rpc.retryinfo-bin"]
             seconds = retry_info["retry_delay"].seconds
             nanos = retry_info["retry_delay"].nanos
             return seconds if nanos.zero?

--- a/google-cloud-spanner/lib/google/cloud/spanner/client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/client.rb
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# frozen_string_literal: true
 
 
 require "google/cloud/spanner/errors"

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_retry_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_retry_test.rb
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# frozen_string_literal: true
 
 require "google/rpc/error_details_pb"
 require "helper"

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_retry_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_retry_test.rb
@@ -11,7 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# frozen_string_literal: true
 
+require "google/rpc/error_details_pb"
 require "helper"
 
 describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
@@ -143,7 +146,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
       # first time called this will raise
       if @called == nil
         @called = true
-        raise GRPC::Aborted.new "aborted", {"retryDelay"=>{"seconds"=>60}}
+        raise GRPC::Aborted.new "aborted", create_retry_info_metadata(60, 0)
       end
       # second call will return correct response
       Google::Cloud::Spanner::V1::CommitResponse.new commit_timestamp: Google::Protobuf::Timestamp.new()
@@ -195,7 +198,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
       # first time called this will raise
       if @called == nil
         @called = true
-        raise GRPC::Aborted.new "aborted", {"retryDelay"=>{"seconds"=>123, "nanos"=>456000000}}
+        raise GRPC::Aborted.new "aborted", create_retry_info_metadata(123, 456000000)
       end
       # second call will return correct response
       Google::Cloud::Spanner::V1::CommitResponse.new commit_timestamp: Google::Protobuf::Timestamp.new()
@@ -254,7 +257,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
       end
       if @called == false
         @called = true
-        raise GRPC::Aborted.new "aborted", {"retryDelay"=>{"seconds"=>30}}
+        raise GRPC::Aborted.new "aborted", create_retry_info_metadata(30, 0)
       end
       # third call will return correct response
       Google::Cloud::Spanner::V1::CommitResponse.new commit_timestamp: Google::Protobuf::Timestamp.new()
@@ -381,4 +384,11 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
     _(row[:avatar].read).must_equal "image"
     _(row[:project_ids]).must_equal [1, 2, 3]
   end
+end
+
+def create_retry_info_metadata seconds, nanos
+  metadata = {}
+  retry_info = Google::Rpc::RetryInfo.new(retry_delay: Google::Protobuf::Duration.new(seconds: seconds, nanos: nanos))
+  metadata["google.rpc.retryinfo-bin"] = Google::Rpc::RetryInfo.encode(retry_info)
+  metadata
 end


### PR DESCRIPTION
Retry info that is returned by Cloud Spanner is binary encoded in the metadata of an error. This was not correctly decoded by the Spanner client.

Fixes #11655
