### PR TITLE
chore(trace): Update test syntax to avoid minitest warnings

### DIFF
--- a/google-cloud-trace/Gemfile
+++ b/google-cloud-trace/Gemfile
@@ -9,7 +9,3 @@ gem "google-cloud-trace-v2", path: "../google-cloud-trace-v2"
 gem "stackdriver-core", path: "../stackdriver-core"
 
 gem "rake"
-
-# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
-# See https://github.com/googleapis/google-cloud-ruby/issues/4110
-gem "minitest", "~> 5.11.3"

--- a/google-cloud-trace/google-cloud-trace.gemspec
+++ b/google-cloud-trace/google-cloud-trace.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "google-cloud-trace-v2", "~> 0.0"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"
-  gem.add_development_dependency "minitest", "~> 5.10"
+  gem.add_development_dependency "minitest", "~> 5.14"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"
   gem.add_development_dependency "minitest-focus", "~> 1.1"
   gem.add_development_dependency "minitest-rg", "~> 5.2"

--- a/google-cloud-trace/test/google/cloud/trace/faraday_middleware_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/faraday_middleware_test.rb
@@ -30,10 +30,10 @@ describe Google::Cloud::Trace::FaradayMiddleware do
   describe "#initialize" do
     it "accepts enable_cross_project_tracing as optional params" do
       middleware = Google::Cloud::Trace::FaradayMiddleware.new app
-      middleware.instance_variable_get(:@enable_cross_project_tracing).must_equal(false)
+      _(middleware.instance_variable_get(:@enable_cross_project_tracing)).must_equal false
 
       middleware = Google::Cloud::Trace::FaradayMiddleware.new app, enable_cross_project_tracing: true
-      middleware.instance_variable_get(:@enable_cross_project_tracing).must_equal(true)
+      _(middleware.instance_variable_get(:@enable_cross_project_tracing)).must_equal true
     end
   end
 
@@ -62,9 +62,9 @@ describe Google::Cloud::Trace::FaradayMiddleware do
 
       middleware.send :add_request_labels, span, env
 
-      span.labels[Google::Cloud::Trace::LabelKey::HTTP_METHOD].must_equal "test-method"
-      span.labels[Google::Cloud::Trace::LabelKey::HTTP_URL].must_equal "full-url"
-      span.labels[Google::Cloud::Trace::LabelKey::RPC_REQUEST_SIZE].must_equal "body".bytesize.to_s
+      _(span.labels[Google::Cloud::Trace::LabelKey::HTTP_METHOD]).must_equal "test-method"
+      _(span.labels[Google::Cloud::Trace::LabelKey::HTTP_URL]).must_equal "full-url"
+      _(span.labels[Google::Cloud::Trace::LabelKey::RPC_REQUEST_SIZE]).must_equal "body".bytesize.to_s
     end
 
     it "doesn't set request size if request is sent already" do
@@ -76,7 +76,7 @@ describe Google::Cloud::Trace::FaradayMiddleware do
 
       middleware.send :add_request_labels, span, env
 
-      span.labels[Google::Cloud::Trace::LabelKey::RPC_REQUEST_SIZE].must_be_nil
+      _(span.labels[Google::Cloud::Trace::LabelKey::RPC_REQUEST_SIZE]).must_be_nil
     end
   end
 
@@ -88,8 +88,8 @@ describe Google::Cloud::Trace::FaradayMiddleware do
 
       middleware.send :add_response_labels, span, env
 
-      span.labels[Google::Cloud::Trace::LabelKey::HTTP_STATUS_CODE].must_equal "42"
-      span.labels[Google::Cloud::Trace::LabelKey::RPC_RESPONSE_SIZE].must_equal "body".bytesize.to_s
+      _(span.labels[Google::Cloud::Trace::LabelKey::HTTP_STATUS_CODE]).must_equal "42"
+      _(span.labels[Google::Cloud::Trace::LabelKey::RPC_RESPONSE_SIZE]).must_equal "body".bytesize.to_s
     end
   end
 
@@ -110,7 +110,7 @@ describe Google::Cloud::Trace::FaradayMiddleware do
 
       middleware.send :add_trace_context_header, env
 
-      env[:request_headers]["X-Cloud-Trace-Context"].must_equal trace_context.to_string
+      _(env[:request_headers]["X-Cloud-Trace-Context"]).must_equal trace_context.to_string
     end
   end
 end

--- a/google-cloud-trace/test/google/cloud/trace/label_key_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/label_key_test.rb
@@ -24,7 +24,7 @@ describe Google::Cloud::Trace::LabelKey, :mock_trace do
       Kernel.stub :caller_locations, frames do
         labels = {}
         Google::Cloud::Trace::LabelKey.set_stack_trace labels
-        labels["/stacktrace"].must_equal '{"stack_frame":[' \
+        _(labels["/stacktrace"]).must_equal '{"stack_frame":[' \
           '{"file_name":"/path/to/lib/mylib/stuff.rb",' \
           '"line_number":90,"method_name":"lib_method1"},' \
           '{"file_name":"/path/to/app/myapp.rb",' \
@@ -53,7 +53,7 @@ describe Google::Cloud::Trace::LabelKey, :mock_trace do
         labels = {}
         Google::Cloud::Trace::LabelKey.set_stack_trace labels,
           truncate_stack: truncation_proc, filter_stack: filter_proc
-        labels["/stacktrace"].must_equal '{"stack_frame":[' \
+        _(labels["/stacktrace"]).must_equal '{"stack_frame":[' \
           '{"file_name":"/path/to/app/myapp.rb",' \
           '"line_number":78,"method_name":"app_method1"},' \
           '{"file_name":"/path/to/app/myapp.rb",' \

--- a/google-cloud-trace/test/google/cloud/trace/middleware_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/middleware_test.rb
@@ -115,14 +115,14 @@ describe Google::Cloud::Trace::Middleware, :mock_trace do
   describe ".initialize" do
     it "uses the service object passed in" do
       middleware = Google::Cloud::Trace::Middleware.new base_app, service: "test-service"
-      middleware.instance_variable_get(:@service).must_equal "test-service"
+      _(middleware.instance_variable_get(:@service)).must_equal "test-service"
     end
 
     it "creates a default AsyncReporter if service isn't passed in" do
       Google::Cloud::Trace.configure.project_id = "test"
       Google::Cloud::Trace.stub :new, OpenStruct.new(service: nil) do
         middleware = Google::Cloud::Trace::Middleware.new base_app, credentials: credentials
-        middleware.instance_variable_get(:@service).must_be_kind_of Google::Cloud::Trace::AsyncReporter
+        _(middleware.instance_variable_get(:@service)).must_be_kind_of Google::Cloud::Trace::AsyncReporter
       end
     end
   end
@@ -132,11 +132,11 @@ describe Google::Cloud::Trace::Middleware, :mock_trace do
       env = rack_env sample: true
       tc = base_middleware.get_trace_context env
 
