### PR TITLE
feat(bigquery): Add policy tag support (Column ACLs)

### DIFF
--- a/google-cloud-bigquery/Rakefile
+++ b/google-cloud-bigquery/Rakefile
@@ -58,6 +58,8 @@ task :acceptance, :project, :keyfile do |_t, args|
   ENV["BIGQUERY_KEYFILE_JSON"] = keyfile
   ENV["STORAGE_PROJECT"] = project
   ENV["STORAGE_KEYFILE_JSON"] = keyfile
+  ENV["DATA_CATALOG_CREDENTIALS"] = project
+  ENV["DATA_CATALOG_KEYFILE"] = keyfile
 
   Rake::Task["acceptance:run"].invoke
 end

--- a/google-cloud-bigquery/acceptance/bigquery/dataset_reference_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/dataset_reference_test.rb
@@ -108,11 +108,12 @@ describe Google::Cloud::Bigquery::Dataset, :reference, :bigquery do
   end
 
   it "deletes itself and knows it no longer exists" do
-    _(dataset.exists?).must_equal true
-    dataset.tables.all(&:delete)
-    _(dataset.delete).must_equal true
-    _(dataset.exists?).must_equal false
-    _(dataset.exists?(force: true)).must_equal false
+    dataset_2_id = "#{prefix}_dataset_delete"
+    dataset_2 = bigquery.create_dataset dataset_2_id
+    _(dataset_2.exists?).must_equal true
+    _(dataset_2.delete).must_equal true
+    _(dataset_2.exists?).must_equal false
+    _(dataset_2.exists?(force: true)).must_equal false
   end
 
   it "should set & get metadata" do

--- a/google-cloud-bigquery/acceptance/bigquery/table_policy_tag_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_policy_tag_test.rb
@@ -1,0 +1,45 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "bigquery_helper"
+
+describe Google::Cloud::Bigquery::Schema, :policy_tags, :bigquery do
+  let(:dataset_id) { "#{prefix}_dataset" }
+  let(:dataset) do
+    d = bigquery.dataset dataset_id
+    if d.nil?
+      d = bigquery.create_dataset dataset_id
+    end
+    d
+  end
+  let(:table_id) { "kittens" }
+  let(:table) do
+    t = dataset.table table_id
+    if t.nil?
+      t = dataset.create_table table_id do |schema|
+        schema.integer   "id",    description: "id description",    mode: :required
+      end
+    end
+    t
+  end
+focus
+  it "knows its policy tags for a field" do
+    schema = table.schema # get
+    _(schema).must_be_kind_of Google::Cloud::Bigquery::Schema
+    _(schema).must_be :frozen?
+    fields = schema.fields
+    _(fields).wont_be :empty?
+    _(fields).must_be :frozen?
+  end
+end

--- a/google-cloud-bigquery/acceptance/bigquery/table_policy_tag_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_policy_tag_test.rb
@@ -43,7 +43,7 @@ describe Google::Cloud::Bigquery::Schema, :policy_tags, :bigquery do
     t
   end
 
