### PR TITLE
fix(iam-v1beta): Add project_path helper

### DIFF
--- a/google-iam-v1beta/lib/google/iam/v1beta/workload_identity_pool_services_pb.rb
+++ b/google-iam-v1beta/lib/google/iam/v1beta/workload_identity_pool_services_pb.rb
@@ -26,7 +26,7 @@ module Google
         # Manages WorkloadIdentityPools.
         class Service
 
-          include ::GRPC::GenericService
+          include GRPC::GenericService
 
           self.marshal_class_method = :encode
           self.unmarshal_class_method = :decode

--- a/google-iam-v1beta/lib/google/iam/v1beta/workload_identity_pools/operations.rb
+++ b/google-iam-v1beta/lib/google/iam/v1beta/workload_identity_pools/operations.rb
@@ -395,9 +395,9 @@ module Google
           end
 
           ##
-          # Waits for the specified long-running operation until it is done or reaches
-          # at most a specified timeout, returning the latest state.  If the operation
-          # is already done, the latest state is immediately returned.  If the timeout
+          # Waits until the specified long-running operation is done or reaches at most
+          # a specified timeout, returning the latest state.  If the operation is
+          # already done, the latest state is immediately returned.  If the timeout
           # specified is greater than the default HTTP/RPC timeout, the HTTP/RPC
           # timeout is used.  If the server does not support this method, it returns
           # `google.rpc.Code.UNIMPLEMENTED`.

--- a/google-iam-v1beta/lib/google/iam/v1beta/workload_identity_pools/paths.rb
+++ b/google-iam-v1beta/lib/google/iam/v1beta/workload_identity_pools/paths.rb
@@ -24,6 +24,20 @@ module Google
         # Path helper methods for the WorkloadIdentityPools API.
         module Paths
           ##
+          # Create a fully-qualified Project resource string.
+          #
+          # The resource will be in the following format:
+          #
+          # `projects/{project}`
+          #
+          # @param project [String]
+          #
+          # @return [::String]
+          def project_path project:
+            "projects/#{project}"
+          end
+
+          ##
           # Create a fully-qualified WorkloadIdentityPool resource string.
           #
           # The resource will be in the following format:

--- a/google-iam-v1beta/proto_docs/google/api/field_behavior.rb
+++ b/google-iam-v1beta/proto_docs/google/api/field_behavior.rb
@@ -57,9 +57,15 @@ module Google
 
       # Denotes that a (repeated) field is an unordered list.
       # This indicates that the service may provide the elements of the list
-      # in any arbitrary order, rather than the order the user originally
+      # in any arbitrary  order, rather than the order the user originally
       # provided. Additionally, the list's order may or may not be stable.
       UNORDERED_LIST = 6
+
+      # Denotes that this field returns a non-empty default value if not set.
+      # This indicates that if the user provides the empty value in a request,
+      # a non-empty value will be returned. The user will not be aware of what
+      # non-empty value to expect.
+      NON_EMPTY_DEFAULT = 7
     end
   end
 end

--- a/google-iam-v1beta/synth.py
+++ b/google-iam-v1beta/synth.py
@@ -21,20 +21,11 @@ import logging
 
 logging.basicConfig(level=logging.DEBUG)
 
-gapic = gcp.GAPICMicrogenerator()
+gapic = gcp.GAPICBazel()
 library = gapic.ruby_library(
     "iam", "v1beta",
     proto_path="google/iam/v1beta",
-    generator_args={
-        "ruby-cloud-gem-name": "google-iam-v1beta",
-        "ruby-cloud-title": "Google IAM V1beta",
-        "ruby-cloud-description": "Pre-release client for the WorkloadIdentityPools service.",
-        "ruby-cloud-env-prefix": "IAM",
-        "ruby-cloud-grpc-service-config": "google/iam/v1beta/iam_grpc_service_config.json",
-        "ruby-cloud-product-url": "https://cloud.google.com/iam/docs/manage-workload-identity-pools-providers",
-        "ruby-cloud-api-id": "iam.googleapis.com",
-        "ruby-cloud-api-shortname": "iam",
-    }
+    bazel_target="//google/iam/v1beta:google-iam-v1beta-ruby",
 )
 
 s.copy(library, merge=ruby.global_merge)

--- a/google-iam-v1beta/test/google/iam/v1beta/workload_identity_pools_paths_test.rb
+++ b/google-iam-v1beta/test/google/iam/v1beta/workload_identity_pools_paths_test.rb
@@ -23,6 +23,18 @@ require "gapic/grpc/service_stub"
 require "google/iam/v1beta/workload_identity_pools"
 
 class ::Google::Iam::V1beta::WorkloadIdentityPools::ClientPathsTest < Minitest::Test
+  def test_project_path
+    grpc_channel = ::GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
+    ::Gapic::ServiceStub.stub :new, nil do
+      client = ::Google::Iam::V1beta::WorkloadIdentityPools::Client.new do |config|
+        config.credentials = grpc_channel
+      end
+
+      path = client.project_path project: "value0"
+      assert_equal "projects/value0", path
+    end
+  end
+
   def test_workload_identity_pool_path
     grpc_channel = ::GRPC::Core::Channel.new "localhost:8888", nil, :this_channel_is_insecure
     ::Gapic::ServiceStub.stub :new, nil do


### PR DESCRIPTION
Switches codegen from docker to bazel. The change is a byproduct of that switch, due to a missing configuration on the docker side.