### PR TITLE
chore: fix codeowner issue for spanner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,7 +16,7 @@
 /google-cloud-firestore*/.           @googleapis/yoshi-ruby @googleapis/firestore-dpe
 /google-cloud-language*/.            @googleapis/yoshi-ruby @googleapis/ml-apis
 /google-cloud-pubsub*/.              @googleapis/yoshi-ruby @googleapis/api-pubsub
-/google-cloud-spanner*/.             @googleapis/yoshi-ruby @googleapis/api-spanner-ruby
+/google-cloud-spanner*/              @googleapis/yoshi-ruby @googleapis/api-spanner-ruby
 /google-cloud-speech*/.              @googleapis/yoshi-ruby @googleapis/ml-apis
 /google-cloud-storage/               @googleapis/yoshi-ruby @googleapis/storage-dpe
 /google-cloud-talent*/.              @googleapis/yoshi-ruby @googleapis/ml-apis


### PR DESCRIPTION
Fix an issue that code reviews always require an approval from the yoshi-ruby team instead of any team in the code owners. 