### PR TITLE
fix(pubsub): Fix Project#schema and #schemas to return full resource

### DIFF
--- a/google-cloud-pubsub/acceptance/pubsub/schema_test.rb
+++ b/google-cloud-pubsub/acceptance/pubsub/schema_test.rb
@@ -60,7 +60,7 @@ describe Google::Cloud::PubSub::Schema, :pubsub do
     _(schema.definition).must_equal definition
 
     # list
-    schemas = pubsub.schemas view: :full
+    schemas = pubsub.schemas
     _(schemas).wont_be :empty?
     schema = schemas.first
     _(schema).must_be_kind_of Google::Cloud::PubSub::Schema
@@ -69,7 +69,7 @@ describe Google::Cloud::PubSub::Schema, :pubsub do
     _(schema.definition).wont_be :nil?
 
     # get
-    schema = pubsub.schema schema_name, view: :full
+    schema = pubsub.schema schema_name
     _(schema).must_be_kind_of Google::Cloud::PubSub::Schema
     _(schema.name).must_equal "projects/#{pubsub.project_id}/schemas/#{schema_name}"
     _(schema.type).must_equal :AVRO
@@ -135,7 +135,7 @@ describe Google::Cloud::PubSub::Schema, :pubsub do
     schema.delete
 
     wait_for_condition description: "schema delete" do
-      schema = pubsub.schema schema_name
+      schema = pubsub.schema schema_name, view: :basic
       schema.nil?
     end
     _(schema).must_be :nil?

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/project.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/project.rb
@@ -443,7 +443,7 @@ module Google
         #   * `BASIC` - Include the `name` and `type` of the schema, but not the `definition`.
         #   * `FULL` - Include all Schema object fields.
         #
-        #   The default value is `BASIC`.
+        #   The default value is `FULL`.
         # @param [String] project If the schema belongs to a project other
         #   than the one currently connected to, the alternate project ID can be
         #   specified here. Not used if a fully-qualified schema name is
@@ -464,7 +464,7 @@ module Google
         #   schema = pubsub.schema "my-schema"
         #   schema.name #=> "projects/my-project/schemas/my-schema"
         #   schema.type #=> :PROTOCOL_BUFFER
-        #   # schema.definition # nil - Use view: :full to load complete resource.
+        #   schema.definition # The schema definition
         #
         # @example Skip the lookup against the service with `skip_lookup`:
         #   require "google/cloud/pubsub"
@@ -478,21 +478,21 @@ module Google
         #   schema.type #=> nil
         #   schema.definition #=> nil
         #
-        # @example Get the schema definition with `view: :full`:
+        # @example Omit the schema definition with `view: :basic`:
         #   require "google/cloud/pubsub"
         #
         #   pubsub = Google::Cloud::PubSub.new
         #
-        #   schema = pubsub.schema "my-schema", view: :full
+        #   schema = pubsub.schema "my-schema", view: :basic
         #   schema.name #=> "projects/my-project/schemas/my-schema"
         #   schema.type #=> :PROTOCOL_BUFFER
-        #   schema.definition # The schema definition
+        #   schema.definition #=> nil
         #
         def schema schema_name, view: nil, project: nil, skip_lookup: nil
           ensure_service!
           options = { project: project }
           return Schema.from_name schema_name, view, service, options if skip_lookup
-          view ||= :BASIC
+          view ||= :FULL
           grpc = service.get_schema schema_name, view, options
           Schema.from_grpc grpc, service
         rescue Google::Cloud::NotFoundError
@@ -551,7 +551,7 @@ module Google
         #     * `BASIC` - Include the `name` and `type` of the schema, but not the `definition`.
         #     * `FULL` - Include all Schema object fields.
         #
-        #   The default value is `BASIC`.
+        #   The default value is `FULL`.
         # @param [String] token A previously-returned page token representing
         #   part of the larger set of results to view.
         # @param [Integer] max Maximum number of schemas to return.
@@ -581,7 +581,7 @@ module Google
         #
         def schemas view: nil, token: nil, max: nil
           ensure_service!