-      tc.trace_id.must_equal my_trace_id
-      tc.span_id.must_equal my_span_id
-      tc.sampled?.must_equal true
-      tc.capture_stack?.must_equal false
-      tc.new?.must_equal false
+      _(tc.trace_id).must_equal my_trace_id
+      _(tc.span_id).must_equal my_span_id
+      _(tc.sampled?).must_equal true
+      _(tc.capture_stack?).must_equal false
+      _(tc.new?).must_equal false
     end
 
     it "makes a new sampling decision" do
@@ -146,11 +146,11 @@ describe Google::Cloud::Trace::Middleware, :mock_trace do
         middleware.get_trace_context env
       end
 
-      tc.trace_id.must_equal my_trace_id
-      tc.span_id.must_equal my_span_id
-      tc.sampled?.must_equal true
-      tc.capture_stack?.must_equal false
-      tc.new?.must_equal false
+      _(tc.trace_id).must_equal my_trace_id
+      _(tc.span_id).must_equal my_span_id
+      _(tc.sampled?).must_equal true
+      _(tc.capture_stack?).must_equal false
+      _(tc.new?).must_equal false
     end
 
     it "honors path blacklist" do
@@ -160,24 +160,24 @@ describe Google::Cloud::Trace::Middleware, :mock_trace do
         middleware.get_trace_context env
       end
 
-      tc.trace_id.must_equal my_trace_id
-      tc.span_id.must_equal my_span_id
-      tc.sampled?.must_equal false
-      tc.capture_stack?.must_equal false
-      tc.new?.must_equal false
+      _(tc.trace_id).must_equal my_trace_id
+      _(tc.span_id).must_equal my_span_id
+      _(tc.sampled?).must_equal false
+      _(tc.capture_stack?).must_equal false
+      _(tc.new?).must_equal false
     end
   end
 
   describe ".get_url" do
     it "returns an URL without a query string" do
       url = base_middleware.get_url rack_env
-      url.must_equal "http://#{hostname}#{my_path}"
+      _(url).must_equal "http://#{hostname}#{my_path}"
     end
 
     it "returns an URL with a query string" do
       env = rack_env.merge({"QUERY_STRING" => "foo=bar"})
       url = base_middleware.get_url env
-      url.must_equal "http://#{hostname}#{my_path}?foo=bar"
+      _(url).must_equal "http://#{hostname}#{my_path}?foo=bar"
     end
   end
 
@@ -200,7 +200,7 @@ describe Google::Cloud::Trace::Middleware, :mock_trace do
       end
 
       mock.verify
-      result[1]["X-Cloud-Trace-Context"].must_equal "#{my_trace_id};o=1"
+      _(result[1]["X-Cloud-Trace-Context"]).must_equal "#{my_trace_id};o=1"
     end
 
     it "provides app access to the trace structure" do
@@ -210,7 +210,7 @@ describe Google::Cloud::Trace::Middleware, :mock_trace do
 
       env = rack_env sample: true, span_id: nil
       myapp = ::Proc.new do |env|
-        Google::Cloud::Trace.get.span_id.must_equal my_span_id
+        _(Google::Cloud::Trace.get.span_id).must_equal my_span_id
         ["200", {}, "Hello, world!\n"]
       end
 

--- a/google-cloud-trace/test/google/cloud/trace/notifications_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/notifications_test.rb
@@ -45,9 +45,9 @@ describe Google::Cloud::Trace::Notifications, :mock_trace do
           end
         end
       end
-      trace.all_spans.size.must_equal 1
+      _(trace.all_spans.size).must_equal 1
       span = trace.root_spans.first
-      span.name.must_equal event_type
+      _(span.name).must_equal event_type
       expected_labels = {
         "/ruby/foo" => "barrr",
         "/ruby/whoops" => "x" * 1021 + "...",
@@ -61,11 +61,12 @@ describe Google::Cloud::Trace::Notifications, :mock_trace do
           '"line_number":1,"method_name":"main"}' \
           ']}'
       }
-      span.labels.must_equal expected_labels
+      _(span.labels).must_equal expected_labels
       # Protobuf expects labels to always be instance_of?(::String)
-      (span.labels.keys + span.labels.values).all? do |k|
+      is_all = (span.labels.keys + span.labels.values).all? do |k|
         k.instance_of?(::String)
-      end.must_equal true
+      end
+      _(is_all).must_equal true
     end
   end
 end

--- a/google-cloud-trace/test/google/cloud/trace/patches/active_call_with_trace_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/patches/active_call_with_trace_test.rb
@@ -39,13 +39,13 @@ describe GRPC::ActiveCallWithTrace do
   describe "#request_response" do
     it "calls super even if a span is not set" do
       Google::Cloud::Trace.stub :get, nil do
-        active_call_with_trace.request_response("test").must_equal "test-response"
+        _(active_call_with_trace.request_response("test")).must_equal "test-response"
       end
     end
 
     it "handles keyword arguments properly" do
       Google::Cloud::Trace.stub :get, nil do
-        active_call_with_trace.request_response("test", metadata: {foo: "bar"}).must_equal "test-response"
+        _(active_call_with_trace.request_response("test", metadata: {foo: "bar"})).must_equal "test-response"
       end
     end
 
@@ -56,10 +56,10 @@ describe GRPC::ActiveCallWithTrace do
       end
 
       Google::Cloud::Trace.stub :get, stubbed_span do
-        active_call_with_trace.request_response("test").must_equal "test-response"
+        _(active_call_with_trace.request_response("test")).must_equal "test-response"
       end
 
-      stubbed_span.labels[Google::Cloud::Trace::LabelKey::RPC_REQUEST_TYPE].must_equal "String"
+      _(stubbed_span.labels[Google::Cloud::Trace::LabelKey::RPC_REQUEST_TYPE]).must_equal "String"
     end
   end
 end

--- a/google-cloud-trace/test/google/cloud/trace/patches/call_with_trace_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/patches/call_with_trace_test.rb
@@ -47,14 +47,14 @@ describe GRPC::Core::CallWithTrace do
         call_with_trace.run_batch
       end
 
-      call_with_trace.run_batch_count.must_equal 1
+      _(call_with_trace.run_batch_count).must_equal 1
     end
 
     it "calls add_request_labels with first message" do
       add_labels_called = false
 
       stubbed_add_labels = ->(_, message, _) do
-        message.must_equal "grpc-test-message"
+        _(message).must_equal "grpc-test-message"
         add_labels_called = true
       end
       stubbed_span = OpenStruct.new(labels: {}, name: GRPC::ActiveCallWithTrace::SPAN_NAME)
@@ -70,7 +70,7 @@ describe GRPC::Core::CallWithTrace do
         end
       end
 
-      add_labels_called.must_equal true
+      _(add_labels_called).must_equal true
     end
 
     it "addes all the labels" do
@@ -84,17 +84,17 @@ describe GRPC::Core::CallWithTrace do
       end
 
       label_keys = Google::Cloud::Trace::LabelKey
