### PR TITLE
fix(service_control-v1): Update timeout and retry policy

### DIFF
--- a/google-cloud-service_control-v1/lib/google/api/servicecontrol/v1/quota_controller_services_pb.rb
+++ b/google-cloud-service_control-v1/lib/google/api/servicecontrol/v1/quota_controller_services_pb.rb
@@ -30,7 +30,7 @@ module Google
           # service](https://cloud.google.com/service-management/reference/rpc/google.api/servicemanagement.v1#google.api.servicemanagement.v1.ManagedService).
           class Service
 
-            include ::GRPC::GenericService
+            include GRPC::GenericService
 
             self.marshal_class_method = :encode
             self.unmarshal_class_method = :decode

--- a/google-cloud-service_control-v1/lib/google/api/servicecontrol/v1/service_controller_services_pb.rb
+++ b/google-cloud-service_control-v1/lib/google/api/servicecontrol/v1/service_controller_services_pb.rb
@@ -30,7 +30,7 @@ module Google
           # service](https://cloud.google.com/service-management/reference/rpc/google.api/servicemanagement.v1#google.api.servicemanagement.v1.ManagedService).
           class Service
 
-            include ::GRPC::GenericService
+            include GRPC::GenericService
 
             self.marshal_class_method = :encode
             self.unmarshal_class_method = :decode

--- a/google-cloud-service_control-v1/lib/google/cloud/service_control/v1/service_controller/client.rb
+++ b/google-cloud-service_control-v1/lib/google/cloud/service_control/v1/service_controller/client.rb
@@ -66,6 +66,13 @@ module Google
                                 end
                 default_config = Client::Configuration.new parent_config
 
+                default_config.rpcs.check.timeout = 5.0
+                default_config.rpcs.check.retry_policy = {
+                  initial_delay: 1.0, max_delay: 10.0, multiplier: 1.3, retry_codes: [14]
+                }
+
+                default_config.rpcs.report.timeout = 16.0
+
                 default_config
               end
               yield @configure if block_given?

--- a/google-cloud-service_control-v1/proto_docs/google/api/distribution.rb
+++ b/google-cloud-service_control-v1/proto_docs/google/api/distribution.rb
@@ -49,7 +49,7 @@ module Google
     #
     #         Sum[i=1..n]((x_i - mean)^2)
     #
-    #     Knuth, "The Art of Computer Programming", Vol. 2, page 323, 3rd edition
+    #     Knuth, "The Art of Computer Programming", Vol. 2, page 232, 3rd edition
     #     describes Welford's method for accumulating this sum in one pass.
     #
     #     If `count` is zero then this field must be zero.
@@ -207,7 +207,7 @@ module Google
       #   @return [::Array<::Google::Protobuf::Any>]
       #     Contextual information about the example value. Examples are:
       #
-      #       Trace ID: type.googleapis.com/google.devtools.cloudtrace.v1.Trace
+      #       Trace: type.googleapis.com/google.monitoring.v3.SpanContext
       #
       #       Literal string: type.googleapis.com/google.protobuf.StringValue
       #

--- a/google-cloud-service_control-v1/proto_docs/google/api/servicecontrol/v1/log_entry.rb
+++ b/google-cloud-service_control-v1/proto_docs/google/api/servicecontrol/v1/log_entry.rb
@@ -31,7 +31,7 @@ module Google
         #     The time the event described by the log entry occurred. If
         #     omitted, defaults to operation start time.
         # @!attribute [rw] severity
-        #   @return [::Google::Logging::Type::LogSeverity]
+        #   @return [::Google::Cloud::Logging::Type::LogSeverity]
         #     The severity of the log entry. The default value is
         #     `LogSeverity.DEFAULT`.
         # @!attribute [rw] http_request

--- a/google-cloud-service_control-v1/proto_docs/google/logging/type/log_severity.rb
+++ b/google-cloud-service_control-v1/proto_docs/google/logging/type/log_severity.rb
@@ -18,51 +18,53 @@
 
 
 module Google
