### PR TITLE
chore: Update synth files to include new service versions of workflows, private_ca, and document_ai

### DIFF
--- a/google-cloud-document_ai/synth.py
+++ b/google-cloud-document_ai/synth.py
@@ -29,7 +29,7 @@ library = gapic.ruby_library(
         "ruby-cloud-title": "Document AI",
         "ruby-cloud-description": "Document AI uses machine learning on a single cloud-based platform to automatically classify, extract, and enrich data within your documents to unlock insights.",
         "ruby-cloud-env-prefix": "DOCUMENT_AI",
-        "ruby-cloud-wrapper-of": "v1beta3:0.0",
+        "ruby-cloud-wrapper-of": "v1:0.0;v1beta3:0.0",
         "ruby-cloud-product-url": "https://cloud.google.com/document-ai/",
         "ruby-cloud-api-id": "us-documentai.googleapis.com",
         "ruby-cloud-api-shortname": "documentai",

--- a/google-cloud-security-private_ca/synth.py
+++ b/google-cloud-security-private_ca/synth.py
@@ -30,7 +30,7 @@ library = gapic.ruby_library(
         "ruby-cloud-title": "Certificate Authority Service",
         "ruby-cloud-description": "Certificate Authority Service is a highly available, scalable Google Cloud service that enables you to simplify, automate, and customize the deployment, management, and security of private certificate authorities (CA).",
         "ruby-cloud-env-prefix": "PRIVATE_CA",
-        "ruby-cloud-wrapper-of": "v1beta1:0.0",
+        "ruby-cloud-wrapper-of": "v1:0.0;v1beta1:0.0",
         "ruby-cloud-product-url": "https://cloud.google.com/certificate-authority-service/",
         "ruby-cloud-api-id": "privateca.googleapis.com",
         "ruby-cloud-api-shortname": "privateca",

--- a/google-cloud-workflows/synth.py
+++ b/google-cloud-workflows/synth.py
@@ -30,7 +30,7 @@ library = gapic.ruby_library(
         "ruby-cloud-title": "Workflows",
         "ruby-cloud-description": "Workflows link series of serverless tasks together in an order you define. Combine the power of Google Cloud's APIs, serverless products like Cloud Functions and Cloud Run, and calls to external APIs to create flexible serverless applications. Workflows requires no infrastructure management and scales seamlessly with demand, including scaling down to zero..",
         "ruby-cloud-env-prefix": "WORKFLOWS",
-        "ruby-cloud-wrapper-of": "v1beta:0.0",
+        "ruby-cloud-wrapper-of": "v1:0.0;v1beta:0.0",
         "ruby-cloud-product-url": "https://cloud.google.com/workflows",
         "ruby-cloud-api-id": "workflows.googleapis.com",
         "ruby-cloud-api-shortname": "workflows",


### PR DESCRIPTION
This will cause the next autosynth to update these three wrappers to include (and default to) the GA version of the service. We will release those wrappers as gem version 1.0.