-  it "knows its policy tags for a field" do
+  it "sets, updates and removes policy tags for a field" do
     taxonomy_id = nil
     begin
       taxonomy = Google::Cloud::DataCatalog::V1::Taxonomy.new(
@@ -85,12 +85,23 @@ describe Google::Cloud::Bigquery::Schema, :policy_tags, :bigquery do
           schema.integer   "id",    description: "id description",    mode: :required
           schema.string    "name",  description: "name description",  mode: :required
           schema.timestamp "dob",   description: "dob description",   mode: :required, policy_tags: [policy_tag_id]
+
+          schema.record "spells", mode: :repeated do |spells|
+            spells.string "name", mode: :nullable, policy_tags: [policy_tag_id]
+            spells.record "properties", mode: :repeated do |properties|
+              properties.float "power", mode: :nullable, policy_tags: [policy_tag_id]
+            end
+          end
         end
       end
 
       _(table_2.schema.field("dob").policy_tags).must_equal [policy_tag_id]
+      _(table_2.schema.field("spells").field("name").policy_tags).must_equal [policy_tag_id]
+      _(table_2.schema.field("spells").field("properties").field("power").policy_tags).must_equal [policy_tag_id]
       table_2.reload!
       _(table_2.schema.field("dob").policy_tags).must_equal [policy_tag_id]
+      _(table_2.schema.field("spells").field("name").policy_tags).must_equal [policy_tag_id]
+      _(table_2.schema.field("spells").field("properties").field("power").policy_tags).must_equal [policy_tag_id]
       
     ensure
       policy_tag_manager.delete_taxonomy name: taxonomy_id if taxonomy_id

--- a/google-cloud-bigquery/acceptance/bigquery/table_reference_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_reference_test.rb
@@ -95,10 +95,12 @@ describe Google::Cloud::Bigquery::Table, :reference, :bigquery do
   end
 
   it "deletes itself and knows it no longer exists" do
-    _(table.exists?).must_equal true
-    _(table.delete).must_equal true
-    _(table.exists?).must_equal false
-    _(table.exists?(force: true)).must_equal false
+    table_2_id = "kittens_reference_delete"
+    table_2 = dataset.create_table table_2_id
+    _(table_2.exists?).must_equal true
+    _(table_2.delete).must_equal true
+    _(table_2.exists?).must_equal false
+    _(table_2.exists?(force: true)).must_equal false
   end
 
   it "gets and sets metadata" do

--- a/google-cloud-bigquery/google-cloud-bigquery.gemspec
+++ b/google-cloud-bigquery/google-cloud-bigquery.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "mini_mime", "~> 1.0"
 
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
+  gem.add_development_dependency "google-cloud-data_catalog", "~> 1.2"
   gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
@@ -751,6 +751,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -762,8 +765,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def string name, description: nil, mode: :nullable
-            schema.string name, description: description, mode: mode
+          def string name, description: nil, mode: :nullable, policy_tags: nil
+            schema.string name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -779,6 +782,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -790,8 +796,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def integer name, description: nil, mode: :nullable
-            schema.integer name, description: description, mode: mode
+          def integer name, description: nil, mode: :nullable, policy_tags: nil
+            schema.integer name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -807,6 +813,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -818,8 +827,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def float name, description: nil, mode: :nullable
-            schema.float name, description: description, mode: mode
+          def float name, description: nil, mode: :nullable, policy_tags: nil
+            schema.float name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -846,6 +855,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -857,8 +869,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def numeric name, description: nil, mode: :nullable
-            schema.numeric name, description: description, mode: mode
+          def numeric name, description: nil, mode: :nullable, policy_tags: nil
+            schema.numeric name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -885,6 +897,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -896,8 +911,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def bignumeric name, description: nil, mode: :nullable
-            schema.bignumeric name, description: description, mode: mode
+          def bignumeric name, description: nil, mode: :nullable, policy_tags: nil
+            schema.bignumeric name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -913,6 +928,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -924,8 +942,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def boolean name, description: nil, mode: :nullable
-            schema.boolean name, description: description, mode: mode
+          def boolean name, description: nil, mode: :nullable, policy_tags: nil
+            schema.boolean name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -941,6 +959,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -952,8 +973,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def bytes name, description: nil, mode: :nullable
-            schema.bytes name, description: description, mode: mode
+          def bytes name, description: nil, mode: :nullable, policy_tags: nil
+            schema.bytes name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -969,6 +990,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -980,8 +1004,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def timestamp name, description: nil, mode: :nullable
-            schema.timestamp name, description: description, mode: mode
+          def timestamp name, description: nil, mode: :nullable, policy_tags: nil
+            schema.timestamp name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -997,6 +1021,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -1008,8 +1035,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def time name, description: nil, mode: :nullable
-            schema.time name, description: description, mode: mode
+          def time name, description: nil, mode: :nullable, policy_tags: nil
+            schema.time name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -1025,6 +1052,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -1036,8 +1066,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def datetime name, description: nil, mode: :nullable
-            schema.datetime name, description: description, mode: mode
+          def datetime name, description: nil, mode: :nullable, policy_tags: nil
+            schema.datetime name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -1053,6 +1083,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -1064,8 +1097,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def date name, description: nil, mode: :nullable
-            schema.date name, description: description, mode: mode
+          def date name, description: nil, mode: :nullable, policy_tags: nil
+            schema.date name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
@@ -754,6 +754,7 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          #   At most 1 policy tag is currently allowed.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -785,6 +786,7 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          #   At most 1 policy tag is currently allowed.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -816,6 +818,7 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          #   At most 1 policy tag is currently allowed.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -858,6 +861,7 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          #   At most 1 policy tag is currently allowed.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -900,6 +904,7 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          #   At most 1 policy tag is currently allowed.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -931,6 +936,7 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          #   At most 1 policy tag is currently allowed.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -962,6 +968,7 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          #   At most 1 policy tag is currently allowed.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -993,6 +1000,7 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          #   At most 1 policy tag is currently allowed.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -1024,6 +1032,7 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          #   At most 1 policy tag is currently allowed.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -1055,6 +1064,7 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          #   At most 1 policy tag is currently allowed.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -1086,6 +1096,7 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          #   At most 1 policy tag is currently allowed.
           #
           # @example
           #   require "google/cloud/bigquery"

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
@@ -294,9 +294,12 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
+        # @param [Array<String>] policy_tags The policy tag list for the field.
+        #   Policy tag identifiers are of the form
+        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #
-        def string name, description: nil, mode: :nullable
-          add_field name, :string, description: description, mode: mode
+        def string name, description: nil, mode: :nullable, policy_tags: nil
+          add_field name, :string, description: description, mode: mode, policy_tags: policy_tags
         end
 
         ##
@@ -310,9 +313,12 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
+        # @param [Array<String>] policy_tags The policy tag list for the field.
+        #   Policy tag identifiers are of the form
+        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #
-        def integer name, description: nil, mode: :nullable
-          add_field name, :integer, description: description, mode: mode
+        def integer name, description: nil, mode: :nullable, policy_tags: nil
+          add_field name, :integer, description: description, mode: mode, policy_tags: policy_tags
         end
 
         ##
@@ -326,9 +332,12 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
+        # @param [Array<String>] policy_tags The policy tag list for the field.
+        #   Policy tag identifiers are of the form
+        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #
-        def float name, description: nil, mode: :nullable
-          add_field name, :float, description: description, mode: mode
+        def float name, description: nil, mode: :nullable, policy_tags: nil
+          add_field name, :float, description: description, mode: mode, policy_tags: policy_tags
         end
 
         ##
@@ -353,9 +362,12 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
+        # @param [Array<String>] policy_tags The policy tag list for the field.
+        #   Policy tag identifiers are of the form
+        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #
-        def numeric name, description: nil, mode: :nullable
-          add_field name, :numeric, description: description, mode: mode
+        def numeric name, description: nil, mode: :nullable, policy_tags: nil
+          add_field name, :numeric, description: description, mode: mode, policy_tags: policy_tags
         end
 
         ##
@@ -380,9 +392,12 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
+        # @param [Array<String>] policy_tags The policy tag list for the field.
+        #   Policy tag identifiers are of the form
+        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #
-        def bignumeric name, description: nil, mode: :nullable
-          add_field name, :bignumeric, description: description, mode: mode
+        def bignumeric name, description: nil, mode: :nullable, policy_tags: nil
+          add_field name, :bignumeric, description: description, mode: mode, policy_tags: policy_tags
         end
 
         ##
@@ -396,9 +411,12 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
+        # @param [Array<String>] policy_tags The policy tag list for the field.
+        #   Policy tag identifiers are of the form
+        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #
-        def boolean name, description: nil, mode: :nullable
-          add_field name, :boolean, description: description, mode: mode
+        def boolean name, description: nil, mode: :nullable, policy_tags: nil
+          add_field name, :boolean, description: description, mode: mode, policy_tags: policy_tags
         end
 
         ##
@@ -412,9 +430,12 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
+        # @param [Array<String>] policy_tags The policy tag list for the field.
+        #   Policy tag identifiers are of the form
+        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #
-        def bytes name, description: nil, mode: :nullable
-          add_field name, :bytes, description: description, mode: mode
+        def bytes name, description: nil, mode: :nullable, policy_tags: nil
+          add_field name, :bytes, description: description, mode: mode, policy_tags: policy_tags
         end
 
         ##
@@ -428,8 +449,12 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
-        def timestamp name, description: nil, mode: :nullable
-          add_field name, :timestamp, description: description, mode: mode
+        # @param [Array<String>] policy_tags The policy tag list for the field.
+        #   Policy tag identifiers are of the form
+        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
+        #
+        def timestamp name, description: nil, mode: :nullable, policy_tags: nil
+          add_field name, :timestamp, description: description, mode: mode, policy_tags: policy_tags
         end
 
         ##
@@ -443,9 +468,12 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
+        # @param [Array<String>] policy_tags The policy tag list for the field.
+        #   Policy tag identifiers are of the form
+        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #
-        def time name, description: nil, mode: :nullable
-          add_field name, :time, description: description, mode: mode
+        def time name, description: nil, mode: :nullable, policy_tags: nil
+          add_field name, :time, description: description, mode: mode, policy_tags: policy_tags
         end
 
         ##
@@ -459,9 +487,12 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
+        # @param [Array<String>] policy_tags The policy tag list for the field.
+        #   Policy tag identifiers are of the form
+        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #
-        def datetime name, description: nil, mode: :nullable
-          add_field name, :datetime, description: description, mode: mode
+        def datetime name, description: nil, mode: :nullable, policy_tags: nil
+          add_field name, :datetime, description: description, mode: mode, policy_tags: policy_tags
         end
 
         ##
@@ -475,9 +506,12 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
+        # @param [Array<String>] policy_tags The policy tag list for the field.
+        #   Policy tag identifiers are of the form
+        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #
-        def date name, description: nil, mode: :nullable
-          add_field name, :date, description: description, mode: mode
+        def date name, description: nil, mode: :nullable, policy_tags: nil
+          add_field name, :date, description: description, mode: mode, policy_tags: policy_tags
         end
 
         ##
@@ -560,7 +594,7 @@ module Google
           raise ArgumentError, "Cannot modify a frozen schema"
         end
 
-        def add_field name, type, description: nil, mode: :nullable
+        def add_field name, type, description: nil, mode: :nullable, policy_tags: nil
           frozen_check!
 
           new_gapi = Google::Apis::BigqueryV2::TableFieldSchema.new(
@@ -570,7 +604,9 @@ module Google
             mode:        verify_mode(mode),
             fields:      []
           )
-
+          if policy_tags
+            new_gapi.policy_tags = Google::Apis::BigqueryV2::TableFieldSchema::PolicyTags.new names: policy_tags
+          end
           # Remove any existing field of this name
           @gapi.fields ||= []
           @gapi.fields.reject! { |f| f.name == new_gapi.name }

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
@@ -294,9 +294,9 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
-        # @param [Array<String>] policy_tags The policy tag list for the field.
-        #   Policy tag identifiers are of the form
-        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
+        # @param [Array<String>, String] policy_tags The policy tag list or
+        #   single policy tag for the field. Policy tag identifiers are of
+        #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #
         def string name, description: nil, mode: :nullable, policy_tags: nil
           add_field name, :string, description: description, mode: mode, policy_tags: policy_tags
@@ -313,9 +313,9 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
-        # @param [Array<String>] policy_tags The policy tag list for the field.
-        #   Policy tag identifiers are of the form
-        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
+        # @param [Array<String>, String] policy_tags The policy tag list or
+        #   single policy tag for the field. Policy tag identifiers are of
+        #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #
         def integer name, description: nil, mode: :nullable, policy_tags: nil
           add_field name, :integer, description: description, mode: mode, policy_tags: policy_tags
@@ -332,9 +332,9 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
-        # @param [Array<String>] policy_tags The policy tag list for the field.
-        #   Policy tag identifiers are of the form
-        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
+        # @param [Array<String>, String] policy_tags The policy tag list or
+        #   single policy tag for the field. Policy tag identifiers are of
+        #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #
         def float name, description: nil, mode: :nullable, policy_tags: nil
           add_field name, :float, description: description, mode: mode, policy_tags: policy_tags
@@ -362,9 +362,9 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
-        # @param [Array<String>] policy_tags The policy tag list for the field.
-        #   Policy tag identifiers are of the form
-        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
+        # @param [Array<String>, String] policy_tags The policy tag list or
+        #   single policy tag for the field. Policy tag identifiers are of
+        #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #
         def numeric name, description: nil, mode: :nullable, policy_tags: nil
           add_field name, :numeric, description: description, mode: mode, policy_tags: policy_tags
@@ -392,9 +392,9 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
-        # @param [Array<String>] policy_tags The policy tag list for the field.
-        #   Policy tag identifiers are of the form
-        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
+        # @param [Array<String>, String] policy_tags The policy tag list or
+        #   single policy tag for the field. Policy tag identifiers are of
+        #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #
         def bignumeric name, description: nil, mode: :nullable, policy_tags: nil
           add_field name, :bignumeric, description: description, mode: mode, policy_tags: policy_tags
@@ -411,9 +411,9 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
-        # @param [Array<String>] policy_tags The policy tag list for the field.
-        #   Policy tag identifiers are of the form
-        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
+        # @param [Array<String>, String] policy_tags The policy tag list or
+        #   single policy tag for the field. Policy tag identifiers are of
+        #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #
         def boolean name, description: nil, mode: :nullable, policy_tags: nil
           add_field name, :boolean, description: description, mode: mode, policy_tags: policy_tags
@@ -430,9 +430,9 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
-        # @param [Array<String>] policy_tags The policy tag list for the field.
-        #   Policy tag identifiers are of the form
-        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
+        # @param [Array<String>, String] policy_tags The policy tag list or
+        #   single policy tag for the field. Policy tag identifiers are of
+        #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #
         def bytes name, description: nil, mode: :nullable, policy_tags: nil
           add_field name, :bytes, description: description, mode: mode, policy_tags: policy_tags
@@ -449,9 +449,9 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
-        # @param [Array<String>] policy_tags The policy tag list for the field.
-        #   Policy tag identifiers are of the form
-        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
+        # @param [Array<String>, String] policy_tags The policy tag list or
+        #   single policy tag for the field. Policy tag identifiers are of
+        #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #
         def timestamp name, description: nil, mode: :nullable, policy_tags: nil
           add_field name, :timestamp, description: description, mode: mode, policy_tags: policy_tags
@@ -468,9 +468,9 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
-        # @param [Array<String>] policy_tags The policy tag list for the field.
-        #   Policy tag identifiers are of the form
-        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
+        # @param [Array<String>, String] policy_tags The policy tag list or
+        #   single policy tag for the field. Policy tag identifiers are of
+        #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #
         def time name, description: nil, mode: :nullable, policy_tags: nil
           add_field name, :time, description: description, mode: mode, policy_tags: policy_tags
@@ -487,9 +487,9 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
-        # @param [Array<String>] policy_tags The policy tag list for the field.
-        #   Policy tag identifiers are of the form
-        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
+        # @param [Array<String>, String] policy_tags The policy tag list or
+        #   single policy tag for the field. Policy tag identifiers are of
+        #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #
         def datetime name, description: nil, mode: :nullable, policy_tags: nil
           add_field name, :datetime, description: description, mode: mode, policy_tags: policy_tags
@@ -506,9 +506,9 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
-        # @param [Array<String>] policy_tags The policy tag list for the field.
-        #   Policy tag identifiers are of the form
-        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
+        # @param [Array<String>, String] policy_tags The policy tag list or
+        #   single policy tag for the field. Policy tag identifiers are of
+        #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #
         def date name, description: nil, mode: :nullable, policy_tags: nil
           add_field name, :date, description: description, mode: mode, policy_tags: policy_tags
@@ -605,6 +605,7 @@ module Google
             fields:      []
           )
           if policy_tags