-          view ||= :BASIC
+          view ||= :FULL
           options = { token: token, max: max }
           grpc = service.list_schemas view, options
           Schema::List.from_grpc grpc, service, view, max

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/schema.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/schema.rb
@@ -48,7 +48,7 @@ module Google
           @grpc = grpc
           @service = service
           @exists = nil
-          @view = view || :BASIC
+          @view = view || :FULL
         end
 
         ##
@@ -81,7 +81,7 @@ module Google
         #
         def definition
           return nil if reference?
-          @grpc.definition
+          @grpc.definition if @grpc.definition && !@grpc.definition.empty?
         end
 
         ##
@@ -141,7 +141,7 @@ module Google
         #   * `FULL` - Include all Schema object fields.
         #
         #   Optional. If not provided or `nil`, the last non-nil `view` argument to this method will be used if one has
-        #   been given, othewise `BASIC` will be used.
+        #   been given, othewise `FULL` will be used.
         #
         # @return [Google::Cloud::PubSub::Schema] Returns the reloaded schema.
         #
@@ -153,7 +153,7 @@ module Google
         #
         #   schema.reload!
         #
-        # @example Use the `view` option to load the full resource:
+        # @example Use the `view` option to load the basic or full resource:
         #   require "google/cloud/pubsub"
         #
         #   pubsub = Google::Cloud::PubSub.new
@@ -267,7 +267,7 @@ module Google
         #   require "google/cloud/pubsub"
         #
         #   pubsub = Google::Cloud::PubSub.new
-        #   schema = pubsub.schema "my-schema", view: :full
+        #   schema = pubsub.schema "my-schema"
         #
         #   schema.resource_full? #=> true
         #

--- a/google-cloud-pubsub/support/doctest_helper.rb
+++ b/google-cloud-pubsub/support/doctest_helper.rb
@@ -236,7 +236,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::PubSub::Project#schema" do
     mock_pubsub do |mock_publisher, mock_subscriber, mock_iam, mock_schema|
-      mock_schema.expect :get_schema, schema_resp("my-schema"), [name: schema_path("my-schema"), view: 1]
+      mock_schema.expect :get_schema, schema_resp("my-schema"), [name: schema_path("my-schema"), view: 2]
     end
   end
 
@@ -246,9 +246,9 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
-  doctest.before "Google::Cloud::PubSub::Project#schema@Get the schema definition with `view: :full`:" do
+  doctest.before "Google::Cloud::PubSub::Project#schema@Omit the schema definition with `view: :basic`:" do
     mock_pubsub do |mock_publisher, mock_subscriber, mock_iam, mock_schema|
-      mock_schema.expect :get_schema, schema_resp("my-schema", definition: "the schema definition"), [name: schema_path("my-schema"), view: 2]
+      mock_schema.expect :get_schema, schema_resp("my-schema"), [name: schema_path("my-schema"), view: 1]
     end
   end
 
@@ -346,24 +346,24 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::PubSub::Schema" do
     mock_pubsub do |mock_publisher, mock_subscriber, mock_iam, mock_schema|
-      mock_schema.expect :get_schema, schema_resp("my-schema"), [name: schema_path("my-schema"), view: 1]
+      mock_schema.expect :get_schema, schema_resp("my-schema"), [name: schema_path("my-schema"), view: 2]
     end
   end
 
   doctest.before "Google::Cloud::PubSub::Schema#delete" do
     mock_pubsub do |mock_publisher, mock_subscriber, mock_iam, mock_schema|
-      mock_schema.expect :get_schema, schema_resp("my-schema"), [name: schema_path("my-schema"), view: 1]
+      mock_schema.expect :get_schema, schema_resp("my-schema"), [name: schema_path("my-schema"), view: 2]
       mock_schema.expect :delete_schema, nil, [name: schema_path("my-schema")]
     end
   end
 
   doctest.before "Google::Cloud::PubSub::Schema#reload!" do
     mock_pubsub do |mock_publisher, mock_subscriber, mock_iam, mock_schema|
-      mock_schema.expect :get_schema, schema_resp("my-schema", definition: "the schema definition"), [name: schema_path("my-schema"), view: 1]
+      mock_schema.expect :get_schema, schema_resp("my-schema", definition: "the schema definition"), [name: schema_path("my-schema"), view: 2]
     end
   end
 
