### PR TITLE
feat(storage): Add support for if_(meta)generation_(not_)match to File operations

### DIFF
--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -1040,6 +1040,19 @@ module Google
         # @param [String] path Name (path) of the file.
         # @param [Integer] generation When present, selects a specific revision
         #   of this object. Default is the latest version.
+        # @param [Integer] if_generation_match Makes the operation conditional
+        #   on whether the file's current generation matches the given value.
+        #   Setting to 0 makes the operation succeed only if there are no live
+        #   versions of the file.
+        # @param [Integer] if_generation_not_match Makes the operation conditional
+        #   on whether the file's current generation does not match the given
+        #   value. If no live file exists, the precondition fails. Setting to 0
+        #   makes the operation succeed only if there is a live version of the file.
+        # @param [Integer] if_metageneration_match Makes the operation conditional
+        #   on whether the file's current metageneration matches the given value.
+        # @param [Integer] if_metageneration_not_match Makes the operation
+        #   conditional on whether the file's current metageneration does not
+        #   match the given value.
         # @param [Boolean] skip_lookup Optionally create a Bucket object
         #   without verifying the bucket resource exists on the Storage service.
         #   Calls made on this object will raise errors if the bucket resource
@@ -1061,7 +1074,14 @@ module Google
         #   file = bucket.file "path/to/my-file.ext"
         #   puts file.name
         #
-        def file path, generation: nil, skip_lookup: nil, encryption_key: nil
+        def file path,
+                 generation: nil,
+                 if_generation_match: nil,
+                 if_generation_not_match: nil,
+                 if_metageneration_match: nil,
+                 if_metageneration_not_match: nil,
+                 skip_lookup: nil,
+                 encryption_key: nil
           ensure_service!
           if skip_lookup
             return File.new_lazy name, path, service,
@@ -1069,6 +1089,10 @@ module Google
                                  user_project: user_project
           end
           gapi = service.get_file name, path, generation: generation,
+                                              if_generation_match: if_generation_match,
+                                              if_generation_not_match: if_generation_not_match,
+                                              if_metageneration_match: if_metageneration_match,
+                                              if_metageneration_not_match: if_metageneration_not_match,
                                               key: encryption_key,
                                               user_project: user_project
           File.from_gapi gapi, service, user_project: user_project

--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -1393,6 +1393,12 @@ module Google
         #   used. All source files must have been encrypted with the same key,
         #   and the resulting destination file will also be encrypted with the
         #   key.
+        # @param [Integer] if_generation_match Makes the operation conditional
+        #   on whether the file's current generation matches the given value.
+        #   Setting to 0 makes the operation succeed only if there are no live
+        #   versions of the file.
+        # @param [Integer] if_metageneration_match Makes the operation conditional
+        #   on whether the file's current metageneration matches the given value.
         #
         # @yield [file] A block yielding a delegate file object for setting the
         #   properties of the destination file.
@@ -1441,7 +1447,12 @@ module Google
         #
         #   new_file = bucket.compose [file_1, file_2], "path/to/new-file.ext"
         #
-        def compose sources, destination, acl: nil, encryption_key: nil
+        def compose sources,
+                    destination,
+                    acl: nil,
+                    encryption_key: nil,
+                    if_generation_match: nil,
+                    if_metageneration_match: nil
           ensure_service!
           sources = Array sources
           if sources.size < 2
@@ -1457,9 +1468,15 @@ module Google
           end
 
           acl_rule = File::Acl.predefined_rule_for acl
-          gapi = service.compose_file name, sources, destination, destination_gapi, acl: acl_rule,
-                                                                                    key: encryption_key,
-                                                                                    user_project: user_project
+          gapi = service.compose_file name,
+                                      sources,
+                                      destination,
+                                      destination_gapi,
+                                      acl: acl_rule,
+                                      key: encryption_key,
+                                      if_generation_match: if_generation_match,
+                                      if_metageneration_match: if_metageneration_match,
+                                      user_project: user_project
           File.from_gapi gapi, service, user_project: user_project
         end
         alias compose_file compose

--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -1203,6 +1203,19 @@ module Google
         #   the same location as the bucket.The Service Account associated with
         #   your project requires access to this encryption key. Do not provide
         #   if `encryption_key` is used.
+        # @param [Integer] if_generation_match Makes the operation conditional
+        #   on whether the file's current generation matches the given value.
+        #   Setting to 0 makes the operation succeed only if there are no live
+        #   versions of the file.
+        # @param [Integer] if_generation_not_match Makes the operation conditional
+        #   on whether the file's current generation does not match the given
+        #   value. If no live file exists, the precondition fails. Setting to 0
+        #   makes the operation succeed only if there is a live version of the file.
+        # @param [Integer] if_metageneration_match Makes the operation conditional
+        #   on whether the file's current metageneration matches the given value.
+        # @param [Integer] if_metageneration_not_match Makes the operation
+        #   conditional on whether the file's current metageneration does not
+        #   match the given value.
         #
         # @return [Google::Cloud::Storage::File]
         #
@@ -1286,12 +1299,27 @@ module Google
         #   file.download "path/to/downloaded/gzipped.txt",
         #                 skip_decompress: true
         #
-        def create_file file, path = nil, acl: nil, cache_control: nil,
-                        content_disposition: nil, content_encoding: nil,
-                        content_language: nil, content_type: nil, custom_time: nil,
-                        crc32c: nil, md5: nil, metadata: nil,
-                        storage_class: nil, encryption_key: nil, kms_key: nil,
-                        temporary_hold: nil, event_based_hold: nil
+        def create_file file,
+                        path = nil,
+                        acl: nil,
+                        cache_control: nil,
+                        content_disposition: nil,
+                        content_encoding: nil,
+                        content_language: nil,
+                        content_type: nil,
+                        custom_time: nil,
+                        crc32c: nil,
+                        md5: nil,
+                        metadata: nil,
+                        storage_class: nil,
+                        encryption_key: nil,
+                        kms_key: nil,
+                        temporary_hold: nil,
+                        event_based_hold: nil,
+                        if_generation_match: nil,
+                        if_generation_not_match: nil,
+                        if_metageneration_match: nil,
+                        if_metageneration_not_match: nil
           ensure_service!
           ensure_io_or_file_exists! file
           path ||= file.path if file.respond_to? :path
@@ -1299,22 +1327,29 @@ module Google
           raise ArgumentError, "must provide path" if path.nil?
 
 
-          gapi = service.insert_file name, file, path, acl: File::Acl.predefined_rule_for(acl),
-                                                       md5: md5,
-                                                       cache_control: cache_control,
-                                                       content_type: content_type,
-                                                       custom_time: custom_time,
-                                                       content_disposition: content_disposition,
-                                                       crc32c: crc32c,
-                                                       content_encoding: content_encoding,
-                                                       metadata: metadata,
-                                                       content_language: content_language,
-                                                       key: encryption_key,
-                                                       kms_key: kms_key,
-                                                       storage_class: storage_class_for(storage_class),
-                                                       temporary_hold: temporary_hold,
-                                                       event_based_hold: event_based_hold,
-                                                       user_project: user_project
+          gapi = service.insert_file name,
+                                     file,
+                                     path,
+                                     acl: File::Acl.predefined_rule_for(acl),
+                                     md5: md5,
+                                     cache_control: cache_control,
+                                     content_type: content_type,
+                                     custom_time: custom_time,
+                                     content_disposition: content_disposition,
+                                     crc32c: crc32c,
+                                     content_encoding: content_encoding,
+                                     metadata: metadata,
+                                     content_language: content_language,
+                                     key: encryption_key,
+                                     kms_key: kms_key,
+                                     storage_class: storage_class_for(storage_class),
+                                     temporary_hold: temporary_hold,
+                                     event_based_hold: event_based_hold,
+                                     if_generation_match: if_generation_match,
+                                     if_generation_not_match: if_generation_not_match,
+                                     if_metageneration_match: if_metageneration_match,
+                                     if_metageneration_not_match: if_metageneration_not_match,
+                                     user_project: user_project
           File.from_gapi gapi, service, user_project: user_project
         end
         alias upload_file create_file

--- a/google-cloud-storage/lib/google/cloud/storage/file.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file.rb
@@ -1375,6 +1375,20 @@ module Google
         #   {#generation}. The default behavior is to delete the latest version
         #   of the file (regardless of the version to which the file is set,
         #   which is the version returned by {#generation}.)
+        # @param [Integer] if_generation_match Makes the operation conditional
+        #   on whether the file's current generation matches the given value.
+        #   Setting to 0 makes the operation succeed only if there are no live
+        #   versions of the file.
+        # @param [Integer] if_generation_not_match Makes the operation conditional
+        #   on whether the file's current generation does not match the given
+        #   value. If no live file exists, the precondition fails. Setting to 0
+        #   makes the operation succeed only if there is a live version of the file.
+        # @param [Integer] if_metageneration_match Makes the operation conditional
+        #   on whether the file's current metageneration matches the given value.
+        # @param [Integer] if_metageneration_not_match Makes the operation
+        #   conditional on whether the file's current metageneration does not
+        #   match the given value.
+        #
         # @return [Boolean] Returns `true` if the file was deleted.
         #
         # @example
@@ -1407,11 +1421,21 @@ module Google
         #   file = bucket.file "path/to/my-file.ext"
         #   file.delete generation: 123456
         #
-        def delete generation: nil
+        def delete generation: nil,
+                   if_generation_match: nil,
+                   if_generation_not_match: nil,
+                   if_metageneration_match: nil,
+                   if_metageneration_not_match: nil
           generation = self.generation if generation == true
           ensure_service!
-          service.delete_file bucket, name, generation: generation,
-                                            user_project: user_project
+          service.delete_file bucket,
+                              name,
+                              generation: generation,
+                              if_generation_match: if_generation_match,
+                              if_generation_not_match: if_generation_not_match,
+                              if_metageneration_match: if_metageneration_match,
+                              if_metageneration_not_match: if_metageneration_not_match,
+                              user_project: user_project
           true
         end
 

--- a/google-cloud-storage/lib/google/cloud/storage/file.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file.rb
@@ -1138,6 +1138,27 @@ module Google
         #     access, and allUsers get READER access.
         # @param [Integer] generation Select a specific revision of the file to
         #   rewrite. The default is the latest version.
+        # @param [Integer] if_generation_match Makes the operation conditional
+        #   on whether the destination file's current generation matches the given value.
+        #   Setting to 0 makes the operation succeed only if there are no live
+        #   versions of the file.
+        # @param [Integer] if_generation_not_match Makes the operation conditional
+        #   on whether the destination file's current generation does not match the given
+        #   value. If no live file exists, the precondition fails. Setting to 0
+        #   makes the operation succeed only if there is a live version of the file.
+        # @param [Integer] if_metageneration_match Makes the operation conditional
+        #   on whether the destination file's current metageneration matches the given value.
+        # @param [Integer] if_metageneration_not_match Makes the operation
+        #   conditional on whether the destination file's current metageneration does not
+        #   match the given value.
+        # @param [Integer] if_source_generation_match Makes the operation conditional on
+        #   whether the source object's current generation matches the given value.
+        # @param [Integer] if_source_generation_not_match Makes the operation conditional
+        #   on whether the source object's current generation does not match the given value.
+        # @param [Integer] if_source_metageneration_match Makes the operation conditional
+        #   on whether the source object's current metageneration matches the given value.
+        # @param [Integer] if_source_metageneration_not_match Makes the operation conditional
+        #   on whether the source object's current metageneration does not match the given value.
         # @param [String] encryption_key Optional. The customer-supplied,
         #   AES-256 encryption key used to decrypt the file, if the existing
         #   file is encrypted.
@@ -1259,11 +1280,24 @@ module Google
         #     f.metadata["rewritten_from"] = "#{file.bucket}/#{file.name}"
         #   end
         #
-        def rewrite dest_bucket_or_path, dest_path = nil, acl: nil, generation: nil, encryption_key: nil,
-                    new_encryption_key: nil, new_kms_key: nil, force_copy_metadata: nil
+        def rewrite dest_bucket_or_path,
+                    dest_path = nil,
+                    acl: nil,
+                    generation: nil,
+                    if_generation_match: nil,
+                    if_generation_not_match: nil,
+                    if_metageneration_match: nil,
+                    if_metageneration_not_match: nil,
+                    if_source_generation_match: nil,
+                    if_source_generation_not_match: nil,
+                    if_source_metageneration_match: nil,
+                    if_source_metageneration_not_match: nil,
+                    encryption_key: nil,
+                    new_encryption_key: nil,
+                    new_kms_key: nil,
+                    force_copy_metadata: nil
           ensure_service!
-          dest_bucket, dest_path = fix_rewrite_args dest_bucket_or_path,
-                                                    dest_path
+          dest_bucket, dest_path = fix_rewrite_args dest_bucket_or_path, dest_path
 
           update_gapi = nil
           if block_given?
@@ -1276,9 +1310,21 @@ module Google
             end
           end
 
-          new_gapi = rewrite_gapi bucket, name, update_gapi,
-                                  new_bucket: dest_bucket, new_name: dest_path,
-                                  acl: acl, generation: generation,
+          new_gapi = rewrite_gapi bucket,
+                                  name,
+                                  update_gapi,
+                                  new_bucket: dest_bucket,
+                                  new_name: dest_path,
+                                  acl: acl,
+                                  generation: generation,
+                                  if_generation_match: if_generation_match,
+                                  if_generation_not_match: if_generation_not_match,
+                                  if_metageneration_match: if_metageneration_match,
+                                  if_metageneration_not_match: if_metageneration_not_match,
+                                  if_source_generation_match: if_source_generation_match,
+                                  if_source_generation_not_match: if_source_generation_not_match,
+                                  if_source_metageneration_match: if_source_metageneration_match,
+                                  if_source_metageneration_not_match: if_source_metageneration_not_match,
                                   encryption_key: encryption_key,
                                   new_encryption_key: new_encryption_key,
                                   new_kms_key: new_kms_key,
@@ -1907,18 +1953,43 @@ module Google
                   end
         end
 
-        def rewrite_gapi bucket, name, updated_gapi,
-                         new_bucket: nil, new_name: nil, acl: nil,
-                         generation: nil, encryption_key: nil,
-                         new_encryption_key: nil, new_kms_key: nil,
+        def rewrite_gapi bucket,
+                         name,
+                         updated_gapi,
+                         new_bucket: nil,
+                         new_name: nil,
+                         acl: nil,
+                         generation: nil,
+                         if_generation_match: nil,
+                         if_generation_not_match: nil,
+                         if_metageneration_match: nil,
+                         if_metageneration_not_match: nil,
+                         if_source_generation_match: nil,
+                         if_source_generation_not_match: nil,
+                         if_source_metageneration_match: nil,
+                         if_source_metageneration_not_match: nil,
+                         encryption_key: nil,
+                         new_encryption_key: nil,
+                         new_kms_key: nil,
                          user_project: nil
           new_bucket ||= bucket
           new_name ||= name
-          options = { acl: File::Acl.predefined_rule_for(acl),
-                      generation: generation, source_key: encryption_key,
-                      destination_key: new_encryption_key,
-                      destination_kms_key: new_kms_key,
-                      user_project: user_project }.delete_if { |_k, v| v.nil? }
+          options = {
+            acl: File::Acl.predefined_rule_for(acl),
+            generation: generation,
+            if_generation_match: if_generation_match,
+            if_generation_not_match: if_generation_not_match,
+            if_metageneration_match: if_metageneration_match,
+            if_metageneration_not_match: if_metageneration_not_match,
+            if_source_generation_match: if_source_generation_match,
+            if_source_generation_not_match: if_source_generation_not_match,
+            if_source_metageneration_match: if_source_metageneration_match,
+            if_source_metageneration_not_match: if_source_metageneration_not_match,
+            source_key: encryption_key,
+            destination_key: new_encryption_key,
+            destination_kms_key: new_kms_key,
+            user_project: user_project
+          }.delete_if { |_k, v| v.nil? }
 
           resp = service.rewrite_file \
             bucket, name, new_bucket, new_name, updated_gapi, **options

--- a/google-cloud-storage/lib/google/cloud/storage/file/acl.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/acl.rb
@@ -297,6 +297,22 @@ module Google
           # Convenience method to apply the `authenticatedRead` predefined ACL
           # rule to the file.
           #
+          # @param [Integer] generation Select a specific revision of the file to
+          #   update. The default is the latest version.
+          # @param [Integer] if_generation_match Makes the operation conditional
+          #   on whether the file's current generation matches the given value.
+          #   Setting to 0 makes the operation succeed only if there are no live
+          #   versions of the file.
+          # @param [Integer] if_generation_not_match Makes the operation conditional
+          #   on whether the file's current generation does not match the given
+          #   value. If no live file exists, the precondition fails. Setting to 0
+          #   makes the operation succeed only if there is a live version of the file.
+          # @param [Integer] if_metageneration_match Makes the operation conditional
+          #   on whether the file's current metageneration matches the given value.
+          # @param [Integer] if_metageneration_not_match Makes the operation
+          #   conditional on whether the file's current metageneration does not
+          #   match the given value.
+          #
           # @example
           #   require "google/cloud/storage"
           #
@@ -307,8 +323,17 @@ module Google
           #   file = bucket.file "path/to/my-file.ext"
           #   file.acl.auth!
           #
-          def auth!
-            update_predefined_acl! "authenticatedRead"
+          def auth! generation: nil,
+                    if_generation_match: nil,
+                    if_generation_not_match: nil,
+                    if_metageneration_match: nil,
+                    if_metageneration_not_match: nil
+            update_predefined_acl! "authenticatedRead",
+                                   generation: generation,
+                                   if_generation_match: if_generation_match,
+                                   if_generation_not_match: if_generation_not_match,
+                                   if_metageneration_match: if_metageneration_match,
+                                   if_metageneration_not_match: if_metageneration_not_match
           end
           alias authenticatedRead! auth!
           alias auth_read! auth!
@@ -318,6 +343,22 @@ module Google
           ##
           # Convenience method to apply the `bucketOwnerFullControl` predefined
           # ACL rule to the file.
+          #
+          # @param [Integer] generation Select a specific revision of the file to
+          #   update. The default is the latest version.
+          # @param [Integer] if_generation_match Makes the operation conditional
+          #   on whether the file's current generation matches the given value.
+          #   Setting to 0 makes the operation succeed only if there are no live
+          #   versions of the file.
+          # @param [Integer] if_generation_not_match Makes the operation conditional
+          #   on whether the file's current generation does not match the given
+          #   value. If no live file exists, the precondition fails. Setting to 0
+          #   makes the operation succeed only if there is a live version of the file.
+          # @param [Integer] if_metageneration_match Makes the operation conditional
+          #   on whether the file's current metageneration matches the given value.
+          # @param [Integer] if_metageneration_not_match Makes the operation
+          #   conditional on whether the file's current metageneration does not
+          #   match the given value.
           #
           # @example
           #   require "google/cloud/storage"
@@ -329,14 +370,39 @@ module Google
           #   file = bucket.file "path/to/my-file.ext"
           #   file.acl.owner_full!
           #
