### PR TITLE
fix!(analytics-data-v1alpha): Rename service-specific environment variable prefix to ANALYTICS_DATA

### DIFF
--- a/google-analytics-data-v1alpha/.repo-metadata.json
+++ b/google-analytics-data-v1alpha/.repo-metadata.json
@@ -8,7 +8,7 @@
     "repo": "googleapis/google-cloud-ruby",
     "requires_billing": true,
     "ruby-cloud-description": "The Google Analytics Data API provides programmatic methods to access report data in Google Analytics App+Web properties. With the Google Analytics Data API, you can build custom dashboards to display Google Analytics data, automate complex reporting tasks to save time, and integrate your Google Analytics data with other business applications. Note that google-analytics-data-v1alpha is a version-specific client library. For most uses, we recommend installing the main client library google-analytics-data instead. See the readme for more details.",
-    "ruby-cloud-env-prefix": "ANALYTICS",
+    "ruby-cloud-env-prefix": "ANALYTICS_DATA",
     "ruby-cloud-service-override": "AlphaAnalyticsData=AnalyticsData",
     "library_type": "GAPIC_AUTO"
 }

--- a/google-analytics-data-v1alpha/AUTHENTICATION.md
+++ b/google-analytics-data-v1alpha/AUTHENTICATION.md
@@ -19,7 +19,7 @@ during development.
 2. Set the [environment variable](#environment-variables).
 
 ```sh
-export ANALYTICS_CREDENTIALS=path/to/keyfile.json
+export ANALYTICS_DATA_CREDENTIALS=path/to/keyfile.json
 ```
 
 3. Initialize the client.
@@ -66,8 +66,8 @@ The environment variables that google-analytics-data-v1alpha
 checks for credentials are configured on the service Credentials class (such as
 {::Google::Analytics::Data::V1alpha::AnalyticsData::Credentials}):
 
-* `ANALYTICS_CREDENTIALS` - Path to JSON file, or JSON contents
-* `ANALYTICS_KEYFILE` - Path to JSON file, or JSON contents
+* `ANALYTICS_DATA_CREDENTIALS` - Path to JSON file, or JSON contents
+* `ANALYTICS_DATA_KEYFILE` - Path to JSON file, or JSON contents
 * `GOOGLE_CLOUD_CREDENTIALS` - Path to JSON file, or JSON contents
 * `GOOGLE_CLOUD_KEYFILE` - Path to JSON file, or JSON contents
 * `GOOGLE_APPLICATION_CREDENTIALS` - Path to JSON file
@@ -75,7 +75,7 @@ checks for credentials are configured on the service Credentials class (such as
 ```ruby
 require "google/analytics/data/v1alpha"
 
-ENV["ANALYTICS_CREDENTIALS"] = "path/to/keyfile.json"
+ENV["ANALYTICS_DATA_CREDENTIALS"] = "path/to/keyfile.json"
 
 client = ::Google::Analytics::Data::V1alpha::AnalyticsData::Client.new
 ```

--- a/google-analytics-data-v1alpha/Rakefile
+++ b/google-analytics-data-v1alpha/Rakefile
@@ -69,29 +69,29 @@ desc "Run the google-analytics-data-v1alpha acceptance tests."
 task :acceptance, :project, :keyfile do |t, args|
   project = args[:project]
   project ||=
-    ENV["ANALYTICS_TEST_PROJECT"] ||
+    ENV["ANALYTICS_DATA_TEST_PROJECT"] ||
     ENV["GCLOUD_TEST_PROJECT"]
   keyfile = args[:keyfile]
   keyfile ||=
-    ENV["ANALYTICS_TEST_KEYFILE"] ||
+    ENV["ANALYTICS_DATA_TEST_KEYFILE"] ||
     ENV["GCLOUD_TEST_KEYFILE"]
   if keyfile
     keyfile = File.read keyfile
   else
     keyfile ||=
-      ENV["ANALYTICS_TEST_KEYFILE_JSON"] ||
+      ENV["ANALYTICS_DATA_TEST_KEYFILE_JSON"] ||
       ENV["GCLOUD_TEST_KEYFILE_JSON"]
   end
   if project.nil? || keyfile.nil?
-    fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or ANALYTICS_TEST_PROJECT=test123 ANALYTICS_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
+    fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or ANALYTICS_DATA_TEST_PROJECT=test123 ANALYTICS_DATA_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
   require "google/analytics/data/v1alpha/analytics_data/credentials"
   ::Google::Analytics::Data::V1alpha::AnalyticsData::Credentials.env_vars.each do |path|
     ENV[path] = nil
   end
-  ENV["ANALYTICS_PROJECT"] = project
-  ENV["ANALYTICS_TEST_PROJECT"] = project
-  ENV["ANALYTICS_KEYFILE_JSON"] = keyfile
+  ENV["ANALYTICS_DATA_PROJECT"] = project
+  ENV["ANALYTICS_DATA_TEST_PROJECT"] = project
+  ENV["ANALYTICS_DATA_KEYFILE_JSON"] = keyfile
 
   Rake::Task["acceptance:run"].invoke
 end

--- a/google-analytics-data-v1alpha/lib/google/analytics/data/v1alpha/analytics_data/credentials.rb
+++ b/google-analytics-data-v1alpha/lib/google/analytics/data/v1alpha/analytics_data/credentials.rb
@@ -30,13 +30,13 @@ module Google
               "https://www.googleapis.com/auth/analytics.readonly"
             ]
             self.env_vars = [
-              "ANALYTICS_CREDENTIALS",
-              "ANALYTICS_KEYFILE",
+              "ANALYTICS_DATA_CREDENTIALS",
+              "ANALYTICS_DATA_KEYFILE",
               "GOOGLE_CLOUD_CREDENTIALS",
               "GOOGLE_CLOUD_KEYFILE",
               "GCLOUD_KEYFILE",
-              "ANALYTICS_CREDENTIALS_JSON",
-              "ANALYTICS_KEYFILE_JSON",
+              "ANALYTICS_DATA_CREDENTIALS_JSON",
+              "ANALYTICS_DATA_KEYFILE_JSON",
               "GOOGLE_CLOUD_CREDENTIALS_JSON",
               "GOOGLE_CLOUD_KEYFILE_JSON",
               "GCLOUD_KEYFILE_JSON"

--- a/google-analytics-data-v1alpha/lib/google/analytics/data/v1alpha/analytics_data_api_services_pb.rb
+++ b/google-analytics-data-v1alpha/lib/google/analytics/data/v1alpha/analytics_data_api_services_pb.rb
@@ -27,7 +27,7 @@ module Google
           # Google Analytics reporting data service.
           class Service
 
-            include ::GRPC::GenericService
+            include GRPC::GenericService
 
             self.marshal_class_method = :encode
             self.unmarshal_class_method = :decode

--- a/google-analytics-data-v1alpha/proto_docs/google/api/field_behavior.rb
+++ b/google-analytics-data-v1alpha/proto_docs/google/api/field_behavior.rb
@@ -57,9 +57,15 @@ module Google
 
       # Denotes that a (repeated) field is an unordered list.
       # This indicates that the service may provide the elements of the list
-      # in any arbitrary order, rather than the order the user originally
+      # in any arbitrary  order, rather than the order the user originally
       # provided. Additionally, the list's order may or may not be stable.
       UNORDERED_LIST = 6
+
+      # Denotes that this field returns a non-empty default value if not set.
+      # This indicates that if the user provides the empty value in a request,
+      # a non-empty value will be returned. The user will not be aware of what
+      # non-empty value to expect.
+      NON_EMPTY_DEFAULT = 7
     end
   end
 end

--- a/google-analytics-data-v1alpha/synth.py
+++ b/google-analytics-data-v1alpha/synth.py
@@ -21,20 +21,11 @@ import logging
 
 logging.basicConfig(level=logging.DEBUG)
 
-gapic = gcp.GAPICMicrogenerator()
+gapic = gcp.GAPICBazel()
 library = gapic.ruby_library(
     "analytics/data", "v1alpha",
     proto_path="google/analytics/data/v1alpha",
-    generator_args={
-        "ruby-cloud-gem-name": "google-analytics-data-v1alpha",
-        "ruby-cloud-title": "Google Analytics Data V1alpha",
-        "ruby-cloud-description": "The Google Analytics Data API provides programmatic methods to access report data in Google Analytics App+Web properties. With the Google Analytics Data API, you can build custom dashboards to display Google Analytics data, automate complex reporting tasks to save time, and integrate your Google Analytics data with other business applications.",
-        "ruby-cloud-env-prefix": "ANALYTICS",
-        "ruby-cloud-grpc-service-config": "google/analytics/data/v1alpha/analytics_data_grpc_service_config.json",
-        "ruby-cloud-api-id": "analyticsdata.googleapis.com",
-        "ruby-cloud-api-shortname": "analyticsdata",
-        "ruby-cloud-service-override": "AlphaAnalyticsData=AnalyticsData",
-    }
+    bazel_target="//google/analytics/data/v1alpha:google-analytics-data-v1alpha-ruby",
 )
 
 s.copy(library, merge=ruby.global_merge)


### PR DESCRIPTION
Switches codegen from docker to bazel. The change is a byproduct of that switch, due to an incorrect configuration on the docker side.