-  doctest.before "Google::Cloud::PubSub::Schema#reload!@Use the `view` option to load the full resource:" do
+  doctest.before "Google::Cloud::PubSub::Schema#reload!@Use the `view` option to load the basic or full resource:" do
     mock_pubsub do |mock_publisher, mock_subscriber, mock_iam, mock_schema|
       mock_schema.expect :get_schema, schema_resp("my-schema"), [name: schema_path("my-schema"), view: 1]
       mock_schema.expect :get_schema, schema_resp("my-schema", definition: "the schema definition"), [name: schema_path("my-schema"), view: 2]
@@ -385,7 +385,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::PubSub::Schema#validate_message" do
     mock_pubsub do |mock_publisher, mock_subscriber, mock_iam, mock_schema|
-      mock_schema.expect :get_schema, schema_resp("my-schema"), [name: schema_path("my-schema"), view: 1]
+      mock_schema.expect :get_schema, schema_resp("my-schema"), [name: schema_path("my-schema"), view: 2]
       message_data = { "name" => "Alaska", "post_abbr" => "AK" }.to_json
       mock_schema.expect :validate_message, nil, [parent: project_path, name: schema_path("my-schema"), schema: nil, message: message_data, encoding: "JSON"]
     end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/project/schemas_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/project/schemas_test.rb
@@ -146,7 +146,7 @@ describe Google::Cloud::PubSub::Project, :schemas, :mock_pubsub do
 
     get_res = Google::Cloud::PubSub::V1::Schema.new schema_hash(schema_id, definition: nil)
     mock = Minitest::Mock.new
-    mock.expect :get_schema, get_res, [name: schema_path(schema_id), view: 1]
+    mock.expect :get_schema, get_res, [name: schema_path(schema_id), view: 2]
     pubsub.service.mocked_schemas = mock
 
     schema = pubsub.schema schema_id
@@ -163,7 +163,7 @@ describe Google::Cloud::PubSub::Project, :schemas, :mock_pubsub do
 
     get_res = Google::Cloud::PubSub::V1::Schema.new schema_hash(schema_full_path, definition: nil)
     mock = Minitest::Mock.new
-    mock.expect :get_schema, get_res, [name: schema_path(schema_full_path), view: 1]
+    mock.expect :get_schema, get_res, [name: schema_path(schema_full_path), view: 2]
     pubsub.service.mocked_schemas = mock
 
     schema = pubsub.schema schema_full_path
@@ -178,7 +178,7 @@ describe Google::Cloud::PubSub::Project, :schemas, :mock_pubsub do
 
     get_res = Google::Cloud::PubSub::V1::Schema.new schema_hash(schema_id, definition: nil)
     mock = Minitest::Mock.new
-    mock.expect :get_schema, get_res, [name: schema_path(schema_id), view: 1]
+    mock.expect :get_schema, get_res, [name: schema_path(schema_id), view: 2]
     pubsub.service.mocked_schemas = mock
 
     schema = pubsub.get_schema schema_id
@@ -195,7 +195,7 @@ describe Google::Cloud::PubSub::Project, :schemas, :mock_pubsub do
 
     get_res = Google::Cloud::PubSub::V1::Schema.new schema_hash(schema_id, definition: nil)
     mock = Minitest::Mock.new
-    mock.expect :get_schema, get_res, [name: schema_path(schema_id), view: 1]
+    mock.expect :get_schema, get_res, [name: schema_path(schema_id), view: 2]
     pubsub.service.mocked_schemas = mock
 
     schema = pubsub.find_schema schema_id
@@ -225,10 +225,10 @@ describe Google::Cloud::PubSub::Project, :schemas, :mock_pubsub do
 
     get_res = Google::Cloud::PubSub::V1::Schema.new schema_hash(schema_id)
     mock = Minitest::Mock.new
-    mock.expect :get_schema, get_res, [name: schema_path(schema_id), view: 2]
+    mock.expect :get_schema, get_res, [name: schema_path(schema_id), view: 1]
     pubsub.service.mocked_schemas = mock
 
