### PR TITLE
Fix broken Ruby 3.0 support for GRPC::ActiveCallWithTrace patch

### DIFF
--- a/google-cloud-trace/lib/google/cloud/trace/patches/active_call_with_trace.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/patches/active_call_with_trace.rb
@@ -27,7 +27,7 @@ module GRPC
     # Override GRPC::ActiveCall#request_response method. Wrap the original
     # method with a trace span that will get submitted with the overall request
     # trace span tree.
-    def request_response *args
+    def request_response *args, **kwargs
       Google::Cloud::Trace.in_span SPAN_NAME do |span|
         if span && !args.empty?
           grpc_request = args[0]

--- a/google-cloud-trace/test/google/cloud/trace/patches/active_call_with_trace_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/patches/active_call_with_trace_test.rb
@@ -27,19 +27,25 @@ class MockActiveCall
     @request_response_count = 0
   end
 
-  def request_response *args
+  def request_response request, metadata: {}
     @request_response_count += 1
     "test-response"
   end
 end
 
 describe GRPC::ActiveCallWithTrace do
-  let (:active_call_with_trace) { MockActiveCall.new }
+  let(:active_call_with_trace) { MockActiveCall.new }
 
   describe "#request_response" do
     it "calls super even if a span is not set" do
       Google::Cloud::Trace.stub :get, nil do
         active_call_with_trace.request_response("test").must_equal "test-response"
+      end
+    end
+
+    it "handles keyword arguments properly" do
+      Google::Cloud::Trace.stub :get, nil do
+        active_call_with_trace.request_response("test", metadata: {foo: "bar"}).must_equal "test-response"
       end
     end
 


### PR DESCRIPTION
In Ruby 3.0 kwargs are explicitly separated from regular arguments and
must be handled accordingly.

https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

closes: #11666

