### PR TITLE
chore: generate toc when publishing docs to cloudrad

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ jsondoc/*
 # Ignore YARD stuffs
 .yardoc
 
+# Ignore devsite/cloudrad stuffs
+*/docs.metadata
+
 # directories left by gh-pages
 _site/*
 .DS_STORE

--- a/template/default/fulldoc/yaml/setup.rb
+++ b/template/default/fulldoc/yaml/setup.rb
@@ -11,6 +11,7 @@ def init
     end
   end
   serialize_index options
+  toc
 end
 
 def serialize(object)
@@ -25,5 +26,17 @@ def serialize_index(options)
   return
   Templates::Engine.with_serializer('index.yml', options.serializer) do
     T('layout').run(options.merge(:index => true))
+  end
+end
+
+def toc
+  roots = []
+  options.objects.each do |object|
+    next if object.root?
+    roots << object if object.parent.root?
+  end
+
+  Templates::Engine.with_serializer("toc.yml", options.serializer) do
+    T('toc').run(options.merge(:item => roots))
   end
 end

--- a/template/default/toc/yaml/setup.rb
+++ b/template/default/toc/yaml/setup.rb
@@ -1,0 +1,21 @@
+def init
+  roots = options.item
+  text = []
+  roots.each do |root|
+    populate_items root, text
+  end
+  @text = text
+  sections :toc
+end
+
+def populate_items obj, text, indent = "    "
+  text << "#{indent}- uid: #{obj.path}"
+  text << "#{indent}  name: #{obj.name}"
+  children = obj.children.reject { |child| [:method, :constant].include? child.type }
+  unless children.empty?
+    text << "#{indent}  items:"
+    children.each do |child|
+      populate_items child, text, "#{indent}  "
+    end
+  end
+end

--- a/template/default/toc/yaml/toc.erb
+++ b/template/default/toc/yaml/toc.erb
@@ -1,0 +1,4 @@
+- uid: <%= ENV["CLOUDRAD_GEM_NAME"] %>
+  name: <%= ENV["CLOUDRAD_GEM_NAME"] %>
+  items:
+<%= @text.join "\n" %>


### PR DESCRIPTION
Creates a menu entry for every class and module. Classes and modules with children that are either classes or modules get a dropdown containing their class/module children.

Add docs.metadata to gitignore