### PR TITLE
feat(bigquery): Add support for parameterized types

### DIFF
--- a/google-cloud-bigquery/Rakefile
+++ b/google-cloud-bigquery/Rakefile
@@ -58,6 +58,8 @@ task :acceptance, :project, :keyfile do |_t, args|
   ENV["BIGQUERY_KEYFILE_JSON"] = keyfile
   ENV["STORAGE_PROJECT"] = project
   ENV["STORAGE_KEYFILE_JSON"] = keyfile
+  ENV["DATA_CATALOG_CREDENTIALS"] = project
+  ENV["DATA_CATALOG_KEYFILE"] = keyfile
 
   Rake::Task["acceptance:run"].invoke
 end

--- a/google-cloud-bigquery/acceptance/bigquery/advanced_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/advanced_test.rb
@@ -22,6 +22,8 @@ describe Google::Cloud::Bigquery, :advanced, :bigquery do
 
   let(:string_numeric) { "0.123456789" }
   let(:string_bignumeric) { "0.12345678901234567890123456789012345678" }
+  let(:max_length_string) { 50 }
+  let(:max_length_bytes) { 1024 }
 
   before do
     @table = get_or_create_example_table dataset, table_id
@@ -183,6 +185,12 @@ describe Google::Cloud::Bigquery, :advanced, :bigquery do
     _(rows[0][:my_bignumeric]).must_equal BigDecimal(string_bignumeric)
   end
 
+  it "knows its schema max_length for string and bytes fields" do
+    _(table.schema.field("age").max_length).must_be :nil?
+    _(table.schema.field("name").max_length).must_equal max_length_string
+    _(table.schema.field("spells").field("icon").max_length).must_equal max_length_bytes
+  end
+
   def assert_rows_equal returned_row, example_row
     _(returned_row[:id]).must_equal example_row[:id]
     _(returned_row[:name]).must_equal example_row[:name]
@@ -208,7 +216,7 @@ describe Google::Cloud::Bigquery, :advanced, :bigquery do
     if t.nil?
       t = dataset.create_table table_id do |schema|
         schema.integer "id", mode: :nullable
-        schema.string "name", mode: :nullable
+        schema.string "name", mode: :nullable, max_length: max_length_string
         schema.integer "age", mode: :nullable
         schema.float "weight", mode: :nullable
         schema.numeric "my_numeric", mode: :nullable
@@ -222,7 +230,7 @@ describe Google::Cloud::Bigquery, :advanced, :bigquery do
             properties.string "name", mode: :nullable
             properties.float "power", mode: :nullable
           end
-          spells.bytes "icon", mode: :nullable
+          spells.bytes "icon", mode: :nullable, max_length: max_length_bytes
           spells.timestamp "last_used", mode: :nullable
         end
         schema.time "tea_time", mode: :nullable

--- a/google-cloud-bigquery/acceptance/bigquery/advanced_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/advanced_test.rb
@@ -20,10 +20,14 @@ describe Google::Cloud::Bigquery, :advanced, :bigquery do
   let(:table_id) { "examples_table" }
   let(:table) { @table }
 
-  let(:string_numeric) { "0.123456789" }
-  let(:string_bignumeric) { "0.12345678901234567890123456789012345678" }
+  let(:string_numeric) { "1.123456789" }
+  let(:string_bignumeric) { "1.1234567890123456789012345678901234567" }
   let(:max_length_string) { 50 }
   let(:max_length_bytes) { 1024 }
+  let(:precision_numeric) { 10 }
+  let(:precision_bignumeric) { 38 }
+  let(:scale_numeric) { 9 }
+  let(:scale_bignumeric) { 37 }
 
   before do
     @table = get_or_create_example_table dataset, table_id
@@ -191,6 +195,15 @@ describe Google::Cloud::Bigquery, :advanced, :bigquery do
     _(table.schema.field("spells").field("icon").max_length).must_equal max_length_bytes
   end
 
+  it "knows its schema precision and scale for numeric and bignumeric fields" do
+    _(table.schema.field("age").precision).must_be :nil?
+    _(table.schema.field("age").scale).must_be :nil?
+    _(table.schema.field("my_numeric").precision).must_equal precision_numeric
+    _(table.schema.field("my_numeric").scale).must_equal scale_numeric
+    _(table.schema.field("my_bignumeric").precision).must_equal precision_bignumeric
+    _(table.schema.field("my_bignumeric").scale).must_equal scale_bignumeric
+  end
+
   def assert_rows_equal returned_row, example_row
     _(returned_row[:id]).must_equal example_row[:id]
     _(returned_row[:name]).must_equal example_row[:name]
@@ -219,8 +232,8 @@ describe Google::Cloud::Bigquery, :advanced, :bigquery do
         schema.string "name", mode: :nullable, max_length: max_length_string
         schema.integer "age", mode: :nullable
         schema.float "weight", mode: :nullable
-        schema.numeric "my_numeric", mode: :nullable
-        schema.bignumeric "my_bignumeric", mode: :nullable
+        schema.numeric "my_numeric", mode: :nullable, precision: precision_numeric, scale: scale_numeric
+        schema.bignumeric "my_bignumeric", mode: :nullable, precision: precision_bignumeric, scale: scale_bignumeric
         schema.boolean "is_magic", mode: :nullable
         schema.float "scores", mode: :repeated
         schema.record "spells", mode: :repeated do |spells|

--- a/google-cloud-bigquery/acceptance/bigquery/dataset_reference_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/dataset_reference_test.rb
@@ -108,11 +108,12 @@ describe Google::Cloud::Bigquery::Dataset, :reference, :bigquery do
   end
 
   it "deletes itself and knows it no longer exists" do
-    _(dataset.exists?).must_equal true
-    dataset.tables.all(&:delete)
-    _(dataset.delete).must_equal true
-    _(dataset.exists?).must_equal false
-    _(dataset.exists?(force: true)).must_equal false
+    dataset_2_id = "#{prefix}_dataset_delete"
+    dataset_2 = bigquery.create_dataset dataset_2_id
+    _(dataset_2.exists?).must_equal true
+    _(dataset_2.delete).must_equal true
+    _(dataset_2.exists?).must_equal false
+    _(dataset_2.exists?(force: true)).must_equal false
   end
 
   it "should set & get metadata" do

--- a/google-cloud-bigquery/acceptance/bigquery/table_policy_tag_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_policy_tag_test.rb
@@ -1,0 +1,45 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "bigquery_helper"
+
+describe Google::Cloud::Bigquery::Schema, :policy_tags, :bigquery do
+  let(:dataset_id) { "#{prefix}_dataset" }
+  let(:dataset) do
+    d = bigquery.dataset dataset_id
+    if d.nil?
+      d = bigquery.create_dataset dataset_id
+    end
+    d
+  end
+  let(:table_id) { "kittens" }
+  let(:table) do
+    t = dataset.table table_id
+    if t.nil?
+      t = dataset.create_table table_id do |schema|
+        schema.integer   "id",    description: "id description",    mode: :required
+      end
+    end
+    t
+  end
+focus
+  it "knows its policy tags for a field" do
+    schema = table.schema # get
+    _(schema).must_be_kind_of Google::Cloud::Bigquery::Schema
+    _(schema).must_be :frozen?
+    fields = schema.fields
+    _(fields).wont_be :empty?
+    _(fields).must_be :frozen?
+  end
+end

--- a/google-cloud-bigquery/acceptance/bigquery/table_policy_tag_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_policy_tag_test.rb
@@ -43,7 +43,7 @@ describe Google::Cloud::Bigquery::Schema, :policy_tags, :bigquery do
     t
   end
 