-      stubbed_span.labels[label_keys::RPC_REQUEST_SIZE].must_equal "grpc-test-message".bytesize.to_s
-      stubbed_span.labels[label_keys::RPC_HOST].must_equal "test-host.googleapi.com"
-      stubbed_span.labels[label_keys::RPC_RESPONSE_SIZE].must_equal "test-grpc-response-message".bytesize.to_s
-      stubbed_span.labels[label_keys::RPC_STATUS_CODE].must_equal "OK"
+      _(stubbed_span.labels[label_keys::RPC_REQUEST_SIZE]).must_equal "grpc-test-message".bytesize.to_s
+      _(stubbed_span.labels[label_keys::RPC_HOST]).must_equal "test-host.googleapi.com"
+      _(stubbed_span.labels[label_keys::RPC_RESPONSE_SIZE]).must_equal "test-grpc-response-message".bytesize.to_s
+      _(stubbed_span.labels[label_keys::RPC_STATUS_CODE]).must_equal "OK"
     end
   end
 
   describe ".status_code_to_label" do
     it "returns correct label" do
-      GRPC::Core::CallWithTrace.status_code_to_label(0).must_equal "OK"
-      GRPC::Core::CallWithTrace.status_code_to_label(7).must_equal "PERMISSION_DENIED"
+      _(GRPC::Core::CallWithTrace.status_code_to_label(0)).must_equal "OK"
+      _(GRPC::Core::CallWithTrace.status_code_to_label(7)).must_equal "PERMISSION_DENIED"
     end
   end
 end

--- a/google-cloud-trace/test/google/cloud/trace/project_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/project_test.rb
@@ -110,8 +110,8 @@ describe Google::Cloud::Trace::Project, :mock_trace do
   }
 
   it "knows the project identifier" do
-    tracer.must_be_kind_of Google::Cloud::Trace::Project
-    tracer.project.must_equal project
+    _(tracer).must_be_kind_of Google::Cloud::Trace::Project
+    _(tracer.project).must_equal project
   end
 
   it "gets a single trace" do
@@ -122,7 +122,7 @@ describe Google::Cloud::Trace::Project, :mock_trace do
     actual_trace = tracer.get_trace simple_trace_id
 
     mock.verify
-    actual_trace.must_equal simple_trace
+    _(actual_trace).must_equal simple_trace
   end
 
   it "lists traces" do
@@ -141,13 +141,13 @@ describe Google::Cloud::Trace::Project, :mock_trace do
     actual_result = tracer.list_traces range_start, range_end
 
     mock.verify
-    actual_result.must_be_kind_of Google::Cloud::Trace::ResultSet
-    actual_result.project.must_equal project
-    actual_result.next_page_token.must_equal next_page_token
-    actual_result.start_time.must_equal range_start
-    actual_result.end_time.must_equal range_end
-    actual_result.results_pending?.must_equal true
-    actual_result.to_a.must_equal [simple_trace, second_trace]
+    _(actual_result).must_be_kind_of Google::Cloud::Trace::ResultSet
+    _(actual_result.project).must_equal project
+    _(actual_result.next_page_token).must_equal next_page_token
+    _(actual_result.start_time).must_equal range_start
+    _(actual_result.end_time).must_equal range_end
+    _(actual_result.results_pending?).must_equal true
+    _(actual_result.to_a).must_equal [simple_trace, second_trace]
   end
 
   it "patches a trace" do

--- a/google-cloud-trace/test/google/cloud/trace/rails_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/rails_test.rb
@@ -51,13 +51,13 @@ describe Google::Cloud::Trace::Railtie do
         Google::Cloud::Trace::Railtie.send :consolidate_rails_config, rails_config
 
         Google::Cloud::Trace.configure do |config|
-          config.project_id.must_equal "test-project"
-          config.credentials.must_equal "test/keyfile"
-          config.capture_stack.must_equal true
-          config.notifications.must_equal ["foo", "boo"]
-          config.max_data_length.must_equal 123
-          config.sampler.must_equal "test-sampler"
-          config.span_id_generator.must_equal a_test_generator
+          _(config.project_id).must_equal "test-project"
+          _(config.credentials).must_equal "test/keyfile"
+          _(config.capture_stack).must_equal true
+          _(config.notifications).must_equal ["foo", "boo"]
+          _(config.max_data_length).must_equal 123
+          _(config.sampler).must_equal "test-sampler"
+          _(config.span_id_generator).must_equal a_test_generator
         end
       end
     end
@@ -77,13 +77,13 @@ describe Google::Cloud::Trace::Railtie do
         Google::Cloud::Trace::Railtie.send :consolidate_rails_config, rails_config
 
         Google::Cloud::Trace.configure do |config|
-          config.project_id.must_equal "another-test-project"
-          config.credentials.must_equal "/another/test/keyfile"
-          config.capture_stack.must_equal false
-          config.notifications.must_equal ["blah"]
-          config.max_data_length.must_equal 345
-          config.sampler.must_equal "another-test-sampler"
-          config.span_id_generator.must_equal another_generator
+          _(config.project_id).must_equal "another-test-project"
+          _(config.credentials).must_equal "/another/test/keyfile"
+          _(config.capture_stack).must_equal false
+          _(config.notifications).must_equal ["blah"]
+          _(config.max_data_length).must_equal 345
+          _(config.sampler).must_equal "another-test-sampler"
+          _(config.span_id_generator).must_equal another_generator
         end
       end
     end
@@ -93,16 +93,16 @@ describe Google::Cloud::Trace::Railtie do
 
       Google::Cloud::Trace::Railtie.stub :valid_credentials?, false do
         Google::Cloud::Trace::Railtie.send :consolidate_rails_config, rails_config
-        Google::Cloud.configure.use_trace.must_equal false
+        _(Google::Cloud.configure.use_trace).must_equal false
       end
     end
 
     it "Set use_trace to true if Rails is in production" do
       Google::Cloud::Trace::Railtie.stub :valid_credentials?, true do
         Rails.env.stub :production?, true do
-          Google::Cloud.configure.use_trace.must_be_nil
+          _(Google::Cloud.configure.use_trace).must_be_nil
           Google::Cloud::Trace::Railtie.send :consolidate_rails_config, rails_config
-          Google::Cloud.configure.use_trace.must_equal true
+          _(Google::Cloud.configure.use_trace).must_equal true
         end
       end
     end
@@ -113,7 +113,7 @@ describe Google::Cloud::Trace::Railtie do
       Google::Cloud::Trace::Railtie.stub :valid_credentials?, true do
         Rails.env.stub :production?, false do
           Google::Cloud::Trace::Railtie.send :consolidate_rails_config, rails_config
-          Google::Cloud.configure.use_trace.must_equal true
+          _(Google::Cloud.configure.use_trace).must_equal true
         end
       end
     end
@@ -139,13 +139,13 @@ describe Google::Cloud::Trace::Railtie do
         Google::Cloud::Trace::Railtie.send :consolidate_rails_config, rails_config
 
         Google::Cloud::Trace.configure do |config|