+            policy_tags = Array(policy_tags)
             new_gapi.policy_tags = Google::Apis::BigqueryV2::TableFieldSchema::PolicyTags.new names: policy_tags
           end
           # Remove any existing field of this name

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
@@ -297,6 +297,7 @@ module Google
         # @param [Array<String>, String] policy_tags The policy tag list or
         #   single policy tag for the field. Policy tag identifiers are of
         #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+        #   At most 1 policy tag is currently allowed.
         #
         def string name, description: nil, mode: :nullable, policy_tags: nil
           add_field name, :string, description: description, mode: mode, policy_tags: policy_tags
@@ -316,6 +317,7 @@ module Google
         # @param [Array<String>, String] policy_tags The policy tag list or
         #   single policy tag for the field. Policy tag identifiers are of
         #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+        #   At most 1 policy tag is currently allowed.
         #
         def integer name, description: nil, mode: :nullable, policy_tags: nil
           add_field name, :integer, description: description, mode: mode, policy_tags: policy_tags
@@ -335,6 +337,7 @@ module Google
         # @param [Array<String>, String] policy_tags The policy tag list or
         #   single policy tag for the field. Policy tag identifiers are of
         #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+        #   At most 1 policy tag is currently allowed.
         #
         def float name, description: nil, mode: :nullable, policy_tags: nil
           add_field name, :float, description: description, mode: mode, policy_tags: policy_tags