-  it "knows its policy tags for a field" do
+  it "sets, updates and removes policy tags for a field" do
     taxonomy_id = nil
     begin
       taxonomy = Google::Cloud::DataCatalog::V1::Taxonomy.new(
@@ -85,12 +85,23 @@ describe Google::Cloud::Bigquery::Schema, :policy_tags, :bigquery do
           schema.integer   "id",    description: "id description",    mode: :required
           schema.string    "name",  description: "name description",  mode: :required
           schema.timestamp "dob",   description: "dob description",   mode: :required, policy_tags: [policy_tag_id]
+
+          schema.record "spells", mode: :repeated do |spells|
+            spells.string "name", mode: :nullable, policy_tags: [policy_tag_id]
+            spells.record "properties", mode: :repeated do |properties|
+              properties.float "power", mode: :nullable, policy_tags: [policy_tag_id]
+            end
+          end
         end
       end
 
       _(table_2.schema.field("dob").policy_tags).must_equal [policy_tag_id]
+      _(table_2.schema.field("spells").field("name").policy_tags).must_equal [policy_tag_id]
+      _(table_2.schema.field("spells").field("properties").field("power").policy_tags).must_equal [policy_tag_id]
       table_2.reload!
       _(table_2.schema.field("dob").policy_tags).must_equal [policy_tag_id]
+      _(table_2.schema.field("spells").field("name").policy_tags).must_equal [policy_tag_id]
+      _(table_2.schema.field("spells").field("properties").field("power").policy_tags).must_equal [policy_tag_id]
       
     ensure
       policy_tag_manager.delete_taxonomy name: taxonomy_id if taxonomy_id

--- a/google-cloud-bigquery/acceptance/bigquery/table_reference_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_reference_test.rb
@@ -95,10 +95,12 @@ describe Google::Cloud::Bigquery::Table, :reference, :bigquery do
   end
 
   it "deletes itself and knows it no longer exists" do
-    _(table.exists?).must_equal true
-    _(table.delete).must_equal true
-    _(table.exists?).must_equal false
-    _(table.exists?(force: true)).must_equal false
+    table_2_id = "kittens_reference_delete"
+    table_2 = dataset.create_table table_2_id
+    _(table_2.exists?).must_equal true
+    _(table_2.delete).must_equal true
+    _(table_2.exists?).must_equal false
+    _(table_2.exists?(force: true)).must_equal false
   end
 
   it "gets and sets metadata" do

--- a/google-cloud-bigquery/google-cloud-bigquery.gemspec
+++ b/google-cloud-bigquery/google-cloud-bigquery.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "mini_mime", "~> 1.0"
 
   gem.add_development_dependency "autotest-suffix", "~> 1.1"
+  gem.add_development_dependency "google-cloud-data_catalog", "~> 1.2"
   gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
@@ -751,6 +751,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -762,8 +765,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def string name, description: nil, mode: :nullable
-            schema.string name, description: description, mode: mode
+          def string name, description: nil, mode: :nullable, policy_tags: nil
+            schema.string name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -779,6 +782,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -790,8 +796,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def integer name, description: nil, mode: :nullable
-            schema.integer name, description: description, mode: mode
+          def integer name, description: nil, mode: :nullable, policy_tags: nil
+            schema.integer name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -807,6 +813,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -818,8 +827,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def float name, description: nil, mode: :nullable
-            schema.float name, description: description, mode: mode
+          def float name, description: nil, mode: :nullable, policy_tags: nil
+            schema.float name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -846,6 +855,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -857,8 +869,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def numeric name, description: nil, mode: :nullable
-            schema.numeric name, description: description, mode: mode
+          def numeric name, description: nil, mode: :nullable, policy_tags: nil
+            schema.numeric name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -885,6 +897,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -896,8 +911,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def bignumeric name, description: nil, mode: :nullable
-            schema.bignumeric name, description: description, mode: mode
+          def bignumeric name, description: nil, mode: :nullable, policy_tags: nil
+            schema.bignumeric name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -913,6 +928,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -924,8 +942,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def boolean name, description: nil, mode: :nullable
-            schema.boolean name, description: description, mode: mode
+          def boolean name, description: nil, mode: :nullable, policy_tags: nil
+            schema.boolean name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -941,6 +959,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -952,8 +973,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def bytes name, description: nil, mode: :nullable
-            schema.bytes name, description: description, mode: mode
+          def bytes name, description: nil, mode: :nullable, policy_tags: nil
+            schema.bytes name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -969,6 +990,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -980,8 +1004,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def timestamp name, description: nil, mode: :nullable
-            schema.timestamp name, description: description, mode: mode
+          def timestamp name, description: nil, mode: :nullable, policy_tags: nil
+            schema.timestamp name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -997,6 +1021,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -1008,8 +1035,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def time name, description: nil, mode: :nullable
-            schema.time name, description: description, mode: mode
+          def time name, description: nil, mode: :nullable, policy_tags: nil
+            schema.time name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -1025,6 +1052,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -1036,8 +1066,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def datetime name, description: nil, mode: :nullable
-            schema.datetime name, description: description, mode: mode
+          def datetime name, description: nil, mode: :nullable, policy_tags: nil
+            schema.datetime name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -1053,6 +1083,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -1064,8 +1097,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def date name, description: nil, mode: :nullable
-            schema.date name, description: description, mode: mode
+          def date name, description: nil, mode: :nullable, policy_tags: nil
+            schema.date name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
@@ -754,6 +754,8 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          # @param [Integer] max_length The maximum UTF-8 length of strings
+          #   allowed in the field.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -765,8 +767,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def string name, description: nil, mode: :nullable, policy_tags: nil
-            schema.string name, description: description, mode: mode, policy_tags: policy_tags
+          def string name, description: nil, mode: :nullable, policy_tags: nil, max_length: nil
+            schema.string name, description: description, mode: mode, policy_tags: policy_tags, max_length: max_length
           end
 
           ##
@@ -858,6 +860,16 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          # @param [Integer] precision The precision (maximum number of total
+          #   digits) for the field. Acceptable values for precision must be:
+          #   `1 ≤ (precision - scale) ≤ 29`. Values for scale must be:
+          #   `0 ≤ scale ≤ 9`. If the scale value is set, the precision value
+          #   must be set as well.
+          # @param [Integer] scale The scale (maximum number of digits in the
+          #   fractional part) for the field. Acceptable values for precision
+          #   must be: `1 ≤ (precision - scale) ≤ 29`. Values for scale must
+          #   be: `0 ≤ scale ≤ 9`. If the scale value is set, the precision
+          #   value must be set as well.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -869,8 +881,13 @@ module Google
           #   end
           #
           # @!group Schema
-          def numeric name, description: nil, mode: :nullable, policy_tags: nil
-            schema.numeric name, description: description, mode: mode, policy_tags: policy_tags
+          def numeric name, description: nil, mode: :nullable, policy_tags: nil, precision: nil, scale: nil
+            schema.numeric name,
+                           description: description,
+                           mode: mode,
+                           policy_tags: policy_tags,
+                           precision: precision,
+                           scale: scale
           end
 
           ##
@@ -900,6 +917,16 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          # @param [Integer] precision The precision (maximum number of total
+          #   digits) for the field. Acceptable values for precision must be:
+          #   `1 ≤ (precision - scale) ≤ 38`. Values for scale must be:
+          #   `0 ≤ scale ≤ 38`. If the scale value is set, the precision value
+          #   must be set as well.
+          # @param [Integer] scale The scale (maximum number of digits in the
+          #   fractional part) for the field. Acceptable values for precision
+          #   must be: `1 ≤ (precision - scale) ≤ 38`. Values for scale must
+          #   be: `0 ≤ scale ≤ 38`. If the scale value is set, the precision
+          #   value must be set as well.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -911,8 +938,13 @@ module Google
           #   end
           #
           # @!group Schema
-          def bignumeric name, description: nil, mode: :nullable, policy_tags: nil
-            schema.bignumeric name, description: description, mode: mode, policy_tags: policy_tags
+          def bignumeric name, description: nil, mode: :nullable, policy_tags: nil, precision: nil, scale: nil
+            schema.bignumeric name,
+                              description: description,
+                              mode: mode,
+                              policy_tags: policy_tags,
+                              precision: precision,
+                              scale: scale
           end
 
           ##
@@ -962,6 +994,8 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          # @param [Integer] max_length The maximum the maximum number of
+          #   bytes in the field.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -973,8 +1007,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def bytes name, description: nil, mode: :nullable, policy_tags: nil
-            schema.bytes name, description: description, mode: mode, policy_tags: policy_tags
+          def bytes name, description: nil, mode: :nullable, policy_tags: nil, max_length: nil
+            schema.bytes name, description: description, mode: mode, policy_tags: policy_tags, max_length: max_length
           end
 
           ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
@@ -372,9 +372,25 @@ module Google
         # @param [Array<String>, String] policy_tags The policy tag list or
         #   single policy tag for the field. Policy tag identifiers are of
         #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+        # @param [Integer] precision The precision (maximum number of total
+        #   digits) for the field. Acceptable values for precision must be:
+        #   `1 ≤ (precision - scale) ≤ 29`. Values for scale must be:
+        #   `0 ≤ scale ≤ 9`. If the scale value is set, the precision value
+        #   must be set as well.
+        # @param [Integer] scale The scale (maximum number of digits in the
+        #   fractional part) for the field. Acceptable values for precision
+        #   must be: `1 ≤ (precision - scale) ≤ 29`. Values for scale must
+        #   be: `0 ≤ scale ≤ 9`. If the scale value is set, the precision
+        #   value must be set as well.
         #
-        def numeric name, description: nil, mode: :nullable, policy_tags: nil
-          add_field name, :numeric, description: description, mode: mode, policy_tags: policy_tags
+        def numeric name, description: nil, mode: :nullable, policy_tags: nil, precision: nil, scale: nil
+          add_field name,
+                    :numeric,
+                    description: description,
+                    mode: mode,
+                    policy_tags: policy_tags,
+                    precision: precision,
+                    scale: scale
         end
 
         ##
@@ -402,9 +418,25 @@ module Google
         # @param [Array<String>, String] policy_tags The policy tag list or
         #   single policy tag for the field. Policy tag identifiers are of
         #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+        # @param [Integer] precision The precision (maximum number of total
+        #   digits) for the field. Acceptable values for precision must be:
+        #   `1 ≤ (precision - scale) ≤ 38`. Values for scale must be:
+        #   `0 ≤ scale ≤ 38`. If the scale value is set, the precision value
+        #   must be set as well.
+        # @param [Integer] scale The scale (maximum number of digits in the
+        #   fractional part) for the field. Acceptable values for precision
+        #   must be: `1 ≤ (precision - scale) ≤ 38`. Values for scale must
+        #   be: `0 ≤ scale ≤ 38`. If the scale value is set, the precision
+        #   value must be set as well.
         #
-        def bignumeric name, description: nil, mode: :nullable, policy_tags: nil
-          add_field name, :bignumeric, description: description, mode: mode, policy_tags: policy_tags
+        def bignumeric name, description: nil, mode: :nullable, policy_tags: nil, precision: nil, scale: nil
+          add_field name,
+                    :bignumeric,
+                    description: description,
+                    mode: mode,
+                    policy_tags: policy_tags,
+                    precision: precision,
+                    scale: scale
         end
 
         ##
@@ -603,7 +635,14 @@ module Google
           raise ArgumentError, "Cannot modify a frozen schema"
         end
 
-        def add_field name, type, description: nil, mode: :nullable, policy_tags: nil, max_length: nil
+        def add_field name,
+                      type,
+                      description: nil,
+                      mode: :nullable,
+                      policy_tags: nil,
+                      max_length: nil,
+                      precision: nil,
+                      scale: nil
           frozen_check!
 
           new_gapi = Google::Apis::BigqueryV2::TableFieldSchema.new(
@@ -618,6 +657,8 @@ module Google
             new_gapi.policy_tags = Google::Apis::BigqueryV2::TableFieldSchema::PolicyTags.new names: policy_tags
           end
           new_gapi.max_length = max_length if max_length
+          new_gapi.precision = precision if precision
+          new_gapi.scale = scale if scale
           # Remove any existing field of this name
           @gapi.fields ||= []
           @gapi.fields.reject! { |f| f.name == new_gapi.name }

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
@@ -294,9 +294,12 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
+        # @param [Array<String>] policy_tags The policy tag list for the field.
+        #   Policy tag identifiers are of the form
+        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #
-        def string name, description: nil, mode: :nullable
-          add_field name, :string, description: description, mode: mode
+        def string name, description: nil, mode: :nullable, policy_tags: nil
+          add_field name, :string, description: description, mode: mode, policy_tags: policy_tags
         end
 
         ##
@@ -310,9 +313,12 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
+        # @param [Array<String>] policy_tags The policy tag list for the field.
+        #   Policy tag identifiers are of the form
+        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #
-        def integer name, description: nil, mode: :nullable
-          add_field name, :integer, description: description, mode: mode
+        def integer name, description: nil, mode: :nullable, policy_tags: nil
+          add_field name, :integer, description: description, mode: mode, policy_tags: policy_tags
         end
 
         ##
@@ -326,9 +332,12 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
+        # @param [Array<String>] policy_tags The policy tag list for the field.
+        #   Policy tag identifiers are of the form
+        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #
-        def float name, description: nil, mode: :nullable
-          add_field name, :float, description: description, mode: mode
+        def float name, description: nil, mode: :nullable, policy_tags: nil
+          add_field name, :float, description: description, mode: mode, policy_tags: policy_tags
         end
 
         ##
@@ -353,9 +362,12 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
+        # @param [Array<String>] policy_tags The policy tag list for the field.
+        #   Policy tag identifiers are of the form
+        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #
-        def numeric name, description: nil, mode: :nullable
-          add_field name, :numeric, description: description, mode: mode
+        def numeric name, description: nil, mode: :nullable, policy_tags: nil
+          add_field name, :numeric, description: description, mode: mode, policy_tags: policy_tags
         end
 
         ##
@@ -380,9 +392,12 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
+        # @param [Array<String>] policy_tags The policy tag list for the field.
+        #   Policy tag identifiers are of the form
+        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #
-        def bignumeric name, description: nil, mode: :nullable
-          add_field name, :bignumeric, description: description, mode: mode
+        def bignumeric name, description: nil, mode: :nullable, policy_tags: nil
+          add_field name, :bignumeric, description: description, mode: mode, policy_tags: policy_tags
         end
 
         ##
@@ -396,9 +411,12 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
+        # @param [Array<String>] policy_tags The policy tag list for the field.
+        #   Policy tag identifiers are of the form
+        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #
-        def boolean name, description: nil, mode: :nullable
-          add_field name, :boolean, description: description, mode: mode
+        def boolean name, description: nil, mode: :nullable, policy_tags: nil
+          add_field name, :boolean, description: description, mode: mode, policy_tags: policy_tags
         end
 
         ##
@@ -412,9 +430,12 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
+        # @param [Array<String>] policy_tags The policy tag list for the field.
+        #   Policy tag identifiers are of the form
+        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #
-        def bytes name, description: nil, mode: :nullable
-          add_field name, :bytes, description: description, mode: mode
+        def bytes name, description: nil, mode: :nullable, policy_tags: nil
+          add_field name, :bytes, description: description, mode: mode, policy_tags: policy_tags
         end
 
         ##
@@ -428,8 +449,12 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
-        def timestamp name, description: nil, mode: :nullable
-          add_field name, :timestamp, description: description, mode: mode
+        # @param [Array<String>] policy_tags The policy tag list for the field.
+        #   Policy tag identifiers are of the form
+        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
+        #
+        def timestamp name, description: nil, mode: :nullable, policy_tags: nil
+          add_field name, :timestamp, description: description, mode: mode, policy_tags: policy_tags
         end
 
         ##
@@ -443,9 +468,12 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
+        # @param [Array<String>] policy_tags The policy tag list for the field.
+        #   Policy tag identifiers are of the form
+        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #
-        def time name, description: nil, mode: :nullable
-          add_field name, :time, description: description, mode: mode
+        def time name, description: nil, mode: :nullable, policy_tags: nil
+          add_field name, :time, description: description, mode: mode, policy_tags: policy_tags
         end
 
         ##
@@ -459,9 +487,12 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
+        # @param [Array<String>] policy_tags The policy tag list for the field.
+        #   Policy tag identifiers are of the form
+        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #
-        def datetime name, description: nil, mode: :nullable
-          add_field name, :datetime, description: description, mode: mode
+        def datetime name, description: nil, mode: :nullable, policy_tags: nil
+          add_field name, :datetime, description: description, mode: mode, policy_tags: policy_tags
         end
 
         ##
@@ -475,9 +506,12 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
+        # @param [Array<String>] policy_tags The policy tag list for the field.
+        #   Policy tag identifiers are of the form
+        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #
-        def date name, description: nil, mode: :nullable
-          add_field name, :date, description: description, mode: mode
+        def date name, description: nil, mode: :nullable, policy_tags: nil
+          add_field name, :date, description: description, mode: mode, policy_tags: policy_tags
         end
 
         ##
@@ -560,7 +594,7 @@ module Google
           raise ArgumentError, "Cannot modify a frozen schema"
         end
 
-        def add_field name, type, description: nil, mode: :nullable
+        def add_field name, type, description: nil, mode: :nullable, policy_tags: nil
           frozen_check!
 
           new_gapi = Google::Apis::BigqueryV2::TableFieldSchema.new(
@@ -570,7 +604,9 @@ module Google
             mode:        verify_mode(mode),
             fields:      []
           )
-
+          if policy_tags
+            new_gapi.policy_tags = Google::Apis::BigqueryV2::TableFieldSchema::PolicyTags.new names: policy_tags
+          end
           # Remove any existing field of this name
           @gapi.fields ||= []
           @gapi.fields.reject! { |f| f.name == new_gapi.name }

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
@@ -297,9 +297,16 @@ module Google
         # @param [Array<String>, String] policy_tags The policy tag list or
         #   single policy tag for the field. Policy tag identifiers are of
         #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+        # @param [Integer] max_length The maximum UTF-8 length of strings
+        #   allowed in the field.
         #
-        def string name, description: nil, mode: :nullable, policy_tags: nil
-          add_field name, :string, description: description, mode: mode, policy_tags: policy_tags
+        def string name, description: nil, mode: :nullable, policy_tags: nil, max_length: nil
+          add_field name,
+                    :string,
+                    description: description,
+                    mode: mode,
+                    policy_tags: policy_tags,
+                    max_length: max_length
         end
 
         ##
@@ -433,9 +440,11 @@ module Google
         # @param [Array<String>, String] policy_tags The policy tag list or
         #   single policy tag for the field. Policy tag identifiers are of
         #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+        # @param [Integer] max_length The maximum the maximum number of
+        #   bytes in the field.
         #
-        def bytes name, description: nil, mode: :nullable, policy_tags: nil
-          add_field name, :bytes, description: description, mode: mode, policy_tags: policy_tags
+        def bytes name, description: nil, mode: :nullable, policy_tags: nil, max_length: nil
+          add_field name, :bytes, description: description, mode: mode, policy_tags: policy_tags, max_length: max_length
         end
 
         ##
@@ -594,7 +603,7 @@ module Google
           raise ArgumentError, "Cannot modify a frozen schema"
         end
 
-        def add_field name, type, description: nil, mode: :nullable, policy_tags: nil
+        def add_field name, type, description: nil, mode: :nullable, policy_tags: nil, max_length: nil
           frozen_check!
 
           new_gapi = Google::Apis::BigqueryV2::TableFieldSchema.new(
@@ -608,6 +617,7 @@ module Google
             policy_tags = Array(policy_tags)
             new_gapi.policy_tags = Google::Apis::BigqueryV2::TableFieldSchema::PolicyTags.new names: policy_tags
           end
+          new_gapi.max_length = max_length if max_length
           # Remove any existing field of this name
           @gapi.fields ||= []
           @gapi.fields.reject! { |f| f.name == new_gapi.name }

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
@@ -294,9 +294,9 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
-        # @param [Array<String>] policy_tags The policy tag list for the field.
-        #   Policy tag identifiers are of the form
-        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
+        # @param [Array<String>, String] policy_tags The policy tag list or
+        #   single policy tag for the field. Policy tag identifiers are of
+        #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #
         def string name, description: nil, mode: :nullable, policy_tags: nil
           add_field name, :string, description: description, mode: mode, policy_tags: policy_tags
@@ -313,9 +313,9 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
-        # @param [Array<String>] policy_tags The policy tag list for the field.
-        #   Policy tag identifiers are of the form
-        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
+        # @param [Array<String>, String] policy_tags The policy tag list or
+        #   single policy tag for the field. Policy tag identifiers are of
+        #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #
         def integer name, description: nil, mode: :nullable, policy_tags: nil
           add_field name, :integer, description: description, mode: mode, policy_tags: policy_tags
@@ -332,9 +332,9 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
-        # @param [Array<String>] policy_tags The policy tag list for the field.
-        #   Policy tag identifiers are of the form
-        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
+        # @param [Array<String>, String] policy_tags The policy tag list or
+        #   single policy tag for the field. Policy tag identifiers are of
+        #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #
         def float name, description: nil, mode: :nullable, policy_tags: nil
           add_field name, :float, description: description, mode: mode, policy_tags: policy_tags
@@ -362,9 +362,9 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
-        # @param [Array<String>] policy_tags The policy tag list for the field.
-        #   Policy tag identifiers are of the form
-        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
+        # @param [Array<String>, String] policy_tags The policy tag list or
+        #   single policy tag for the field. Policy tag identifiers are of
+        #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #
         def numeric name, description: nil, mode: :nullable, policy_tags: nil
           add_field name, :numeric, description: description, mode: mode, policy_tags: policy_tags
@@ -392,9 +392,9 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
-        # @param [Array<String>] policy_tags The policy tag list for the field.
-        #   Policy tag identifiers are of the form
-        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
+        # @param [Array<String>, String] policy_tags The policy tag list or
+        #   single policy tag for the field. Policy tag identifiers are of
+        #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #
         def bignumeric name, description: nil, mode: :nullable, policy_tags: nil
           add_field name, :bignumeric, description: description, mode: mode, policy_tags: policy_tags
@@ -411,9 +411,9 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
-        # @param [Array<String>] policy_tags The policy tag list for the field.
-        #   Policy tag identifiers are of the form
-        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
+        # @param [Array<String>, String] policy_tags The policy tag list or
+        #   single policy tag for the field. Policy tag identifiers are of
+        #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #
         def boolean name, description: nil, mode: :nullable, policy_tags: nil
           add_field name, :boolean, description: description, mode: mode, policy_tags: policy_tags
@@ -430,9 +430,9 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
-        # @param [Array<String>] policy_tags The policy tag list for the field.
-        #   Policy tag identifiers are of the form
-        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
+        # @param [Array<String>, String] policy_tags The policy tag list or
+        #   single policy tag for the field. Policy tag identifiers are of
+        #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #
         def bytes name, description: nil, mode: :nullable, policy_tags: nil
           add_field name, :bytes, description: description, mode: mode, policy_tags: policy_tags
@@ -449,9 +449,9 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
-        # @param [Array<String>] policy_tags The policy tag list for the field.
-        #   Policy tag identifiers are of the form
-        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
+        # @param [Array<String>, String] policy_tags The policy tag list or
+        #   single policy tag for the field. Policy tag identifiers are of
+        #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #
         def timestamp name, description: nil, mode: :nullable, policy_tags: nil
           add_field name, :timestamp, description: description, mode: mode, policy_tags: policy_tags
@@ -468,9 +468,9 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
-        # @param [Array<String>] policy_tags The policy tag list for the field.
-        #   Policy tag identifiers are of the form
-        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
+        # @param [Array<String>, String] policy_tags The policy tag list or
+        #   single policy tag for the field. Policy tag identifiers are of
+        #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #
         def time name, description: nil, mode: :nullable, policy_tags: nil
           add_field name, :time, description: description, mode: mode, policy_tags: policy_tags
@@ -487,9 +487,9 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
-        # @param [Array<String>] policy_tags The policy tag list for the field.
-        #   Policy tag identifiers are of the form
-        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
+        # @param [Array<String>, String] policy_tags The policy tag list or
+        #   single policy tag for the field. Policy tag identifiers are of
+        #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #
         def datetime name, description: nil, mode: :nullable, policy_tags: nil
           add_field name, :datetime, description: description, mode: mode, policy_tags: policy_tags
@@ -506,9 +506,9 @@ module Google
         # @param [Symbol] mode The field's mode. The possible values are
         #   `:nullable`, `:required`, and `:repeated`. The default value is
         #   `:nullable`.
-        # @param [Array<String>] policy_tags The policy tag list for the field.
-        #   Policy tag identifiers are of the form
-        #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
+        # @param [Array<String>, String] policy_tags The policy tag list or
+        #   single policy tag for the field. Policy tag identifiers are of
+        #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #
         def date name, description: nil, mode: :nullable, policy_tags: nil
           add_field name, :date, description: description, mode: mode, policy_tags: policy_tags
@@ -605,6 +605,7 @@ module Google
             fields:      []
           )
           if policy_tags
+            policy_tags = Array(policy_tags)
             new_gapi.policy_tags = Google::Apis::BigqueryV2::TableFieldSchema::PolicyTags.new names: policy_tags
           end
           # Remove any existing field of this name

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
@@ -167,10 +167,56 @@ module Google
           # The policy tag list for the field. Policy tag identifiers are of the form
           # `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
+          # @see https://cloud.google.com/bigquery/docs/column-level-security-intro
+          #   Introduction to BigQuery column-level security
+          #
           # @return [Array<String>, nil] The policy tag list for the field, or `nil`.
           #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #   table = dataset.table "my_table"
+          #
+          #   table.schema.field("age").policy_tags
+          #
           def policy_tags
-            @gapi.policy_tags&.names&.to_a
+            names = @gapi.policy_tags&.names
+            names.to_a if names && !names.empty?
+          end
+
+          ##
+          # Updates the policy tag list for the field.
+          #
+          # @see https://cloud.google.com/bigquery/docs/column-level-security-intro
+          #   Introduction to BigQuery column-level security
+          #
+          # @param [Array<String>, String, nil] new_policy_tags The policy tag list or
+          #   single policy tag for the field, or `nil` to remove the existing policy tags.
+          #   Policy tag identifiers are of the form
+          #   `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #   dataset = bigquery.dataset "my_dataset"
+          #   table = dataset.table "my_table"
+          #
+          #   policy_tag = "projects/my-project/locations/us/taxonomies/my-taxonomy/policyTags/my-policy-tag"
+          #   table.schema do |schema|
+          #     schema.field("age").policy_tags = policy_tag
+          #   end
+          #
+          #   table.schema.field("age").policy_tags
+          #
+          def policy_tags= new_policy_tags
+            # If new_policy_tags is nil, send an empty array.
+            # Sending a nil value for policy_tags results in no change.
+            new_policy_tags = Array(new_policy_tags)
+            policy_tag_list = Google::Apis::BigqueryV2::TableFieldSchema::PolicyTags.new names: new_policy_tags
+            @gapi.update! policy_tags: policy_tag_list
           end
 
           ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
@@ -232,6 +232,32 @@ module Google
           end
 
           ##
+          # The precision (maximum number of total digits) for `NUMERIC` or `BIGNUMERIC` types. For {#numeric?} fields,
+          # acceptable values for precision must be `1 ≤ (precision - scale) ≤ 29` and values for scale must be `0 ≤
+          # scale ≤ 9`. For {#bignumeric?} fields, acceptable values for precision must be `1 ≤ (precision - scale) ≤
+          # 38` and values for scale must be `0 ≤ scale ≤ 38`. If the scale value is set, the precision value must be
+          # set as well.
+          #
+          # @return [Integer, nil] The precision for the field, or `nil`.
+          #
+          def precision
+            @gapi.precision
+          end
+
+          ##
+          # The scale (maximum number of digits in the fractional part) for `NUMERIC` or `BIGNUMERIC` types. For
+          # {#numeric?} fields, acceptable values for precision must be `1 ≤ (precision - scale) ≤ 29` and values for
+          # scale must be `0 ≤ scale ≤ 9`. For {#bignumeric?} fields, acceptable values for precision must be `1 ≤
+          # (precision - scale) ≤ 38` and values for scale must be `0 ≤ scale ≤ 38`. If the scale value is set, the
+          # precision value must be set as well.
+          #
+          # @return [Integer, nil] The scale for the field, or `nil`.
+          #
+          def scale
+            @gapi.scale
+          end
+
+          ##
           # Checks if the type of the field is `STRING`.
           #
           # @return [Boolean] `true` when `STRING`, `false` otherwise.
@@ -514,11 +540,27 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          # @param [Integer] precision The precision (maximum number of total
+          #   digits) for the field. Acceptable values for precision must be:
+          #   `1 ≤ (precision - scale) ≤ 29`. Values for scale must be:
+          #   `0 ≤ scale ≤ 9`. If the scale value is set, the precision value
+          #   must be set as well.
+          # @param [Integer] scale The scale (maximum number of digits in the
+          #   fractional part) for the field. Acceptable values for precision
+          #   must be: `1 ≤ (precision - scale) ≤ 29`. Values for scale must
+          #   be: `0 ≤ scale ≤ 9`. If the scale value is set, the precision
+          #   value must be set as well.
           #
-          def numeric name, description: nil, mode: :nullable, policy_tags: nil
+          def numeric name, description: nil, mode: :nullable, policy_tags: nil, precision: nil, scale: nil
             record_check!
 
-            add_field name, :numeric, description: description, mode: mode, policy_tags: policy_tags
+            add_field name,
+                      :numeric,
+                      description: description,
+                      mode: mode,
+                      policy_tags: policy_tags,
+                      precision: precision,
+                      scale: scale
           end
 
           ##
@@ -548,11 +590,27 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          # @param [Integer] precision The precision (maximum number of total
+          #   digits) for the field. Acceptable values for precision must be:
+          #   `1 ≤ (precision - scale) ≤ 38`. Values for scale must be:
+          #   `0 ≤ scale ≤ 38`. If the scale value is set, the precision value
+          #   must be set as well.
+          # @param [Integer] scale The scale (maximum number of digits in the
+          #   fractional part) for the field. Acceptable values for precision
+          #   must be: `1 ≤ (precision - scale) ≤ 38`. Values for scale must
+          #   be: `0 ≤ scale ≤ 38`. If the scale value is set, the precision
+          #   value must be set as well.
           #
-          def bignumeric name, description: nil, mode: :nullable, policy_tags: nil
+          def bignumeric name, description: nil, mode: :nullable, policy_tags: nil, precision: nil, scale: nil
             record_check!
 
-            add_field name, :bignumeric, description: description, mode: mode, policy_tags: policy_tags
+            add_field name,
+                      :bignumeric,
+                      description: description,
+                      mode: mode,
+                      policy_tags: policy_tags,
+                      precision: precision,
+                      scale: scale
           end
 
           ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
@@ -411,11 +411,14 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
-          def string name, description: nil, mode: :nullable
+          def string name, description: nil, mode: :nullable, policy_tags: nil
             record_check!
 
-            add_field name, :string, description: description, mode: mode
+            add_field name, :string, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -431,11 +434,14 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
-          def integer name, description: nil, mode: :nullable
+          def integer name, description: nil, mode: :nullable, policy_tags: nil
             record_check!
 
-            add_field name, :integer, description: description, mode: mode
+            add_field name, :integer, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -452,11 +458,14 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
-          def float name, description: nil, mode: :nullable
+          def float name, description: nil, mode: :nullable, policy_tags: nil
             record_check!
 
-            add_field name, :float, description: description, mode: mode
+            add_field name, :float, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -483,11 +492,14 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
-          def numeric name, description: nil, mode: :nullable
+          def numeric name, description: nil, mode: :nullable, policy_tags: nil
             record_check!
 
-            add_field name, :numeric, description: description, mode: mode
+            add_field name, :numeric, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -514,11 +526,14 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
-          def bignumeric name, description: nil, mode: :nullable
+          def bignumeric name, description: nil, mode: :nullable, policy_tags: nil
             record_check!
 
-            add_field name, :bignumeric, description: description, mode: mode
+            add_field name, :bignumeric, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -534,11 +549,14 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
-          def boolean name, description: nil, mode: :nullable
+          def boolean name, description: nil, mode: :nullable, policy_tags: nil
             record_check!
 
-            add_field name, :boolean, description: description, mode: mode
+            add_field name, :boolean, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -554,11 +572,14 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
-          def bytes name, description: nil, mode: :nullable
+          def bytes name, description: nil, mode: :nullable, policy_tags: nil
             record_check!
 
-            add_field name, :bytes, description: description, mode: mode
+            add_field name, :bytes, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -574,11 +595,14 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
-          def timestamp name, description: nil, mode: :nullable
+          def timestamp name, description: nil, mode: :nullable, policy_tags: nil
             record_check!
 
-            add_field name, :timestamp, description: description, mode: mode
+            add_field name, :timestamp, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -594,11 +618,14 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
-          def time name, description: nil, mode: :nullable
+          def time name, description: nil, mode: :nullable, policy_tags: nil
             record_check!
 
-            add_field name, :time, description: description, mode: mode
+            add_field name, :time, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -614,11 +641,14 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
-          def datetime name, description: nil, mode: :nullable
+          def datetime name, description: nil, mode: :nullable, policy_tags: nil
             record_check!
 
-            add_field name, :datetime, description: description, mode: mode
+            add_field name, :datetime, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -634,11 +664,14 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
-          def date name, description: nil, mode: :nullable
+          def date name, description: nil, mode: :nullable, policy_tags: nil
             record_check!
 
-            add_field name, :date, description: description, mode: mode
+            add_field name, :date, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -734,7 +767,7 @@ module Google
                   "Cannot add fields to a non-RECORD field (#{type})"
           end
 
-          def add_field name, type, description: nil, mode: :nullable
+          def add_field name, type, description: nil, mode: :nullable, policy_tags: nil
             frozen_check!
 
             new_gapi = Google::Apis::BigqueryV2::TableFieldSchema.new(
@@ -744,7 +777,10 @@ module Google
               mode:        verify_mode(mode),
               fields:      []
             )
-
+            if policy_tags
+              policy_tags = Array(policy_tags)
+              new_gapi.policy_tags = Google::Apis::BigqueryV2::TableFieldSchema::PolicyTags.new names: policy_tags
+            end
             # Remove any existing field of this name
             @gapi.fields ||= []
             @gapi.fields.reject! { |f| f.name == new_gapi.name }

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
@@ -220,6 +220,18 @@ module Google
           end
 
           ##
+          # The maximum length of values of this field for {#string?} or {bytes?} fields. If `max_length` is not
+          # specified, no maximum length constraint is imposed on this field. If type = `STRING`, then `max_length`
+          # represents the maximum UTF-8 length of strings in this field. If type = `BYTES`, then `max_length`
+          # represents the maximum number of bytes in this field.
+          #
+          # @return [Integer, nil] The maximum length of values of this field, or `nil`.
+          #
+          def max_length
+            @gapi.max_length
+          end
+
+          ##
           # Checks if the type of the field is `STRING`.
           #
           # @return [Boolean] `true` when `STRING`, `false` otherwise.
@@ -414,11 +426,18 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          # @param [Integer] max_length The maximum UTF-8 length of strings
+          #   allowed in the field.
           #
-          def string name, description: nil, mode: :nullable, policy_tags: nil
+          def string name, description: nil, mode: :nullable, policy_tags: nil, max_length: nil
             record_check!
 
-            add_field name, :string, description: description, mode: mode, policy_tags: policy_tags
+            add_field name,
+                      :string,
+                      description: description,
+                      mode: mode,
+                      policy_tags: policy_tags,
+                      max_length: max_length
           end
 
           ##
@@ -575,11 +594,18 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          # @param [Integer] max_length The maximum the maximum number of
+          #   bytes in the field.
           #
-          def bytes name, description: nil, mode: :nullable, policy_tags: nil
+          def bytes name, description: nil, mode: :nullable, policy_tags: nil, max_length: nil
             record_check!
 
-            add_field name, :bytes, description: description, mode: mode, policy_tags: policy_tags
+            add_field name,
+                      :bytes,
+                      description: description,
+                      mode: mode,
+                      policy_tags: policy_tags,
+                      max_length: max_length
           end
 
           ##
@@ -767,7 +793,7 @@ module Google
                   "Cannot add fields to a non-RECORD field (#{type})"
           end
 
-          def add_field name, type, description: nil, mode: :nullable, policy_tags: nil
+          def add_field name, type, description: nil, mode: :nullable, policy_tags: nil, max_length: nil
             frozen_check!
 
             new_gapi = Google::Apis::BigqueryV2::TableFieldSchema.new(
@@ -781,6 +807,7 @@ module Google
               policy_tags = Array(policy_tags)
               new_gapi.policy_tags = Google::Apis::BigqueryV2::TableFieldSchema::PolicyTags.new names: policy_tags
             end
+            new_gapi.max_length = max_length if max_length
             # Remove any existing field of this name
             @gapi.fields ||= []
             @gapi.fields.reject! { |f| f.name == new_gapi.name }

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
@@ -164,6 +164,16 @@ module Google
           end
 
           ##
+          # The policy tag list for the field. Policy tag identifiers are of the form
+          # `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          #
+          # @return [Array<String>, nil] The policy tag list for the field, or `nil`.
+          #
+          def policy_tags
+            @gapi.policy_tags&.names&.to_a
+          end
+
+          ##
           # Checks if the type of the field is `STRING`.
           #
           # @return [Boolean] `true` when `STRING`, `false` otherwise.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -3241,6 +3241,8 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          # @param [Integer] max_length The maximum UTF-8 length of strings
+          #   allowed in the field.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -3252,8 +3254,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def string name, description: nil, mode: :nullable, policy_tags: nil
-            schema.string name, description: description, mode: mode, policy_tags: policy_tags
+          def string name, description: nil, mode: :nullable, policy_tags: nil, max_length: nil
+            schema.string name, description: description, mode: mode, policy_tags: policy_tags, max_length: max_length
           end
 
           ##
@@ -3449,6 +3451,8 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          # @param [Integer] max_length The maximum the maximum number of
+          #   bytes in the field.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -3460,8 +3464,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def bytes name, description: nil, mode: :nullable, policy_tags: nil
-            schema.bytes name, description: description, mode: mode, policy_tags: policy_tags
+          def bytes name, description: nil, mode: :nullable, policy_tags: nil, max_length: nil
+            schema.bytes name, description: description, mode: mode, policy_tags: policy_tags, max_length: max_length
           end
 
           ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -3238,6 +3238,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -3249,8 +3252,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def string name, description: nil, mode: :nullable
-            schema.string name, description: description, mode: mode
+          def string name, description: nil, mode: :nullable, policy_tags: nil
+            schema.string name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -3266,6 +3269,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -3277,8 +3283,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def integer name, description: nil, mode: :nullable
-            schema.integer name, description: description, mode: mode
+          def integer name, description: nil, mode: :nullable, policy_tags: nil
+            schema.integer name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -3294,6 +3300,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -3305,8 +3314,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def float name, description: nil, mode: :nullable
-            schema.float name, description: description, mode: mode
+          def float name, description: nil, mode: :nullable, policy_tags: nil
+            schema.float name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -3333,6 +3342,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -3344,8 +3356,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def numeric name, description: nil, mode: :nullable
-            schema.numeric name, description: description, mode: mode
+          def numeric name, description: nil, mode: :nullable, policy_tags: nil
+            schema.numeric name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -3372,6 +3384,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -3383,8 +3398,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def bignumeric name, description: nil, mode: :nullable
-            schema.bignumeric name, description: description, mode: mode
+          def bignumeric name, description: nil, mode: :nullable, policy_tags: nil
+            schema.bignumeric name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -3400,6 +3415,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -3411,8 +3429,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def boolean name, description: nil, mode: :nullable
-            schema.boolean name, description: description, mode: mode
+          def boolean name, description: nil, mode: :nullable, policy_tags: nil
+            schema.boolean name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -3428,6 +3446,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -3439,8 +3460,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def bytes name, description: nil, mode: :nullable
-            schema.bytes name, description: description, mode: mode
+          def bytes name, description: nil, mode: :nullable, policy_tags: nil
+            schema.bytes name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -3456,6 +3477,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -3467,8 +3491,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def timestamp name, description: nil, mode: :nullable
-            schema.timestamp name, description: description, mode: mode
+          def timestamp name, description: nil, mode: :nullable, policy_tags: nil
+            schema.timestamp name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -3484,6 +3508,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -3495,8 +3522,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def time name, description: nil, mode: :nullable
-            schema.time name, description: description, mode: mode
+          def time name, description: nil, mode: :nullable, policy_tags: nil
+            schema.time name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -3512,6 +3539,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -3523,8 +3553,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def datetime name, description: nil, mode: :nullable
-            schema.datetime name, description: description, mode: mode
+          def datetime name, description: nil, mode: :nullable, policy_tags: nil
+            schema.datetime name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##
@@ -3540,6 +3570,9 @@ module Google
           # @param [Symbol] mode The field's mode. The possible values are
           #   `:nullable`, `:required`, and `:repeated`. The default value is
           #   `:nullable`.
+          # @param [Array<String>, String] policy_tags The policy tag list or
+          #   single policy tag for the field. Policy tag identifiers are of
+          #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -3551,8 +3584,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def date name, description: nil, mode: :nullable
-            schema.date name, description: description, mode: mode
+          def date name, description: nil, mode: :nullable, policy_tags: nil
+            schema.date name, description: description, mode: mode, policy_tags: policy_tags
           end
 
           ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -3347,6 +3347,16 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          # @param [Integer] precision The precision (maximum number of total
+          #   digits) for the field. Acceptable values for precision must be:
+          #   `1 ≤ (precision - scale) ≤ 29`. Values for scale must be:
+          #   `0 ≤ scale ≤ 9`. If the scale value is set, the precision value
+          #   must be set as well.
+          # @param [Integer] scale The scale (maximum number of digits in the
+          #   fractional part) for the field. Acceptable values for precision
+          #   must be: `1 ≤ (precision - scale) ≤ 29`. Values for scale must
+          #   be: `0 ≤ scale ≤ 9`. If the scale value is set, the precision
+          #   value must be set as well.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -3358,8 +3368,13 @@ module Google
           #   end
           #
           # @!group Schema
-          def numeric name, description: nil, mode: :nullable, policy_tags: nil
-            schema.numeric name, description: description, mode: mode, policy_tags: policy_tags
+          def numeric name, description: nil, mode: :nullable, policy_tags: nil, precision: nil, scale: nil
+            schema.numeric name,
+                           description: description,
+                           mode: mode,
+                           policy_tags: policy_tags,
+                           precision: precision,
+                           scale: scale
           end
 
           ##
@@ -3389,6 +3404,16 @@ module Google
           # @param [Array<String>, String] policy_tags The policy tag list or
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
+          # @param [Integer] precision The precision (maximum number of total
+          #   digits) for the field. Acceptable values for precision must be:
+          #   `1 ≤ (precision - scale) ≤ 38`. Values for scale must be:
+          #   `0 ≤ scale ≤ 38`. If the scale value is set, the precision value
+          #   must be set as well.
+          # @param [Integer] scale The scale (maximum number of digits in the
+          #   fractional part) for the field. Acceptable values for precision
+          #   must be: `1 ≤ (precision - scale) ≤ 38`. Values for scale must
+          #   be: `0 ≤ scale ≤ 38`. If the scale value is set, the precision
+          #   value must be set as well.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -3400,8 +3425,13 @@ module Google
           #   end
           #
           # @!group Schema
-          def bignumeric name, description: nil, mode: :nullable, policy_tags: nil
-            schema.bignumeric name, description: description, mode: mode, policy_tags: policy_tags
+          def bignumeric name, description: nil, mode: :nullable, policy_tags: nil, precision: nil, scale: nil
+            schema.bignumeric name,
+                              description: description,
+                              mode: mode,
+                              policy_tags: policy_tags,
+                              precision: precision,
+                              scale: scale
           end
 
           ##

--- a/google-cloud-bigquery/support/doctest_helper.rb
+++ b/google-cloud-bigquery/support/doctest_helper.rb
@@ -841,6 +841,15 @@ YARD::Doctest.configure do |doctest|
     end
   end
 
+  doctest.before "Google::Cloud::Bigquery::Schema::Field#policy_tags" do
+    mock_bigquery do |mock|
+      mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
+      mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
+      mock.expect :patch_table, table_full_gapi, ["my-project", "my_dataset", "my_table", Google::Apis::BigqueryV2::Table, Hash]
+      mock.expect :get_table, table_full_gapi, ["my-project", "my_dataset", "my_table"]
+    end
+  end
+
   doctest.before "Google::Cloud::Bigquery::StandardSql" do
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_schema_test.rb
@@ -35,12 +35,6 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :schema, :mock_bigquery do
 
   let(:table_name) { "My Table" }
   let(:table_description) { "This is my table" }
-
-  let(:policy_tag) { "projects/#{project}/locations/us/taxonomies/1/policyTags/1" }
-  let(:policy_tag_2) { "projects/#{project}/locations/us/taxonomies/1/policyTags/2" }
-  let(:policy_tags) { [ policy_tag, policy_tag_2 ] }
-  let(:policy_tags_gapi) { Google::Apis::BigqueryV2::TableFieldSchema::PolicyTags.new names: policy_tags }
-
   let(:table_schema) {
     {
       fields: [
@@ -227,10 +221,8 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :schema, :mock_bigquery do
 
   it "can specify a schema both as an option and in a block during load" do
     mock = Minitest::Mock.new
-    schema_gapi_with_policy_tags = table_schema_gapi.dup
-    schema_gapi_with_policy_tags.fields.last.policy_tags = policy_tags_gapi
     job_gapi = load_job_url_gapi table_reference, load_url
-    job_gapi.configuration.load.schema = schema_gapi_with_policy_tags
+    job_gapi.configuration.load.schema = table_schema_gapi
     job_gapi.configuration.load.create_disposition = "CREATE_IF_NEEDED"
     job_gapi.configuration.load.schema_update_options = schema_update_options
 
@@ -249,7 +241,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :schema, :mock_bigquery do
       schema.bignumeric "my_bignumeric"
       schema.boolean "active"
       schema.bytes "avatar"
-      schema.timestamp "dob", mode: :required, policy_tags: policy_tags
+      schema.timestamp "dob", mode: :required
       schema.schema_update_options = schema_update_options
     end
     _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_schema_test.rb
@@ -35,6 +35,12 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :schema, :mock_bigquery do
 
   let(:table_name) { "My Table" }
   let(:table_description) { "This is my table" }
+
+  let(:policy_tag) { "projects/#{project}/locations/us/taxonomies/1/policyTags/1" }
+  let(:policy_tag_2) { "projects/#{project}/locations/us/taxonomies/1/policyTags/2" }
+  let(:policy_tags) { [ policy_tag, policy_tag_2 ] }
+  let(:policy_tags_gapi) { Google::Apis::BigqueryV2::TableFieldSchema::PolicyTags.new names: policy_tags }
+
   let(:table_schema) {
     {
       fields: [
@@ -221,8 +227,10 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :schema, :mock_bigquery do
 
   it "can specify a schema both as an option and in a block during load" do
     mock = Minitest::Mock.new
+    schema_gapi_with_policy_tags = table_schema_gapi.dup
+    schema_gapi_with_policy_tags.fields.last.policy_tags = policy_tags_gapi
     job_gapi = load_job_url_gapi table_reference, load_url
-    job_gapi.configuration.load.schema = table_schema_gapi
+    job_gapi.configuration.load.schema = schema_gapi_with_policy_tags
     job_gapi.configuration.load.create_disposition = "CREATE_IF_NEEDED"
     job_gapi.configuration.load.schema_update_options = schema_update_options
 
@@ -241,7 +249,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :schema, :mock_bigquery do
       schema.bignumeric "my_bignumeric"
       schema.boolean "active"
       schema.bytes "avatar"
-      schema.timestamp "dob", mode: :required
+      schema.timestamp "dob", mode: :required, policy_tags: policy_tags
       schema.schema_update_options = schema_update_options
     end
     _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
@@ -342,7 +342,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
         project_id: project, dataset_id: dataset_id, table_id: table_id),
       schema: Google::Apis::BigqueryV2::TableSchema.new(fields: [
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "REQUIRED", name: "name",          type: "STRING", description: nil, fields: []),
-        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "age",           type: "INTEGER", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "age",           type: "INTEGER", policy_tags: policy_tags_gapi, description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "score",         type: "FLOAT", description: "A score from 0.0 to 10.0", fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "cost",          type: "NUMERIC", description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "my_bignumeric", type: "BIGNUMERIC", description: nil, fields: []),
@@ -363,7 +363,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
 
     table = dataset.create_table table_id do |schema|
       schema.string "name", mode: :required
-      schema.integer "age"
+      schema.integer "age", policy_tags: policy_tags
       schema.float "score", description: "A score from 0.0 to 10.0"
       schema.numeric "cost"
       schema.bignumeric "my_bignumeric"

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
@@ -41,23 +41,20 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
   let(:clustering_gapi) do
     Google::Apis::BigqueryV2::Clustering.new fields: clustering_fields
   end
-  let(:table_schema) {
-    {
-      fields: [
-        { mode: "REQUIRED", name: "name", type: "STRING", description: nil, fields: [] },
-        { mode: "NULLABLE", name: "age", type: "INTEGER", description: nil, fields: [] },
-        { mode: "NULLABLE", name: "score", type: "FLOAT", description: "A score from 0.0 to 10.0", fields: [] },
-        { mode: "NULLABLE", name: "active", type: "BOOLEAN", description: nil, fields: [] },
-        { mode: "NULLABLE", name: "avatar", type: "BYTES", description: nil, fields: [] }
-      ]
-    }
-  }
+  let(:policy_tag) { "projects/#{project}/locations/us/taxonomies/1/policyTags/1" }
+  let(:policy_tag_2) { "projects/#{project}/locations/us/taxonomies/1/policyTags/2" }
+  let(:policy_tags) { [ policy_tag, policy_tag_2 ] }
+  let(:policy_tags_gapi) { Google::Apis::BigqueryV2::TableFieldSchema::PolicyTags.new names: policy_tags }
   let(:table_schema_gapi) do
-    gapi = Google::Apis::BigqueryV2::TableSchema.from_json table_schema.to_json
-    gapi.fields.each do |f|
-      f.update! fields: []
-    end
-    gapi
+    Google::Apis::BigqueryV2::TableSchema.new(
+      fields: [
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "REQUIRED", name: "name", type: "STRING", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "age", type: "INTEGER", description: nil, fields: [], policy_tags: policy_tags_gapi),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "score", type: "FLOAT", description: "A score from 0.0 to 10.0", fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "active", type: "BOOLEAN", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "avatar", type: "BYTES", description: nil, fields: [])
+      ]
+    )
   end
   let(:view_id) { "my_view" }
   let(:view_name) { "My View" }
@@ -319,7 +316,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
       t.name = table_name
       t.description = table_description
       t.schema.string "name", mode: :required
-      t.schema.integer "age"
+      t.schema.integer "age", policy_tags: policy_tags
       t.schema.float "score", description: "A score from 0.0 to 10.0"
       t.schema.boolean "active"
       t.schema.bytes "avatar"
@@ -413,7 +410,7 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
       t.description = table_description
       t.schema do |s|
         s.string "name", mode: :required
-        s.integer "age"
+        s.integer "age", policy_tags: policy_tags
         s.float "score", description: "A score from 0.0 to 10.0"
         s.boolean "active"
         s.bytes "avatar"

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
@@ -48,11 +48,11 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
   let(:table_schema_gapi) do
     Google::Apis::BigqueryV2::TableSchema.new(
       fields: [
-        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "REQUIRED", name: "name", type: "STRING", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "REQUIRED", name: "name", type: "STRING", description: nil, fields: [], max_length: max_length_string),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "age", type: "INTEGER", description: nil, fields: [], policy_tags: policy_tags_gapi),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "score", type: "FLOAT", description: "A score from 0.0 to 10.0", fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "active", type: "BOOLEAN", description: nil, fields: []),
-        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "avatar", type: "BYTES", description: nil, fields: [])
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "avatar", type: "BYTES", description: nil, fields: [], max_length: max_length_bytes)
       ]
     )
   end
@@ -68,6 +68,8 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
   let(:dataset_hash) { random_dataset_hash dataset_id, dataset_name, dataset_description, default_expiration }
   let(:dataset_gapi) { Google::Apis::BigqueryV2::Dataset.from_json dataset_hash.to_json }
   let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi, bigquery.service }
