### PR TITLE
chore: Unpin minitest for a few remaining gemfiles

### DIFF
--- a/google-cloud-asset/samples/Gemfile
+++ b/google-cloud-asset/samples/Gemfile
@@ -36,6 +36,6 @@ else
 end
 
 group :test do
-  gem "minitest", "~> 5.11.3"
+  gem "minitest", "~> 5.14"
   gem "rake"
 end

--- a/google-cloud-webrisk/Gemfile
+++ b/google-cloud-webrisk/Gemfile
@@ -3,7 +3,3 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake", "~> 12.0"
-
-# Pin minitest to 5.11.x to avoid warnings emitted by 5.12.
-# See https://github.com/googleapis/google-cloud-ruby/issues/4110
-gem "minitest", "~> 5.11.3"

--- a/google-cloud-webrisk/google-cloud-webrisk.gemspec
+++ b/google-cloud-webrisk/google-cloud-webrisk.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "googleapis-common-protos", ">= 1.3.9", "< 2.0"
   gem.add_dependency "googleapis-common-protos-types", ">= 1.0.4", "< 2.0"
 
-  gem.add_development_dependency "minitest", "~> 5.10"
+  gem.add_development_dependency "minitest", "~> 5.14"
   gem.add_development_dependency "redcarpet", "~> 3.0"
   gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "simplecov", "~> 0.9"


### PR DESCRIPTION
A few more gemfiles where minitest was pinned. These apparently do not require actual syntax fixes to avoid warnings.