@@ -365,6 +368,7 @@ module Google
         # @param [Array<String>, String] policy_tags The policy tag list or
         #   single policy tag for the field. Policy tag identifiers are of
         #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+        #   At most 1 policy tag is currently allowed.
         #
         def numeric name, description: nil, mode: :nullable, policy_tags: nil
           add_field name, :numeric, description: description, mode: mode, policy_tags: policy_tags
@@ -395,6 +399,7 @@ module Google
         # @param [Array<String>, String] policy_tags The policy tag list or
         #   single policy tag for the field. Policy tag identifiers are of
         #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+        #   At most 1 policy tag is currently allowed.
         #
         def bignumeric name, description: nil, mode: :nullable, policy_tags: nil
           add_field name, :bignumeric, description: description, mode: mode, policy_tags: policy_tags
@@ -414,6 +419,7 @@ module Google
         # @param [Array<String>, String] policy_tags The policy tag list or
         #   single policy tag for the field. Policy tag identifiers are of
         #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+        #   At most 1 policy tag is currently allowed.
         #
         def boolean name, description: nil, mode: :nullable, policy_tags: nil
           add_field name, :boolean, description: description, mode: mode, policy_tags: policy_tags
@@ -433,6 +439,7 @@ module Google
         # @param [Array<String>, String] policy_tags The policy tag list or
         #   single policy tag for the field. Policy tag identifiers are of
         #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+        #   At most 1 policy tag is currently allowed.
         #
         def bytes name, description: nil, mode: :nullable, policy_tags: nil
           add_field name, :bytes, description: description, mode: mode, policy_tags: policy_tags
@@ -452,6 +459,7 @@ module Google
         # @param [Array<String>, String] policy_tags The policy tag list or
         #   single policy tag for the field. Policy tag identifiers are of
         #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+        #   At most 1 policy tag is currently allowed.
         #
         def timestamp name, description: nil, mode: :nullable, policy_tags: nil
           add_field name, :timestamp, description: description, mode: mode, policy_tags: policy_tags
@@ -471,6 +479,7 @@ module Google
         # @param [Array<String>, String] policy_tags The policy tag list or
         #   single policy tag for the field. Policy tag identifiers are of
         #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+        #   At most 1 policy tag is currently allowed.
         #
         def time name, description: nil, mode: :nullable, policy_tags: nil
           add_field name, :time, description: description, mode: mode, policy_tags: policy_tags
@@ -490,6 +499,7 @@ module Google
         # @param [Array<String>, String] policy_tags The policy tag list or
         #   single policy tag for the field. Policy tag identifiers are of
         #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+        #   At most 1 policy tag is currently allowed.
         #
         def datetime name, description: nil, mode: :nullable, policy_tags: nil
           add_field name, :datetime, description: description, mode: mode, policy_tags: policy_tags
@@ -509,6 +519,7 @@ module Google
         # @param [Array<String>, String] policy_tags The policy tag list or
         #   single policy tag for the field. Policy tag identifiers are of
         #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+        #   At most 1 policy tag is currently allowed.
         #
         def date name, description: nil, mode: :nullable, policy_tags: nil
           add_field name, :date, description: description, mode: mode, policy_tags: policy_tags

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
@@ -414,6 +414,7 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          #   At most 1 policy tag is currently allowed.
           #
           def string name, description: nil, mode: :nullable, policy_tags: nil
             record_check!
@@ -437,6 +438,7 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          #   At most 1 policy tag is currently allowed.
           #
           def integer name, description: nil, mode: :nullable, policy_tags: nil
             record_check!
@@ -461,6 +463,7 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          #   At most 1 policy tag is currently allowed.
           #
           def float name, description: nil, mode: :nullable, policy_tags: nil
             record_check!
@@ -495,6 +498,7 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          #   At most 1 policy tag is currently allowed.
           #
           def numeric name, description: nil, mode: :nullable, policy_tags: nil
             record_check!
@@ -529,6 +533,7 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          #   At most 1 policy tag is currently allowed.
           #
           def bignumeric name, description: nil, mode: :nullable, policy_tags: nil
             record_check!
@@ -552,6 +557,7 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          #   At most 1 policy tag is currently allowed.
           #
           def boolean name, description: nil, mode: :nullable, policy_tags: nil
             record_check!
@@ -575,6 +581,7 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          #   At most 1 policy tag is currently allowed.
           #
           def bytes name, description: nil, mode: :nullable, policy_tags: nil
             record_check!
@@ -598,6 +605,7 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          #   At most 1 policy tag is currently allowed.
           #
           def timestamp name, description: nil, mode: :nullable, policy_tags: nil
             record_check!
@@ -621,6 +629,7 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          #   At most 1 policy tag is currently allowed.
           #
           def time name, description: nil, mode: :nullable, policy_tags: nil
             record_check!
@@ -644,6 +653,7 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          #   At most 1 policy tag is currently allowed.
           #
           def datetime name, description: nil, mode: :nullable, policy_tags: nil
             record_check!
@@ -667,6 +677,7 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          #   At most 1 policy tag is currently allowed.
           #
           def date name, description: nil, mode: :nullable, policy_tags: nil
             record_check!

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
@@ -167,10 +167,56 @@ module Google
           # The policy tag list for the field. Policy tag identifiers are of the form
           # `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