-          def owner_full!
-            update_predefined_acl! "bucketOwnerFullControl"
+          def owner_full! generation: nil,
+                          if_generation_match: nil,
+                          if_generation_not_match: nil,
+                          if_metageneration_match: nil,
+                          if_metageneration_not_match: nil
+            update_predefined_acl! "bucketOwnerFullControl",
+                                   generation: generation,
+                                   if_generation_match: if_generation_match,
+                                   if_generation_not_match: if_generation_not_match,
+                                   if_metageneration_match: if_metageneration_match,
+                                   if_metageneration_not_match: if_metageneration_not_match
           end
           alias bucketOwnerFullControl! owner_full!
 
           ##
           # Convenience method to apply the `bucketOwnerRead` predefined ACL
           # rule to the file.
+          #
+          # @param [Integer] generation Select a specific revision of the file to
+          #   update. The default is the latest version.
+          # @param [Integer] if_generation_match Makes the operation conditional
+          #   on whether the file's current generation matches the given value.
+          #   Setting to 0 makes the operation succeed only if there are no live
+          #   versions of the file.
+          # @param [Integer] if_generation_not_match Makes the operation conditional
+          #   on whether the file's current generation does not match the given
+          #   value. If no live file exists, the precondition fails. Setting to 0
+          #   makes the operation succeed only if there is a live version of the file.
+          # @param [Integer] if_metageneration_match Makes the operation conditional
+          #   on whether the file's current metageneration matches the given value.
+          # @param [Integer] if_metageneration_not_match Makes the operation
+          #   conditional on whether the file's current metageneration does not
+          #   match the given value.
           #
           # @example
           #   require "google/cloud/storage"
@@ -348,14 +414,39 @@ module Google
           #   file = bucket.file "path/to/my-file.ext"
           #   file.acl.owner_read!
           #
-          def owner_read!
-            update_predefined_acl! "bucketOwnerRead"
+          def owner_read! generation: nil,
+                          if_generation_match: nil,
+                          if_generation_not_match: nil,
+                          if_metageneration_match: nil,
+                          if_metageneration_not_match: nil
+            update_predefined_acl! "bucketOwnerRead",
+                                   generation: generation,
+                                   if_generation_match: if_generation_match,
+                                   if_generation_not_match: if_generation_not_match,
+                                   if_metageneration_match: if_metageneration_match,
+                                   if_metageneration_not_match: if_metageneration_not_match
           end
           alias bucketOwnerRead! owner_read!
 
           ##
           # Convenience method to apply the `private` predefined ACL
           # rule to the file.
+          #
+          # @param [Integer] generation Select a specific revision of the file to
+          #   update. The default is the latest version.
+          # @param [Integer] if_generation_match Makes the operation conditional
+          #   on whether the file's current generation matches the given value.
+          #   Setting to 0 makes the operation succeed only if there are no live
+          #   versions of the file.
+          # @param [Integer] if_generation_not_match Makes the operation conditional
+          #   on whether the file's current generation does not match the given
+          #   value. If no live file exists, the precondition fails. Setting to 0
+          #   makes the operation succeed only if there is a live version of the file.
+          # @param [Integer] if_metageneration_match Makes the operation conditional
+          #   on whether the file's current metageneration matches the given value.
+          # @param [Integer] if_metageneration_not_match Makes the operation
+          #   conditional on whether the file's current metageneration does not
+          #   match the given value.
           #
           # @example
           #   require "google/cloud/storage"
@@ -367,13 +458,38 @@ module Google
           #   file = bucket.file "path/to/my-file.ext"
           #   file.acl.private!
           #
-          def private!
-            update_predefined_acl! "private"
+          def private! generation: nil,
+                       if_generation_match: nil,
+                       if_generation_not_match: nil,
+                       if_metageneration_match: nil,
+                       if_metageneration_not_match: nil
+            update_predefined_acl! "private",
+                                   generation: generation,
+                                   if_generation_match: if_generation_match,
+                                   if_generation_not_match: if_generation_not_match,
+                                   if_metageneration_match: if_metageneration_match,
+                                   if_metageneration_not_match: if_metageneration_not_match
           end
 
           ##
           # Convenience method to apply the `projectPrivate` predefined ACL
           # rule to the file.
+          #
+          # @param [Integer] generation Select a specific revision of the file to
+          #   update. The default is the latest version.
+          # @param [Integer] if_generation_match Makes the operation conditional
+          #   on whether the file's current generation matches the given value.
+          #   Setting to 0 makes the operation succeed only if there are no live
+          #   versions of the file.
+          # @param [Integer] if_generation_not_match Makes the operation conditional
+          #   on whether the file's current generation does not match the given
+          #   value. If no live file exists, the precondition fails. Setting to 0
+          #   makes the operation succeed only if there is a live version of the file.
+          # @param [Integer] if_metageneration_match Makes the operation conditional
+          #   on whether the file's current metageneration matches the given value.
+          # @param [Integer] if_metageneration_not_match Makes the operation
+          #   conditional on whether the file's current metageneration does not
+          #   match the given value.
           #
           # @example
           #   require "google/cloud/storage"
@@ -385,14 +501,39 @@ module Google
           #   file = bucket.file "path/to/my-file.ext"
           #   file.acl.project_private!
           #
-          def project_private!
-            update_predefined_acl! "projectPrivate"
+          def project_private! generation: nil,
+                               if_generation_match: nil,
+                               if_generation_not_match: nil,
+                               if_metageneration_match: nil,
+                               if_metageneration_not_match: nil
+            update_predefined_acl! "projectPrivate",
+                                   generation: generation,
+                                   if_generation_match: if_generation_match,
+                                   if_generation_not_match: if_generation_not_match,
+                                   if_metageneration_match: if_metageneration_match,
+                                   if_metageneration_not_match: if_metageneration_not_match
           end
           alias projectPrivate! project_private!
 
           ##
           # Convenience method to apply the `publicRead` predefined ACL
           # rule to the file.
+          #
+          # @param [Integer] generation Select a specific revision of the file to
+          #   update. The default is the latest version.
+          # @param [Integer] if_generation_match Makes the operation conditional
+          #   on whether the file's current generation matches the given value.
+          #   Setting to 0 makes the operation succeed only if there are no live
+          #   versions of the file.
+          # @param [Integer] if_generation_not_match Makes the operation conditional
+          #   on whether the file's current generation does not match the given
+          #   value. If no live file exists, the precondition fails. Setting to 0
+          #   makes the operation succeed only if there is a live version of the file.
+          # @param [Integer] if_metageneration_match Makes the operation conditional
+          #   on whether the file's current metageneration matches the given value.
+          # @param [Integer] if_metageneration_not_match Makes the operation
+          #   conditional on whether the file's current metageneration does not
+          #   match the given value.
           #
           # @example
           #   require "google/cloud/storage"
@@ -404,8 +545,17 @@ module Google
           #   file = bucket.file "path/to/my-file.ext"
           #   file.acl.public!
           #
-          def public!
-            update_predefined_acl! "publicRead"
+          def public! generation: nil,
+                      if_generation_match: nil,
+                      if_generation_not_match: nil,
+                      if_metageneration_match: nil,
+                      if_metageneration_not_match: nil
+            update_predefined_acl! "publicRead",
+                                   generation: generation,
+                                   if_generation_match: if_generation_match,
+                                   if_generation_not_match: if_generation_not_match,
+                                   if_metageneration_match: if_metageneration_match,
+                                   if_metageneration_not_match: if_metageneration_not_match
           end
           alias publicRead! public!
           alias public_read! public!
@@ -418,9 +568,21 @@ module Google
             self
           end
 
-          def update_predefined_acl! acl_role
+          def update_predefined_acl! acl_role,
+                                     generation: nil,
+                                     if_generation_match: nil,
+                                     if_generation_not_match: nil,
+                                     if_metageneration_match: nil,
+                                     if_metageneration_not_match: nil
             patched_file = Google::Apis::StorageV1::Object.new acl: []
-            @service.patch_file @bucket, @file, patched_file,
+            @service.patch_file @bucket,
+                                @file,
+                                patched_file,
+                                generation: generation,
+                                if_generation_match: if_generation_match,
+                                if_generation_not_match: if_generation_not_match,
+                                if_metageneration_match: if_metageneration_match,
+                                if_metageneration_not_match: if_metageneration_not_match,
                                 predefined_acl: acl_role,
                                 user_project: user_project
             clear!

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -290,30 +290,61 @@ module Google
 
         ##
         # Inserts a new file for the given bucket
-        def insert_file bucket_name, source, path = nil, acl: nil,
-                        cache_control: nil, content_disposition: nil,
-                        content_encoding: nil, content_language: nil,
-                        content_type: nil, custom_time: nil, crc32c: nil, md5: nil, metadata: nil,
-                        storage_class: nil, key: nil, kms_key: nil,
-                        temporary_hold: nil, event_based_hold: nil,
+        def insert_file bucket_name,
+                        source,
+                        path = nil,
+                        acl: nil,
+                        cache_control: nil,
+                        content_disposition: nil,
+                        content_encoding: nil,
+                        content_language: nil,
+                        content_type: nil,
+                        custom_time: nil,
+                        crc32c: nil,
+                        md5: nil,
+                        metadata: nil,
+                        storage_class: nil,
+                        key: nil,
+                        kms_key: nil,
+                        temporary_hold: nil,
+                        event_based_hold: nil,
+                        if_generation_match: nil,
+                        if_generation_not_match: nil,
+                        if_metageneration_match: nil,
+                        if_metageneration_not_match: nil,
                         user_project: nil
-          params =
-            { cache_control: cache_control, content_type: content_type, custom_time: custom_time,
-              content_disposition: content_disposition, md5_hash: md5,
-              content_encoding: content_encoding, crc32c: crc32c,
-              content_language: content_language, metadata: metadata,
-              storage_class: storage_class, temporary_hold: temporary_hold,
-              event_based_hold: event_based_hold }.delete_if { |_k, v| v.nil? }
+          params = {
+            cache_control: cache_control,
+            content_type: content_type,
+            custom_time: custom_time,
+            content_disposition: content_disposition,
+            md5_hash: md5,
+            content_encoding: content_encoding,
+            crc32c: crc32c,
+            content_language: content_language,
+            metadata: metadata,
+            storage_class: storage_class,
+            temporary_hold: temporary_hold,
+            event_based_hold: event_based_hold
+          }.delete_if { |_k, v| v.nil? }
           file_obj = Google::Apis::StorageV1::Object.new(**params)
           content_type ||= mime_type_for(path || Pathname(source).to_path)
 
           execute do
-            service.insert_object \
-              bucket_name, file_obj,
-              name: path, predefined_acl: acl, upload_source: source,
-              content_encoding: content_encoding, content_type: content_type,
-              kms_key_name: kms_key, user_project: user_project(user_project),
-              options: key_options(key)
+            service.insert_object bucket_name,
+                                  file_obj,
+                                  name: path,
+                                  predefined_acl: acl,
+                                  upload_source: source,
+                                  content_encoding: content_encoding,
+                                  content_type: content_type,
+                                  if_generation_match: if_generation_match,
+                                  if_generation_not_match: if_generation_not_match,
+                                  if_metageneration_match: if_metageneration_match,
+                                  if_metageneration_not_match: if_metageneration_not_match,
+                                  kms_key_name: kms_key,
+                                  user_project: user_project(user_project),
+                                  options: key_options(key)
           end
         end
 

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -374,23 +374,47 @@ module Google
 
         ## Rewrite a file from source bucket/object to a
         # destination bucket/object.
-        def rewrite_file source_bucket_name, source_file_path,
-                         destination_bucket_name, destination_file_path,
-                         file_gapi = nil, source_key: nil, destination_key: nil,
-                         destination_kms_key: nil, acl: nil, generation: nil,
-                         token: nil, user_project: nil
+        def rewrite_file source_bucket_name,
+                         source_file_path,
+                         destination_bucket_name,
+                         destination_file_path,
+                         file_gapi = nil,
+                         source_key: nil,
+                         destination_key: nil,
+                         destination_kms_key: nil,
+                         acl: nil,
+                         generation: nil,
+                         if_generation_match: nil,
+                         if_generation_not_match: nil,
+                         if_metageneration_match: nil,
+                         if_metageneration_not_match: nil,
+                         if_source_generation_match: nil,
+                         if_source_generation_not_match: nil,
+                         if_source_metageneration_match: nil,
+                         if_source_metageneration_not_match: nil,
+                         token: nil,
+                         user_project: nil
           key_options = rewrite_key_options source_key, destination_key
           execute do
-            service.rewrite_object \
-              source_bucket_name, source_file_path,
-              destination_bucket_name, destination_file_path,
-              file_gapi,
-              destination_kms_key_name: destination_kms_key,
-              destination_predefined_acl: acl,
-              source_generation: generation,
-              rewrite_token: token,
-              user_project: user_project(user_project),
-              options: key_options
+            service.rewrite_object source_bucket_name,
+                                   source_file_path,
+                                   destination_bucket_name,
+                                   destination_file_path,
+                                   file_gapi,
+                                   destination_kms_key_name: destination_kms_key,
+                                   destination_predefined_acl: acl,
+                                   source_generation: generation,
+                                   if_generation_match: if_generation_match,
+                                   if_generation_not_match: if_generation_not_match,
+                                   if_metageneration_match: if_metageneration_match,
+                                   if_metageneration_not_match: if_metageneration_not_match,
+                                   if_source_generation_match: if_source_generation_match,
+                                   if_source_generation_not_match: if_source_generation_not_match,
+                                   if_source_metageneration_match: if_source_metageneration_match,
+                                   if_source_metageneration_not_match: if_source_metageneration_not_match,
+                                   rewrite_token: token,
+                                   user_project: user_project(user_project),
+                                   options: key_options
           end
         end
 

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -409,11 +409,21 @@ module Google
 
         ##
         # Permanently deletes a file.
-        def delete_file bucket_name, file_path, generation: nil,
+        def delete_file bucket_name,
+                        file_path,
+                        generation: nil,
+                        if_generation_match: nil,
+                        if_generation_not_match: nil,
+                        if_metageneration_match: nil,
+                        if_metageneration_not_match: nil,
                         user_project: nil
           execute do
             service.delete_object bucket_name, file_path,
                                   generation: generation,
+                                  if_generation_match: if_generation_match,
+                                  if_generation_not_match: if_generation_not_match,
+                                  if_metageneration_match: if_metageneration_match,
+                                  if_metageneration_not_match: if_metageneration_not_match,
                                   user_project: user_project(user_project)
           end
         end

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -319,12 +319,23 @@ module Google
 
         ##
         # Retrieves an object or its metadata.
-        def get_file bucket_name, file_path, generation: nil, key: nil,
+        def get_file bucket_name,
+                     file_path,
+                     generation: nil,
+                     if_generation_match: nil,
+                     if_generation_not_match: nil,
+                     if_metageneration_match: nil,
+                     if_metageneration_not_match: nil,
+                     key: nil,
                      user_project: nil
           execute do
             service.get_object \
               bucket_name, file_path,
               generation: generation,
+              if_generation_match: if_generation_match,
+              if_generation_not_match: if_generation_not_match,
+              if_metageneration_match: if_metageneration_match,
+              if_metageneration_not_match: if_metageneration_not_match,
               user_project: user_project(user_project),
               options: key_options(key)
           end

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -420,20 +420,28 @@ module Google
 
         ## Copy a file from source bucket/object to a
         # destination bucket/object.
-        def compose_file bucket_name, source_files, destination_path,
-                         destination_gapi, acl: nil, key: nil, user_project: nil
+        def compose_file bucket_name,
+                         source_files,
+                         destination_path,
+                         destination_gapi,
+                         acl: nil,
+                         key: nil,
+                         if_generation_match: nil,
+                         if_metageneration_match: nil,
+                         user_project: nil
 
           compose_req = Google::Apis::StorageV1::ComposeRequest.new \
-            source_objects: compose_file_source_objects(source_files),
-            destination: destination_gapi
+            source_objects: compose_file_source_objects(source_files), destination: destination_gapi
 
           execute do
-            service.compose_object \
-              bucket_name, destination_path,
-              compose_req,
-              destination_predefined_acl: acl,
-              user_project: user_project(user_project),
-              options: key_options(key)
+            service.compose_object bucket_name,
+                                   destination_path,
+                                   compose_req,
+                                   destination_predefined_acl: acl,
+                                   if_generation_match: if_generation_match,
+                                   if_metageneration_match: if_metageneration_match,
+                                   user_project: user_project(user_project),
+                                   options: key_options(key)
           end
         end
 

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -470,14 +470,28 @@ module Google
 
         ##
         # Updates a file's metadata.
-        def patch_file bucket_name, file_path, file_gapi = nil,
-                       predefined_acl: nil, user_project: nil
+        def patch_file bucket_name,
+                       file_path,
+                       file_gapi = nil,
+                       generation: nil,
+                       if_generation_match: nil,
+                       if_generation_not_match: nil,
+                       if_metageneration_match: nil,
+                       if_metageneration_not_match: nil,
+                       predefined_acl: nil,
+                       user_project: nil
           file_gapi ||= Google::Apis::StorageV1::Object.new
           execute do
-            service.patch_object \
-              bucket_name, file_path, file_gapi,
-              predefined_acl: predefined_acl,
-              user_project: user_project(user_project)
+            service.patch_object bucket_name,
+                                 file_path,
+                                 file_gapi,
+                                 generation: generation,
+                                 if_generation_match: if_generation_match,
+                                 if_generation_not_match: if_generation_not_match,
+                                 if_metageneration_match: if_metageneration_match,
+                                 if_metageneration_not_match: if_metageneration_not_match,
+                                 predefined_acl: predefined_acl,
+                                 user_project: user_project(user_project)
           end
         end
 

--- a/google-cloud-storage/test/google/cloud/storage/bucket_encryption_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_encryption_test.rb
@@ -55,7 +55,7 @@ describe Google::Cloud::Storage::Bucket, :encryption, :mock_storage do
 
       mock = Minitest::Mock.new
       mock.expect :get_object, find_file_gapi(bucket.name, file_name),
-                  [bucket.name, file_name, generation: nil, user_project: nil, options: key_options]
+        get_object_args(bucket.name, file_name, options: key_options)
 
       bucket.service.mocked_service = mock
 

--- a/google-cloud-storage/test/google/cloud/storage/bucket_encryption_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_encryption_test.rb
@@ -40,7 +40,7 @@ describe Google::Cloud::Storage::Bucket, :encryption, :mock_storage do
 
         mock = Minitest::Mock.new
         mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
