### PR TITLE
fix(trace): Error reporting no longer fails due to loading the wrong constant

### DIFF
--- a/google-cloud-trace/lib/google/cloud/trace/async_reporter.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/async_reporter.rb
@@ -282,7 +282,7 @@ module Google
         def default_error_callbacks
           # This is memoized to reduce calls to the configuration.
           @default_error_callbacks ||= begin
-            error_callback = Google::Cloud::Pubsub.configure.on_error
+            error_callback = Google::Cloud::Trace.configure.on_error
             error_callback ||= Google::Cloud.configure.on_error
             if error_callback
               [error_callback]


### PR DESCRIPTION
Fixes #11668 