+  let(:max_length_string) { 50 }
+  let(:max_length_bytes) { 1024 }
 
   it "knows its attributes" do
     _(dataset.name).must_equal dataset_name
@@ -315,11 +317,11 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     table = dataset.create_table table_id do |t|
       t.name = table_name
       t.description = table_description
-      t.schema.string "name", mode: :required
+      t.schema.string "name", mode: :required, max_length: max_length_string
       t.schema.integer "age", policy_tags: policy_tags
       t.schema.float "score", description: "A score from 0.0 to 10.0"
       t.schema.boolean "active"
-      t.schema.bytes "avatar"
+      t.schema.bytes "avatar", max_length: max_length_bytes
     end
 
     mock.verify
@@ -341,13 +343,13 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
       table_reference: Google::Apis::BigqueryV2::TableReference.new(
         project_id: project, dataset_id: dataset_id, table_id: table_id),
       schema: Google::Apis::BigqueryV2::TableSchema.new(fields: [
-        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "REQUIRED", name: "name",          type: "STRING", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "REQUIRED", name: "name",          type: "STRING", description: nil, fields: [], max_length: max_length_string),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "age",           type: "INTEGER", policy_tags: policy_tags_gapi, description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "score",         type: "FLOAT", description: "A score from 0.0 to 10.0", fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "cost",          type: "NUMERIC", description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "my_bignumeric", type: "BIGNUMERIC", description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "active",        type: "BOOLEAN", description: nil, fields: []),
-        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "avatar",        type: "BYTES", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "avatar",        type: "BYTES", description: nil, fields: [], max_length: max_length_bytes),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "creation_date", type: "TIMESTAMP", description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "duration",      type: "TIME", description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "target_end",    type: "DATETIME", description: nil, fields: []),
@@ -362,13 +364,13 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     dataset.service.mocked_service = mock
 
     table = dataset.create_table table_id do |schema|