+          # @see https://cloud.google.com/bigquery/docs/column-level-security-intro
+          #   Introduction to BigQuery column-level security
+          #
           # @return [Array<String>, nil] The policy tag list for the field, or `nil`.
           #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #   table = dataset.table "my_table"
+          #
+          #   table.schema.field("age").policy_tags
+          #
           def policy_tags
-            @gapi.policy_tags&.names&.to_a
+            names = @gapi.policy_tags&.names
+            names.to_a if names && !names.empty?
+          end
+
+          ##
+          # Updates the policy tag list for the field.
+          #
+          # @see https://cloud.google.com/bigquery/docs/column-level-security-intro
+          #   Introduction to BigQuery column-level security
+          #
+          # @param [Array<String>, String, nil] new_policy_tags The policy tag list or
+          #   single policy tag for the field, or `nil` to remove the existing policy tags.
+          #   Policy tag identifiers are of the form
+          #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #   table = dataset.table "my_table"
+          #
+          #   policy_tag = "projects/my-project/locations/us/taxonomies/my-taxonomy/policyTags/my-policy-tag"
+          #   table.schema do |schema|
+          #     schema.field("age").policy_tags = policy_tag
+          #   end
+          #
+          #   table.schema.field("age").policy_tags
+          #
+          def policy_tags= new_policy_tags
+            # If new_policy_tags is nil, send an empty array.
+            # Sending a nil value for policy_tags results in no change.
+            new_policy_tags = Array(new_policy_tags)
+            policy_tag_list = Google::Apis::BigqueryV2::TableFieldSchema::PolicyTags.new names: new_policy_tags
+            @gapi.update! policy_tags: policy_tag_list
           end
 
           ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
@@ -411,11 +411,14 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
-          def string name, description: nil, mode: :nullable
+          def string name, description: nil, mode: :nullable, policy_tags: nil
             record_check!
 
-            add_field name, :string, description: description, mode: mode
+            add_field name, :string, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -431,11 +434,14 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
-          def integer name, description: nil, mode: :nullable
+          def integer name, description: nil, mode: :nullable, policy_tags: nil
             record_check!
 
-            add_field name, :integer, description: description, mode: mode
+            add_field name, :integer, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -452,11 +458,14 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
-          def float name, description: nil, mode: :nullable
+          def float name, description: nil, mode: :nullable, policy_tags: nil
             record_check!
 
-            add_field name, :float, description: description, mode: mode
+            add_field name, :float, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -483,11 +492,14 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
-          def numeric name, description: nil, mode: :nullable
+          def numeric name, description: nil, mode: :nullable, policy_tags: nil
             record_check!
 
-            add_field name, :numeric, description: description, mode: mode
+            add_field name, :numeric, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -514,11 +526,14 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
-          def bignumeric name, description: nil, mode: :nullable
+          def bignumeric name, description: nil, mode: :nullable, policy_tags: nil
             record_check!
 
-            add_field name, :bignumeric, description: description, mode: mode
+            add_field name, :bignumeric, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -534,11 +549,14 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
-          def boolean name, description: nil, mode: :nullable
+          def boolean name, description: nil, mode: :nullable, policy_tags: nil
             record_check!
 
-            add_field name, :boolean, description: description, mode: mode
+            add_field name, :boolean, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -554,11 +572,14 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
-          def bytes name, description: nil, mode: :nullable
+          def bytes name, description: nil, mode: :nullable, policy_tags: nil
             record_check!
 
-            add_field name, :bytes, description: description, mode: mode
+            add_field name, :bytes, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -574,11 +595,14 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
-          def timestamp name, description: nil, mode: :nullable
+          def timestamp name, description: nil, mode: :nullable, policy_tags: nil
             record_check!
 
-            add_field name, :timestamp, description: description, mode: mode
+            add_field name, :timestamp, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -594,11 +618,14 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
-          def time name, description: nil, mode: :nullable
+          def time name, description: nil, mode: :nullable, policy_tags: nil
             record_check!
 
-            add_field name, :time, description: description, mode: mode
+            add_field name, :time, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -614,11 +641,14 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
-          def datetime name, description: nil, mode: :nullable
+          def datetime name, description: nil, mode: :nullable, policy_tags: nil
             record_check!
 
-            add_field name, :datetime, description: description, mode: mode
+            add_field name, :datetime, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -634,11 +664,14 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
-          def date name, description: nil, mode: :nullable
+          def date name, description: nil, mode: :nullable, policy_tags: nil
             record_check!
 
-            add_field name, :date, description: description, mode: mode
+            add_field name, :date, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -734,7 +767,7 @@ module Google
                   "Cannot add fields to a non-RECORD field (#{type})"
           end
 
-          def add_field name, type, description: nil, mode: :nullable
+          def add_field name, type, description: nil, mode: :nullable, policy_tags: nil
             frozen_check!
 
             new_gapi = Google::Apis::BigqueryV2::TableFieldSchema.new(
@@ -744,7 +777,10 @@ module Google
               mode:        verify_mode(mode),
               fields:      []
             )
-
+            if policy_tags
+              policy_tags = Array(policy_tags)
+              new_gapi.policy_tags = Google::Apis::BigqueryV2::TableFieldSchema::PolicyTags.new names: policy_tags
+            end
             # Remove any existing field of this name
             @gapi.fields ||= []
             @gapi.fields.reject! { |f| f.name == new_gapi.name }

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
@@ -164,6 +164,16 @@ module Google
           end
 
           ##
+          # The policy tag list for the field. Policy tag identifiers are of the form
+          # `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          #
+          # @return [Array<String>, nil] The policy tag list for the field, or `nil`.
+          #
+          def policy_tags
+            @gapi.policy_tags&.names&.to_a
+          end
+
+          ##
           # Checks if the type of the field is `STRING`.
           #
           # @return [Boolean] `true` when `STRING`, `false` otherwise.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
@@ -165,7 +165,8 @@ module Google
 
           ##
           # The policy tag list for the field. Policy tag identifiers are of the form
-          # `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          # `projects/*/locations/*/taxonomies/*/policyTags/*`. At most 1 policy tag
+          # is currently allowed.
           #
           # @see https://cloud.google.com/bigquery/docs/column-level-security-intro
           #   Introduction to BigQuery column-level security
@@ -194,8 +195,8 @@ module Google
           #
           # @param [Array<String>, String, nil] new_policy_tags The policy tag list or
           #   single policy tag for the field, or `nil` to remove the existing policy tags.