-          config.project_id.must_equal "test-project"
-          config.credentials.must_equal "test/keyfile"
-          config.capture_stack.must_equal true
-          config.notifications.must_equal ["foo", "boo"]
-          config.max_data_length.must_equal 123
-          config.sampler.must_equal "test-sampler"
-          config.span_id_generator.must_equal a_test_generator
+          _(config.project_id).must_equal "test-project"
+          _(config.credentials).must_equal "test/keyfile"
+          _(config.capture_stack).must_equal true
+          _(config.notifications).must_equal ["foo", "boo"]
+          _(config.max_data_length).must_equal 123
+          _(config.sampler).must_equal "test-sampler"
+          _(config.span_id_generator).must_equal a_test_generator
         end
       end
     end
@@ -165,13 +165,13 @@ describe Google::Cloud::Trace::Railtie do
         Google::Cloud::Trace::Railtie.send :consolidate_rails_config, rails_config
 
         Google::Cloud::Trace.configure do |config|
-          config.project_id.must_equal "another-test-project"
-          config.credentials.must_equal "/another/test/keyfile"
-          config.capture_stack.must_equal false
-          config.notifications.must_equal ["blah"]
-          config.max_data_length.must_equal 345
-          config.sampler.must_equal "another-test-sampler"
-          config.span_id_generator.must_equal another_generator
+          _(config.project_id).must_equal "another-test-project"
+          _(config.credentials).must_equal "/another/test/keyfile"
+          _(config.capture_stack).must_equal false
+          _(config.notifications).must_equal ["blah"]
+          _(config.max_data_length).must_equal 345
+          _(config.sampler).must_equal "another-test-sampler"
+          _(config.span_id_generator).must_equal another_generator
         end
       end
     end
@@ -181,16 +181,16 @@ describe Google::Cloud::Trace::Railtie do
 
       Google::Cloud::Trace::Railtie.stub :valid_credentials?, false do
         Google::Cloud::Trace::Railtie.send :consolidate_rails_config, rails_config
-        Google::Cloud.configure.use_trace.must_equal false
+        _(Google::Cloud.configure.use_trace).must_equal false
       end
     end
 
     it "Set use_trace to true if Rails is in production" do
       Google::Cloud::Trace::Railtie.stub :valid_credentials?, true do
         Rails.env.stub :production?, true do
-          Google::Cloud.configure.use_trace.must_be_nil
+          _(Google::Cloud.configure.use_trace).must_be_nil
           Google::Cloud::Trace::Railtie.send :consolidate_rails_config, rails_config
-          Google::Cloud.configure.use_trace.must_equal true
+          _(Google::Cloud.configure.use_trace).must_equal true
         end
       end
     end
@@ -200,7 +200,7 @@ describe Google::Cloud::Trace::Railtie do
         Rails.env.stub :production?, true do
           Google::Cloud.configure.use_trace = false
           Google::Cloud::Trace::Railtie.send :consolidate_rails_config, rails_config
-          Google::Cloud.configure.use_trace.must_equal false
+          _(Google::Cloud.configure.use_trace).must_equal false
         end
       end
     end
@@ -211,7 +211,7 @@ describe Google::Cloud::Trace::Railtie do
       Google::Cloud::Trace::Railtie.stub :valid_credentials?, true do
         Rails.env.stub :production?, false do
           Google::Cloud::Trace::Railtie.send :consolidate_rails_config, rails_config
-          Google::Cloud.configure.use_trace.must_equal true
+          _(Google::Cloud.configure.use_trace).must_equal true
         end
       end
     end

--- a/google-cloud-trace/test/google/cloud/trace/time_sampler_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/time_sampler_test.rb
@@ -27,52 +27,52 @@ describe Google::Cloud::Trace::TimeSampler do
   describe ".call" do
     it "samples the first time called" do
       sam = Google::Cloud::Trace::TimeSampler.new
-      sam.call(env).must_equal true
+      _(sam.call(env)).must_equal true
     end
 
     it "omits the default blacklisted path" do
       sam = Google::Cloud::Trace::TimeSampler.new
       blacklisted_env = { "PATH_INFO" => "/_ah/health" }
-      sam.call(blacklisted_env).must_equal false
+      _(sam.call(blacklisted_env)).must_equal false
     end
 
     it "doesn't sample when called too soon" do
       sam = sampler
       ::Time.stub :now, start_time - 1 do
-        sam.call(env).must_equal false
+        _(sam.call(env)).must_equal false
       end
     end
 
     it "samples when called after a suitable delay" do
       sam = sampler
       ::Time.stub :now, start_time + 1 do
-        sam.call(env).must_equal true
+        _(sam.call(env)).must_equal true
       end
     end
 
     it "advances last sampling time" do
       sam = sampler
       ::Time.stub :now, start_time + 3 do
-        sam.call(env).must_equal true
+        _(sam.call(env)).must_equal true
       end
       ::Time.stub :now, start_time + 9 do
-        sam.call(env).must_equal false
+        _(sam.call(env)).must_equal false
       end
       ::Time.stub :now, start_time + 11 do
-        sam.call(env).must_equal true
+        _(sam.call(env)).must_equal true
       end
     end
 
     it "advances last sampling time after a large gap" do
       sam = sampler
       ::Time.stub :now, start_time + 30 do
-        sam.call(env).must_equal true
+        _(sam.call(env)).must_equal true
       end
       ::Time.stub :now, start_time + 31 do
-        sam.call(env).must_equal true
+        _(sam.call(env)).must_equal true
       end
       ::Time.stub :now, start_time + 32 do
-        sam.call(env).must_equal false
+        _(sam.call(env)).must_equal false
       end
     end
   end

--- a/google-cloud-trace/test/google/cloud/trace/trace_record_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/trace_record_test.rb
@@ -30,15 +30,15 @@ describe Google::Cloud::Trace::TraceRecord do
                                              sampled: true,
                                              capture_stack: false
     trace = Google::Cloud::Trace::TraceRecord.new project_id, tc
-    trace.trace_context.must_equal tc
-    trace.trace_id.must_equal my_trace_id
+    _(trace.trace_context).must_equal tc
+    _(trace.trace_id).must_equal my_trace_id
   end
 
   it "initializes with no spans" do
     trace = empty_trace
 
-    trace.all_spans.must_be_empty
-    trace.root_spans.must_be_empty
+    _(trace.all_spans).must_be_empty
+    _(trace.root_spans).must_be_empty
   end
 
   it "can create a new populated span" do
@@ -52,35 +52,35 @@ describe Google::Cloud::Trace::TraceRecord do
                              start_time: start_time, end_time: end_time,
                              labels: labels
 
-    span.trace.must_equal trace
-    span.parent.must_be_nil
-    span.kind.must_equal Google::Cloud::Trace::SpanKind::RPC_SERVER
-    span.name.must_equal "aname"
-    span.start_time.must_equal start_time
-    span.end_time.must_equal end_time
-    span.labels.must_equal labels
-    span.children.must_be_empty
-    trace.all_spans.size.must_equal 1
-    trace.all_spans.must_include span
-    trace.root_spans.size.must_equal 1
-    trace.root_spans.must_include span
+    _(span.trace).must_equal trace
+    _(span.parent).must_be_nil
+    _(span.kind).must_equal Google::Cloud::Trace::SpanKind::RPC_SERVER
+    _(span.name).must_equal "aname"
+    _(span.start_time).must_equal start_time
+    _(span.end_time).must_equal end_time
+    _(span.labels).must_equal labels
+    _(span.children).must_be_empty
+    _(trace.all_spans.size).must_equal 1
+    _(trace.all_spans).must_include span
+    _(trace.root_spans.size).must_equal 1
+    _(trace.root_spans).must_include span
   end
 
   it "can create a new empty span" do
     trace = empty_trace
     span = trace.create_span ""
 