-  module Logging
-    module Type
-      # The severity of the event described in a log entry, expressed as one of the
-      # standard severity levels listed below.  For your reference, the levels are
-      # assigned the listed numeric values. The effect of using numeric values other
-      # than those listed is undefined.
-      #
-      # You can filter for log entries by severity.  For example, the following
-      # filter expression will match log entries with severities `INFO`, `NOTICE`,
-      # and `WARNING`:
-      #
-      #     severity > DEBUG AND severity <= WARNING
-      #
-      # If you are writing log entries, you should map other severity encodings to
-      # one of these standard levels. For example, you might map all of Java's FINE,
-      # FINER, and FINEST levels to `LogSeverity.DEBUG`. You can preserve the
-      # original severity level in the log entry payload if you wish.
-      module LogSeverity
-        # (0) The log entry has no assigned severity level.
-        DEFAULT = 0
+  module Cloud
+    module Logging
+      module Type
+        # The severity of the event described in a log entry, expressed as one of the
+        # standard severity levels listed below.  For your reference, the levels are
+        # assigned the listed numeric values. The effect of using numeric values other
+        # than those listed is undefined.
+        #
+        # You can filter for log entries by severity.  For example, the following
+        # filter expression will match log entries with severities `INFO`, `NOTICE`,
+        # and `WARNING`:
+        #
+        #     severity > DEBUG AND severity <= WARNING
+        #
+        # If you are writing log entries, you should map other severity encodings to
+        # one of these standard levels. For example, you might map all of Java's FINE,
+        # FINER, and FINEST levels to `LogSeverity.DEBUG`. You can preserve the
+        # original severity level in the log entry payload if you wish.
+        module LogSeverity
+          # (0) The log entry has no assigned severity level.
+          DEFAULT = 0
 
-        # (100) Debug or trace information.
-        DEBUG = 100
+          # (100) Debug or trace information.
+          DEBUG = 100
 
-        # (200) Routine information, such as ongoing status or performance.
-        INFO = 200
+          # (200) Routine information, such as ongoing status or performance.
+          INFO = 200
 
-        # (300) Normal but significant events, such as start up, shut down, or
-        # a configuration change.
-        NOTICE = 300
+          # (300) Normal but significant events, such as start up, shut down, or
+          # a configuration change.
+          NOTICE = 300
 
-        # (400) Warning events might cause problems.
-        WARNING = 400
+          # (400) Warning events might cause problems.
+          WARNING = 400
 
-        # (500) Error events are likely to cause problems.
-        ERROR = 500
+          # (500) Error events are likely to cause problems.
+          ERROR = 500
 
-        # (600) Critical events cause more severe problems or outages.
-        CRITICAL = 600
+          # (600) Critical events cause more severe problems or outages.
+          CRITICAL = 600
 
-        # (700) A person must take an action immediately.
-        ALERT = 700
+          # (700) A person must take an action immediately.
+          ALERT = 700
 
-        # (800) One or more systems are unusable.
-        EMERGENCY = 800
+          # (800) One or more systems are unusable.
+          EMERGENCY = 800
+        end
       end
     end
   end

--- a/google-cloud-service_control-v1/synth.py
+++ b/google-cloud-service_control-v1/synth.py
@@ -19,23 +19,13 @@ import synthtool.gcp as gcp
 import synthtool.languages.ruby as ruby
 import logging
 
-
 logging.basicConfig(level=logging.DEBUG)
 
-gapic = gcp.GAPICMicrogenerator()
+gapic = gcp.GAPICBazel()
 library = gapic.ruby_library(
     "servicecontrol", "v1",
     proto_path="google/api/servicecontrol/v1",
-    extra_proto_files=["google/cloud/common_resources.proto"],
-    generator_args={
-        "ruby-cloud-gem-name": "google-cloud-service_control-v1",
-        "ruby-cloud-title": "Service Control API V1",
-        "ruby-cloud-description": "The Service Control API provides control plane functionality to managed services, such as logging, monitoring, and status checks.",
-        "ruby-cloud-env-prefix": "SERVICE_CONTROL",
-        "ruby-cloud-product-url": "https://cloud.google.com/service-infrastructure/docs/overview/",
-        "ruby-cloud-api-id": "servicecontrol.googleapis.com",
-        "ruby-cloud-api-shortname": "servicecontrol",
-    }
+    bazel_target="//google/api/servicecontrol/v1:google-cloud-api-servicecontrol-v1-ruby",
 )
 
 s.copy(library, merge=ruby.global_merge)


### PR DESCRIPTION
Switches codegen from docker to bazel. The change is a byproduct of that switch, due to a missing configuration on the docker side. This also fixes some namespaces in the generated documentation for common logging types.