-                    [bucket.name, empty_file_gapi, name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", kms_key_name: nil, user_project: nil, options: key_options]
+          insert_object_args(bucket.name, empty_file_gapi, name: new_file_name, upload_source: tmpfile, options: key_options)
 
         bucket.service.mocked_service = mock
 
@@ -113,7 +113,7 @@ describe Google::Cloud::Storage::Bucket, :encryption, :mock_storage do
 
         mock = Minitest::Mock.new
         mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
-                    [bucket.name, empty_file_gapi, name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", kms_key_name: kms_key, user_project: nil, options: {}]
+          insert_object_args(bucket.name, empty_file_gapi, name: new_file_name, upload_source: tmpfile, kms_key_name: kms_key)
 
         bucket.service.mocked_service = mock
 

--- a/google-cloud-storage/test/google/cloud/storage/bucket_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_test.rb
@@ -897,8 +897,8 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
     file_name = "file.ext"
 
     mock = Minitest::Mock.new
-    mock.expect :get_object, find_file_gapi(bucket.name, file_name),
-      [bucket.name, file_name, generation: nil, user_project: nil, options: {}]
+    mock.expect :get_object, find_file_gapi(bucket.name, file_name), get_object_args(bucket.name, file_name)
+      
 
     bucket.service.mocked_service = mock
 
@@ -915,8 +915,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
     file_name = "file.ext"
 
     mock = Minitest::Mock.new
-    mock.expect :get_object, find_file_gapi(bucket.name, file_name),
-      [bucket.name, file_name, generation: nil, user_project: nil, options: {}]
+    mock.expect :get_object, find_file_gapi(bucket.name, file_name), get_object_args(bucket.name, file_name)
 
     bucket.service.mocked_service = mock
 
@@ -935,11 +934,30 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock = Minitest::Mock.new
     mock.expect :get_object, find_file_gapi(bucket.name, file_name),
-      [bucket.name, file_name, generation: generation, user_project: nil, options: {}]
+      get_object_args(bucket.name, file_name, generation: generation)
 
     bucket.service.mocked_service = mock
 
     file = bucket.file file_name, generation: generation
+
+    mock.verify
+
+    _(file.name).must_equal file_name
+    _(file.user_project).must_be :nil?
+    _(file).wont_be :lazy?
+  end
+
+  it "finds a file with if_generation_match" do
+    file_name = "file.ext"
+    generation = 123
+
+    mock = Minitest::Mock.new
+    mock.expect :get_object, find_file_gapi(bucket.name, file_name),
+      get_object_args(bucket.name, file_name, if_generation_match: generation)
+
+    bucket.service.mocked_service = mock
+
+    file = bucket.file file_name, if_generation_match: generation
 
     mock.verify
 
@@ -953,7 +971,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock = Minitest::Mock.new
     mock.expect :get_object, find_file_gapi(bucket_user_project.name, file_name),
-      [bucket_user_project.name, file_name, generation: nil, user_project: "test", options: {}]
+      get_object_args(bucket_user_project.name, file_name, generation: nil, user_project: "test")
 
     bucket_user_project.service.mocked_service = mock
 

--- a/google-cloud-storage/test/google/cloud/storage/bucket_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_test.rb
@@ -39,6 +39,8 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
   let(:bucket_website_404) { "404.html" }
   let(:bucket_requester_pays) { true }
   let(:bucket_labels) { { "env" => "production", "foo" => "bar" } }
+  let(:generation) { 1234567890 }
+  let(:metageneration) { 6 }
   let :bucket_complete_hash do
     h = random_bucket_hash bucket_name, bucket_url_root,
                            bucket_location, bucket_storage_class, bucket_versioning,
@@ -121,7 +123,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
       mock = Minitest::Mock.new
       mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
-        [bucket.name, empty_file_gapi, name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", kms_key_name: nil, user_project: nil, options: {}]
+        insert_object_args(bucket.name, empty_file_gapi, name: new_file_name, upload_source: tmpfile)
 
       bucket.service.mocked_service = mock
 
@@ -140,7 +142,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
       mock = Minitest::Mock.new
       mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
-        [bucket.name, empty_file_gapi, name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", kms_key_name: nil, user_project: nil, options: {}]
+        insert_object_args(bucket.name, empty_file_gapi, name: new_file_name, upload_source: tmpfile)
 
       bucket.service.mocked_service = mock
 
@@ -159,7 +161,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
       mock = Minitest::Mock.new
       mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
-        [bucket.name, empty_file_gapi, name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", kms_key_name: nil, user_project: nil, options: {}]
+        insert_object_args(bucket.name, empty_file_gapi, name: new_file_name, upload_source: tmpfile)
 
       bucket.service.mocked_service = mock
 
@@ -175,7 +177,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock = Minitest::Mock.new
     mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
-      [bucket.name, empty_file_gapi, name: new_file_name, predefined_acl: nil, upload_source: new_file_contents, content_encoding: nil, content_type: "text/plain", kms_key_name: nil, user_project: nil, options: {}]
+      insert_object_args(bucket.name, empty_file_gapi, name: new_file_name, upload_source: new_file_contents)
 
     bucket.service.mocked_service = mock
 
@@ -200,7 +202,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
       mock = Minitest::Mock.new
       mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
-        [bucket.name, empty_file_gapi, name: new_file_name, predefined_acl: "private", upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", kms_key_name: nil, user_project: nil, options: {}]
+        insert_object_args(bucket.name, empty_file_gapi, name: new_file_name, predefined_acl: "private", upload_source: tmpfile)
 
       bucket.service.mocked_service = mock
 
@@ -219,7 +221,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
       mock = Minitest::Mock.new
       mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
-        [bucket.name, empty_file_gapi, name: new_file_name, predefined_acl: "publicRead", upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", kms_key_name: nil, user_project: nil, options: {}]
+        insert_object_args(bucket.name, empty_file_gapi, name: new_file_name, predefined_acl: "publicRead", upload_source: tmpfile)
 
       bucket.service.mocked_service = mock
 
@@ -238,7 +240,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
       mock = Minitest::Mock.new
       mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
-        [bucket.name, empty_file_gapi(md5: "HXB937GQDFxDFqUGi//weQ=="), name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", kms_key_name: nil, user_project: nil, options: {}]
+        insert_object_args(bucket.name, empty_file_gapi(md5: "HXB937GQDFxDFqUGi//weQ=="), name: new_file_name, upload_source: tmpfile)
 
       bucket.service.mocked_service = mock
 
@@ -257,7 +259,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
       mock = Minitest::Mock.new
       mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
-        [bucket.name, empty_file_gapi(crc32c: "Lm1F3g=="), name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", kms_key_name: nil, user_project: nil, options: {}]
+        insert_object_args(bucket.name, empty_file_gapi(crc32c: "Lm1F3g=="), name: new_file_name, upload_source: tmpfile)
 
       bucket.service.mocked_service = mock
 
@@ -285,7 +287,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
       mock = Minitest::Mock.new
       mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
-        [bucket.name, empty_file_gapi(**options), name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: options[:content_encoding], content_type: options[:content_type], kms_key_name: nil, user_project: nil, options: {}]
+        insert_object_args(bucket.name, empty_file_gapi(**options), name: new_file_name, upload_source: tmpfile, content_encoding: options[:content_encoding], content_type: options[:content_type])
 
       bucket.service.mocked_service = mock
 
@@ -309,7 +311,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
       mock = Minitest::Mock.new
       mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
-        [bucket.name, empty_file_gapi(metadata: metadata), name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", kms_key_name: nil, user_project: nil, options: {}]
+        insert_object_args(bucket.name, empty_file_gapi(metadata: metadata), name: new_file_name, upload_source: tmpfile)
 
       bucket.service.mocked_service = mock
 
@@ -328,7 +330,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
       mock = Minitest::Mock.new
       mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
-                  [bucket.name, empty_file_gapi(temporary_hold: true), name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", kms_key_name: nil, user_project: nil, options: {}]
+        insert_object_args(bucket.name, empty_file_gapi(temporary_hold: true), name: new_file_name, upload_source: tmpfile)
 
       bucket.service.mocked_service = mock
 
@@ -347,11 +349,87 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
       mock = Minitest::Mock.new
       mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
-                  [bucket.name, empty_file_gapi(event_based_hold: true), name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", kms_key_name: nil, user_project: nil, options: {}]
+        insert_object_args(bucket.name, empty_file_gapi(event_based_hold: true), name: new_file_name, upload_source: tmpfile)
 
       bucket.service.mocked_service = mock
 
       bucket.create_file tmpfile, new_file_name, event_based_hold: true
+
+      mock.verify
+    end
+  end
+
+  it "creates a file with if_generation_match" do
+    new_file_name = random_file_path
+
+    Tempfile.open ["google-cloud", ".txt"] do |tmpfile|
+      tmpfile.write "Hello world"
+      tmpfile.rewind
+
+      mock = Minitest::Mock.new
+      mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
+        insert_object_args(bucket.name, empty_file_gapi, name: new_file_name, upload_source: tmpfile, if_generation_match: generation)
+
+      bucket.service.mocked_service = mock
+
+      bucket.create_file tmpfile, new_file_name, if_generation_match: generation
+
+      mock.verify
+    end
+  end
+
+  it "creates a file with if_generation_not_match" do
+    new_file_name = random_file_path
+
+    Tempfile.open ["google-cloud", ".txt"] do |tmpfile|
+      tmpfile.write "Hello world"
+      tmpfile.rewind
+
+      mock = Minitest::Mock.new
+      mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
+        insert_object_args(bucket.name, empty_file_gapi, name: new_file_name, upload_source: tmpfile, if_generation_not_match: generation)
+
+      bucket.service.mocked_service = mock
+
+      bucket.create_file tmpfile, new_file_name, if_generation_not_match: generation
+
+      mock.verify
+    end
+  end
+
+  it "creates a file with if_metageneration_match" do
+    new_file_name = random_file_path
+
+    Tempfile.open ["google-cloud", ".txt"] do |tmpfile|
+      tmpfile.write "Hello world"
+      tmpfile.rewind
+
+      mock = Minitest::Mock.new
+      mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
+        insert_object_args(bucket.name, empty_file_gapi, name: new_file_name, upload_source: tmpfile, if_metageneration_match: metageneration)
+
+      bucket.service.mocked_service = mock
+
+      bucket.create_file tmpfile, new_file_name, if_metageneration_match: metageneration
+
+      mock.verify
+    end
+  end
+
+  it "creates a file with if_metageneration_not_match" do
+    new_file_name = random_file_path
+
+    Tempfile.open ["google-cloud", ".txt"] do |tmpfile|
+      tmpfile.write "Hello world"
+      tmpfile.rewind
+
+      mock = Minitest::Mock.new
+      mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
+        insert_object_args(bucket.name, empty_file_gapi, name: new_file_name, upload_source: tmpfile, if_metageneration_not_match: metageneration)
+
+      bucket.service.mocked_service = mock
+
+      bucket.create_file tmpfile, new_file_name, if_metageneration_not_match: metageneration
 
       mock.verify
     end
@@ -366,7 +444,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
       mock = Minitest::Mock.new
       mock.expect :insert_object, create_file_gapi(bucket_user_project.name, new_file_name),
-        [bucket_user_project.name, empty_file_gapi, name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", kms_key_name: nil, user_project: "test", options: {}]
+        insert_object_args(bucket.name, empty_file_gapi, name: new_file_name, upload_source: tmpfile, user_project: "test")
 
       bucket_user_project.service.mocked_service = mock
 

--- a/google-cloud-storage/test/google/cloud/storage/file_acl_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_acl_test.rb
@@ -27,7 +27,7 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
 
   it "retrieves the ACL" do
     mock = Minitest::Mock.new
-    mock.expect :get_object, file_gapi, [bucket_name, file_name, generation: nil, user_project: nil, options: {}]
+    mock.expect :get_object, file_gapi, get_object_args(bucket.name, file_name)
     mock.expect :list_object_access_controls,
       Google::Apis::StorageV1::ObjectAccessControls.from_json(random_file_acl_hash(bucket_name, file_name).to_json),
       [bucket_name, file_name, user_project: nil]
@@ -44,7 +44,7 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
 
   it "retrieves the ACL with user_project set to true" do
     mock = Minitest::Mock.new
-    mock.expect :get_object, file_gapi, [bucket_name, file_name, generation: nil, user_project: "test", options: {}]
+    mock.expect :get_object, file_gapi, get_object_args(bucket_name, file_name, user_project: "test")
     mock.expect :list_object_access_controls,
       Google::Apis::StorageV1::ObjectAccessControls.from_json(random_file_acl_hash(bucket_name, file_name).to_json),
       [bucket_name, file_name, user_project: "test"]
@@ -73,7 +73,7 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
       }
 
     mock = Minitest::Mock.new
-    mock.expect :get_object, file_gapi, [bucket_name, file_name, generation: nil, user_project: nil, options: {}]
+    mock.expect :get_object, file_gapi, get_object_args(bucket_name, file_name)
     mock.expect :list_object_access_controls,
       Google::Apis::StorageV1::ObjectAccessControls.from_json(random_file_acl_hash(bucket_name, file_name).to_json),
       [bucket_name, file_name, user_project: nil]
@@ -111,7 +111,7 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
       }
 
     mock = Minitest::Mock.new
-    mock.expect :get_object, file_gapi, [bucket_name, file_name, generation: nil, user_project: nil, options: {}]
+    mock.expect :get_object, file_gapi, get_object_args(bucket_name, file_name)
     mock.expect :list_object_access_controls,
       Google::Apis::StorageV1::ObjectAccessControls.from_json(random_file_acl_hash(bucket_name, file_name).to_json),
       [bucket_name, file_name, user_project: nil]
@@ -148,7 +148,7 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
       }
 
     mock = Minitest::Mock.new
-    mock.expect :get_object, file_gapi, [bucket_name, file_name, generation: nil, user_project: "test", options: {}]
+    mock.expect :get_object, file_gapi, get_object_args(bucket_name, file_name, user_project: "test")
     mock.expect :list_object_access_controls,
       Google::Apis::StorageV1::ObjectAccessControls.from_json(random_file_acl_hash(bucket_name, file_name).to_json),
       [bucket_name, file_name, user_project: "test"]
@@ -175,7 +175,7 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
     existing_reader_entity = "project-viewers-1234567890"
 
     mock = Minitest::Mock.new
-    mock.expect :get_object, file_gapi, [bucket_name, file_name, generation: nil, user_project: nil, options: {}]
+    mock.expect :get_object, file_gapi, get_object_args(bucket_name, file_name)
     mock.expect :list_object_access_controls,
       Google::Apis::StorageV1::ObjectAccessControls.from_json(random_file_acl_hash(bucket_name, file_name).to_json),
       [bucket_name, file_name, user_project: nil]
@@ -202,7 +202,7 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
     existing_reader_entity = "project-viewers-1234567890"
 
     mock = Minitest::Mock.new
-    mock.expect :get_object, file_gapi, [bucket_name, file_name, generation: nil, user_project: nil, options: {}]
+    mock.expect :get_object, file_gapi, get_object_args(bucket_name, file_name)
     mock.expect :list_object_access_controls,
       Google::Apis::StorageV1::ObjectAccessControls.from_json(random_file_acl_hash(bucket_name, file_name).to_json),
       [bucket_name, file_name, user_project: nil]
@@ -228,7 +228,7 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
     existing_reader_entity = "project-viewers-1234567890"
 
     mock = Minitest::Mock.new
-    mock.expect :get_object, file_gapi, [bucket_name, file_name, generation: nil, user_project: "test", options: {}]
+    mock.expect :get_object, file_gapi, get_object_args(bucket_name, file_name, user_project: "test")
     mock.expect :list_object_access_controls,
       Google::Apis::StorageV1::ObjectAccessControls.from_json(random_file_acl_hash(bucket_name, file_name).to_json),
       [bucket_name, file_name, user_project: "test"]

--- a/google-cloud-storage/test/google/cloud/storage/file_acl_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_acl_test.rb
@@ -434,7 +434,7 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
     mock = Minitest::Mock.new
     mock.expect :patch_object,
       Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket_name, file_name).to_json),
-      [bucket_name, file_name, Google::Apis::StorageV1::Bucket.new(acl: []), predefined_acl: acl_role, user_project: nil]
+      patch_object_args(bucket_name, file_name, predefined_acl: acl_role)
 
     storage.service.mocked_service = mock
 

--- a/google-cloud-storage/test/google/cloud/storage/file_acl_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_acl_test.rb
@@ -24,6 +24,8 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
   let(:file_hash) { random_file_hash bucket.name, file_name }
   let(:file_gapi) { Google::Apis::StorageV1::Object.from_json file_hash.to_json }
   let(:file) { Google::Cloud::Storage::File.from_gapi file_gapi, storage.service }
+  let(:generation) { 1234567890 }
+  let(:metageneration) { 6 }
 
   it "retrieves the ACL" do
     mock = Minitest::Mock.new
@@ -262,6 +264,36 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
     end
   end
 
+  it "sets the predefined ACL rule auth with generation" do
+    predefined_acl_update "authenticatedRead", generation: generation do |acl|
+      acl.auth! generation: generation
+    end
+  end
+
+  it "sets the predefined ACL rule auth with if_generation_match" do
+    predefined_acl_update "authenticatedRead", if_generation_match: generation do |acl|
+      acl.auth! if_generation_match: generation
+    end
+  end
+
+  it "sets the predefined ACL rule auth with if_generation_not_match" do
+    predefined_acl_update "authenticatedRead", if_generation_not_match: generation do |acl|
+      acl.auth! if_generation_not_match: generation
+    end
+  end
+
+  it "sets the predefined ACL rule auth with if_metageneration_match" do
+    predefined_acl_update "authenticatedRead", if_metageneration_match: metageneration do |acl|
+      acl.auth! if_metageneration_match: metageneration
+    end
+  end
+
+  it "sets the predefined ACL rule auth with if_metageneration_not_match" do
+    predefined_acl_update "authenticatedRead", if_metageneration_not_match: metageneration do |acl|
+      acl.auth! if_metageneration_not_match: metageneration
+    end
+  end
+
   it "sets the predefined ACL rule auth_read" do
     predefined_acl_update "authenticatedRead" do |acl|
       acl.auth_read!
@@ -292,6 +324,36 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
     end
   end
 
+  it "sets the predefined ACL rule owner_full with generation" do
+    predefined_acl_update "bucketOwnerFullControl", generation: generation do |acl|
+      acl.owner_full! generation: generation
+    end
+  end
+
+  it "sets the predefined ACL rule owner_full with if_generation_match" do
+    predefined_acl_update "bucketOwnerFullControl", if_generation_match: generation do |acl|
+      acl.owner_full! if_generation_match: generation
+    end
+  end
+
+  it "sets the predefined ACL rule owner_full with if_generation_not_match" do
+    predefined_acl_update "bucketOwnerFullControl", if_generation_not_match: generation do |acl|
+      acl.owner_full! if_generation_not_match: generation
+    end
+  end
+
+  it "sets the predefined ACL rule owner_full with if_metageneration_match" do
+    predefined_acl_update "bucketOwnerFullControl", if_metageneration_match: metageneration do |acl|
+      acl.owner_full! if_metageneration_match: metageneration
+    end
+  end
+
+  it "sets the predefined ACL rule owner_full with if_metageneration_not_match" do
+    predefined_acl_update "bucketOwnerFullControl", if_metageneration_not_match: metageneration do |acl|
+      acl.owner_full! if_metageneration_not_match: metageneration
+    end
+  end
+
   it "sets the predefined ACL rule bucketOwnerRead" do
     predefined_acl_update "bucketOwnerRead" do |acl|
       acl.bucketOwnerRead!
@@ -304,9 +366,69 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
     end
   end
 
+  it "sets the predefined ACL rule owner_read with generation" do
+    predefined_acl_update "bucketOwnerRead", generation: generation do |acl|
+      acl.owner_read! generation: generation
+    end
+  end
+
+  it "sets the predefined ACL rule owner_read with if_generation_match" do
+    predefined_acl_update "bucketOwnerRead", if_generation_match: generation do |acl|
+      acl.owner_read! if_generation_match: generation
+    end
+  end
+
+  it "sets the predefined ACL rule owner_read with if_generation_not_match" do
+    predefined_acl_update "bucketOwnerRead", if_generation_not_match: generation do |acl|
+      acl.owner_read! if_generation_not_match: generation
+    end
+  end
+
+  it "sets the predefined ACL rule owner_read with if_metageneration_match" do
+    predefined_acl_update "bucketOwnerRead", if_metageneration_match: metageneration do |acl|
+      acl.owner_read! if_metageneration_match: metageneration
+    end
+  end
+
+  it "sets the predefined ACL rule owner_read with if_metageneration_not_match" do
+    predefined_acl_update "bucketOwnerRead", if_metageneration_not_match: metageneration do |acl|
+      acl.owner_read! if_metageneration_not_match: metageneration
+    end
+  end
+
   it "sets the predefined ACL rule private" do
     predefined_acl_update "private" do |acl|
       acl.private!
+    end
+  end
+
+  it "sets the predefined ACL rule private with generation" do
+    predefined_acl_update "private", generation: generation do |acl|
+      acl.private! generation: generation
+    end
+  end
+
+  it "sets the predefined ACL rule private with if_generation_match" do
+    predefined_acl_update "private", if_generation_match: generation do |acl|
+      acl.private! if_generation_match: generation
+    end
+  end
+
+  it "sets the predefined ACL rule private with if_generation_not_match" do
+    predefined_acl_update "private", if_generation_not_match: generation do |acl|
+      acl.private! if_generation_not_match: generation
+    end
+  end
+
+  it "sets the predefined ACL rule private with if_metageneration_match" do
+    predefined_acl_update "private", if_metageneration_match: metageneration do |acl|
+      acl.private! if_metageneration_match: metageneration
+    end
+  end
+
+  it "sets the predefined ACL rule private with if_metageneration_not_match" do
+    predefined_acl_update "private", if_metageneration_not_match: metageneration do |acl|
+      acl.private! if_metageneration_not_match: metageneration
     end
   end
 
@@ -322,6 +444,36 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
     end
   end
 
+  it "sets the predefined ACL rule project_private with generation" do
+    predefined_acl_update "projectPrivate", generation: generation do |acl|
+      acl.project_private! generation: generation
+    end
+  end
+
+  it "sets the predefined ACL rule project_private with if_generation_match" do
+    predefined_acl_update "projectPrivate", if_generation_match: generation do |acl|
+      acl.project_private! if_generation_match: generation
+    end
+  end
+
+  it "sets the predefined ACL rule project_private with if_generation_not_match" do
+    predefined_acl_update "projectPrivate", if_generation_not_match: generation do |acl|
+      acl.project_private! if_generation_not_match: generation
+    end
+  end
+
+  it "sets the predefined ACL rule project_private with if_metageneration_match" do
+    predefined_acl_update "projectPrivate", if_metageneration_match: metageneration do |acl|
+      acl.project_private! if_metageneration_match: metageneration
+    end
+  end
+
+  it "sets the predefined ACL rule project_private with if_metageneration_not_match" do
+    predefined_acl_update "projectPrivate", if_metageneration_not_match: metageneration do |acl|
+      acl.project_private! if_metageneration_not_match: metageneration
+    end
+  end
+
   it "sets the predefined ACL rule publicRead" do
     predefined_acl_update "publicRead" do |acl|
       acl.publicRead!
@@ -331,6 +483,36 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
   it "sets the predefined ACL rule public" do
     predefined_acl_update "publicRead" do |acl|
       acl.public!
+    end
+  end
+
+  it "sets the predefined ACL rule public with generation" do
+    predefined_acl_update "publicRead", generation: generation do |acl|
+      acl.public! generation: generation
+    end
+  end
+
+  it "sets the predefined ACL rule public with if_generation_match" do
+    predefined_acl_update "publicRead", if_generation_match: generation do |acl|
+      acl.public! if_generation_match: generation
+    end
+  end
+
+  it "sets the predefined ACL rule public with if_generation_not_match" do
+    predefined_acl_update "publicRead", if_generation_not_match: generation do |acl|
+      acl.public! if_generation_not_match: generation
+    end
+  end
+
+  it "sets the predefined ACL rule public with if_metageneration_match" do
+    predefined_acl_update "publicRead", if_metageneration_match: metageneration do |acl|
+      acl.public! if_metageneration_match: metageneration
+    end
+  end
+
+  it "sets the predefined ACL rule public with if_metageneration_not_match" do
+    predefined_acl_update "publicRead", if_metageneration_not_match: metageneration do |acl|
+      acl.public! if_metageneration_not_match: metageneration
     end
   end
 
@@ -430,11 +612,11 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
     end
   end
 
-  def predefined_acl_update acl_role
+  def predefined_acl_update acl_role, **opts
     mock = Minitest::Mock.new
     mock.expect :patch_object,
       Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket_name, file_name).to_json),
-      patch_object_args(bucket_name, file_name, predefined_acl: acl_role)
+      patch_object_args(bucket_name, file_name, predefined_acl: acl_role, **opts)
 
     storage.service.mocked_service = mock
 

--- a/google-cloud-storage/test/google/cloud/storage/file_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_test.rb
@@ -651,7 +651,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
     it "can copy itself in the same bucket" do
       mock = Minitest::Mock.new
       mock.expect :rewrite_object, done_rewrite(file_gapi),
-        [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
+        rewrite_object_args(bucket.name, file.name, bucket.name, "new-file.ext")
 
       file.service.mocked_service = mock
 
@@ -663,11 +663,11 @@ describe Google::Cloud::Storage::File, :mock_storage do
     it "can copy itself in the same bucket with generation" do
       mock = Minitest::Mock.new
       mock.expect :rewrite_object, done_rewrite(file_gapi),
-        [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: 123, rewrite_token: nil, user_project: nil, options: {}]
+        rewrite_object_args(bucket.name, file.name, bucket.name, "new-file.ext", source_generation: generation)
 
       file.service.mocked_service = mock
 
-      file.copy "new-file.ext", generation: 123
+      file.copy "new-file.ext", generation: generation
 
       mock.verify
     end
@@ -675,7 +675,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
     it "can copy itself in the same bucket with predefined ACL" do
       mock = Minitest::Mock.new
       mock.expect :rewrite_object, done_rewrite(file_gapi),
-        [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: "private", source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
+        rewrite_object_args(bucket.name, file.name, bucket.name, "new-file.ext", destination_predefined_acl: "private")
 
       file.service.mocked_service = mock
 
@@ -687,7 +687,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
     it "can copy itself in the same bucket with ACL alias" do
       mock = Minitest::Mock.new
       mock.expect :rewrite_object, done_rewrite(file_gapi),
-        [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: "publicRead", source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
+        rewrite_object_args(bucket.name, file.name, bucket.name, "new-file.ext", destination_predefined_acl: "publicRead")
 
       file.service.mocked_service = mock
 
@@ -699,7 +699,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
     it "can copy itself with customer-supplied encryption key" do
       mock = Minitest::Mock.new
       mock.expect :rewrite_object, done_rewrite(file_gapi),
-        [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: copy_key_options]
+        rewrite_object_args(bucket.name, file.name, bucket.name, "new-file.ext", rewrite_token: nil, user_project: nil, options: copy_key_options)
 
       file.service.mocked_service = mock
 
@@ -711,7 +711,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
     it "can copy itself with user_project set to true" do
       mock = Minitest::Mock.new
       mock.expect :rewrite_object, done_rewrite(file_gapi),
-        [bucket.name, file_user_project.name, bucket.name, "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: "test", options: {}]
+        rewrite_object_args(bucket.name, file_user_project.name, bucket.name, "new-file.ext", rewrite_token: nil, user_project: "test")
 
       file_user_project.service.mocked_service = mock
 
@@ -724,7 +724,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
     it "can copy itself to a different bucket" do
       mock = Minitest::Mock.new
       mock.expect :rewrite_object, done_rewrite(file_gapi),
-        [bucket.name, file.name, "new-bucket", "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
+        rewrite_object_args(bucket.name, file.name, "new-bucket", "new-file.ext")
 
       file.service.mocked_service = mock
 
@@ -736,11 +736,11 @@ describe Google::Cloud::Storage::File, :mock_storage do
     it "can copy itself to a different bucket with generation" do
       mock = Minitest::Mock.new
       mock.expect :rewrite_object, done_rewrite(file_gapi),
-        [bucket.name, file.name, "new-bucket", "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: 123, rewrite_token: nil, user_project: nil, options: {}]
+        rewrite_object_args(bucket.name, file.name, "new-bucket", "new-file.ext", source_generation: generation)
 
       file.service.mocked_service = mock
 
-      file.copy "new-bucket", "new-file.ext", generation: 123
+      file.copy "new-bucket", "new-file.ext", generation: generation
 
       mock.verify
     end
@@ -748,7 +748,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
     it "can copy itself to a different bucket with predefined ACL" do
       mock = Minitest::Mock.new
       mock.expect :rewrite_object, done_rewrite(file_gapi),
-        [bucket.name, file.name, "new-bucket", "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: "private", source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
+        rewrite_object_args(bucket.name, file.name, "new-bucket", "new-file.ext", destination_predefined_acl: "private")
 
       file.service.mocked_service = mock
 
@@ -760,7 +760,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
     it "can copy itself to a different bucket with ACL alias" do
       mock = Minitest::Mock.new
       mock.expect :rewrite_object, done_rewrite(file_gapi),
-        [bucket.name, file.name, "new-bucket", "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: "publicRead", source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
+        rewrite_object_args(bucket.name, file.name, "new-bucket", "new-file.ext", destination_predefined_acl: "publicRead")
 
       file.service.mocked_service = mock
 
@@ -772,7 +772,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
     it "can copy itself to a different bucket with customer-supplied encryption key" do
       mock = Minitest::Mock.new
       mock.expect :rewrite_object, done_rewrite(file_gapi),
-        [bucket.name, file.name, "new-bucket", "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: copy_key_options]
+        rewrite_object_args(bucket.name, file.name, "new-bucket", "new-file.ext", rewrite_token: nil, user_project: nil, options: copy_key_options)
 
       file.service.mocked_service = mock
 
@@ -784,13 +784,13 @@ describe Google::Cloud::Storage::File, :mock_storage do
     it "can copy itself calling rewrite multiple times" do
       mock = Minitest::Mock.new
       mock.expect :rewrite_object, undone_rewrite("notyetcomplete"),
-        [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
+        rewrite_object_args(bucket.name, file.name, bucket.name, "new-file.ext")
       mock.expect :rewrite_object, undone_rewrite("keeptrying"),
-        [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "notyetcomplete", user_project: nil, options: {}]
+        rewrite_object_args(bucket.name, file.name, bucket.name, "new-file.ext", rewrite_token: "notyetcomplete")
       mock.expect :rewrite_object, undone_rewrite("almostthere"),
-        [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "keeptrying", user_project: nil, options: {}]
+        rewrite_object_args(bucket.name, file.name, bucket.name, "new-file.ext", rewrite_token: "keeptrying")
       mock.expect :rewrite_object, done_rewrite(file_gapi),
-        [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "almostthere", user_project: nil, options: {}]
+        rewrite_object_args(bucket.name, file.name, bucket.name, "new-file.ext", rewrite_token: "almostthere")
 
       file.service.mocked_service = mock
 
@@ -806,13 +806,13 @@ describe Google::Cloud::Storage::File, :mock_storage do
     it "can copy itself calling rewrite multiple times with user_project set to true" do
       mock = Minitest::Mock.new
       mock.expect :rewrite_object, undone_rewrite("notyetcomplete"),
-        [bucket.name, file_user_project.name, bucket.name, "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: "test", options: {}]
+        rewrite_object_args(bucket.name, file_user_project.name, bucket.name, "new-file.ext", rewrite_token: nil, user_project: "test")
       mock.expect :rewrite_object, undone_rewrite("keeptrying"),
-        [bucket.name, file_user_project.name, bucket.name, "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "notyetcomplete", user_project: "test", options: {}]
+        rewrite_object_args(bucket.name, file_user_project.name, bucket.name, "new-file.ext", rewrite_token: "notyetcomplete", user_project: "test")
       mock.expect :rewrite_object, undone_rewrite("almostthere"),
-        [bucket.name, file_user_project.name, bucket.name, "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "keeptrying", user_project: "test", options: {}]
+        rewrite_object_args(bucket.name, file_user_project.name, bucket.name, "new-file.ext", rewrite_token: "keeptrying", user_project: "test")
       mock.expect :rewrite_object, done_rewrite(file_gapi),
-        [bucket.name, file_user_project.name, bucket.name, "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "almostthere", user_project: "test", options: {}]
+        rewrite_object_args(bucket.name, file_user_project.name, bucket.name, "new-file.ext", rewrite_token: "almostthere", user_project: "test")
 
       file_user_project.service.mocked_service = mock
 
@@ -838,7 +838,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
       update_file_gapi.storage_class = "NEARLINE"
 
       mock.expect :rewrite_object, done_rewrite(file_gapi),
-        [bucket.name, file.name, bucket.name, "new-file.ext", update_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
+        rewrite_object_args(bucket.name, file.name, bucket.name, "new-file.ext", update_file_gapi)
 
       file.service.mocked_service = mock
 
@@ -868,7 +868,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
       update_file_gapi.storage_class = "NEARLINE"
 
       mock.expect :rewrite_object, done_rewrite(file_gapi),
-                  [bucket.name, file.name, bucket.name, "new-file.ext", update_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
+                  rewrite_object_args(bucket.name, file.name, bucket.name, "new-file.ext", update_file_gapi)
 
       file.service.mocked_service = mock
 
@@ -898,7 +898,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
       update_file_gapi.storage_class = "NEARLINE"
 
       mock.expect :rewrite_object, done_rewrite(file_gapi),
-        [bucket.name, file_user_project.name, bucket.name, "new-file.ext", update_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: "test", options: {}]
+        rewrite_object_args(bucket.name, file_user_project.name, bucket.name, "new-file.ext", update_file_gapi, rewrite_token: nil, user_project: "test")
 
       file_user_project.service.mocked_service = mock
 
@@ -922,7 +922,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
     it "can rewrite itself in the same bucket" do
       mock = Minitest::Mock.new
       mock.expect :rewrite_object, done_rewrite(file_gapi),
-        [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
+        rewrite_object_args(bucket.name, file.name, bucket.name, "new-file.ext")
 
       file.service.mocked_service = mock
 
@@ -934,11 +934,107 @@ describe Google::Cloud::Storage::File, :mock_storage do
     it "can rewrite itself in the same bucket with generation" do
       mock = Minitest::Mock.new
       mock.expect :rewrite_object, done_rewrite(file_gapi),
-        [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: 123, rewrite_token: nil, user_project: nil, options: {}]
+        rewrite_object_args(bucket.name, file.name, bucket.name, "new-file.ext", source_generation: generation)
 
       file.service.mocked_service = mock
 
-      file.rewrite "new-file.ext", generation: 123
+      file.rewrite "new-file.ext", generation: generation
+
+      mock.verify
+    end
+
+    it "can rewrite itself with if_generation_match" do
+      mock = Minitest::Mock.new
+      mock.expect :rewrite_object, done_rewrite(file_gapi),
+        rewrite_object_args(bucket.name, file.name, bucket.name, "new-file.ext", if_generation_match: generation)
+
+      file.service.mocked_service = mock
+
+      file.rewrite "new-file.ext", if_generation_match: generation
+
+      mock.verify
+    end
+
+    it "can rewrite itself with if_generation_not_match" do
+      mock = Minitest::Mock.new
+      mock.expect :rewrite_object, done_rewrite(file_gapi),
+        rewrite_object_args(bucket.name, file.name, bucket.name, "new-file.ext", if_generation_not_match: generation)
+
+      file.service.mocked_service = mock
+
+      file.rewrite "new-file.ext", if_generation_not_match: generation
+
+      mock.verify
+    end
+
+    it "can rewrite itself with if_metageneration_match" do
+      mock = Minitest::Mock.new
+      mock.expect :rewrite_object, done_rewrite(file_gapi),
+        rewrite_object_args(bucket.name, file.name, bucket.name, "new-file.ext", if_metageneration_match: metageneration)
+
+      file.service.mocked_service = mock
+
+      file.rewrite "new-file.ext", if_metageneration_match: metageneration
+
+      mock.verify
+    end
+
+    it "can rewrite itself with if_metageneration_not_match" do
+      mock = Minitest::Mock.new
+      mock.expect :rewrite_object, done_rewrite(file_gapi),
+        rewrite_object_args(bucket.name, file.name, bucket.name, "new-file.ext", if_metageneration_not_match: metageneration)
+
+      file.service.mocked_service = mock
+
+      file.rewrite "new-file.ext", if_metageneration_not_match: metageneration
+
+      mock.verify
+    end
+
+    it "can rewrite itself with if_source_generation_match" do
+      mock = Minitest::Mock.new
+      mock.expect :rewrite_object, done_rewrite(file_gapi),
+        rewrite_object_args(bucket.name, file.name, bucket.name, "new-file.ext", if_source_generation_match: generation)
+
+      file.service.mocked_service = mock
+
+      file.rewrite "new-file.ext", if_source_generation_match: generation
+
+      mock.verify
+    end
+
+    it "can rewrite itself with if_source_generation_not_match" do
+      mock = Minitest::Mock.new
+      mock.expect :rewrite_object, done_rewrite(file_gapi),
+        rewrite_object_args(bucket.name, file.name, bucket.name, "new-file.ext", if_source_generation_not_match: generation)
+
+      file.service.mocked_service = mock
+
+      file.rewrite "new-file.ext", if_source_generation_not_match: generation
+
+      mock.verify
+    end
+
+    it "can rewrite itself with if_source_metageneration_match" do
+      mock = Minitest::Mock.new
+      mock.expect :rewrite_object, done_rewrite(file_gapi),
+        rewrite_object_args(bucket.name, file.name, bucket.name, "new-file.ext", if_source_metageneration_match: metageneration)
+
+      file.service.mocked_service = mock
+
+      file.rewrite "new-file.ext", if_source_metageneration_match: metageneration
+
+      mock.verify
+    end
+
+    it "can rewrite itself with if_source_metageneration_not_match" do
+      mock = Minitest::Mock.new
+      mock.expect :rewrite_object, done_rewrite(file_gapi),
+        rewrite_object_args(bucket.name, file.name, bucket.name, "new-file.ext", if_source_metageneration_not_match: metageneration)
+
+      file.service.mocked_service = mock
+
+      file.rewrite "new-file.ext", if_source_metageneration_not_match: metageneration
 
       mock.verify
     end
@@ -946,7 +1042,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
     it "can rewrite itself in the same bucket with predefined ACL" do
       mock = Minitest::Mock.new
       mock.expect :rewrite_object, done_rewrite(file_gapi),
-        [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: "private", source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
+        rewrite_object_args(bucket.name, file.name, bucket.name, "new-file.ext", destination_predefined_acl: "private")
 
       file.service.mocked_service = mock
 
@@ -958,7 +1054,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
     it "can rewrite itself in the same bucket with ACL alias" do
       mock = Minitest::Mock.new
       mock.expect :rewrite_object, done_rewrite(file_gapi),
-        [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: "publicRead", source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
+        rewrite_object_args(bucket.name, file.name, bucket.name, "new-file.ext", destination_predefined_acl: "publicRead")
 
       file.service.mocked_service = mock
 
@@ -971,7 +1067,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
       options = { header: source_key_headers.merge(key_headers) }
       mock = Minitest::Mock.new
       mock.expect :rewrite_object, done_rewrite(file_gapi),
-        [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: options]
+        rewrite_object_args(bucket.name, file.name, bucket.name, "new-file.ext", rewrite_token: nil, user_project: nil, options: options)
 
       file.service.mocked_service = mock
 
@@ -983,7 +1079,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
     it "can rewrite itself from default service encryption to a new customer-managed encryption key (CMEK) with new_kms_key" do
       mock = Minitest::Mock.new
       mock.expect :rewrite_object, done_rewrite(file_gapi),
-                  [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_kms_key_name: kms_key, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
+                  rewrite_object_args(bucket.name, file.name, bucket.name, "new-file.ext", destination_kms_key_name: kms_key)
 
       file.service.mocked_service = mock
 
@@ -996,7 +1092,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
       options = { header: source_key_headers }
       mock = Minitest::Mock.new
       mock.expect :rewrite_object, done_rewrite(file_gapi),
-                  [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_kms_key_name: kms_key, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: options]
+                  rewrite_object_args(bucket.name, file.name, bucket.name, "new-file.ext", destination_kms_key_name: kms_key, rewrite_token: nil, user_project: nil, options: options)
 
       file.service.mocked_service = mock
 
@@ -1008,7 +1104,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
     it "can rewrite itself with user_project set to true" do
       mock = Minitest::Mock.new
       mock.expect :rewrite_object, done_rewrite(file_gapi),
-        [bucket.name, file_user_project.name, bucket.name, "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: "test", options: {}]
+        rewrite_object_args(bucket.name, file_user_project.name, bucket.name, "new-file.ext", rewrite_token: nil, user_project: "test")
 
       file_user_project.service.mocked_service = mock
 
@@ -1021,7 +1117,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
     it "can rewrite itself to a different bucket" do
       mock = Minitest::Mock.new
       mock.expect :rewrite_object, done_rewrite(file_gapi),
-        [bucket.name, file.name, "new-bucket", "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
+        rewrite_object_args(bucket.name, file.name, "new-bucket", "new-file.ext")
 
       file.service.mocked_service = mock
 
@@ -1033,11 +1129,11 @@ describe Google::Cloud::Storage::File, :mock_storage do
     it "can rewrite itself to a different bucket with generation" do
       mock = Minitest::Mock.new
       mock.expect :rewrite_object, done_rewrite(file_gapi),
-        [bucket.name, file.name, "new-bucket", "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: 123, rewrite_token: nil, user_project: nil, options: {}]
+        rewrite_object_args(bucket.name, file.name, "new-bucket", "new-file.ext", source_generation: generation)
 
       file.service.mocked_service = mock
 
-      file.rewrite "new-bucket", "new-file.ext", generation: 123
+      file.rewrite "new-bucket", "new-file.ext", generation: generation
 
       mock.verify
     end
@@ -1045,7 +1141,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
     it "can rewrite itself to a different bucket with predefined ACL" do
       mock = Minitest::Mock.new
       mock.expect :rewrite_object, done_rewrite(file_gapi),
-        [bucket.name, file.name, "new-bucket", "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: "private", source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
+        rewrite_object_args(bucket.name, file.name, "new-bucket", "new-file.ext", destination_predefined_acl: "private")
 
       file.service.mocked_service = mock
 
@@ -1057,7 +1153,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
     it "can rewrite itself to a different bucket with ACL alias" do
       mock = Minitest::Mock.new
       mock.expect :rewrite_object, done_rewrite(file_gapi),
-        [bucket.name, file.name, "new-bucket", "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: "publicRead", source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
+        rewrite_object_args(bucket.name, file.name, "new-bucket", "new-file.ext", destination_predefined_acl: "publicRead")
 
       file.service.mocked_service = mock
 
@@ -1070,7 +1166,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
       options = { header: source_key_headers.merge(key_headers) }
       mock = Minitest::Mock.new
       mock.expect :rewrite_object, done_rewrite(file_gapi),
-        [bucket.name, file.name, "new-bucket", "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: options]
+        rewrite_object_args(bucket.name, file.name, "new-bucket", "new-file.ext", rewrite_token: nil, user_project: nil, options: options)
 
 
       file.service.mocked_service = mock
@@ -1083,13 +1179,13 @@ describe Google::Cloud::Storage::File, :mock_storage do
     it "can rewrite itself calling rewrite multiple times" do
       mock = Minitest::Mock.new
       mock.expect :rewrite_object, undone_rewrite("notyetcomplete"),
-        [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
+        rewrite_object_args(bucket.name, file.name, bucket.name, "new-file.ext")
       mock.expect :rewrite_object, undone_rewrite("keeptrying"),
-        [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "notyetcomplete", user_project: nil, options: {}]
+        rewrite_object_args(bucket.name, file.name, bucket.name, "new-file.ext", rewrite_token: "notyetcomplete")
       mock.expect :rewrite_object, undone_rewrite("almostthere"),
-        [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "keeptrying", user_project: nil, options: {}]
+        rewrite_object_args(bucket.name, file.name, bucket.name, "new-file.ext", rewrite_token: "keeptrying")
       mock.expect :rewrite_object, done_rewrite(file_gapi),
-        [bucket.name, file.name, bucket.name, "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "almostthere", user_project: nil, options: {}]
+        rewrite_object_args(bucket.name, file.name, bucket.name, "new-file.ext", rewrite_token: "almostthere")
 
       file.service.mocked_service = mock
 
@@ -1105,13 +1201,13 @@ describe Google::Cloud::Storage::File, :mock_storage do
     it "can rewrite itself calling rewrite multiple times with user_project set to true" do
       mock = Minitest::Mock.new
       mock.expect :rewrite_object, undone_rewrite("notyetcomplete"),
-        [bucket.name, file_user_project.name, bucket.name, "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: "test", options: {}]
+        rewrite_object_args(bucket.name, file_user_project.name, bucket.name, "new-file.ext", rewrite_token: nil, user_project: "test")
       mock.expect :rewrite_object, undone_rewrite("keeptrying"),
-        [bucket.name, file_user_project.name, bucket.name, "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "notyetcomplete", user_project: "test", options: {}]
+        rewrite_object_args(bucket.name, file_user_project.name, bucket.name, "new-file.ext", rewrite_token: "notyetcomplete", user_project: "test")
       mock.expect :rewrite_object, undone_rewrite("almostthere"),
-        [bucket.name, file_user_project.name, bucket.name, "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "keeptrying", user_project: "test", options: {}]
+        rewrite_object_args(bucket.name, file_user_project.name, bucket.name, "new-file.ext", rewrite_token: "keeptrying", user_project: "test")
       mock.expect :rewrite_object, done_rewrite(file_gapi),
-        [bucket.name, file_user_project.name, bucket.name, "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "almostthere", user_project: "test", options: {}]
+        rewrite_object_args(bucket.name, file_user_project.name, bucket.name, "new-file.ext", rewrite_token: "almostthere", user_project: "test")
 
       file_user_project.service.mocked_service = mock
 
@@ -1137,7 +1233,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
       update_file_gapi.storage_class = "NEARLINE"
 
       mock.expect :rewrite_object, done_rewrite(file_gapi),
-                  [bucket.name, file.name, bucket.name, "new-file.ext", update_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
+                  rewrite_object_args(bucket.name, file.name, bucket.name, "new-file.ext", update_file_gapi)
 
       file.service.mocked_service = mock
 
@@ -1167,7 +1263,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
       update_file_gapi.storage_class = "NEARLINE"
 
       mock.expect :rewrite_object, done_rewrite(file_gapi),
-                  [bucket.name, file.name, bucket.name, "new-file.ext", update_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
+                  rewrite_object_args(bucket.name, file.name, bucket.name, "new-file.ext", update_file_gapi)
 
       file.service.mocked_service = mock
 
@@ -1197,7 +1293,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
       update_file_gapi.storage_class = "NEARLINE"
 
       mock.expect :rewrite_object, done_rewrite(file_gapi),
-                  [bucket.name, file_user_project.name, bucket.name, "new-file.ext", update_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: "test", options: {}]
+                  rewrite_object_args(bucket.name, file_user_project.name, bucket.name, "new-file.ext", update_file_gapi, rewrite_token: nil, user_project: "test")
 
       file_user_project.service.mocked_service = mock
 
@@ -1222,9 +1318,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
       mock = Minitest::Mock.new
       options = { header: source_key_headers.merge(key_headers) }
       mock.expect :rewrite_object, done_rewrite(file_gapi),
-                  [bucket.name, file.name, bucket.name, file.name, nil,
-                   destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil,
-                   rewrite_token: nil, user_project: nil, options: options ]
+        rewrite_object_args(bucket.name, file.name, bucket.name, file.name, options: options)
 
       file.service.mocked_service = mock
 
@@ -1238,9 +1332,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
       mock = Minitest::Mock.new
       options = { header: source_key_headers.merge(key_headers) }
       mock.expect :rewrite_object, done_rewrite(file_gapi),
-                  [bucket.name, file_user_project.name, bucket.name, file_user_project.name, nil,
-                   destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil,
-                   rewrite_token: nil, user_project: "test", options: options ]
+        rewrite_object_args(bucket.name, file_user_project.name, bucket.name, file_user_project.name, user_project: "test", options: options)
 
       file_user_project.service.mocked_service = mock
 
@@ -1255,9 +1347,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
       mock = Minitest::Mock.new
       options = { header: key_headers }
       mock.expect :rewrite_object, done_rewrite(file_gapi),
-                  [bucket.name, file.name, bucket.name, file.name, nil,
-                   destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil,
-                   rewrite_token: nil, user_project: nil, options: options ]
+        rewrite_object_args(bucket.name, file.name, bucket.name, file.name, options: options)
 
       file.service.mocked_service = mock
 
@@ -1271,9 +1361,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
       mock = Minitest::Mock.new
       options = { header: source_key_headers }
       mock.expect :rewrite_object, done_rewrite(file_gapi),
-                  [bucket.name, file.name, bucket.name, file.name, nil,
-                   destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil,
-                   rewrite_token: nil, user_project: nil, options: options ]
+        rewrite_object_args(bucket.name, file.name, bucket.name, file.name, options: options)
 
       file.service.mocked_service = mock
 
@@ -1285,10 +1373,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
 
     it "can rotate from default service encryption to a new customer-managed encryption key (CMEK) with new_kms_key" do
       mock = Minitest::Mock.new
-      mock.expect :rewrite_object, done_rewrite(file_gapi),
-                  [bucket.name, file.name, bucket.name, file.name, nil,
-                   destination_kms_key_name: kms_key, destination_predefined_acl: nil, source_generation: nil,
-                   rewrite_token: nil, user_project: nil, options: {} ]
+      mock.expect :rewrite_object, done_rewrite(file_gapi), rewrite_object_args(bucket.name, file.name, bucket.name, file.name, destination_kms_key_name: kms_key)
 
       file.service.mocked_service = mock
 
@@ -1301,10 +1386,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
     it "can rotate from a customer-supplied encryption key (CSEK) to a new customer-managed encryption key (CMEK) with new_kms_key" do
       mock = Minitest::Mock.new
       options = { header: source_key_headers }
-      mock.expect :rewrite_object, done_rewrite(file_gapi),
-                  [bucket.name, file.name, bucket.name, file.name, nil,
-                   destination_kms_key_name: kms_key, destination_predefined_acl: nil, source_generation: nil,
-                   rewrite_token: nil, user_project: nil, options: options ]
+      mock.expect :rewrite_object, done_rewrite(file_gapi), rewrite_object_args(bucket.name, file.name, bucket.name, file.name, destination_kms_key_name: kms_key, options: options)
 
       file.service.mocked_service = mock
 
@@ -1317,14 +1399,9 @@ describe Google::Cloud::Storage::File, :mock_storage do
     it "can rotate its customer-supplied encryption keys with multiple requests for large objects" do
       mock = Minitest::Mock.new
       options = { header: source_key_headers.merge(key_headers) }
-      mock.expect :rewrite_object, undone_rewrite("notyetcomplete"),
-                  [bucket.name, file.name, bucket.name, file.name, nil,
-                   destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil,
-                   rewrite_token: nil, user_project: nil, options: options ]
+      mock.expect :rewrite_object, undone_rewrite("notyetcomplete"), rewrite_object_args(bucket.name, file.name, bucket.name, file.name, options: options)
       mock.expect :rewrite_object, done_rewrite(file_gapi),
-                  [bucket.name, file.name, bucket.name, file.name, nil,
-                   destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil,
-                   rewrite_token: "notyetcomplete", user_project: nil, options: options ]
+                  rewrite_object_args(bucket.name, file.name, bucket.name, file.name, rewrite_token: "notyetcomplete", options: options)
 
       file.service.mocked_service = mock
 
@@ -1342,13 +1419,9 @@ describe Google::Cloud::Storage::File, :mock_storage do
       mock = Minitest::Mock.new
       options = { header: source_key_headers.merge(key_headers) }
       mock.expect :rewrite_object, undone_rewrite("notyetcomplete"),
-                  [bucket.name, file_user_project.name, bucket.name, file_user_project.name, nil,
-                   destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil,
-                   rewrite_token: nil, user_project: "test", options: options ]
+                  rewrite_object_args(bucket.name, file_user_project.name, bucket.name, file_user_project.name, user_project: "test", options: options)
       mock.expect :rewrite_object, done_rewrite(file_gapi),
-                  [bucket.name, file_user_project.name, bucket.name, file_user_project.name, nil,
-                   destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil,
-                   rewrite_token: "notyetcomplete", user_project: "test", options: options ]
+                  rewrite_object_args(bucket.name, file_user_project.name, bucket.name, file_user_project.name, rewrite_token: "notyetcomplete", user_project: "test", options: options)
 
       file_user_project.service.mocked_service = mock
 

--- a/google-cloud-storage/test/google/cloud/storage/file_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_test.rb
@@ -1369,9 +1369,9 @@ describe Google::Cloud::Storage::File, :mock_storage do
 
     mock = Minitest::Mock.new
     mock.expect :get_object, Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket.name, file_name, generations[3]).to_json),
-      [bucket.name, file_name, generation: nil, user_project: nil, options: {}]
+      get_object_args(bucket.name, file_name)
     mock.expect :get_object, Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket.name, file_name, generations[2]).to_json),
-      [bucket.name, file_name, generation: nil, user_project: nil, options: {}]
+      get_object_args(bucket.name, file_name)
 
     bucket.service.mocked_service = mock
     file.service.mocked_service = mock
@@ -1389,9 +1389,9 @@ describe Google::Cloud::Storage::File, :mock_storage do
 
     mock = Minitest::Mock.new
     mock.expect :get_object, Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket_user_project.name, file_name, generations[3]).to_json),
-      [bucket_user_project.name, file_name, generation: nil, user_project: "test", options: {}]
+      get_object_args(bucket_user_project.name, file_name, user_project: "test")
     mock.expect :get_object, Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket_user_project.name, file_name, generations[2]).to_json),
-      [bucket_user_project.name, file_name, generation: nil, user_project: "test", options: {}]
+      get_object_args(bucket_user_project.name, file_name, user_project: "test")
 
     bucket_user_project.service.mocked_service = mock
     file.service.mocked_service = mock
@@ -1409,7 +1409,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
 
     mock = Minitest::Mock.new
     mock.expect :get_object, Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket.name, file_name, generations[0]).to_json),
-      [bucket.name, file_name, generation: nil, user_project: nil, options: {}]
+      get_object_args(bucket.name, file_name)
     mock.expect :list_objects, Google::Apis::StorageV1::Objects.new(kind: "storage#objects", items: file_gapis),
       [bucket.name, delimiter: nil, max_results: nil, page_token: nil, prefix: file_name, versions: true, user_project: nil]
 
@@ -1435,7 +1435,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
 
     mock = Minitest::Mock.new
     mock.expect :get_object, Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket_user_project.name, file_name, generations[0]).to_json),
-      [bucket_user_project.name, file_name, generation: nil, user_project: "test", options: {}]
+      get_object_args(bucket_user_project.name, file_name, user_project: "test")
     mock.expect :list_objects, Google::Apis::StorageV1::Objects.new(kind: "storage#objects", items: file_gapis),
       [bucket.name, delimiter: nil, max_results: nil, page_token: nil, prefix: file_name, versions: true, user_project: "test"]
 

--- a/google-cloud-storage/test/google/cloud/storage/file_update_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_update_test.rb
@@ -22,13 +22,13 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
   let(:file_gapi) { Google::Apis::StorageV1::Object.from_json file_hash.to_json }
   let(:file) { Google::Cloud::Storage::File.from_gapi file_gapi, storage.service }
   let(:file_user_project) { Google::Cloud::Storage::File.from_gapi file_gapi, storage.service, user_project: true }
+  let(:generation) { 1234567890 }
+  let(:metageneration) { 6 }
 
   it "updates its cache control" do
     mock = Minitest::Mock.new
     patch_file_gapi = Google::Apis::StorageV1::Object.new cache_control: "private, max-age=0, no-cache"
-    mock.expect :patch_object, file_gapi,
-      [bucket_name, file.name, patch_file_gapi, predefined_acl: nil, user_project: nil]
-
+    mock.expect :patch_object, file_gapi, patch_object_args(bucket_name, file.name, patch_file_gapi)
     file.service.mocked_service = mock
 
     _(file.cache_control).must_equal "public, max-age=3600"
@@ -40,8 +40,7 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
   it "updates its content_disposition" do
     mock = Minitest::Mock.new
     patch_file_gapi = Google::Apis::StorageV1::Object.new content_disposition: "inline; filename=filename.ext"
-    mock.expect :patch_object, file_gapi,
-      [bucket_name, file.name, patch_file_gapi, predefined_acl: nil, user_project: nil]
+    mock.expect :patch_object, file_gapi, patch_object_args(bucket_name, file.name, patch_file_gapi)
 
     file.service.mocked_service = mock
 
@@ -54,9 +53,7 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
   it "updates its content_encoding" do
     mock = Minitest::Mock.new
     patch_file_gapi = Google::Apis::StorageV1::Object.new content_encoding: "deflate"
-    mock.expect :patch_object, file_gapi,
-      [bucket_name, file.name, patch_file_gapi, predefined_acl: nil, user_project: nil]
-
+    mock.expect :patch_object, file_gapi, patch_object_args(bucket_name, file.name, patch_file_gapi)
     file.service.mocked_service = mock
 
     _(file.content_encoding).must_equal "gzip"
@@ -68,8 +65,7 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
   it "updates its content_language" do
     mock = Minitest::Mock.new
     patch_file_gapi = Google::Apis::StorageV1::Object.new content_language: "de"
-    mock.expect :patch_object, file_gapi,
-      [bucket_name, file.name, patch_file_gapi, predefined_acl: nil, user_project: nil]
+    mock.expect :patch_object, file_gapi, patch_object_args(bucket_name, file.name, patch_file_gapi)
 
     file.service.mocked_service = mock
 
@@ -82,8 +78,7 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
   it "updates its content_type" do
     mock = Minitest::Mock.new
     patch_file_gapi = Google::Apis::StorageV1::Object.new content_type: "application/json"
-    mock.expect :patch_object, file_gapi,
-      [bucket_name, file.name, patch_file_gapi, predefined_acl: nil, user_project: nil]
+    mock.expect :patch_object, file_gapi, patch_object_args(bucket_name, file.name, patch_file_gapi)
 
     file.service.mocked_service = mock
 
@@ -96,9 +91,7 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
   it "updates its custom_time" do
     mock = Minitest::Mock.new
     patch_file_gapi = Google::Apis::StorageV1::Object.new custom_time: custom_time_2
-    mock.expect :patch_object, file_gapi,
-      [bucket_name, file.name, patch_file_gapi, predefined_acl: nil, user_project: nil]
-
+    mock.expect :patch_object, file_gapi, patch_object_args(bucket_name, file.name, patch_file_gapi)
     file.service.mocked_service = mock
 
     _(file.custom_time).must_equal custom_time
@@ -110,8 +103,7 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
   it "updates its metadata" do
     mock = Minitest::Mock.new
     patch_file_gapi = Google::Apis::StorageV1::Object.new metadata: { "player" => "Bob", score: 10 }
-    mock.expect :patch_object, file_gapi,
-      [bucket_name, file.name, patch_file_gapi, predefined_acl: nil, user_project: nil]
+    mock.expect :patch_object, file_gapi, patch_object_args(bucket_name, file.name, patch_file_gapi)
 
     file.service.mocked_service = mock
 
@@ -212,9 +204,7 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
   it "updates its temporary_hold" do
     mock = Minitest::Mock.new
     patch_file_gapi = Google::Apis::StorageV1::Object.new temporary_hold: false
-    mock.expect :patch_object, file_gapi,
-                [bucket_name, file.name, patch_file_gapi, predefined_acl: nil, user_project: nil]
-
+    mock.expect :patch_object, file_gapi, patch_object_args(bucket_name, file.name, patch_file_gapi)
     file.service.mocked_service = mock
 
     _(file.temporary_hold?).must_equal true
@@ -226,8 +216,7 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
   it "updates its event_based_hold" do
     mock = Minitest::Mock.new
     patch_file_gapi = Google::Apis::StorageV1::Object.new event_based_hold: false
-    mock.expect :patch_object, file_gapi,
-                [bucket_name, file.name, patch_file_gapi, predefined_acl: nil, user_project: nil]
+    mock.expect :patch_object, file_gapi, patch_object_args(bucket_name, file.name, patch_file_gapi)
 
     file.service.mocked_service = mock
 
@@ -248,8 +237,7 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
       custom_time: custom_time_2,
       metadata: { "player" => "Bob", "score" => "10" }
     )
-    mock.expect :patch_object, file_gapi,
-      [bucket_name, file.name, patch_file_gapi, predefined_acl: nil, user_project: nil]
+    mock.expect :patch_object, file_gapi, patch_object_args(bucket_name, file.name, patch_file_gapi)
 
     file.service.mocked_service = mock
 
@@ -278,8 +266,7 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
       custom_time: custom_time_2,
       metadata: { "player" => "Bob", "score" => "10" }
     )
-    mock.expect :patch_object, file_gapi,
-      [bucket_name, file_user_project.name, patch_file_gapi, predefined_acl: nil, user_project: "test"]
+    mock.expect :patch_object, file_gapi, patch_object_args(bucket_name, file.name, patch_file_gapi, user_project: "test")
 
     file_user_project.service.mocked_service = mock
 
@@ -302,9 +289,7 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
     patch_file_gapi = Google::Apis::StorageV1::Object.new(
       content_language: "de"
     )
-    mock.expect :patch_object, file_gapi,
-      [bucket_name, file.name, patch_file_gapi, predefined_acl: nil, user_project: nil]
-
+    mock.expect :patch_object, file_gapi, patch_object_args(bucket_name, file.name, patch_file_gapi)
     file.service.mocked_service = mock
 
     file.update do |f|
@@ -326,6 +311,71 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
 
     file.update do |f|
       f.storage_class = :nearline
+    end
+
+    mock.verify
+  end
+
+  it "updates with generation" do
+    mock = Minitest::Mock.new
+    patch_file_gapi = Google::Apis::StorageV1::Object.new content_language: "de"
+    mock.expect :patch_object, file_gapi, patch_object_args(bucket_name, file.name, patch_file_gapi, generation: generation)
+    file.service.mocked_service = mock
+
+    file.update generation: generation do |f|
+      f.content_language = "de"
+    end
+
+    mock.verify
+  end
+
+  it "updates with if_generation_match" do
+    mock = Minitest::Mock.new
+    patch_file_gapi = Google::Apis::StorageV1::Object.new content_language: "de"
+    mock.expect :patch_object, file_gapi, patch_object_args(bucket_name, file.name, patch_file_gapi, if_generation_match: generation)
+    file.service.mocked_service = mock
+
+    file.update if_generation_match: generation do |f|
+      f.content_language = "de"
+    end
+
+    mock.verify
+  end
+
+  it "updates with if_generation_not_match" do
+    mock = Minitest::Mock.new
+    patch_file_gapi = Google::Apis::StorageV1::Object.new content_language: "de"
+    mock.expect :patch_object, file_gapi, patch_object_args(bucket_name, file.name, patch_file_gapi, if_generation_not_match: generation)
+    file.service.mocked_service = mock
+
+    file.update if_generation_not_match: generation do |f|
+      f.content_language = "de"
+    end
+
+    mock.verify
+  end
+
+  it "updates with if_metageneration_match" do
+    mock = Minitest::Mock.new
+    patch_file_gapi = Google::Apis::StorageV1::Object.new content_language: "de"
+    mock.expect :patch_object, file_gapi, patch_object_args(bucket_name, file.name, patch_file_gapi, if_metageneration_match: metageneration)
+    file.service.mocked_service = mock
+
+    file.update if_metageneration_match: metageneration do |f|
+      f.content_language = "de"
+    end
+
+    mock.verify
+  end
+
+  it "updates with if_metageneration_not_match" do
+    mock = Minitest::Mock.new
+    patch_file_gapi = Google::Apis::StorageV1::Object.new content_language: "de"
+    mock.expect :patch_object, file_gapi, patch_object_args(bucket_name, file.name, patch_file_gapi, if_metageneration_not_match: metageneration)
+    file.service.mocked_service = mock
+
+    file.update if_metageneration_not_match: metageneration do |f|
+      f.content_language = "de"
     end
 
     mock.verify

--- a/google-cloud-storage/test/google/cloud/storage/file_update_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_update_test.rb
@@ -127,7 +127,7 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
     patched_file_gapi = file_gapi.dup
     patched_file_gapi.storage_class = "NEARLINE"
     mock.expect :rewrite_object, done_rewrite(patched_file_gapi),
-      [bucket_name, file.name, bucket_name, file.name, patch_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
+      rewrite_object_args(bucket_name, file.name, bucket_name, file.name, patch_file_gapi)
 
     file.service.mocked_service = mock
 
@@ -144,7 +144,7 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
     patched_file_gapi = file_gapi.dup
     patched_file_gapi.storage_class = "COLDLINE"
     mock.expect :rewrite_object, done_rewrite(patched_file_gapi),
-      [bucket_name, file.name, bucket_name, file_user_project.name, patch_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: "test", options: {}]
+      rewrite_object_args(bucket_name, file.name, bucket_name, file_user_project.name, patch_file_gapi, user_project: "test")
 
     file_user_project.service.mocked_service = mock
 
@@ -161,13 +161,13 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
     patched_file_gapi = file_gapi.dup
     patched_file_gapi.storage_class = "ARCHIVE"
     mock.expect :rewrite_object, undone_rewrite("notyetcomplete"),
-      [bucket_name, file.name, bucket_name, file.name, patch_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
+      rewrite_object_args(bucket_name, file.name, bucket_name, file.name, patch_file_gapi)
     mock.expect :rewrite_object, undone_rewrite("keeptrying"),
-      [bucket_name, file.name, bucket_name, file.name, patch_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "notyetcomplete", user_project: nil, options: {}]
+      rewrite_object_args(bucket_name, file.name, bucket_name, file.name, patch_file_gapi, rewrite_token: "notyetcomplete")
     mock.expect :rewrite_object, undone_rewrite("almostthere"),
-      [bucket_name, file.name, bucket_name, file.name, patch_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "keeptrying", user_project: nil, options: {}]
+      rewrite_object_args(bucket_name, file.name, bucket_name, file.name, patch_file_gapi, rewrite_token: "keeptrying")
     mock.expect :rewrite_object, done_rewrite(patched_file_gapi),
-      [bucket_name, file.name, bucket_name, file.name, patch_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "almostthere", user_project: nil, options: {}]
+      rewrite_object_args(bucket_name, file.name, bucket_name, file.name, patch_file_gapi, rewrite_token: "almostthere")
 
     file.service.mocked_service = mock
 
@@ -188,13 +188,13 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
     patched_file_gapi = file_gapi.dup
     patched_file_gapi.storage_class = "DURABLE_REDUCED_AVAILABILITY"
     mock.expect :rewrite_object, undone_rewrite("notyetcomplete"),
-      [bucket_name, file_user_project.name, bucket_name, file_user_project.name, patch_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: "test", options: {}]
+      rewrite_object_args(bucket_name, file_user_project.name, bucket_name, file_user_project.name, patch_file_gapi, user_project: "test")
     mock.expect :rewrite_object, undone_rewrite("keeptrying"),
-      [bucket_name, file_user_project.name, bucket_name, file_user_project.name, patch_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "notyetcomplete", user_project: "test", options: {}]
+      rewrite_object_args(bucket_name, file_user_project.name, bucket_name, file_user_project.name, patch_file_gapi, rewrite_token: "notyetcomplete", user_project: "test")
     mock.expect :rewrite_object, undone_rewrite("almostthere"),
-      [bucket_name, file_user_project.name, bucket_name, file_user_project.name, patch_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "keeptrying", user_project: "test", options: {}]
+      rewrite_object_args(bucket_name, file_user_project.name, bucket_name, file_user_project.name, patch_file_gapi, rewrite_token: "keeptrying", user_project: "test")
     mock.expect :rewrite_object, done_rewrite(patched_file_gapi),
-      [bucket_name, file_user_project.name, bucket_name, file_user_project.name, patch_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "almostthere", user_project: "test", options: {}]
+      rewrite_object_args(bucket_name, file_user_project.name, bucket_name, file_user_project.name, patch_file_gapi, rewrite_token: "almostthere", user_project: "test")
 
     file_user_project.service.mocked_service = mock
 
@@ -320,7 +320,7 @@ describe Google::Cloud::Storage::File, :update, :mock_storage do
     patched_file_gapi = file_gapi.dup
     patched_file_gapi.storage_class = "NEARLINE"
     mock.expect :rewrite_object, done_rewrite(patched_file_gapi),
-      [bucket_name, file.name, bucket_name, file.name, patch_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
+      rewrite_object_args(bucket_name, file.name, bucket_name, file.name, patch_file_gapi)
 
     file.service.mocked_service = mock
 

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_test.rb
@@ -76,7 +76,7 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
       mock = Minitest::Mock.new
       mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
-        [bucket.name, empty_file_gapi, name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", kms_key_name: nil, user_project: nil, options: {}]
+        insert_object_args(bucket.name, empty_file_gapi, name: new_file_name, upload_source: tmpfile)
 
       bucket.service.mocked_service = mock
 
@@ -95,7 +95,7 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
       mock = Minitest::Mock.new
       mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
-        [bucket.name, empty_file_gapi, name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", kms_key_name: nil, user_project: nil, options: {}]
+        insert_object_args(bucket.name, empty_file_gapi, name: new_file_name, upload_source: tmpfile)
 
       bucket.service.mocked_service = mock
 
@@ -114,7 +114,7 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
       mock = Minitest::Mock.new
       mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
-        [bucket.name, empty_file_gapi, name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", kms_key_name: nil, user_project: nil, options: {}]
+        insert_object_args(bucket.name, empty_file_gapi, name: new_file_name, upload_source: tmpfile)
 
       bucket.service.mocked_service = mock
 
@@ -130,7 +130,7 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
     mock = Minitest::Mock.new
     mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
-      [bucket.name, empty_file_gapi, name: new_file_name, predefined_acl: nil, upload_source: new_file_contents, content_encoding: nil, content_type: "text/plain", kms_key_name: nil, user_project: nil, options: {}]
+      insert_object_args(bucket.name, empty_file_gapi, name: new_file_name, upload_source: new_file_contents)
 
     bucket.service.mocked_service = mock
 
@@ -155,7 +155,7 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
       mock = Minitest::Mock.new
       mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
-        [bucket.name, empty_file_gapi, name: new_file_name, predefined_acl: "private", upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", kms_key_name: nil, user_project: nil, options: {}]
+        insert_object_args(bucket.name, empty_file_gapi, name: new_file_name, predefined_acl: "private", upload_source: tmpfile)
 
       bucket.service.mocked_service = mock
 
@@ -174,7 +174,7 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
       mock = Minitest::Mock.new
       mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
-        [bucket.name, empty_file_gapi, name: new_file_name, predefined_acl: "publicRead", upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", kms_key_name: nil, user_project: nil, options: {}]
+        insert_object_args(bucket.name, empty_file_gapi, name: new_file_name, predefined_acl: "publicRead", upload_source: tmpfile)
 
       bucket.service.mocked_service = mock
 
@@ -193,7 +193,7 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
       mock = Minitest::Mock.new
       mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
-        [bucket.name, empty_file_gapi(md5: "HXB937GQDFxDFqUGi//weQ=="), name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", kms_key_name: nil, user_project: nil, options: {}]
+        insert_object_args(bucket.name, empty_file_gapi(md5: "HXB937GQDFxDFqUGi//weQ=="), name: new_file_name, upload_source: tmpfile)
 
       bucket.service.mocked_service = mock
 
@@ -212,7 +212,7 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
       mock = Minitest::Mock.new
       mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
-        [bucket.name, empty_file_gapi(crc32c: "Lm1F3g=="), name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", kms_key_name: nil, user_project: nil, options: {}]
+        insert_object_args(bucket.name, empty_file_gapi(crc32c: "Lm1F3g=="), name: new_file_name, upload_source: tmpfile)
 
       bucket.service.mocked_service = mock
 
@@ -240,7 +240,7 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
       mock = Minitest::Mock.new
       mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
-        [bucket.name, empty_file_gapi(**options), name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: options[:content_encoding], content_type: options[:content_type], kms_key_name: nil, user_project: nil, options: {}]
+        insert_object_args(bucket.name, empty_file_gapi(**options), name: new_file_name, upload_source: tmpfile, content_encoding: options[:content_encoding], content_type: options[:content_type])
 
       bucket.service.mocked_service = mock
 
@@ -264,7 +264,7 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
       mock = Minitest::Mock.new
       mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
-        [bucket.name, empty_file_gapi(metadata: metadata), name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", kms_key_name: nil, user_project: nil, options: {}]
+        insert_object_args(bucket.name, empty_file_gapi(metadata: metadata), name: new_file_name, upload_source: tmpfile)
 
       bucket.service.mocked_service = mock
 
@@ -283,7 +283,7 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
       mock = Minitest::Mock.new
       mock.expect :insert_object, create_file_gapi(bucket.name, new_file_name),
-        [bucket.name, empty_file_gapi, name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", kms_key_name: nil, user_project: nil, options: key_options]
+        insert_object_args(bucket.name, empty_file_gapi, name: new_file_name, upload_source: tmpfile, options: key_options)
 
       bucket.service.mocked_service = mock
 
@@ -302,7 +302,7 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
       mock = Minitest::Mock.new
       mock.expect :insert_object, create_file_gapi(bucket_user_project.name, new_file_name),
-        [bucket_user_project.name, empty_file_gapi, name: new_file_name, predefined_acl: nil, upload_source: tmpfile, content_encoding: nil, content_type: "text/plain", kms_key_name: nil, user_project: "test", options: {}]
+        insert_object_args(bucket.name, empty_file_gapi, name: new_file_name, upload_source: tmpfile, user_project: "test")
 
       bucket_user_project.service.mocked_service = mock
 

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_test.rb
@@ -833,8 +833,7 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
     file_name = "file.ext"
 
     mock = Minitest::Mock.new
-    mock.expect :get_object, find_file_gapi(bucket.name, file_name),
-      [bucket.name, file_name, generation: nil, user_project: nil, options: {}]
+    mock.expect :get_object, find_file_gapi(bucket.name, file_name), get_object_args(bucket.name, file_name)
 
     bucket.service.mocked_service = mock
 
@@ -851,8 +850,7 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
     file_name = "file.ext"
 
     mock = Minitest::Mock.new
-    mock.expect :get_object, find_file_gapi(bucket.name, file_name),
-      [bucket.name, file_name, generation: nil, user_project: nil, options: {}]
+    mock.expect :get_object, find_file_gapi(bucket.name, file_name), get_object_args(bucket.name, file_name)
 
     bucket.service.mocked_service = mock
 
@@ -871,7 +869,7 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
     mock = Minitest::Mock.new
     mock.expect :get_object, find_file_gapi(bucket.name, file_name),
-      [bucket.name, file_name, generation: generation, user_project: nil, options: {}]
+    get_object_args(bucket.name, file_name, generation: generation)
 
     bucket.service.mocked_service = mock
 
@@ -889,7 +887,7 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
     mock = Minitest::Mock.new
     mock.expect :get_object, find_file_gapi(bucket.name, file_name),
-      [bucket.name, file_name, generation: nil, user_project: nil, options: key_options]
+      get_object_args(bucket.name, file_name, options: key_options)
 
     bucket.service.mocked_service = mock
 
@@ -907,7 +905,7 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
     mock = Minitest::Mock.new
     mock.expect :get_object, find_file_gapi(bucket_user_project.name, file_name),
-      [bucket_user_project.name, file_name, generation: nil, user_project: "test", options: {}]
+      get_object_args(bucket_user_project.name, file_name, generation: nil, user_project: "test")
 
     bucket_user_project.service.mocked_service = mock
 

--- a/google-cloud-storage/test/google/cloud/storage/lazy/file_acl_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/file_acl_test.rb
@@ -432,7 +432,7 @@ describe Google::Cloud::Storage::File, :acl, :lazy, :mock_storage do
     mock = Minitest::Mock.new
     mock.expect :patch_object,
       Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket_name, file_name).to_json),
-      [bucket_name, file_name, Google::Apis::StorageV1::Bucket.new(acl: []), predefined_acl: acl_role, user_project: nil]
+      patch_object_args(bucket_name, file_name, predefined_acl: acl_role)
 
     storage.service.mocked_service = mock
 

--- a/google-cloud-storage/test/google/cloud/storage/lazy/file_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/file_test.rb
@@ -872,9 +872,9 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
 
     mock = Minitest::Mock.new
     mock.expect :get_object, Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket_name, file_name, 1234567891).to_json),
-      [bucket_name, file_name, generation: nil, user_project: nil, options: {}]
+      get_object_args(bucket.name, file_name)
     mock.expect :get_object, Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket_name, file_name, 1234567892).to_json),
-      [bucket_name, file_name, generation: nil, user_project: nil, options: {}]
+      get_object_args(bucket.name, file_name)
 
     bucket.service.mocked_service = mock
     file.service.mocked_service = mock
@@ -892,9 +892,9 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
 
     mock = Minitest::Mock.new
     mock.expect :get_object, Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket_user_project.name, file_name, 1234567891).to_json),
-      [bucket_user_project.name, file_name, generation: nil, user_project: "test", options: {}]
+      get_object_args(bucket_name, file_name, user_project: "test")
     mock.expect :get_object, Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket_user_project.name, file_name, 1234567892).to_json),
-      [bucket_user_project.name, file_name, generation: nil, user_project: "test", options: {}]
+      get_object_args(bucket_name, file_name, user_project: "test")
 
     bucket_user_project.service.mocked_service = mock
     file.service.mocked_service = mock

--- a/google-cloud-storage/test/google/cloud/storage/lazy/file_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/file_test.rb
@@ -487,7 +487,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
   it "can copy itself in the same bucket" do
     mock = Minitest::Mock.new
     mock.expect :rewrite_object, rewrite_response,
-      [bucket_name, file_name, bucket_name, "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
+      rewrite_object_args(bucket.name, file.name, bucket.name, "new-file.ext")
 
     file.service.mocked_service = mock
 
@@ -499,7 +499,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
   it "can copy itself in the same bucket with generation" do
     mock = Minitest::Mock.new
     mock.expect :rewrite_object, rewrite_response,
-      [bucket_name, file_name, bucket_name, "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: 123, rewrite_token: nil, user_project: nil, options: {}]
+      rewrite_object_args(bucket.name, file.name, bucket.name, "new-file.ext", source_generation: 123)
 
     file.service.mocked_service = mock
 
@@ -511,7 +511,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
   it "can copy itself in the same bucket with predefined ACL" do
     mock = Minitest::Mock.new
     mock.expect :rewrite_object, rewrite_response,
-      [bucket_name, file_name, bucket_name, "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: "private", source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
+      rewrite_object_args(bucket.name, file.name, bucket.name, "new-file.ext", destination_predefined_acl: "private")
 
     file.service.mocked_service = mock
 
@@ -523,7 +523,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
   it "can copy itself in the same bucket with ACL alias" do
     mock = Minitest::Mock.new
     mock.expect :rewrite_object, rewrite_response,
-      [bucket_name, file_name, bucket_name, "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: "publicRead", source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
+      rewrite_object_args(bucket.name, file.name, bucket.name, "new-file.ext", destination_predefined_acl: "publicRead")
 
     file.service.mocked_service = mock
 
@@ -535,7 +535,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
   it "can copy itself with customer-supplied encryption key" do
     mock = Minitest::Mock.new
     mock.expect :rewrite_object, rewrite_response,
-      [bucket_name, file_name, bucket_name, "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: copy_key_options]
+      rewrite_object_args(bucket.name, file.name, bucket.name, "new-file.ext", rewrite_token: nil, user_project: nil, options: copy_key_options)
 
     file.service.mocked_service = mock
 
@@ -547,7 +547,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
   it "can copy itself with user_project set to true" do
     mock = Minitest::Mock.new
     mock.expect :rewrite_object, rewrite_response,
-      [bucket.name, file_user_project.name, bucket.name, "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: "test", options: {}]
+      rewrite_object_args(bucket.name, file_user_project.name, bucket.name, "new-file.ext", rewrite_token: nil, user_project: "test")
 
     file_user_project.service.mocked_service = mock
 
@@ -560,7 +560,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
   it "can copy itself to a different bucket" do
     mock = Minitest::Mock.new
     mock.expect :rewrite_object, rewrite_response,
-      [bucket_name, file_name, "new-bucket", "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
+      rewrite_object_args(bucket.name, file.name, "new-bucket", "new-file.ext")
 
     file.service.mocked_service = mock
 
@@ -572,7 +572,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
   it "can copy itself to a different bucket with generation" do
     mock = Minitest::Mock.new
     mock.expect :rewrite_object, rewrite_response,
-      [bucket_name, file_name, "new-bucket", "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: 123, rewrite_token: nil, user_project: nil, options: {}]
+      rewrite_object_args(bucket.name, file.name, "new-bucket", "new-file.ext", source_generation: 123)
 
     file.service.mocked_service = mock
 
@@ -584,7 +584,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
   it "can copy itself to a different bucket with predefined ACL" do
     mock = Minitest::Mock.new
     mock.expect :rewrite_object, rewrite_response,
-      [bucket_name, file_name, "new-bucket", "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: "private", source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
+      rewrite_object_args(bucket.name, file.name, "new-bucket", "new-file.ext", destination_predefined_acl: "private")
 
     file.service.mocked_service = mock
 
@@ -596,7 +596,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
   it "can copy itself to a different bucket with ACL alias" do
     mock = Minitest::Mock.new
     mock.expect :rewrite_object, rewrite_response,
-      [bucket_name, file_name, "new-bucket", "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: "publicRead", source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
+      rewrite_object_args(bucket.name, file.name, "new-bucket", "new-file.ext", destination_predefined_acl: "publicRead")
 
     file.service.mocked_service = mock
 
@@ -608,7 +608,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
   it "can copy itself to a different bucket with customer-supplied encryption key" do
     mock = Minitest::Mock.new
     mock.expect :rewrite_object, rewrite_response,
-      [bucket_name, file_name, "new-bucket", "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: copy_key_options]
+      rewrite_object_args(bucket.name, file.name, "new-bucket", "new-file.ext", rewrite_token: nil, user_project: nil, options: copy_key_options)
 
     file.service.mocked_service = mock
 
@@ -620,13 +620,13 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
   it "can copy itself calling rewrite multiple times" do
     mock = Minitest::Mock.new
     mock.expect :rewrite_object, undone_rewrite("notyetcomplete"),
-      [bucket_name, file_name, bucket_name, "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
+      rewrite_object_args(bucket.name, file.name, bucket.name, "new-file.ext")
     mock.expect :rewrite_object, undone_rewrite("keeptrying"),
-      [bucket_name, file_name, bucket_name, "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "notyetcomplete", user_project: nil, options: {}]
+      rewrite_object_args(bucket.name, file.name, bucket.name, "new-file.ext", rewrite_token: "notyetcomplete")
     mock.expect :rewrite_object, undone_rewrite("almostthere"),
-      [bucket_name, file_name, bucket_name, "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "keeptrying", user_project: nil, options: {}]
+      rewrite_object_args(bucket.name, file.name, bucket.name, "new-file.ext", rewrite_token: "keeptrying")
     mock.expect :rewrite_object, rewrite_response,
-      [bucket_name, file_name, bucket_name, "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "almostthere", user_project: nil, options: {}]
+      rewrite_object_args(bucket.name, file.name, bucket.name, "new-file.ext", rewrite_token: "almostthere")
 
     file.service.mocked_service = mock
 
@@ -642,13 +642,13 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
   it "can copy itself calling rewrite multiple times with user_project set to true" do
     mock = Minitest::Mock.new
     mock.expect :rewrite_object, undone_rewrite("notyetcomplete"),
-      [bucket.name, file_user_project.name, bucket.name, "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: "test", options: {}]
+      rewrite_object_args(bucket.name, file_user_project.name, bucket.name, "new-file.ext", rewrite_token: nil, user_project: "test")
     mock.expect :rewrite_object, undone_rewrite("keeptrying"),
-      [bucket.name, file_user_project.name, bucket.name, "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "notyetcomplete", user_project: "test", options: {}]
+      rewrite_object_args(bucket.name, file_user_project.name, bucket.name, "new-file.ext", rewrite_token: "notyetcomplete", user_project: "test")
     mock.expect :rewrite_object, undone_rewrite("almostthere"),
-      [bucket.name, file_user_project.name, bucket.name, "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "keeptrying", user_project: "test", options: {}]
+      rewrite_object_args(bucket.name, file_user_project.name, bucket.name, "new-file.ext", rewrite_token: "keeptrying", user_project: "test")
     mock.expect :rewrite_object, rewrite_response,
-      [bucket.name, file_user_project.name, bucket.name, "new-file.ext", nil, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "almostthere", user_project: "test", options: {}]
+      rewrite_object_args(bucket.name, file_user_project.name, bucket.name, "new-file.ext", rewrite_token: "almostthere", user_project: "test")
 
     file_user_project.service.mocked_service = mock
 
@@ -674,7 +674,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
     update_file_gapi.storage_class = "NEARLINE"
 
     mock.expect :rewrite_object, rewrite_response,
-                [bucket_name, file_name, bucket_name, "new-file.ext", update_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
+      rewrite_object_args(bucket.name, file.name, bucket.name, "new-file.ext", update_file_gapi)
 
     file.service.mocked_service = mock
 
@@ -704,7 +704,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
     update_file_gapi.storage_class = "NEARLINE"
 
     mock.expect :rewrite_object, rewrite_response,
-                [bucket_name, file_name, bucket_name, "new-file.ext", update_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
+      rewrite_object_args(bucket.name, file.name, bucket.name, "new-file.ext", update_file_gapi)
 
     file.service.mocked_service = mock
 
@@ -734,7 +734,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
     update_file_gapi.storage_class = "NEARLINE"
 
     mock.expect :rewrite_object, rewrite_response,
-      [bucket.name, file_user_project.name, bucket.name, "new-file.ext", update_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: "test", options: {}]
+      rewrite_object_args(bucket.name, file_user_project.name, bucket.name, "new-file.ext", update_file_gapi, rewrite_token: nil, user_project: "test")
 
     file_user_project.service.mocked_service = mock
 
@@ -757,9 +757,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
     mock = Minitest::Mock.new
     options = { header: source_key_headers.merge(key_headers) }
     mock.expect :rewrite_object, rewrite_response,
-                [bucket_name, file_name, bucket_name, file_name, nil,
-                 destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil,
-                 rewrite_token: nil, user_project: nil, options: options ]
+      rewrite_object_args(bucket_name, file_name, bucket_name, file_name, options: options)
 
     file.service.mocked_service = mock
 
@@ -772,10 +770,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
   it "can rotate its customer-supplied encryption keys with user_project set to true" do
     mock = Minitest::Mock.new
     options = { header: source_key_headers.merge(key_headers) }
-    mock.expect :rewrite_object, rewrite_response,
-                [bucket.name, file_user_project.name, bucket.name, file_user_project.name, nil,
-                 destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil,
-                 rewrite_token: nil, user_project: "test", options: options ]
+    mock.expect :rewrite_object, rewrite_response, rewrite_object_args(bucket.name, file_user_project.name, bucket.name, file_user_project.name, user_project: "test", options: options)
 
     file_user_project.service.mocked_service = mock
 
@@ -789,10 +784,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
   it "can rotate to a customer-supplied encryption key if previously unencrypted with customer key" do
     mock = Minitest::Mock.new
     options = { header: key_headers }
-    mock.expect :rewrite_object, rewrite_response,
-                [bucket_name, file_name, bucket_name, file_name, nil,
-                 destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil,
-                 rewrite_token: nil, user_project: nil, options: options ]
+    mock.expect :rewrite_object, rewrite_response, rewrite_object_args(bucket_name, file_name, bucket_name, file_name, options: options)
 
     file.service.mocked_service = mock
 
@@ -805,10 +797,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
   it "can rotate from a customer-supplied encryption key to default service encryption" do
     mock = Minitest::Mock.new
     options = { header: source_key_headers }
-    mock.expect :rewrite_object, rewrite_response,
-                [bucket_name, file_name, bucket_name, file_name, nil,
-                 destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil,
-                 rewrite_token: nil, user_project: nil, options: options ]
+    mock.expect :rewrite_object, rewrite_response, rewrite_object_args(bucket_name, file_name, bucket_name, file_name, options: options)
 
     file.service.mocked_service = mock
 
@@ -821,14 +810,8 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
   it "can rotate its customer-supplied encryption keys with multiple requests for large objects" do
     mock = Minitest::Mock.new
     options = { header: source_key_headers.merge(key_headers) }
-    mock.expect :rewrite_object, undone_rewrite("notyetcomplete"),
-                [bucket_name, file_name, bucket_name, file_name, nil,
-                 destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil,
-                 rewrite_token: nil, user_project: nil, options: options ]
-    mock.expect :rewrite_object, rewrite_response,
-                [bucket_name, file_name, bucket_name, file_name, nil,
-                 destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil,
-                 rewrite_token: "notyetcomplete", user_project: nil, options: options ]
+    mock.expect :rewrite_object, undone_rewrite("notyetcomplete"), rewrite_object_args(bucket_name, file_name, bucket_name, file_name, options: options)
+    mock.expect :rewrite_object, rewrite_response, rewrite_object_args(bucket_name, file_name, bucket_name, file_name, rewrite_token: "notyetcomplete", options: options)
 
     file.service.mocked_service = mock
 
@@ -845,14 +828,8 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
   it "can rotate its customer-supplied encryption keys with multiple requests for large objects with user_project set to true" do
     mock = Minitest::Mock.new
     options = { header: source_key_headers.merge(key_headers) }
-    mock.expect :rewrite_object, undone_rewrite("notyetcomplete"),
-                [bucket.name, file_user_project.name, bucket.name, file_user_project.name, nil,
-                 destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil,
-                 rewrite_token: nil, user_project: "test", options: options ]
-    mock.expect :rewrite_object, rewrite_response,
-                [bucket.name, file_user_project.name, bucket.name, file_user_project.name, nil,
-                 destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil,
-                 rewrite_token: "notyetcomplete", user_project: "test", options: options ]
+    mock.expect :rewrite_object, undone_rewrite("notyetcomplete"), rewrite_object_args(bucket.name, file_user_project.name, bucket.name, file_user_project.name, user_project: "test", options: options)
+    mock.expect :rewrite_object, rewrite_response, rewrite_object_args(bucket.name, file_user_project.name, bucket.name, file_user_project.name, rewrite_token: "notyetcomplete", user_project: "test", options: options)
 
     file_user_project.service.mocked_service = mock
 

--- a/google-cloud-storage/test/google/cloud/storage/lazy/file_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/file_test.rb
@@ -25,6 +25,12 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
   let(:file_name) { "file.ext" }
   let(:file) { Google::Cloud::Storage::File.new_lazy bucket_name, file_name, storage.service }
   let(:file_user_project) { Google::Cloud::Storage::File.new_lazy bucket_name, file_name, storage.service, user_project: true }
+  let(:generation) { 1234567890 }
+  let(:generations) { [1234567894, 1234567893, 1234567892, 1234567891] }
+  let(:file_gapis) do
+    generations.map { |g| Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket.name, file.name, g).to_json) }
+  end
+  let(:metageneration) { 6 }
 
   let(:rewrite_response) do
     rewrite_resource = Google::Apis::StorageV1::Object.from_json random_file_hash(bucket_name, file_name).to_json
@@ -88,7 +94,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
 
   it "can delete itself" do
     mock = Minitest::Mock.new
-    mock.expect :delete_object, nil, [bucket_name, file_name, { generation: nil, user_project: nil }]
+    mock.expect :delete_object, nil, delete_object_args(bucket.name, file.name)
 
     file.service.mocked_service = mock
 
@@ -99,7 +105,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
 
   it "can delete itself with generation set to true" do
     mock = Minitest::Mock.new
-    mock.expect :delete_object, nil, [bucket_name, file_name, { generation: nil, user_project: nil }]
+    mock.expect :delete_object, nil, delete_object_args(bucket.name, file.name)
 
     file.service.mocked_service = mock
 
@@ -111,12 +117,12 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
 
   it "can delete itself when having a generation and with generation set to true" do
     mock = Minitest::Mock.new
-    mock.expect :delete_object, nil, [bucket_name, file_name, { generation: 1234567892, user_project: nil }]
+    mock.expect :delete_object, nil, delete_object_args(bucket.name, file.name, generation: generation)
 
     file.service.mocked_service = mock
 
-    file.gapi.generation = 1234567892
-    _(file.generation).must_equal 1234567892
+    file.gapi.generation = generation
+    _(file.generation).must_equal generation
     file.delete generation: true
 
     mock.verify
@@ -124,18 +130,18 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
 
   it "can delete itself with generation set to a generation" do
     mock = Minitest::Mock.new
-    mock.expect :delete_object, nil, [bucket_name, file_name, { generation: 1234567894, user_project: nil }]
+    mock.expect :delete_object, nil, delete_object_args(bucket.name, file.name, generation: generation)
 
     file.service.mocked_service = mock
 
-    file.delete generation: 1234567894
+    file.delete generation: generation
 
     mock.verify
   end
 
   it "can delete itself with user_project set to true" do
     mock = Minitest::Mock.new
-    mock.expect :delete_object, nil, [bucket.name, file_user_project.name, { generation: nil, user_project: "test" }]
+    mock.expect :delete_object, nil, delete_object_args(bucket.name, file_user_project.name, user_project: "test")
 
     file_user_project.service.mocked_service = mock
 
@@ -146,7 +152,7 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
 
   it "can delete itself with generation set to true and user_project set to true" do
     mock = Minitest::Mock.new
-    mock.expect :delete_object, nil, [bucket_name, file_name, { generation: nil, user_project: "test" }]
+    mock.expect :delete_object, nil, delete_object_args(bucket.name, file_user_project.name, user_project: "test")
 
     file_user_project.service.mocked_service = mock
 
@@ -158,12 +164,12 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
 
   it "can delete itself when having a generation and with generation set to true and user_project set to true" do
     mock = Minitest::Mock.new
-    mock.expect :delete_object, nil, [bucket_name, file_name, { generation: 1234567893, user_project: "test" }]
+    mock.expect :delete_object, nil, delete_object_args(bucket.name, file_user_project.name, generation: generation, user_project: "test")
 
     file_user_project.service.mocked_service = mock
 
-    file_user_project.gapi.generation = 1234567893
-    _(file_user_project.generation).must_equal 1234567893
+    file_user_project.gapi.generation = generation
+    _(file_user_project.generation).must_equal generation
     file_user_project.delete generation: true
 
     mock.verify
@@ -171,11 +177,11 @@ describe Google::Cloud::Storage::File, :lazy, :mock_storage do
 
   it "can delete itself with generation set to a generation and user_project set to true" do
     mock = Minitest::Mock.new
-    mock.expect :delete_object, nil, [bucket_name, file_name, { generation: 1234567894, user_project: "test" }]
+    mock.expect :delete_object, nil, delete_object_args(bucket.name, file_user_project.name, generation: generation, user_project: "test")
 
     file_user_project.service.mocked_service = mock
 
-    file_user_project.delete generation: 1234567894
+    file_user_project.delete generation: generation
 
     mock.verify
   end

--- a/google-cloud-storage/test/google/cloud/storage/lazy/file_update_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/file_update_test.rb
@@ -125,7 +125,7 @@ describe Google::Cloud::Storage::File, :update, :lazy, :mock_storage do
     patched_file_gapi = Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket_name, file_name).to_json)
     patched_file_gapi.storage_class = "DURABLE_REDUCED_AVAILABILITY"
     mock.expect :rewrite_object, done_rewrite(patched_file_gapi),
-      [bucket_name, file_name, bucket_name, file_name, patch_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
+      rewrite_object_args(bucket_name, file_name, bucket_name, file_name, patch_file_gapi)
 
     file.service.mocked_service = mock
 
@@ -142,7 +142,7 @@ describe Google::Cloud::Storage::File, :update, :lazy, :mock_storage do
     patched_file_gapi = Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket_name, file_name).to_json)
     patched_file_gapi.storage_class = "DURABLE_REDUCED_AVAILABILITY"
     mock.expect :rewrite_object, done_rewrite(patched_file_gapi),
-      [bucket_name, file_name, bucket_name, file_user_project.name, patch_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: "test", options: {}]
+      rewrite_object_args(bucket_name, file_name, bucket_name, file_user_project.name, patch_file_gapi, user_project: "test")
 
     file_user_project.service.mocked_service = mock
 
@@ -159,13 +159,13 @@ describe Google::Cloud::Storage::File, :update, :lazy, :mock_storage do
     patched_file_gapi = Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket_name, file_name).to_json)
     patched_file_gapi.storage_class = "DURABLE_REDUCED_AVAILABILITY"
     mock.expect :rewrite_object, undone_rewrite("notyetcomplete"),
-      [bucket_name, file_name, bucket_name, file_name, patch_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
+      rewrite_object_args(bucket_name, file_name, bucket_name, file_name, patch_file_gapi)
     mock.expect :rewrite_object, undone_rewrite("keeptrying"),
-      [bucket_name, file_name, bucket_name, file_name, patch_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "notyetcomplete", user_project: nil, options: {}]
+      rewrite_object_args(bucket_name, file_name, bucket_name, file_name, patch_file_gapi, rewrite_token: "notyetcomplete")
     mock.expect :rewrite_object, undone_rewrite("almostthere"),
-      [bucket_name, file_name, bucket_name, file_name, patch_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "keeptrying", user_project: nil, options: {}]
+      rewrite_object_args(bucket_name, file_name, bucket_name, file_name, patch_file_gapi, rewrite_token: "keeptrying")
     mock.expect :rewrite_object, done_rewrite(patched_file_gapi),
-      [bucket_name, file_name, bucket_name, file_name, patch_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "almostthere", user_project: nil, options: {}]
+      rewrite_object_args(bucket_name, file_name, bucket_name, file_name, patch_file_gapi, rewrite_token: "almostthere")
 
     file.service.mocked_service = mock
 
@@ -186,13 +186,13 @@ describe Google::Cloud::Storage::File, :update, :lazy, :mock_storage do
     patched_file_gapi = Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket_name, file_name).to_json)
     patched_file_gapi.storage_class = "DURABLE_REDUCED_AVAILABILITY"
     mock.expect :rewrite_object, undone_rewrite("notyetcomplete"),
-      [bucket_name, file_user_project.name, bucket_name, file_user_project.name, patch_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: "test", options: {}]
+      rewrite_object_args(bucket_name, file_user_project.name, bucket_name, file_user_project.name, patch_file_gapi, user_project: "test")
     mock.expect :rewrite_object, undone_rewrite("keeptrying"),
-      [bucket_name, file_user_project.name, bucket_name, file_user_project.name, patch_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "notyetcomplete", user_project: "test", options: {}]
+      rewrite_object_args(bucket_name, file_user_project.name, bucket_name, file_user_project.name, patch_file_gapi, rewrite_token: "notyetcomplete", user_project: "test")
     mock.expect :rewrite_object, undone_rewrite("almostthere"),
-      [bucket_name, file_user_project.name, bucket_name, file_user_project.name, patch_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "keeptrying", user_project: "test", options: {}]
+      rewrite_object_args(bucket_name, file_user_project.name, bucket_name, file_user_project.name, patch_file_gapi, rewrite_token: "keeptrying", user_project: "test")
     mock.expect :rewrite_object, done_rewrite(patched_file_gapi),
-      [bucket_name, file_user_project.name, bucket_name, file_user_project.name, patch_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: "almostthere", user_project: "test", options: {}]
+      rewrite_object_args(bucket_name, file_user_project.name, bucket_name, file_user_project.name, patch_file_gapi, rewrite_token: "almostthere", user_project: "test")
 
     file_user_project.service.mocked_service = mock
 
@@ -290,7 +290,7 @@ describe Google::Cloud::Storage::File, :update, :lazy, :mock_storage do
     patched_file_gapi = Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket_name, file_name).to_json)
     patched_file_gapi.storage_class = "NEARLINE"
     mock.expect :rewrite_object, done_rewrite(patched_file_gapi),
-      [bucket_name, file_name, bucket_name, file_name, patch_file_gapi, destination_kms_key_name: nil, destination_predefined_acl: nil, source_generation: nil, rewrite_token: nil, user_project: nil, options: {}]
+      rewrite_object_args(bucket_name, file_name, bucket_name, file_name, patch_file_gapi)
 
     file.service.mocked_service = mock
 

--- a/google-cloud-storage/test/google/cloud/storage/lazy/file_update_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/file_update_test.rb
@@ -25,7 +25,7 @@ describe Google::Cloud::Storage::File, :update, :lazy, :mock_storage do
     mock = Minitest::Mock.new
     patch_file_gapi = Google::Apis::StorageV1::Object.new cache_control: "private, max-age=0, no-cache"
     mock.expect :patch_object, Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket_name, file_name).to_json),
-      [bucket_name, file_name, patch_file_gapi, predefined_acl: nil, user_project: nil]
+      patch_object_args(bucket_name, file_name, patch_file_gapi)
 
     file.service.mocked_service = mock
 
@@ -39,7 +39,7 @@ describe Google::Cloud::Storage::File, :update, :lazy, :mock_storage do
     mock = Minitest::Mock.new
     patch_file_gapi = Google::Apis::StorageV1::Object.new content_disposition: "inline; filename=filename.ext"
     mock.expect :patch_object, Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket_name, file_name).to_json),
-      [bucket_name, file_name, patch_file_gapi, predefined_acl: nil, user_project: nil]
+      patch_object_args(bucket_name, file_name, patch_file_gapi)
 
     file.service.mocked_service = mock
 
@@ -53,7 +53,7 @@ describe Google::Cloud::Storage::File, :update, :lazy, :mock_storage do
     mock = Minitest::Mock.new
     patch_file_gapi = Google::Apis::StorageV1::Object.new content_encoding: "deflate"
     mock.expect :patch_object, Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket_name, file_name).to_json),
-      [bucket_name, file_name, patch_file_gapi, predefined_acl: nil, user_project: nil]
+      patch_object_args(bucket_name, file_name, patch_file_gapi)
 
     file.service.mocked_service = mock
 
@@ -67,7 +67,7 @@ describe Google::Cloud::Storage::File, :update, :lazy, :mock_storage do
     mock = Minitest::Mock.new
     patch_file_gapi = Google::Apis::StorageV1::Object.new content_language: "de"
     mock.expect :patch_object, Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket_name, file_name).to_json),
-      [bucket_name, file_name, patch_file_gapi, predefined_acl: nil, user_project: nil]
+      patch_object_args(bucket_name, file_name, patch_file_gapi)
 
     file.service.mocked_service = mock
 
@@ -81,7 +81,7 @@ describe Google::Cloud::Storage::File, :update, :lazy, :mock_storage do
     mock = Minitest::Mock.new
     patch_file_gapi = Google::Apis::StorageV1::Object.new content_type: "application/json"
     mock.expect :patch_object, Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket_name, file_name).to_json),
-      [bucket_name, file_name, patch_file_gapi, predefined_acl: nil, user_project: nil]
+      patch_object_args(bucket_name, file_name, patch_file_gapi)
 
     file.service.mocked_service = mock
 
@@ -95,7 +95,7 @@ describe Google::Cloud::Storage::File, :update, :lazy, :mock_storage do
     mock = Minitest::Mock.new
     patch_file_gapi = Google::Apis::StorageV1::Object.new custom_time: custom_time
     mock.expect :patch_object, Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket_name, file_name).to_json),
-      [bucket_name, file_name, patch_file_gapi, predefined_acl: nil, user_project: nil]
+      patch_object_args(bucket_name, file_name, patch_file_gapi)
 
     file.service.mocked_service = mock
 
@@ -109,7 +109,7 @@ describe Google::Cloud::Storage::File, :update, :lazy, :mock_storage do
     mock = Minitest::Mock.new
     patch_file_gapi = Google::Apis::StorageV1::Object.new metadata: { "player" => "Bob", score: 10 }
     mock.expect :patch_object, Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket_name, file_name).to_json),
-      [bucket_name, file_name, patch_file_gapi, predefined_acl: nil, user_project: nil]
+      patch_object_args(bucket_name, file_name, patch_file_gapi)
 
     file.service.mocked_service = mock
 
@@ -219,7 +219,7 @@ describe Google::Cloud::Storage::File, :update, :lazy, :mock_storage do
       metadata: { "player" => "Bob", "score" => "10" }
     )
     mock.expect :patch_object, Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket_name, file_name).to_json),
-      [bucket_name, file_name, patch_file_gapi, predefined_acl: nil, user_project: nil]
+      patch_object_args(bucket_name, file_name, patch_file_gapi)
 
     file.service.mocked_service = mock
 
@@ -249,7 +249,7 @@ describe Google::Cloud::Storage::File, :update, :lazy, :mock_storage do
       metadata: { "player" => "Bob", "score" => "10" }
     )
     mock.expect :patch_object, Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket_name, file_name).to_json),
-      [bucket_name, file_user_project.name, patch_file_gapi, predefined_acl: nil, user_project: "test"]
+      patch_object_args(bucket_name, file_user_project.name, patch_file_gapi, user_project: "test")
 
     file_user_project.service.mocked_service = mock
 
@@ -273,7 +273,7 @@ describe Google::Cloud::Storage::File, :update, :lazy, :mock_storage do
       content_language: "de"
     )
     mock.expect :patch_object, Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket_name, file_name).to_json),
-      [bucket_name, file_name, patch_file_gapi, predefined_acl: nil, user_project: nil]
+      patch_object_args(bucket_name, file_name, patch_file_gapi)
 
     file.service.mocked_service = mock
 

--- a/google-cloud-storage/test/google/cloud/storage/project_anonymous_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/project_anonymous_test.rb
@@ -83,8 +83,7 @@ describe Google::Cloud::Storage::Project, :anonymous, :mock_storage do
 
     mock = Minitest::Mock.new
     mock.expect :get_bucket, find_bucket_gapi(bucket_name), [bucket_name, {user_project: nil}]
-    mock.expect :get_object, find_file_gapi(bucket_name, file_name),
-      [bucket_name, file_name, generation: nil, user_project: nil, options: {}]
+    mock.expect :get_object, find_file_gapi(bucket_name, file_name), get_object_args(bucket_name, file_name)
 
     anonymous_storage.service.mocked_service = mock
 
@@ -106,8 +105,7 @@ describe Google::Cloud::Storage::Project, :anonymous, :mock_storage do
 
       mock = Minitest::Mock.new
       mock.expect :get_bucket, find_bucket_gapi(bucket_name), [bucket_name, {user_project: nil}]
-      mock.expect :get_object, find_file_gapi(bucket_name, file_name),
-        [bucket_name, file_name, generation: nil, user_project: nil, options: {}]
+      mock.expect :get_object, find_file_gapi(bucket_name, file_name), get_object_args(bucket_name, file_name)
       mock.expect :get_object_with_response, [tmpfile, download_http_resp],
         [bucket_name, file_name, download_dest: tmpfile, generation: 1234567890, user_project: nil, options: {}]
 

--- a/google-cloud-storage/test/helper.rb
+++ b/google-cloud-storage/test/helper.rb
@@ -317,4 +317,41 @@ class MockStorage < Minitest::Spec
     }
     [source_bucket, source_object, destination_bucket, destination_object, object_object, opts]
   end
+
+  def compose_object_args bucket_name,
+                          file_name,
+                          source_files,
+                          destination_gapi = nil,
+                          destination_predefined_acl: nil,
+                          if_generation_match: nil,
+                          if_metageneration_match: nil,
+                          user_project: nil,
+                          options: {}
+    req = compose_request source_files, destination_gapi
+    opts = {
+      destination_predefined_acl: destination_predefined_acl,
+      if_generation_match: if_generation_match,
+      if_metageneration_match: if_metageneration_match,
+      user_project: user_project,
+      options: options
+    }
+    [bucket_name, file_name, req, opts]
+  end
+
+  def compose_request source_files, destination_gapi
+    source_objects = source_files.map do |file|
+      if file.is_a? String
+        Google::Apis::StorageV1::ComposeRequest::SourceObject.new \
+          name: file
+      else
+        Google::Apis::StorageV1::ComposeRequest::SourceObject.new \
+          name: file.name,
+          generation: file.generation
+      end
+    end
+    Google::Apis::StorageV1::ComposeRequest.new(
+      destination: destination_gapi,
+      source_objects: source_objects
+    )
+  end
 end

--- a/google-cloud-storage/test/helper.rb
+++ b/google-cloud-storage/test/helper.rb
@@ -209,6 +209,37 @@ class MockStorage < Minitest::Spec
     Google::Apis::StorageV1::Policy.new etag: etag, version: version, bindings: bindings
   end
 
+  def insert_object_args bucket_name,
+                      file_gapi,
+                      name: nil,
+                      predefined_acl: nil,
+                      upload_source: nil,
+                      content_encoding: nil,
+                      content_type: "text/plain",
+                      kms_key_name: nil,
+                      if_generation_match: nil,
+                      if_generation_not_match: nil,
+                      if_metageneration_match: nil,
+                      if_metageneration_not_match: nil,
+                      user_project: nil,
+                      options: {}
+    opts = {
+      name: name,
+      predefined_acl: predefined_acl,
+      upload_source: upload_source,
+      content_encoding: content_encoding,
+      content_type: content_type,
+      kms_key_name: kms_key_name,
+      if_generation_match: if_generation_match,
+      if_generation_not_match: if_generation_not_match,
+      if_metageneration_match: if_metageneration_match,
+      if_metageneration_not_match: if_metageneration_not_match,
+      user_project: user_project,
+      options: options
+    }
+    [bucket_name, file_gapi, opts]
+  end
+
   def get_object_args bucket_name,
                       file_name,
                       generation: nil,

--- a/google-cloud-storage/test/helper.rb
+++ b/google-cloud-storage/test/helper.rb
@@ -261,6 +261,29 @@ class MockStorage < Minitest::Spec
     [bucket_name, file_name, opts]
   end
 
+  def patch_object_args bucket_name,
+                        file_name,
+                        file_gapi = nil,
+                        generation: nil,
+                        if_generation_match: nil,
+                        if_generation_not_match: nil,
+                        if_metageneration_match: nil,
+                        if_metageneration_not_match: nil,
+                        predefined_acl: nil,
+                        user_project: nil
+    file_gapi ||= Google::Apis::StorageV1::Object.new(acl: [])
+    opts = {
+      generation: generation,
+      if_generation_match: if_generation_match,
+      if_generation_not_match: if_generation_not_match,
+      if_metageneration_match: if_metageneration_match,
+      if_metageneration_not_match: if_metageneration_not_match,
+      predefined_acl: predefined_acl,
+      user_project: user_project
+    }
+    [bucket_name, file_name, file_gapi, opts]
+  end
+
   def delete_object_args bucket_name,
                          file_name,
                          generation: nil,

--- a/google-cloud-storage/test/helper.rb
+++ b/google-cloud-storage/test/helper.rb
@@ -279,4 +279,42 @@ class MockStorage < Minitest::Spec
     }
     [bucket_name, file_name, opts]
   end
+
+  def rewrite_object_args source_bucket,
+                          source_object,
+                          destination_bucket,
+                          destination_object,
+                          object_object = nil,
+                          destination_kms_key_name: nil,
+                          destination_predefined_acl: nil,
+                          if_generation_match: nil,
+                          if_generation_not_match: nil,
+                          if_metageneration_match: nil,
+                          if_metageneration_not_match: nil,
+                          if_source_generation_match: nil,
+                          if_source_generation_not_match: nil,
+                          if_source_metageneration_match: nil,
+                          if_source_metageneration_not_match: nil,
+                          source_generation: nil,
+                          rewrite_token: nil,
+                          user_project: nil,
+                          options: {}
+    opts = {
+      destination_kms_key_name: destination_kms_key_name,
+      destination_predefined_acl: destination_predefined_acl,
+      if_generation_match: if_generation_match,
+      if_generation_not_match: if_generation_not_match,
+      if_metageneration_match: if_metageneration_match,
+      if_metageneration_not_match: if_metageneration_not_match,
+      if_source_generation_match: if_source_generation_match,
+      if_source_generation_not_match: if_source_generation_not_match,
+      if_source_metageneration_match: if_source_metageneration_match,
+      if_source_metageneration_not_match: if_source_metageneration_not_match,
+      source_generation: source_generation,
+      rewrite_token: rewrite_token,
+      user_project: user_project,
+      options: options
+    }
+    [source_bucket, source_object, destination_bucket, destination_object, object_object, opts]
+  end
 end

--- a/google-cloud-storage/test/helper.rb
+++ b/google-cloud-storage/test/helper.rb
@@ -208,4 +208,23 @@ class MockStorage < Minitest::Spec
   def policy_gapi etag: "CAE=", version: 1, bindings: []
     Google::Apis::StorageV1::Policy.new etag: etag, version: version, bindings: bindings
   end
+
+  def delete_object_args bucket_name,
+                         file_name,
+                         generation: nil,
+                         if_generation_match: nil,
+                         if_generation_not_match: nil,
+                         if_metageneration_match: nil,
+                         if_metageneration_not_match: nil,
+                         user_project: nil
+    opts = {
+      generation: generation,
+      if_generation_match: if_generation_match,
+      if_generation_not_match: if_generation_not_match,
+      if_metageneration_match: if_metageneration_match,
+      if_metageneration_not_match: if_metageneration_not_match,
+      user_project: user_project
+    }
+    [bucket_name, file_name, opts]
+  end
 end

--- a/google-cloud-storage/test/helper.rb
+++ b/google-cloud-storage/test/helper.rb
@@ -209,6 +209,27 @@ class MockStorage < Minitest::Spec
     Google::Apis::StorageV1::Policy.new etag: etag, version: version, bindings: bindings
   end
 
+  def get_object_args bucket_name,
+                      file_name,
+                      generation: nil,
+                      if_generation_match: nil,
+                      if_generation_not_match: nil,
+                      if_metageneration_match: nil,
+                      if_metageneration_not_match: nil,
+                      user_project: nil,
+                      options: {}
+    opts = {
+      generation: generation,
+      if_generation_match: if_generation_match,
+      if_generation_not_match: if_generation_not_match,
+      if_metageneration_match: if_metageneration_match,
+      if_metageneration_not_match: if_metageneration_not_match,
+      user_project: user_project,
+      options: options
+    }
+    [bucket_name, file_name, opts]
+  end
+
   def delete_object_args bucket_name,
                          file_name,
                          generation: nil,


### PR DESCRIPTION
- [x] Add `if_(meta)generation_match` options to `Bucket#compose`
- [x] Add `if_(meta)generation_(not_)match` options to `Bucket#create_file`
- [x] Add `if_(meta)generation_(not_)match` options to `Bucket#file`
- [x] Add `if_(meta)generation_(not_)match` options to `File#rewrite`
- [x] Add `generation` and `if_(meta)generation_(not_)match` options to `File#update`
- [x] Add `generation` and `if_(meta)generation_(not_)match` options to `File::Acl` predefined_acl methods

closes: #11259