-          #   Policy tag identifiers are of the form
-          #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          #   Policy tag identifiers are of the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          #   At most 1 policy tag is currently allowed.
           #
           # @example
           #   require "google/cloud/bigquery"

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -3238,6 +3238,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -3249,8 +3252,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def string name, description: nil, mode: :nullable
-            schema.string name, description: description, mode: mode
+          def string name, description: nil, mode: :nullable, policy_tags: nil
+            schema.string name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -3266,6 +3269,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -3277,8 +3283,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def integer name, description: nil, mode: :nullable
-            schema.integer name, description: description, mode: mode
+          def integer name, description: nil, mode: :nullable, policy_tags: nil
+            schema.integer name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -3294,6 +3300,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -3305,8 +3314,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def float name, description: nil, mode: :nullable
-            schema.float name, description: description, mode: mode
+          def float name, description: nil, mode: :nullable, policy_tags: nil
+            schema.float name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -3333,6 +3342,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -3344,8 +3356,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def numeric name, description: nil, mode: :nullable
-            schema.numeric name, description: description, mode: mode
+          def numeric name, description: nil, mode: :nullable, policy_tags: nil
+            schema.numeric name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -3372,6 +3384,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -3383,8 +3398,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def bignumeric name, description: nil, mode: :nullable
-            schema.bignumeric name, description: description, mode: mode
+          def bignumeric name, description: nil, mode: :nullable, policy_tags: nil
+            schema.bignumeric name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -3400,6 +3415,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -3411,8 +3429,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def boolean name, description: nil, mode: :nullable
-            schema.boolean name, description: description, mode: mode
+          def boolean name, description: nil, mode: :nullable, policy_tags: nil
+            schema.boolean name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -3428,6 +3446,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -3439,8 +3460,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def bytes name, description: nil, mode: :nullable
-            schema.bytes name, description: description, mode: mode
+          def bytes name, description: nil, mode: :nullable, policy_tags: nil
+            schema.bytes name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -3456,6 +3477,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -3467,8 +3491,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def timestamp name, description: nil, mode: :nullable
-            schema.timestamp name, description: description, mode: mode
+          def timestamp name, description: nil, mode: :nullable, policy_tags: nil
+            schema.timestamp name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -3484,6 +3508,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -3495,8 +3522,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def time name, description: nil, mode: :nullable
-            schema.time name, description: description, mode: mode
+          def time name, description: nil, mode: :nullable, policy_tags: nil
+            schema.time name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -3512,6 +3539,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -3523,8 +3553,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def datetime name, description: nil, mode: :nullable
-            schema.datetime name, description: description, mode: mode
+          def datetime name, description: nil, mode: :nullable, policy_tags: nil
+            schema.datetime name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -3540,6 +3570,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -3551,8 +3584,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def date name, description: nil, mode: :nullable
-            schema.date name, description: description, mode: mode
+          def date name, description: nil, mode: :nullable, policy_tags: nil
+            schema.date name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -3241,6 +3241,7 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          #   At most 1 policy tag is currently allowed.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -3272,6 +3273,7 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          #   At most 1 policy tag is currently allowed.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -3303,6 +3305,7 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          #   At most 1 policy tag is currently allowed.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -3345,6 +3348,7 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          #   At most 1 policy tag is currently allowed.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -3387,6 +3391,7 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          #   At most 1 policy tag is currently allowed.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -3418,6 +3423,7 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          #   At most 1 policy tag is currently allowed.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -3449,6 +3455,7 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          #   At most 1 policy tag is currently allowed.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -3480,6 +3487,7 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          #   At most 1 policy tag is currently allowed.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -3511,6 +3519,7 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          #   At most 1 policy tag is currently allowed.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -3542,6 +3551,7 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          #   At most 1 policy tag is currently allowed.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -3573,6 +3583,7 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          #   At most 1 policy tag is currently allowed.
           #
           # @example
           #   require "google/cloud/bigquery"

--- a/google-cloud-bigquery/support/doctest_helper.rb
+++ b/google-cloud-bigquery/support/doctest_helper.rb
@@ -841,6 +841,15 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::Bigquery::Schema::Field#policy_tags" do
+    mock_bigquery do |mock|
+      mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
+      mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
+      mock.expect :patch_table, table_full_gapi, ["my-project", "my_dataset", "my_table", Google::Apis::BigqueryV2::Table, Hash]
+      mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
+    end
+  end
+
   doctest.before "Google::Cloud::Bigquery::StandardSql" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_schema_test.rb
@@ -35,6 +35,12 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :schema, :mock_bigquery do
 
   let(:table_name) { "My Table" }
   let(:table_description) { "This is my table" }