-    schema = pubsub.schema schema_id, view: :full
+    schema = pubsub.schema schema_id, view: :basic
 
     mock.verify
 
@@ -239,13 +239,14 @@ describe Google::Cloud::PubSub::Project, :schemas, :mock_pubsub do
 
   it "gets a schema with project option" do
     schema_id = "found-schema"
+    other_project_id = "my-other-project"
 
     get_res = Google::Cloud::PubSub::V1::Schema.new schema_hash(schema_id)
     mock = Minitest::Mock.new
-    mock.expect :get_schema, get_res, [name: schema_path(schema_id), view: 2]
+    mock.expect :get_schema, get_res, [name: "projects/#{other_project_id}/schemas/#{schema_id}", view: 2]
     pubsub.service.mocked_schemas = mock
 
-    schema = pubsub.schema schema_id, view: :full
+    schema = pubsub.schema schema_id, project: other_project_id
 
     mock.verify
 
@@ -262,6 +263,29 @@ describe Google::Cloud::PubSub::Project, :schemas, :mock_pubsub do
     _(schema.name).must_equal schema_path(schema_id)
     _(schema).must_be :reference?
     _(schema).wont_be :resource?
+  end
+
+  it "gets a schema with skip_lookup and basic view option, then schema reloads basic view" do
+    schema_id = "found-schema"
+
+    get_res = Google::Cloud::PubSub::V1::Schema.new schema_hash(schema_id, definition: nil)
+    mock = Minitest::Mock.new
+    mock.expect :get_schema, get_res, [name: schema_path(schema_id), view: 1]
+    pubsub.service.mocked_schemas = mock
+
+    schema = pubsub.schema schema_id, skip_lookup: true, view: :basic
+    _(schema.name).must_equal schema_path(schema_id)
+    _(schema).must_be :reference?
+    _(schema).wont_be :resource?
+
+    schema.reload!
+
+    _(schema).wont_be :reference?
+    _(schema).must_be :resource?
+    _(schema).must_be :resource_partial?
+    _(schema).wont_be :resource_full?
+
+    mock.verify
   end
 
   it "gets a schema with skip_lookup and full view option, then schema reloads full view" do
@@ -289,7 +313,7 @@ describe Google::Cloud::PubSub::Project, :schemas, :mock_pubsub do
 
   it "lists schemas" do
     mock = Minitest::Mock.new
-    mock.expect :list_schemas, schemas_with_token, [parent: "projects/#{project}", view: 1, page_size: nil, page_token: nil]
+    mock.expect :list_schemas, schemas_with_token, [parent: "projects/#{project}", view: 2, page_size: nil, page_token: nil]
     pubsub.service.mocked_schemas = mock
 
     schemas = pubsub.schemas
@@ -301,7 +325,7 @@ describe Google::Cloud::PubSub::Project, :schemas, :mock_pubsub do
 
   it "lists schemas with find_schemas alias" do
     mock = Minitest::Mock.new
-    mock.expect :list_schemas, schemas_with_token, [parent: "projects/#{project}", view: 1, page_size: nil, page_token: nil]
+    mock.expect :list_schemas, schemas_with_token, [parent: "projects/#{project}", view: 2, page_size: nil, page_token: nil]
     pubsub.service.mocked_schemas = mock
 
     schemas = pubsub.find_schemas
@@ -313,7 +337,7 @@ describe Google::Cloud::PubSub::Project, :schemas, :mock_pubsub do
 
   it "lists schemas with list_schemas alias" do
     mock = Minitest::Mock.new
-    mock.expect :list_schemas, schemas_with_token, [parent: "projects/#{project}", view: 1, page_size: nil, page_token: nil]
+    mock.expect :list_schemas, schemas_with_token, [parent: "projects/#{project}", view: 2, page_size: nil, page_token: nil]
     pubsub.service.mocked_schemas = mock
 
     schemas = pubsub.list_schemas
@@ -323,10 +347,22 @@ describe Google::Cloud::PubSub::Project, :schemas, :mock_pubsub do
     _(schemas.size).must_equal 3
   end
 