-      schema.string "name", mode: :required
+      schema.string "name", mode: :required, max_length: max_length_string
       schema.integer "age", policy_tags: policy_tags
       schema.float "score", description: "A score from 0.0 to 10.0"
       schema.numeric "cost"
       schema.bignumeric "my_bignumeric"
       schema.boolean "active"
-      schema.bytes "avatar"
+      schema.bytes "avatar", max_length: max_length_bytes
       schema.timestamp "creation_date"
       schema.time "duration"
       schema.datetime "target_end"
@@ -409,11 +411,11 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
       t.name = table_name
       t.description = table_description
       t.schema do |s|
-        s.string "name", mode: :required
+        s.string "name", mode: :required, max_length: max_length_string
         s.integer "age", policy_tags: policy_tags
         s.float "score", description: "A score from 0.0 to 10.0"
         s.boolean "active"
-        s.bytes "avatar"
+        s.bytes "avatar", max_length: max_length_bytes
       end
     end
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
@@ -70,6 +70,10 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
   let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi, bigquery.service }
   let(:max_length_string) { 50 }
   let(:max_length_bytes) { 1024 }
+  let(:precision_numeric) { 10 }
+  let(:precision_bignumeric) { 38 }
+  let(:scale_numeric) { 9 }
+  let(:scale_bignumeric) { 37 }
 
   it "knows its attributes" do
     _(dataset.name).must_equal dataset_name