-    span.trace.must_equal trace
-    span.parent.must_be_nil
-    span.kind.must_equal Google::Cloud::Trace::SpanKind::UNSPECIFIED
-    span.name.must_be_empty
-    span.start_time.must_be_nil
-    span.end_time.must_be_nil
-    span.labels.must_be_empty
-    trace.all_spans.size.must_equal 1
-    trace.all_spans.must_include span
-    trace.root_spans.size.must_equal 1
-    trace.root_spans.must_include span
+    _(span.trace).must_equal trace
+    _(span.parent).must_be_nil
+    _(span.kind).must_equal Google::Cloud::Trace::SpanKind::UNSPECIFIED
+    _(span.name).must_be_empty
+    _(span.start_time).must_be_nil
+    _(span.end_time).must_be_nil
+    _(span.labels).must_be_empty
+    _(trace.all_spans.size).must_equal 1
+    _(trace.all_spans).must_include span
+    _(trace.root_spans.size).must_equal 1
+    _(trace.root_spans).must_include span
   end
 
   it "can create subspans" do
@@ -90,42 +90,42 @@ describe Google::Cloud::Trace::TraceRecord do
     subspan = span.create_span "bname",
                                kind: Google::Cloud::Trace::SpanKind::RPC_CLIENT
 
-    subspan.trace.must_equal trace
-    subspan.parent.must_equal span
-    subspan.name.must_equal "bname"
-    subspan.kind.must_equal Google::Cloud::Trace::SpanKind::RPC_CLIENT
-    subspan.start_time.must_be_nil
-    subspan.end_time.must_be_nil
-    subspan.labels.must_be_empty
-    trace.all_spans.size.must_equal 2
-    trace.all_spans.must_include span
-    trace.all_spans.must_include subspan
-    trace.root_spans.size.must_equal 1
-    trace.root_spans.must_include span
-    span.children.size.must_equal 1
-    span.children.must_include subspan
+    _(subspan.trace).must_equal trace
+    _(subspan.parent).must_equal span
+    _(subspan.name).must_equal "bname"
+    _(subspan.kind).must_equal Google::Cloud::Trace::SpanKind::RPC_CLIENT
+    _(subspan.start_time).must_be_nil
+    _(subspan.end_time).must_be_nil
+    _(subspan.labels).must_be_empty
+    _(trace.all_spans.size).must_equal 2
+    _(trace.all_spans).must_include span
+    _(trace.all_spans).must_include subspan
+    _(trace.root_spans.size).must_equal 1
+    _(trace.root_spans).must_include span
+    _(span.children.size).must_equal 1
+    _(span.children).must_include subspan
   end
 
   it "can start and finish spans" do
     trace = empty_trace
     span = trace.create_span "aname"
 
-    span.start_time.must_be_nil
-    span.end_time.must_be_nil
+    _(span.start_time).must_be_nil
+    _(span.end_time).must_be_nil
 
     pre_start_time = Time.now.utc
     span.start!
 
-    span.start_time.must_be :>=, pre_start_time
-    span.end_time.must_be_nil
+    _(span.start_time).must_be :>=, pre_start_time
+    _(span.end_time).must_be_nil
 
     between_time = Time.now.utc
     span.finish!
     post_end_time = Time.now.utc
 
-    span.start_time.must_be :<=, between_time
-    span.end_time.must_be :>=, between_time
-    span.end_time.must_be :<=, post_end_time
+    _(span.start_time).must_be :<=, between_time
+    _(span.end_time).must_be :>=, between_time
+    _(span.end_time).must_be :<=, post_end_time
   end
 
   it "can delete spans recursively" do
@@ -135,13 +135,13 @@ describe Google::Cloud::Trace::TraceRecord do
     subsubspan = subspan.create_span "cname"
     subspan.delete
 
-    subspan.exists?.must_equal false
-    subsubspan.exists?.must_equal false
-    span.children.must_be_empty
-    trace.all_spans.size.must_equal 1
-    trace.all_spans.must_include span
-    trace.root_spans.size.must_equal 1
-    trace.root_spans.must_include span
+    _(subspan.exists?).must_equal false
+    _(subsubspan.exists?).must_equal false
+    _(span.children).must_be_empty
+    _(trace.all_spans.size).must_equal 1
+    _(trace.all_spans).must_include span
+    _(trace.root_spans.size).must_equal 1
+    _(trace.root_spans).must_include span
   end
 
   it "can move spans to a new parent" do
@@ -150,15 +150,15 @@ describe Google::Cloud::Trace::TraceRecord do
     span2 = trace.create_span "bname"
     subspan = span1.create_span "cname"
 
-    span1.children.must_include subspan
-    span2.children.must_be_empty
-    subspan.parent.must_equal span1
+    _(span1.children).must_include subspan
+    _(span2.children).must_be_empty
+    _(subspan.parent).must_equal span1
 
     subspan.move_under span2
 
-    span1.children.must_be_empty
-    span2.children.must_include subspan
-    subspan.parent.must_equal span2
+    _(span1.children).must_be_empty
+    _(span2.children).must_include subspan
+    _(subspan.parent).must_equal span2
   end
 
   it "can create span trees using in_span" do
@@ -173,23 +173,23 @@ describe Google::Cloud::Trace::TraceRecord do
     root2 = trace.in_span("dname") { |span| span }
     after_time = Time.now.utc
 
-    trace.all_spans.size.must_equal 4
-    trace.root_spans.size.must_equal 2
+    _(trace.all_spans.size).must_equal 4
+    _(trace.root_spans.size).must_equal 2
 
-    root1.children.size.must_equal 2
-    root1.children.must_include sub1
-    root1.children.must_include sub2
-    root2.children.must_be_empty
+    _(root1.children.size).must_equal 2
+    _(root1.children).must_include sub1
+    _(root1.children).must_include sub2
+    _(root2.children).must_be_empty
 
-    root1.start_time.must_be :>=, before_time
-    sub1.start_time.must_be :>=, root1.start_time
-    sub1.end_time.must_be :>=, sub1.start_time
-    sub2.start_time.must_be :>=, sub1.end_time
-    sub2.end_time.must_be :>=, sub2.start_time
-    root1.end_time.must_be :>=, sub2.end_time
-    root2.start_time.must_be :>=, root1.end_time
-    root2.end_time.must_be :>=, root2.start_time
-    after_time.must_be :>=, root2.end_time
+    _(root1.start_time).must_be :>=, before_time
+    _(sub1.start_time).must_be :>=, root1.start_time
+    _(sub1.end_time).must_be :>=, sub1.start_time
+    _(sub2.start_time).must_be :>=, sub1.end_time
+    _(sub2.end_time).must_be :>=, sub2.start_time
+    _(root1.end_time).must_be :>=, sub2.end_time
+    _(root2.start_time).must_be :>=, root1.end_time
+    _(root2.end_time).must_be :>=, root2.start_time
+    _(after_time).must_be :>=, root2.end_time
   end
 
   it "converts to and from a protobuf" do
