### PR TITLE
chore: Fix release-please invocation for the initial gem release

### DIFF
--- a/.toys/release-please.rb
+++ b/.toys/release-please.rb
@@ -47,7 +47,7 @@ def release_please gem_name
     "--bump-minor-pre-major", "--debug"
   ]
   cmd += ["--fork"] if use_fork
-  cmd += ["--last-package-version", version] if version
+  cmd += ["--last-package-version", version] if version && version >= "0.1"
   cmd += ["--token", github_token] if github_token
   log_cmd = cmd.inspect
   log_cmd.sub! github_token, "****" if github_token


### PR DESCRIPTION
The ruby-yoshi releaser for release-please doesn't like being told a last package version that doesn't correspond to an existing tag. In the case of the initial release where there is no tag, just don't pass in a last-package-version at all.

This also requires https://github.com/googleapis/release-please/pull/933