@@ -346,8 +350,8 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "REQUIRED", name: "name",          type: "STRING", description: nil, fields: [], max_length: max_length_string),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "age",           type: "INTEGER", policy_tags: policy_tags_gapi, description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "score",         type: "FLOAT", description: "A score from 0.0 to 10.0", fields: []),
-        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "cost",          type: "NUMERIC", description: nil, fields: []),
-        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "my_bignumeric", type: "BIGNUMERIC", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "cost",          type: "NUMERIC", description: nil, fields: [], precision: precision_numeric, scale: scale_numeric),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "my_bignumeric", type: "BIGNUMERIC", description: nil, fields: [], precision: precision_bignumeric, scale: scale_bignumeric),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "active",        type: "BOOLEAN", description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "avatar",        type: "BYTES", description: nil, fields: [], max_length: max_length_bytes),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "creation_date", type: "TIMESTAMP", description: nil, fields: []),
@@ -367,8 +371,8 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
       schema.string "name", mode: :required, max_length: max_length_string
       schema.integer "age", policy_tags: policy_tags
       schema.float "score", description: "A score from 0.0 to 10.0"
-      schema.numeric "cost"
-      schema.bignumeric "my_bignumeric"
+      schema.numeric "cost", precision: precision_numeric, scale: scale_numeric
+      schema.bignumeric "my_bignumeric", precision: precision_bignumeric, scale: scale_bignumeric
       schema.boolean "active"
       schema.bytes "avatar", max_length: max_length_bytes
       schema.timestamp "creation_date"