-  it "paginates schemas" do
+  it "lists schemas with view option" do
     mock = Minitest::Mock.new
     mock.expect :list_schemas, schemas_with_token, [parent: "projects/#{project}", view: 1, page_size: nil, page_token: nil]
-    mock.expect :list_schemas, schemas_without_token, [parent: "projects/#{project}", view: 1, page_size: nil, page_token: "next_page_token"]
+    pubsub.service.mocked_schemas = mock
+
+    schemas = pubsub.schemas view: :basic
+
+    mock.verify
+
+    _(schemas.size).must_equal 3
+  end
+
+  it "paginates schemas" do
+    mock = Minitest::Mock.new
+    mock.expect :list_schemas, schemas_with_token, [parent: "projects/#{project}", view: 2, page_size: nil, page_token: nil]
+    mock.expect :list_schemas, schemas_without_token, [parent: "projects/#{project}", view: 2, page_size: nil, page_token: "next_page_token"]
     pubsub.service.mocked_schemas = mock
 
     first_schemas = pubsub.schemas
@@ -345,7 +381,7 @@ describe Google::Cloud::PubSub::Project, :schemas, :mock_pubsub do
 
   it "paginates schemas with max set" do
     mock = Minitest::Mock.new
-    mock.expect :list_schemas, schemas_with_token, [parent: "projects/#{project}", view: 1, page_size: 3, page_token: nil]
+    mock.expect :list_schemas, schemas_with_token, [parent: "projects/#{project}", view: 2, page_size: 3, page_token: nil]
     pubsub.service.mocked_schemas = mock
 
     schemas = pubsub.schemas max: 3
@@ -360,8 +396,8 @@ describe Google::Cloud::PubSub::Project, :schemas, :mock_pubsub do
 
   it "paginates schemas with next? and next" do
     mock = Minitest::Mock.new
-    mock.expect :list_schemas, schemas_with_token, [parent: "projects/#{project}", view: 1, page_size: nil, page_token: nil]
-    mock.expect :list_schemas, schemas_without_token, [parent: "projects/#{project}", view: 1, page_size: nil, page_token: "next_page_token"]
+    mock.expect :list_schemas, schemas_with_token, [parent: "projects/#{project}", view: 2, page_size: nil, page_token: nil]
+    mock.expect :list_schemas, schemas_without_token, [parent: "projects/#{project}", view: 2, page_size: nil, page_token: "next_page_token"]
     pubsub.service.mocked_schemas = mock
 
     first_schemas = pubsub.schemas
@@ -378,8 +414,8 @@ describe Google::Cloud::PubSub::Project, :schemas, :mock_pubsub do
 
   it "paginates schemas with next? and next and max set" do
     mock = Minitest::Mock.new
-    mock.expect :list_schemas, schemas_with_token, [parent: "projects/#{project}", view: 1, page_size: 3, page_token: nil]
-    mock.expect :list_schemas, schemas_without_token, [parent: "projects/#{project}", view: 1, page_size: 3, page_token: "next_page_token"]
+    mock.expect :list_schemas, schemas_with_token, [parent: "projects/#{project}", view: 2, page_size: 3, page_token: nil]
+    mock.expect :list_schemas, schemas_without_token, [parent: "projects/#{project}", view: 2, page_size: 3, page_token: "next_page_token"]
     pubsub.service.mocked_schemas = mock
 
     first_schemas = pubsub.schemas max: 3
@@ -396,8 +432,8 @@ describe Google::Cloud::PubSub::Project, :schemas, :mock_pubsub do
 
   it "paginates schemas with all" do
     mock = Minitest::Mock.new
-    mock.expect :list_schemas, schemas_with_token, [parent: "projects/#{project}", view: 1, page_size: nil, page_token: nil]
-    mock.expect :list_schemas, schemas_without_token, [parent: "projects/#{project}", view: 1, page_size: nil, page_token: "next_page_token"]
+    mock.expect :list_schemas, schemas_with_token, [parent: "projects/#{project}", view: 2, page_size: nil, page_token: nil]
+    mock.expect :list_schemas, schemas_without_token, [parent: "projects/#{project}", view: 2, page_size: nil, page_token: "next_page_token"]
     pubsub.service.mocked_schemas = mock
 
     schemas = pubsub.schemas.all.to_a