@@ -242,8 +242,8 @@ describe Google::Cloud::Trace::TraceRecord do
           labels: sub_labels)
       ]
 
-    trace.to_grpc.must_equal proto
-    Google::Cloud::Trace::TraceRecord.from_grpc(proto).must_equal trace
+    _(trace.to_grpc).must_equal proto
+    _(Google::Cloud::Trace::TraceRecord.from_grpc(proto)).must_equal trace
   end
 
   it "converts to and from a protobuf with an orphaned span" do
@@ -298,7 +298,7 @@ describe Google::Cloud::Trace::TraceRecord do
           labels: sub_labels)
       ]
 
-    trace.to_grpc.must_equal proto
-    Google::Cloud::Trace::TraceRecord.from_grpc(proto).must_equal trace
+    _(trace.to_grpc).must_equal proto
+    _(Google::Cloud::Trace::TraceRecord.from_grpc(proto)).must_equal trace
   end
 end

--- a/google-cloud-trace/test/google/cloud/trace/utils_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/utils_test.rb
@@ -28,29 +28,31 @@ describe Google::Cloud::Trace::Utils do
   }
 
     it "accepts nil" do
-    Google::Cloud::Trace::Utils.time_to_grpc(nil).must_be_nil
+    _(Google::Cloud::Trace::Utils.time_to_grpc(nil)).must_be_nil
   end
 
   it "converts time objects to proto objects" do
-    Google::Cloud::Trace::Utils.time_to_grpc(time_obj).must_equal time_proto
+    _(Google::Cloud::Trace::Utils.time_to_grpc(time_obj)).must_equal time_proto
   end
 
   it "converts float objects to proto objects" do
     # Float math is imprecise, so we're faking a sorta-equal
     result = Google::Cloud::Trace::Utils.time_to_grpc(time_float)
-    result.seconds.must_equal secs
-    result.nanos.must_be_close_to nsecs, 1000
+    _(result.seconds).must_equal secs
+    _(result.nanos).must_be_close_to nsecs, 1000
   end
 
   it "converts int objects to proto objects" do
-    Google::Cloud::Trace::Utils.time_to_grpc(secs).must_equal Google::Protobuf::Timestamp.new seconds: secs
+    _(Google::Cloud::Trace::Utils.time_to_grpc(secs)).must_equal Google::Protobuf::Timestamp.new seconds: secs
   end
 
   it "raises when called with a string" do
-    proc { Google::Cloud::Trace::Utils.time_to_grpc("test")}.must_raise ArgumentError
+    assert_raises ArgumentError do
+      Google::Cloud::Trace::Utils.time_to_grpc("test")
+    end
   end
 
   it "converts proto objects to time objects" do
-    Google::Cloud::Trace::Utils.grpc_to_time(time_proto).must_equal time_obj
+    _(Google::Cloud::Trace::Utils.grpc_to_time(time_proto)).must_equal time_obj
   end
 end

--- a/google-cloud-trace/test/google/cloud/trace_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace_test.rb
@@ -26,48 +26,48 @@ describe Google::Cloud do
     it "calls out to Google::Cloud.trace" do
       gcloud = Google::Cloud.new
       stubbed_trace = ->(project, keyfile, opts = {}) {
-        project.must_be :nil?
-        keyfile.must_be :nil?
-        opts[:scope].must_be :nil?
-        opts[:timeout].must_be :nil?
-        opts[:host].must_be :nil?
+        _(project).must_be :nil?
+        _(keyfile).must_be :nil?
+        _(opts[:scope]).must_be :nil?
+        _(opts[:timeout]).must_be :nil?
+        _(opts[:host]).must_be :nil?
         "trace-project-object-empty"
       }
       Google::Cloud.stub :trace, stubbed_trace do
         project = gcloud.trace
-        project.must_equal "trace-project-object-empty"
+        _(project).must_equal "trace-project-object-empty"
       end
     end
 
     it "passes project and keyfile to Google::Cloud.trace" do
       gcloud = Google::Cloud.new "project-id", "keyfile-path"
       stubbed_trace = ->(project, keyfile, opts = {}) {
-        project.must_equal "project-id"
-        keyfile.must_equal "keyfile-path"
-        opts[:scope].must_be :nil?
-        opts[:timeout].must_be :nil?
-        opts[:host].must_be :nil?
+        _(project).must_equal "project-id"
+        _(keyfile).must_equal "keyfile-path"
+        _(opts[:scope]).must_be :nil?
+        _(opts[:timeout]).must_be :nil?
+        _(opts[:host]).must_be :nil?
         "trace-project-object"
       }
       Google::Cloud.stub :trace, stubbed_trace do
         project = gcloud.trace
-        project.must_equal "trace-project-object"
+        _(project).must_equal "trace-project-object"
       end
     end
 
     it "passes project and keyfile and options to Google::Cloud.trace" do
       gcloud = Google::Cloud.new "project-id", "keyfile-path"
       stubbed_trace = ->(project, keyfile, opts = {}) {
-        project.must_equal "project-id"
-        keyfile.must_equal "keyfile-path"
-        opts[:scope].must_equal "http://example.com/scope"
-        opts[:timeout].must_equal 60
-        opts[:host].must_be :nil?
+        _(project).must_equal "project-id"
+        _(keyfile).must_equal "keyfile-path"
+        _(opts[:scope]).must_equal "http://example.com/scope"
+        _(opts[:timeout]).must_equal 60
+        _(opts[:host]).must_be :nil?
         "trace-project-object-scoped"
       }
       Google::Cloud.stub :trace, stubbed_trace do
         project = gcloud.trace scope: "http://example.com/scope", timeout: 60
-        project.must_equal "trace-project-object-scoped"
+        _(project).must_equal "trace-project-object-scoped"
       end
     end
   end
@@ -89,9 +89,9 @@ describe Google::Cloud do
         Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
           Google::Cloud::Trace::Credentials.stub :default, default_credentials do
             trace = Google::Cloud.trace
-            trace.must_be_kind_of Google::Cloud::Trace::Project
-            trace.project.must_equal "project-id"
-            trace.service.credentials.must_equal default_credentials
+            _(trace).must_be_kind_of Google::Cloud::Trace::Project
+            _(trace.project).must_equal "project-id"
+            _(trace.service.credentials).must_equal default_credentials
           end
         end
       end