+
+  let(:policy_tag) { "projects/#{project}/locations/us/taxonomies/1/policyTags/1" }
+  let(:policy_tag_2) { "projects/#{project}/locations/us/taxonomies/1/policyTags/2" }
+  let(:policy_tags) { [ policy_tag, policy_tag_2 ] }
+  let(:policy_tags_gapi) { Google::Apis::BigqueryV2::TableFieldSchema::PolicyTags.new names: policy_tags }
+
   let(:table_schema) {
     {
       fields: [
@@ -221,8 +227,10 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :schema, :mock_bigquery do
 
   it "can specify a schema both as an option and in a block during load" do
     mock = Minitest::Mock.new
+    schema_gapi_with_policy_tags = table_schema_gapi.dup
+    schema_gapi_with_policy_tags.fields.last.policy_tags = policy_tags_gapi
     job_gapi = load_job_url_gapi table_reference, load_url
-    job_gapi.configuration.load.schema = table_schema_gapi
+    job_gapi.configuration.load.schema = schema_gapi_with_policy_tags
     job_gapi.configuration.load.create_disposition = "CREATE_IF_NEEDED"
     job_gapi.configuration.load.schema_update_options = schema_update_options
 
@@ -241,7 +249,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :schema, :mock_bigquery do
       schema.bignumeric "my_bignumeric"
       schema.boolean "active"
       schema.bytes "avatar"
-      schema.timestamp "dob", mode: :required
+      schema.timestamp "dob", mode: :required, policy_tags: policy_tags
       schema.schema_update_options = schema_update_options
     end
     _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
@@ -342,7 +342,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
         project_id: project, dataset_id: dataset_id, table_id: table_id),
       schema: Google::Apis::BigqueryV2::TableSchema.new(fields: [
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "REQUIRED", name: "name",          type: "STRING", description: nil, fields: []),
-        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "age",           type: "INTEGER", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "age",           type: "INTEGER", policy_tags: policy_tags_gapi, description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "score",         type: "FLOAT", description: "A score from 0.0 to 10.0", fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "cost",          type: "NUMERIC", description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "my_bignumeric", type: "BIGNUMERIC", description: nil, fields: []),
@@ -363,7 +363,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
 
     table = dataset.create_table table_id do |schema|
       schema.string "name", mode: :required
-      schema.integer "age"
+      schema.integer "age", policy_tags: policy_tags
       schema.float "score", description: "A score from 0.0 to 10.0"
       schema.numeric "cost"
       schema.bignumeric "my_bignumeric"

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
@@ -41,23 +41,20 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
   let(:clustering_gapi) do
     Google::Apis::BigqueryV2::Clustering.new fields: clustering_fields
   end
-  let(:table_schema) {
-    {
-      fields: [
-        { mode: "REQUIRED", name: "name", type: "STRING", description: nil, fields: [] },
-        { mode: "NULLABLE", name: "age", type: "INTEGER", description: nil, fields: [] },
-        { mode: "NULLABLE", name: "score", type: "FLOAT", description: "A score from 0.0 to 10.0", fields: [] },
-        { mode: "NULLABLE", name: "active", type: "BOOLEAN", description: nil, fields: [] },
-        { mode: "NULLABLE", name: "avatar", type: "BYTES", description: nil, fields: [] }
-      ]
-    }
-  }
+  let(:policy_tag) { "projects/#{project}/locations/us/taxonomies/1/policyTags/1" }
+  let(:policy_tag_2) { "projects/#{project}/locations/us/taxonomies/1/policyTags/2" }
+  let(:policy_tags) { [ policy_tag, policy_tag_2 ] }
+  let(:policy_tags_gapi) { Google::Apis::BigqueryV2::TableFieldSchema::PolicyTags.new names: policy_tags }
   let(:table_schema_gapi) do
-    gapi = Google::Apis::BigqueryV2::TableSchema.from_json table_schema.to_json
-    gapi.fields.each do |f|
-      f.update! fields: []
-    end
-    gapi
+    Google::Apis::BigqueryV2::TableSchema.new(
+      fields: [
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "REQUIRED", name: "name", type: "STRING", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "age", type: "INTEGER", description: nil, fields: [], policy_tags: policy_tags_gapi),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "score", type: "FLOAT", description: "A score from 0.0 to 10.0", fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "active", type: "BOOLEAN", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "avatar", type: "BYTES", description: nil, fields: [])
+      ]
+    )
   end
   let(:view_id) { "my_view" }
   let(:view_name) { "My View" }
@@ -319,7 +316,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
       t.name = table_name
       t.description = table_description
       t.schema.string "name", mode: :required
-      t.schema.integer "age"
+      t.schema.integer "age", policy_tags: policy_tags
       t.schema.float "score", description: "A score from 0.0 to 10.0"
       t.schema.boolean "active"
       t.schema.bytes "avatar"
@@ -413,7 +410,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
       t.description = table_description
       t.schema do |s|
         s.string "name", mode: :required
-        s.integer "age"
+        s.integer "age", policy_tags: policy_tags
         s.float "score", description: "A score from 0.0 to 10.0"
         s.boolean "active"
         s.bytes "avatar"

--- a/google-cloud-bigquery/test/google/cloud/bigquery/schema/field_policy_tags_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/schema/field_policy_tags_test.rb
@@ -17,6 +17,7 @@ require "helper"
 describe Google::Cloud::Bigquery::Schema, :mock_bigquery do
   let(:policy_tag) { "projects/#{project}/locations/us/taxonomies/1/policyTags/1" }
   let(:policy_tag_2) { "projects/#{project}/locations/us/taxonomies/1/policyTags/2" }
+  let(:policy_tag_3) { "projects/#{project}/locations/us/taxonomies/1/policyTags/3" }
   let(:policy_tags) { [ policy_tag, policy_tag_2 ] }
   let :schema_gapi do
     Google::Apis::BigqueryV2::TableSchema.new(
@@ -36,7 +37,6 @@ describe Google::Cloud::Bigquery::Schema, :mock_bigquery do
 
   it "knows its policy tags" do
     field = schema.field :my_secret_integer
-    _(field.name).must_equal "my_secret_integer"
     _(field.policy_tags).must_equal policy_tags
   end
 
@@ -44,5 +44,32 @@ describe Google::Cloud::Bigquery::Schema, :mock_bigquery do
     gapi = schema.to_gapi
     _(gapi.fields[0].policy_tags).must_be_instance_of Google::Apis::BigqueryV2::TableFieldSchema::PolicyTags
     _(gapi.fields[0].policy_tags.names).must_equal policy_tags
+  end
+
+  it "sets its policy tags to a new array" do
+    field = schema.field :my_secret_integer
+    _(field.policy_tags).must_equal policy_tags
+
+    field.policy_tags = [policy_tag_3]
+    _(field.policy_tags).must_equal [policy_tag_3]
+  end
+
+  it "sets its policy tags to a single string" do
+    field = schema.field :my_secret_integer
+    _(field.policy_tags).must_equal policy_tags
+
+    field.policy_tags = policy_tag_3
+    _(field.policy_tags).must_equal [policy_tag_3]
+  end
+
+  it "removes its policy tags" do
+    field = schema.field :my_secret_integer
+    _(field.policy_tags).must_equal policy_tags
+
+    field.policy_tags = nil
+    _(field.policy_tags).must_be :nil?
+    gapi = schema.to_gapi
+    _(gapi.fields[0].policy_tags).must_be_instance_of Google::Apis::BigqueryV2::TableFieldSchema::PolicyTags
+    _(gapi.fields[0].policy_tags.names).must_equal []
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/schema/field_policy_tags_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/schema/field_policy_tags_test.rb
@@ -1,0 +1,48 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Bigquery::Schema, :mock_bigquery do
+  let(:policy_tag) { "projects/#{project}/locations/us/taxonomies/1/policyTags/1" }
+  let(:policy_tag_2) { "projects/#{project}/locations/us/taxonomies/1/policyTags/2" }
+  let(:policy_tags) { [ policy_tag, policy_tag_2 ] }
+  let :schema_gapi do
+    Google::Apis::BigqueryV2::TableSchema.new(
+      fields: [
+        Google::Apis::BigqueryV2::TableFieldSchema.new(
+          name: "my_secret_integer",
+          type: "INT64",
+          mode: "REQUIRED",
+          policy_tags: Google::Apis::BigqueryV2::TableFieldSchema::PolicyTags.new(
+            names: policy_tags
+          )
+        )
+      ]
+    )
+  end
+  let(:schema) { Google::Cloud::Bigquery::Schema.from_gapi schema_gapi }
+
+  it "knows its policy tags" do
+    field = schema.field :my_secret_integer
+    _(field.name).must_equal "my_secret_integer"
+    _(field.policy_tags).must_equal policy_tags
+  end
+
+  it "includes policy tags in to_gapi" do
+    gapi = schema.to_gapi
+    _(gapi.fields[0].policy_tags).must_be_instance_of Google::Apis::BigqueryV2::TableFieldSchema::PolicyTags
+    _(gapi.fields[0].policy_tags.names).must_equal policy_tags
+  end
+end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/schema/field_policy_tags_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/schema/field_policy_tags_test.rb
@@ -19,6 +19,15 @@ describe Google::Cloud::Bigquery::Schema, :mock_bigquery do
   let(:policy_tag_2) { "projects/#{project}/locations/us/taxonomies/1/policyTags/2" }
   let(:policy_tag_3) { "projects/#{project}/locations/us/taxonomies/1/policyTags/3" }
   let(:policy_tags) { [ policy_tag, policy_tag_2 ] }
+  let(:policy_tags_gapi) { Google::Apis::BigqueryV2::TableFieldSchema::PolicyTags.new names: policy_tags }
+  let :field_integer_gapi do
+    Google::Apis::BigqueryV2::TableFieldSchema.new(
+      name: "rank",
+      type: "INTEGER",
+      mode: "NULLABLE",
+      policy_tags: policy_tags_gapi
+    )
+  end
   let :schema_gapi do
     Google::Apis::BigqueryV2::TableSchema.new(
       fields: [
@@ -26,9 +35,13 @@ describe Google::Cloud::Bigquery::Schema, :mock_bigquery do
           name: "my_secret_integer",
           type: "INT64",
           mode: "REQUIRED",
-          policy_tags: Google::Apis::BigqueryV2::TableFieldSchema::PolicyTags.new(
-            names: policy_tags
-          )
+          policy_tags: policy_tags_gapi
+        ),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(
+          name: "cities_lived",
+          type: "RECORD",
+          mode: "REPEATED",
+          fields: [field_integer_gapi]
         )
       ]
     )