@@ -409,8 +445,8 @@ describe Google::Cloud::PubSub::Project, :schemas, :mock_pubsub do
 
   it "paginates schemas with all and max set" do
     mock = Minitest::Mock.new
-    mock.expect :list_schemas, schemas_with_token, [parent: "projects/#{project}", view: 1, page_size: 3, page_token: nil]
-    mock.expect :list_schemas, schemas_without_token, [parent: "projects/#{project}", view: 1, page_size: 3, page_token: "next_page_token"]
+    mock.expect :list_schemas, schemas_with_token, [parent: "projects/#{project}", view: 2, page_size: 3, page_token: nil]
+    mock.expect :list_schemas, schemas_without_token, [parent: "projects/#{project}", view: 2, page_size: 3, page_token: "next_page_token"]
     pubsub.service.mocked_schemas = mock
 
     schemas = pubsub.schemas(max: 3).all.to_a
@@ -422,8 +458,8 @@ describe Google::Cloud::PubSub::Project, :schemas, :mock_pubsub do
 
   it "iterates schemas with all using Enumerator" do
     mock = Minitest::Mock.new
-    mock.expect :list_schemas, schemas_with_token, [parent: "projects/#{project}", view: 1, page_size: nil, page_token: nil]
-    mock.expect :list_schemas, schemas_with_token_2, [parent: "projects/#{project}", view: 1, page_size: nil, page_token: "next_page_token"]
+    mock.expect :list_schemas, schemas_with_token, [parent: "projects/#{project}", view: 2, page_size: nil, page_token: nil]
+    mock.expect :list_schemas, schemas_with_token_2, [parent: "projects/#{project}", view: 2, page_size: nil, page_token: "next_page_token"]
     pubsub.service.mocked_schemas = mock
 
     schemas = pubsub.schemas.all.take(5)
@@ -435,8 +471,8 @@ describe Google::Cloud::PubSub::Project, :schemas, :mock_pubsub do
 
   it "iterates schemas with all and request_limit set" do
     mock = Minitest::Mock.new
-    mock.expect :list_schemas, schemas_with_token, [parent: "projects/#{project}", view: 1, page_size: nil, page_token: nil]
-    mock.expect :list_schemas, schemas_with_token_2, [parent: "projects/#{project}", view: 1, page_size: nil, page_token: "next_page_token"]
+    mock.expect :list_schemas, schemas_with_token, [parent: "projects/#{project}", view: 2, page_size: nil, page_token: nil]
+    mock.expect :list_schemas, schemas_with_token_2, [parent: "projects/#{project}", view: 2, page_size: nil, page_token: "next_page_token"]
     pubsub.service.mocked_schemas = mock
 
     schemas = pubsub.schemas.all(request_limit: 1).to_a
@@ -448,7 +484,7 @@ describe Google::Cloud::PubSub::Project, :schemas, :mock_pubsub do
 
   it "paginates schemas without max set" do
     mock = Minitest::Mock.new
-    mock.expect :list_schemas, schemas_with_token, [parent: "projects/#{project}", view: 1, page_size: nil, page_token: nil]
+    mock.expect :list_schemas, schemas_with_token, [parent: "projects/#{project}", view: 2, page_size: nil, page_token: nil]
     pubsub.service.mocked_schemas = mock
 
     schemas = pubsub.schemas

--- a/google-cloud-pubsub/test/google/cloud/pubsub/schema/partial/schema_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/schema/partial/schema_test.rb
@@ -26,7 +26,7 @@ describe Google::Cloud::PubSub::Schema, :partial, :mock_pubsub do
   it "knows its attributes" do
     _(schema.name).must_equal schema_path(schema_id)
     _(schema.type).must_equal type
-    _(schema.definition).must_equal ""
+    _(schema.definition).must_be :nil?
   end
 
   it "knows its view state" do


### PR DESCRIPTION
* Include schema definition in default return values.
* Fix Schema#definition to return nil instead of empty string when not present.

closes: #11419