--- a/google-cloud-bigquery/test/google/cloud/bigquery/schema/field_policy_tags_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/schema/field_policy_tags_test.rb
@@ -17,6 +17,7 @@ require "helper"
 describe Google::Cloud::Bigquery::Schema, :mock_bigquery do
   let(:policy_tag) { "projects/#{project}/locations/us/taxonomies/1/policyTags/1" }
   let(:policy_tag_2) { "projects/#{project}/locations/us/taxonomies/1/policyTags/2" }
+  let(:policy_tag_3) { "projects/#{project}/locations/us/taxonomies/1/policyTags/3" }
   let(:policy_tags) { [ policy_tag, policy_tag_2 ] }
   let :schema_gapi do
     Google::Apis::BigqueryV2::TableSchema.new(
@@ -36,7 +37,6 @@ describe Google::Cloud::Bigquery::Schema, :mock_bigquery do
 
   it "knows its policy tags" do
     field = schema.field :my_secret_integer
-    _(field.name).must_equal "my_secret_integer"
     _(field.policy_tags).must_equal policy_tags
   end
 
@@ -44,5 +44,32 @@ describe Google::Cloud::Bigquery::Schema, :mock_bigquery do
     gapi = schema.to_gapi
     _(gapi.fields[0].policy_tags).must_be_instance_of Google::Apis::BigqueryV2::TableFieldSchema::PolicyTags
     _(gapi.fields[0].policy_tags.names).must_equal policy_tags
+  end
+
+  it "sets its policy tags to a new array" do
+    field = schema.field :my_secret_integer
+    _(field.policy_tags).must_equal policy_tags
+
+    field.policy_tags = [policy_tag_3]
+    _(field.policy_tags).must_equal [policy_tag_3]
+  end
+
+  it "sets its policy tags to a single string" do
+    field = schema.field :my_secret_integer
+    _(field.policy_tags).must_equal policy_tags
+
+    field.policy_tags = policy_tag_3
+    _(field.policy_tags).must_equal [policy_tag_3]
+  end
+
+  it "removes its policy tags" do
+    field = schema.field :my_secret_integer
+    _(field.policy_tags).must_equal policy_tags
+
+    field.policy_tags = nil
+    _(field.policy_tags).must_be :nil?
+    gapi = schema.to_gapi
+    _(gapi.fields[0].policy_tags).must_be_instance_of Google::Apis::BigqueryV2::TableFieldSchema::PolicyTags
+    _(gapi.fields[0].policy_tags.names).must_equal []
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/schema/field_policy_tags_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/schema/field_policy_tags_test.rb
@@ -1,0 +1,48 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Bigquery::Schema, :mock_bigquery do
+  let(:policy_tag) { "projects/#{project}/locations/us/taxonomies/1/policyTags/1" }
+  let(:policy_tag_2) { "projects/#{project}/locations/us/taxonomies/1/policyTags/2" }
+  let(:policy_tags) { [ policy_tag, policy_tag_2 ] }
+  let :schema_gapi do
+    Google::Apis::BigqueryV2::TableSchema.new(
+      fields: [
+        Google::Apis::BigqueryV2::TableFieldSchema.new(
+          name: "my_secret_integer",
+          type: "INT64",
+          mode: "REQUIRED",
+          policy_tags: Google::Apis::BigqueryV2::TableFieldSchema::PolicyTags.new(
+            names: policy_tags
+          )
+        )
+      ]
+    )
+  end
+  let(:schema) { Google::Cloud::Bigquery::Schema.from_gapi schema_gapi }
+
+  it "knows its policy tags" do
+    field = schema.field :my_secret_integer
+    _(field.name).must_equal "my_secret_integer"
+    _(field.policy_tags).must_equal policy_tags
+  end
+
+  it "includes policy tags in to_gapi" do
+    gapi = schema.to_gapi
+    _(gapi.fields[0].policy_tags).must_be_instance_of Google::Apis::BigqueryV2::TableFieldSchema::PolicyTags
+    _(gapi.fields[0].policy_tags.names).must_equal policy_tags
+  end
+end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/schema/field_policy_tags_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/schema/field_policy_tags_test.rb
@@ -19,6 +19,15 @@ describe Google::Cloud::Bigquery::Schema, :mock_bigquery do
   let(:policy_tag_2) { "projects/#{project}/locations/us/taxonomies/1/policyTags/2" }
   let(:policy_tag_3) { "projects/#{project}/locations/us/taxonomies/1/policyTags/3" }
   let(:policy_tags) { [ policy_tag, policy_tag_2 ] }
+  let(:policy_tags_gapi) { Google::Apis::BigqueryV2::TableFieldSchema::PolicyTags.new names: policy_tags }
+  let :field_integer_gapi do
+    Google::Apis::BigqueryV2::TableFieldSchema.new(
+      name: "rank",
+      type: "INTEGER",
+      mode: "NULLABLE",
+      policy_tags: policy_tags_gapi
+    )
+  end
   let :schema_gapi do
     Google::Apis::BigqueryV2::TableSchema.new(
       fields: [
@@ -26,9 +35,13 @@ describe Google::Cloud::Bigquery::Schema, :mock_bigquery do
           name: "my_secret_integer",
           type: "INT64",
           mode: "REQUIRED",
-          policy_tags: Google::Apis::BigqueryV2::TableFieldSchema::PolicyTags.new(
-            names: policy_tags
-          )
+          policy_tags: policy_tags_gapi
+        ),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(
+          name: "cities_lived",
+          type: "RECORD",
+          mode: "REPEATED",
+          fields: [field_integer_gapi]
         )
       ]
     )