@@ -99,15 +99,15 @@ describe Google::Cloud do
 
     it "uses provided project_id and keyfile" do
       stubbed_credentials = ->(keyfile, opts = {}) {
-        keyfile.must_equal "path/to/keyfile.json"
-        opts[:scope].must_equal default_scopes
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(opts[:scope]).must_equal default_scopes
         "trace-credentials"
       }
       stubbed_service = ->(project, credentials, opts = {}) {
-        project.must_equal "project-id"
-        credentials.must_equal "trace-credentials"
-        opts[:timeout].must_be :nil?
-        opts[:host].must_equal default_endpoint
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "trace-credentials"
+        _(opts[:timeout]).must_be :nil?
+        _(opts[:host]).must_equal default_endpoint
         OpenStruct.new project: project
       }
 
@@ -118,9 +118,9 @@ describe Google::Cloud do
             Google::Cloud::Trace::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Trace::Service.stub :new, stubbed_service do
                 trace = Google::Cloud.trace "project-id", "path/to/keyfile.json"
-                trace.must_be_kind_of Google::Cloud::Trace::Project
-                trace.project.must_equal "project-id"
-                trace.service.must_be_kind_of OpenStruct
+                _(trace).must_be_kind_of Google::Cloud::Trace::Project
+                _(trace.project).must_equal "project-id"
+                _(trace.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -146,9 +146,9 @@ describe Google::Cloud do
         Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
           Google::Cloud::Trace::Credentials.stub :default, default_credentials do
             trace = Google::Cloud::Trace.new
-            trace.must_be_kind_of Google::Cloud::Trace::Project
-            trace.project.must_equal "project-id"
-            trace.service.credentials.must_equal default_credentials
+            _(trace).must_be_kind_of Google::Cloud::Trace::Project
+            _(trace.project).must_equal "project-id"
+            _(trace.service.credentials).must_equal default_credentials
           end
         end
       end
@@ -156,15 +156,15 @@ describe Google::Cloud do
 
     it "uses provided project_id and credentials" do
       stubbed_credentials = ->(keyfile, opts = {}) {
-        keyfile.must_equal "path/to/keyfile.json"
-        opts[:scope].must_equal default_scopes
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(opts[:scope]).must_equal default_scopes
         "trace-credentials"
       }
       stubbed_service = ->(project, credentials, opts = {}) {
-        project.must_equal "project-id"
-        credentials.must_equal "trace-credentials"
-        opts[:timeout].must_be :nil?
-        opts[:host].must_equal default_endpoint
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "trace-credentials"
+        _(opts[:timeout]).must_be :nil?
+        _(opts[:host]).must_equal default_endpoint
         OpenStruct.new project: project
       }
 
@@ -175,9 +175,9 @@ describe Google::Cloud do
             Google::Cloud::Trace::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Trace::Service.stub :new, stubbed_service do
                 trace = Google::Cloud::Trace.new project_id: "project-id", credentials: "path/to/keyfile.json"
-                trace.must_be_kind_of Google::Cloud::Trace::Project
-                trace.project.must_equal "project-id"
-                trace.service.must_be_kind_of OpenStruct
+                _(trace).must_be_kind_of Google::Cloud::Trace::Project
+                _(trace.project).must_equal "project-id"
+                _(trace.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -188,10 +188,10 @@ describe Google::Cloud do
     it "uses provided endpoint" do
       endpoint = "trace-endpoint2.example.com"
       stubbed_service = ->(project, credentials, opts = {}) {
-        project.must_equal "project-id"
-        credentials.must_equal default_credentials
-        opts[:timeout].must_be :nil?
-        opts[:host].must_equal endpoint
+        _(project).must_equal "project-id"
+        _(credentials).must_equal default_credentials
+        _(opts[:timeout]).must_be :nil?
+        _(opts[:host]).must_equal endpoint
         OpenStruct.new project: project
       }
 
@@ -199,24 +199,24 @@ describe Google::Cloud do
       ENV.stub :[], nil do
         Google::Cloud::Trace::Service.stub :new, stubbed_service do
           trace = Google::Cloud::Trace.new project: "project-id", credentials: default_credentials, endpoint: endpoint
-          trace.must_be_kind_of Google::Cloud::Trace::Project
-          trace.project.must_equal "project-id"
-          trace.service.must_be_kind_of OpenStruct
+          _(trace).must_be_kind_of Google::Cloud::Trace::Project
+          _(trace.project).must_equal "project-id"
+          _(trace.service).must_be_kind_of OpenStruct
         end
       end
     end
 
     it "uses provided project and keyfile aliases" do
       stubbed_credentials = ->(keyfile, opts = {}) {
-        keyfile.must_equal "path/to/keyfile.json"
-        opts[:scope].must_equal default_scopes
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(opts[:scope]).must_equal default_scopes
         "trace-credentials"
       }
       stubbed_service = ->(project, credentials, opts = {}) {
-        project.must_equal "project-id"
-        credentials.must_equal "trace-credentials"
-        opts[:timeout].must_be :nil?
-        opts[:host].must_equal default_endpoint
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "trace-credentials"
+        _(opts[:timeout]).must_be :nil?
+        _(opts[:host]).must_equal default_endpoint
         OpenStruct.new project: project
       }
 
@@ -227,9 +227,9 @@ describe Google::Cloud do
             Google::Cloud::Trace::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Trace::Service.stub :new, stubbed_service do
                 trace = Google::Cloud::Trace.new project: "project-id", keyfile: "path/to/keyfile.json"
-                trace.must_be_kind_of Google::Cloud::Trace::Project
-                trace.project.must_equal "project-id"
-                trace.service.must_be_kind_of OpenStruct
+                _(trace).must_be_kind_of Google::Cloud::Trace::Project
+                _(trace.project).must_equal "project-id"
+                _(trace.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -239,16 +239,16 @@ describe Google::Cloud do
 
     it "gets project_id from credentials" do
       stubbed_credentials = ->(keyfile, opts = {}) {
-        keyfile.must_equal "path/to/keyfile.json"
-        opts[:scope].must_equal default_scopes
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(opts[:scope]).must_equal default_scopes
         OpenStruct.new project_id: "project-id"
       }
       stubbed_service = ->(project, credentials, opts = {}) {
-        project.must_equal "project-id"
-        credentials.must_be_kind_of OpenStruct
-        credentials.project_id.must_equal "project-id"
-        opts[:timeout].must_be :nil?
-        opts[:host].must_equal default_endpoint
+        _(project).must_equal "project-id"
+        _(credentials).must_be_kind_of OpenStruct
+        _(credentials.project_id).must_equal "project-id"
+        _(opts[:timeout]).must_be :nil?
+        _(opts[:host]).must_equal default_endpoint
         OpenStruct.new project: project
       }
       empty_env = OpenStruct.new
@@ -261,9 +261,9 @@ describe Google::Cloud do
               Google::Cloud::Trace::Credentials.stub :new, stubbed_credentials do
                 Google::Cloud::Trace::Service.stub :new, stubbed_service do
                   trace = Google::Cloud::Trace.new credentials: "path/to/keyfile.json"
-                  trace.must_be_kind_of Google::Cloud::Trace::Project
-                  trace.project.must_equal "project-id"
-                  trace.service.must_be_kind_of OpenStruct
+                  _(trace).must_be_kind_of Google::Cloud::Trace::Project
+                  _(trace.project).must_equal "project-id"
+                  _(trace.service).must_be_kind_of OpenStruct
                 end
               end
             end
@@ -282,15 +282,15 @@ describe Google::Cloud do
 
     it "uses shared config for project and keyfile" do
       stubbed_credentials = ->(keyfile, opts = {}) {
-        keyfile.must_equal "path/to/keyfile.json"
-        opts[:scope].must_equal default_scopes
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(opts[:scope]).must_equal default_scopes
         "trace-credentials"
       }
       stubbed_service = ->(project, credentials, opts = {}) {
-        project.must_equal "project-id"
-        credentials.must_equal "trace-credentials"
-        opts[:timeout].must_be :nil?
-        opts[:host].must_equal default_endpoint
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "trace-credentials"
+        _(opts[:timeout]).must_be :nil?
+        _(opts[:host]).must_equal default_endpoint
         OpenStruct.new project: project
       }
 
@@ -307,9 +307,9 @@ describe Google::Cloud do
             Google::Cloud::Trace::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Trace::Service.stub :new, stubbed_service do
                 trace = Google::Cloud::Trace.new
-                trace.must_be_kind_of Google::Cloud::Trace::Project
-                trace.project.must_equal "project-id"
-                trace.service.must_be_kind_of OpenStruct
+                _(trace).must_be_kind_of Google::Cloud::Trace::Project
+                _(trace.project).must_equal "project-id"
+                _(trace.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -319,15 +319,15 @@ describe Google::Cloud do
 
     it "uses shared config for project_id and credentials" do
       stubbed_credentials = ->(keyfile, opts = {}) {
-        keyfile.must_equal "path/to/keyfile.json"
-        opts[:scope].must_equal default_scopes
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(opts[:scope]).must_equal default_scopes
         "trace-credentials"
       }
       stubbed_service = ->(project, credentials, opts = {}) {
-        project.must_equal "project-id"
-        credentials.must_equal "trace-credentials"
-        opts[:timeout].must_be :nil?
-        opts[:host].must_equal default_endpoint
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "trace-credentials"
+        _(opts[:timeout]).must_be :nil?
+        _(opts[:host]).must_equal default_endpoint
         OpenStruct.new project: project
       }
 
@@ -344,9 +344,9 @@ describe Google::Cloud do
             Google::Cloud::Trace::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Trace::Service.stub :new, stubbed_service do
                 trace = Google::Cloud::Trace.new
-                trace.must_be_kind_of Google::Cloud::Trace::Project
-                trace.project.must_equal "project-id"
-                trace.service.must_be_kind_of OpenStruct
+                _(trace).must_be_kind_of Google::Cloud::Trace::Project
+                _(trace.project).must_equal "project-id"
+                _(trace.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -356,15 +356,15 @@ describe Google::Cloud do
 
     it "uses trace config for project and keyfile" do
       stubbed_credentials = ->(keyfile, opts = {}) {
-        keyfile.must_equal "path/to/keyfile.json"
-        opts[:scope].must_equal default_scopes
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(opts[:scope]).must_equal default_scopes
         "trace-credentials"
       }
       stubbed_service = ->(project, credentials, opts = {}) {
-        project.must_equal "project-id"
-        credentials.must_equal "trace-credentials"
-        opts[:timeout].must_equal 42
-        opts[:host].must_equal default_endpoint
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "trace-credentials"
+        _(opts[:timeout]).must_equal 42
+        _(opts[:host]).must_equal default_endpoint
         OpenStruct.new project: project
       }
 
@@ -382,9 +382,9 @@ describe Google::Cloud do
             Google::Cloud::Trace::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Trace::Service.stub :new, stubbed_service do
                 trace = Google::Cloud::Trace.new
-                trace.must_be_kind_of Google::Cloud::Trace::Project
-                trace.project.must_equal "project-id"
-                trace.service.must_be_kind_of OpenStruct
+                _(trace).must_be_kind_of Google::Cloud::Trace::Project
+                _(trace.project).must_equal "project-id"
+                _(trace.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -394,15 +394,15 @@ describe Google::Cloud do
 
     it "uses trace config for project_id and credentials" do
       stubbed_credentials = ->(keyfile, opts = {}) {
-        keyfile.must_equal "path/to/keyfile.json"
-        opts[:scope].must_equal default_scopes
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(opts[:scope]).must_equal default_scopes
         "trace-credentials"
       }
       stubbed_service = ->(project, credentials, opts = {}) {
-        project.must_equal "project-id"
-        credentials.must_equal "trace-credentials"
-        opts[:timeout].must_equal 42
-        opts[:host].must_equal default_endpoint
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "trace-credentials"
+        _(opts[:timeout]).must_equal 42
+        _(opts[:host]).must_equal default_endpoint
         OpenStruct.new project: project
       }
 
@@ -420,9 +420,9 @@ describe Google::Cloud do
             Google::Cloud::Trace::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Trace::Service.stub :new, stubbed_service do
                 trace = Google::Cloud::Trace.new
-                trace.must_be_kind_of Google::Cloud::Trace::Project
-                trace.project.must_equal "project-id"
-                trace.service.must_be_kind_of OpenStruct
+                _(trace).must_be_kind_of Google::Cloud::Trace::Project
+                _(trace.project).must_equal "project-id"
+                _(trace.service).must_be_kind_of OpenStruct
               end
             end
           end
@@ -433,15 +433,15 @@ describe Google::Cloud do
     it "uses trace config for endpoint" do
       endpoint = "trace-endpoint2.example.com"
       stubbed_credentials = ->(keyfile, opts = {}) {
-        keyfile.must_equal "path/to/keyfile.json"
-        opts[:scope].must_equal default_scopes
+        _(keyfile).must_equal "path/to/keyfile.json"
+        _(opts[:scope]).must_equal default_scopes
         "trace-credentials"
       }
       stubbed_service = ->(project, credentials, opts = {}) {
-        project.must_equal "project-id"
-        credentials.must_equal "trace-credentials"
-        opts[:timeout].must_be :nil?
-        opts[:host].must_equal endpoint
+        _(project).must_equal "project-id"
+        _(credentials).must_equal "trace-credentials"
+        _(opts[:timeout]).must_be :nil?
+        _(opts[:host]).must_equal endpoint
         OpenStruct.new project: project
       }
 
@@ -459,9 +459,9 @@ describe Google::Cloud do
             Google::Cloud::Trace::Credentials.stub :new, stubbed_credentials do
               Google::Cloud::Trace::Service.stub :new, stubbed_service do
                 trace = Google::Cloud::Trace.new
-                trace.must_be_kind_of Google::Cloud::Trace::Project
-                trace.project.must_equal "project-id"
-                trace.service.must_be_kind_of OpenStruct
+                _(trace).must_be_kind_of Google::Cloud::Trace::Project
+                _(trace.project).must_equal "project-id"
+                _(trace.service).must_be_kind_of OpenStruct
               end
             end
           end


### PR DESCRIPTION
Looks like we never updated the minitest expectation syntax for google-cloud-trace.