@@ -36,8 +49,8 @@ describe Google::Cloud::Bigquery::Schema, :mock_bigquery do
   let(:schema) { Google::Cloud::Bigquery::Schema.from_gapi schema_gapi }
 
   it "knows its policy tags" do
-    field = schema.field :my_secret_integer
-    _(field.policy_tags).must_equal policy_tags
+    _(schema.field("my_secret_integer").policy_tags).must_equal policy_tags
+    _(schema.field("cities_lived").field("rank").policy_tags).must_equal policy_tags
   end
 
   it "includes policy tags in to_gapi" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/schema_test.rb
@@ -136,6 +136,7 @@ describe Google::Cloud::Bigquery::Schema, :mock_bigquery do
     _(schema.field(:name).mode).must_equal "REQUIRED"
     _(schema.field(:name)).must_be :string?
     _(schema.field(:name)).must_be :required?
+    _(schema.field(:name).policy_tags).must_be :nil?
 
     _(schema.field(:age)).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
     _(schema.field(:age).name).must_equal "age"

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
@@ -34,6 +34,11 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
 
   let(:new_table_hash) { random_table_hash dataset, table_id, table_name, description }
 
+  let(:policy_tag) { "projects/#{project}/locations/us/taxonomies/1/policyTags/1" }
+  let(:policy_tag_2) { "projects/#{project}/locations/us/taxonomies/1/policyTags/2" }
+  let(:policy_tags) { [ policy_tag, policy_tag_2 ] }
+  let(:policy_tags_gapi) { Google::Apis::BigqueryV2::TableFieldSchema::PolicyTags.new names: policy_tags }
+
   let(:field_string_required_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "first_name", type: "STRING", mode: "REQUIRED", description: nil, fields: [] }
   let(:field_integer_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "rank", type: "INTEGER", description: "An integer value from 1 to 100", mode: "NULLABLE", fields: [] }
   let(:field_float_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "accuracy", type: "FLOAT", mode: "NULLABLE", description: nil, fields: [] }
@@ -41,7 +46,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
   let(:field_bignumeric_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "my_bignumeric", type: "BIGNUMERIC", mode: "NULLABLE", description: nil, fields: [] }
   let(:field_boolean_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "approved", type: "BOOLEAN", mode: "NULLABLE", description: nil, fields: [] }
   let(:field_bytes_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "avatar", type: "BYTES", mode: "NULLABLE", description: nil, fields: [] }
-  let(:field_timestamp_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "started_at", type: "TIMESTAMP", mode: "NULLABLE", description: nil, fields: [] }
+  let(:field_timestamp_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "started_at", type: "TIMESTAMP", mode: "NULLABLE", policy_tags: policy_tags_gapi, description: nil, fields: [] }
   let(:field_time_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "duration", type: "TIME", mode: "NULLABLE", description: nil, fields: [] }
   let(:field_datetime_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "target_end", type: "DATETIME", mode: "NULLABLE", description: nil, fields: [] }
   let(:field_date_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "birthday", type: "DATE", mode: "NULLABLE", description: nil, fields: [] }
@@ -167,7 +172,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
       schema.bignumeric "my_bignumeric"
       schema.boolean "approved"
       schema.bytes "avatar"
-      schema.timestamp "started_at"
+      schema.timestamp "started_at", policy_tags: policy_tags
       schema.time "duration"
       schema.datetime "target_end"
       schema.date "birthday"
@@ -192,7 +197,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     table.service.mocked_service = mock
 
     table.schema do |schema|
-      schema.timestamp "end_date"
+      schema.timestamp "end_date", policy_tags: policy_tags
     end
 
     mock.verify
@@ -213,7 +218,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     table.service.mocked_service = mock
 
     table.schema replace: true do |schema|
-      schema.timestamp "started_at"
+      schema.timestamp "started_at", policy_tags: policy_tags
     end
 
     mock.verify
@@ -259,7 +264,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
       schema.string "first_name", mode: :required
       schema.record "cities_lived", mode: :repeated do |nested|
         nested.integer "rank", description: "An integer value from 1 to 100"
-        nested.timestamp "started_at"
+        nested.timestamp "started_at", policy_tags: policy_tags
       end
     end
 
@@ -286,7 +291,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
       schema.string "first_name", mode: :required
       schema.record "cities_lived", mode: :repeated do |nested|
         nested.integer "rank", description: "An integer value from 1 to 100"
-        nested.timestamp "started_at"
+        nested.timestamp "started_at", policy_tags: policy_tags
       end
     end
 


### PR DESCRIPTION
* Add `policy_tags` to `Schema` field helper methods
* Add `Schema::Field#policy_tags`
* Add `Schema::Field#policy_tags=`
* Add `policy_tags` to `Schema::Field` field helper methods
* Add `policy_tags` to `Table` field helper methods
* Add `policy_tags` to `LoadJob` field helper methods

closes: #11156