@@ -36,8 +49,8 @@ describe Google::Cloud::Bigquery::Schema, :mock_bigquery do
   let(:schema) { Google::Cloud::Bigquery::Schema.from_gapi schema_gapi }
 
   it "knows its policy tags" do
-    field = schema.field :my_secret_integer
-    _(field.policy_tags).must_equal policy_tags
+    _(schema.field("my_secret_integer").policy_tags).must_equal policy_tags
+    _(schema.field("cities_lived").field("rank").policy_tags).must_equal policy_tags
   end
 
   it "includes policy tags in to_gapi" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/schema_test.rb
@@ -136,6 +136,7 @@ describe Google::Cloud::Bigquery::Schema, :mock_bigquery do
     _(schema.field(:name).mode).must_equal "REQUIRED"
     _(schema.field(:name)).must_be :string?
     _(schema.field(:name)).must_be :required?
+    _(schema.field(:name).policy_tags).must_be :nil?
 
     _(schema.field(:age)).must_be_kind_of Google::Cloud::Bigquery::Schema::Field
     _(schema.field(:age).name).must_equal "age"

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
@@ -34,6 +34,11 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
 
   let(:new_table_hash) { random_table_hash dataset, table_id, table_name, description }
 
+  let(:policy_tag) { "projects/#{project}/locations/us/taxonomies/1/policyTags/1" }
+  let(:policy_tag_2) { "projects/#{project}/locations/us/taxonomies/1/policyTags/2" }
+  let(:policy_tags) { [ policy_tag, policy_tag_2 ] }
+  let(:policy_tags_gapi) { Google::Apis::BigqueryV2::TableFieldSchema::PolicyTags.new names: policy_tags }
+
   let(:field_string_required_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "first_name", type: "STRING", mode: "REQUIRED", description: nil, fields: [] }
   let(:field_integer_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "rank", type: "INTEGER", description: "An integer value from 1 to 100", mode: "NULLABLE", fields: [] }
   let(:field_float_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "accuracy", type: "FLOAT", mode: "NULLABLE", description: nil, fields: [] }
@@ -41,7 +46,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
   let(:field_bignumeric_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "my_bignumeric", type: "BIGNUMERIC", mode: "NULLABLE", description: nil, fields: [] }
   let(:field_boolean_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "approved", type: "BOOLEAN", mode: "NULLABLE", description: nil, fields: [] }
   let(:field_bytes_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "avatar", type: "BYTES", mode: "NULLABLE", description: nil, fields: [] }
-  let(:field_timestamp_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "started_at", type: "TIMESTAMP", mode: "NULLABLE", description: nil, fields: [] }
+  let(:field_timestamp_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "started_at", type: "TIMESTAMP", mode: "NULLABLE", policy_tags: policy_tags_gapi, description: nil, fields: [] }
   let(:field_time_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "duration", type: "TIME", mode: "NULLABLE", description: nil, fields: [] }
   let(:field_datetime_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "target_end", type: "DATETIME", mode: "NULLABLE", description: nil, fields: [] }
   let(:field_date_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "birthday", type: "DATE", mode: "NULLABLE", description: nil, fields: [] }
@@ -167,7 +172,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
       schema.bignumeric "my_bignumeric"
       schema.boolean "approved"
       schema.bytes "avatar"
-      schema.timestamp "started_at"
+      schema.timestamp "started_at", policy_tags: policy_tags
       schema.time "duration"
       schema.datetime "target_end"
       schema.date "birthday"
@@ -192,7 +197,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     table.service.mocked_service = mock
 
     table.schema do |schema|
-      schema.timestamp "end_date"
+      schema.timestamp "end_date", policy_tags: policy_tags
     end
 
     mock.verify
@@ -213,7 +218,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     table.service.mocked_service = mock
 
     table.schema replace: true do |schema|
-      schema.timestamp "started_at"
+      schema.timestamp "started_at", policy_tags: policy_tags
     end
 
     mock.verify
@@ -259,7 +264,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
       schema.string "first_name", mode: :required
       schema.record "cities_lived", mode: :repeated do |nested|
         nested.integer "rank", description: "An integer value from 1 to 100"
-        nested.timestamp "started_at"
+        nested.timestamp "started_at", policy_tags: policy_tags
       end
     end
 
@@ -286,7 +291,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
       schema.string "first_name", mode: :required
       schema.record "cities_lived", mode: :repeated do |nested|
         nested.integer "rank", description: "An integer value from 1 to 100"
-        nested.timestamp "started_at"
+        nested.timestamp "started_at", policy_tags: policy_tags
       end
     end
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
@@ -40,12 +40,16 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
   let(:policy_tags_gapi) { Google::Apis::BigqueryV2::TableFieldSchema::PolicyTags.new names: policy_tags }
   let(:max_length_string) { 50 }
   let(:max_length_bytes) { 1024 }
+  let(:precision_numeric) { 10 }
+  let(:precision_bignumeric) { 38 }
+  let(:scale_numeric) { 9 }
+  let(:scale_bignumeric) { 37 }
 
   let(:field_string_required_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "first_name", type: "STRING", mode: "REQUIRED", description: nil, fields: [], max_length: max_length_string }
   let(:field_integer_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "rank", type: "INTEGER", description: "An integer value from 1 to 100", mode: "NULLABLE", fields: [] }
   let(:field_float_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "accuracy", type: "FLOAT", mode: "NULLABLE", description: nil, fields: [] }
-  let(:field_numeric_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "pi", type: "NUMERIC", mode: "NULLABLE", description: nil, fields: [] }
-  let(:field_bignumeric_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "my_bignumeric", type: "BIGNUMERIC", mode: "NULLABLE", description: nil, fields: [] }
+  let(:field_numeric_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "pi", type: "NUMERIC", mode: "NULLABLE", description: nil, fields: [], precision: precision_numeric, scale: scale_numeric }
+  let(:field_bignumeric_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "my_bignumeric", type: "BIGNUMERIC", mode: "NULLABLE", description: nil, fields: [], precision: precision_bignumeric, scale: scale_bignumeric }
   let(:field_boolean_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "approved", type: "BOOLEAN", mode: "NULLABLE", description: nil, fields: [] }
   let(:field_bytes_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "avatar", type: "BYTES", mode: "NULLABLE", description: nil, fields: [], max_length: max_length_bytes }
   let(:field_timestamp_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "started_at", type: "TIMESTAMP", mode: "NULLABLE", policy_tags: policy_tags_gapi, description: nil, fields: [] }
@@ -170,8 +174,8 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
       schema.string "first_name", mode: :required, max_length: max_length_string
       schema.integer "rank", description: "An integer value from 1 to 100"
       schema.float "accuracy"
-      schema.numeric "pi"
-      schema.bignumeric "my_bignumeric"
+      schema.numeric "pi", precision: precision_numeric, scale: scale_numeric
+      schema.bignumeric "my_bignumeric", precision: precision_bignumeric, scale: scale_bignumeric
       schema.boolean "approved"
       schema.bytes "avatar", max_length: max_length_bytes
       schema.timestamp "started_at", policy_tags: policy_tags
@@ -180,9 +184,15 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
       schema.date "birthday"
     end
 
-    _(table.schema.field("first_name").max_length).must_equal max_length_string
     _(table.schema.field("rank").max_length).must_be :nil?
+    _(table.schema.field("first_name").max_length).must_equal max_length_string
     _(table.schema.field("avatar").max_length).must_equal max_length_bytes
+    _(table.schema.field("rank").precision).must_be :nil?
+    _(table.schema.field("rank").scale).must_be :nil?
+    _(table.schema.field("pi").precision).must_equal precision_numeric
+    _(table.schema.field("pi").scale).must_equal scale_numeric
+    _(table.schema.field("my_bignumeric").precision).must_equal precision_bignumeric
+    _(table.schema.field("my_bignumeric").scale).must_equal scale_bignumeric
 
     mock.verify
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
@@ -38,14 +38,16 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
   let(:policy_tag_2) { "projects/#{project}/locations/us/taxonomies/1/policyTags/2" }
   let(:policy_tags) { [ policy_tag, policy_tag_2 ] }
   let(:policy_tags_gapi) { Google::Apis::BigqueryV2::TableFieldSchema::PolicyTags.new names: policy_tags }
+  let(:max_length_string) { 50 }
+  let(:max_length_bytes) { 1024 }
 
-  let(:field_string_required_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "first_name", type: "STRING", mode: "REQUIRED", description: nil, fields: [] }
+  let(:field_string_required_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "first_name", type: "STRING", mode: "REQUIRED", description: nil, fields: [], max_length: max_length_string }
   let(:field_integer_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "rank", type: "INTEGER", description: "An integer value from 1 to 100", mode: "NULLABLE", fields: [] }
   let(:field_float_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "accuracy", type: "FLOAT", mode: "NULLABLE", description: nil, fields: [] }
   let(:field_numeric_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "pi", type: "NUMERIC", mode: "NULLABLE", description: nil, fields: [] }
   let(:field_bignumeric_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "my_bignumeric", type: "BIGNUMERIC", mode: "NULLABLE", description: nil, fields: [] }
   let(:field_boolean_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "approved", type: "BOOLEAN", mode: "NULLABLE", description: nil, fields: [] }
-  let(:field_bytes_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "avatar", type: "BYTES", mode: "NULLABLE", description: nil, fields: [] }
+  let(:field_bytes_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "avatar", type: "BYTES", mode: "NULLABLE", description: nil, fields: [], max_length: max_length_bytes }
   let(:field_timestamp_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "started_at", type: "TIMESTAMP", mode: "NULLABLE", policy_tags: policy_tags_gapi, description: nil, fields: [] }
   let(:field_time_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "duration", type: "TIME", mode: "NULLABLE", description: nil, fields: [] }
   let(:field_datetime_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "target_end", type: "DATETIME", mode: "NULLABLE", description: nil, fields: [] }
@@ -165,18 +167,22 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     table.service.mocked_service = mock
 
     table.schema replace: true do |schema|
-      schema.string "first_name", mode: :required
+      schema.string "first_name", mode: :required, max_length: max_length_string
       schema.integer "rank", description: "An integer value from 1 to 100"
       schema.float "accuracy"
       schema.numeric "pi"
       schema.bignumeric "my_bignumeric"
       schema.boolean "approved"
-      schema.bytes "avatar"
+      schema.bytes "avatar", max_length: max_length_bytes
       schema.timestamp "started_at", policy_tags: policy_tags
       schema.time "duration"
       schema.datetime "target_end"
       schema.date "birthday"
     end
+
+    _(table.schema.field("first_name").max_length).must_equal max_length_string
+    _(table.schema.field("rank").max_length).must_be :nil?
+    _(table.schema.field("avatar").max_length).must_equal max_length_bytes
 
     mock.verify
   end
@@ -261,7 +267,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     table.service.mocked_service = mock
 
     table.schema replace: true do |schema|
-      schema.string "first_name", mode: :required
+      schema.string "first_name", mode: :required, max_length: max_length_string
       schema.record "cities_lived", mode: :repeated do |nested|
         nested.integer "rank", description: "An integer value from 1 to 100"
         nested.timestamp "started_at", policy_tags: policy_tags
@@ -288,7 +294,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     table.service.mocked_service = mock
 
     table.schema replace: true do |schema|
-      schema.string "first_name", mode: :required
+      schema.string "first_name", mode: :required, max_length: max_length_string
       schema.record "cities_lived", mode: :repeated do |nested|
         nested.integer "rank", description: "An integer value from 1 to 100"
         nested.timestamp "started_at", policy_tags: policy_tags
@@ -313,7 +319,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
       _(schema.field("first_name").mode).must_equal "REQUIRED"
       schema.field "cities_lived" do |nested|
         # Add a new field to the existing record
-        nested.string "first_name", mode: :required
+        nested.string "first_name", mode: :required, max_length: max_length_string
       end
     end
 


### PR DESCRIPTION
This PR depends on #12174.

* Add `Schema::Field#max_length`
* Add `max_length` to `Table#string`
* Add `max_length` to `Schema#string`
* Add `max_length` to `Schema::Field#string`
* Add `Schema::Field#precision`
* Add `Schema::Field#scale`
* Add `precision` and `scale` to `Table#numeric`
* Add `precision` and `scale` to `Table#bignumeric`
* Add `precision` and `scale` to `Schema#numeric`
* Add `precision` and `scale` to `Schema#bignumeric`
* Add `precision` and `scale` to `Schema::Field#numeric`
* Add `precision` and `scale` to `Schema::Field#bignumeric`

closes: #11673