### PR TITLE
feat(bigquery): Add support for parameterized types

### DIFF
--- a/google-cloud-bigquery/acceptance/bigquery/advanced_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/advanced_test.rb
@@ -22,6 +22,8 @@ describe Google::Cloud::Bigquery, :advanced, :bigquery do
 
   let(:string_numeric) { "0.123456789" }
   let(:string_bignumeric) { "0.12345678901234567890123456789012345678" }
+  let(:max_length_string) { 50 }
+  let(:max_length_bytes) { 1024 }
 
   before do
     @table = get_or_create_example_table dataset, table_id
@@ -183,6 +185,12 @@ describe Google::Cloud::Bigquery, :advanced, :bigquery do
     _(rows[0][:my_bignumeric]).must_equal BigDecimal(string_bignumeric)
   end
 
+  it "knows its schema max_length for string and bytes fields" do
+    _(table.schema.field("age").max_length).must_be :nil?
+    _(table.schema.field("name").max_length).must_equal max_length_string
+    _(table.schema.field("spells").field("icon").max_length).must_equal max_length_bytes
+  end
+
   def assert_rows_equal returned_row, example_row
     _(returned_row[:id]).must_equal example_row[:id]
     _(returned_row[:name]).must_equal example_row[:name]
@@ -208,7 +216,7 @@ describe Google::Cloud::Bigquery, :advanced, :bigquery do
     if t.nil?
       t = dataset.create_table table_id do |schema|
         schema.integer "id", mode: :nullable
-        schema.string "name", mode: :nullable
+        schema.string "name", mode: :nullable, max_length: max_length_string
         schema.integer "age", mode: :nullable
         schema.float "weight", mode: :nullable
         schema.numeric "my_numeric", mode: :nullable
@@ -222,7 +230,7 @@ describe Google::Cloud::Bigquery, :advanced, :bigquery do
             properties.string "name", mode: :nullable
             properties.float "power", mode: :nullable
           end
-          spells.bytes "icon", mode: :nullable
+          spells.bytes "icon", mode: :nullable, max_length: max_length_bytes
           spells.timestamp "last_used", mode: :nullable
         end
         schema.time "tea_time", mode: :nullable

--- a/google-cloud-bigquery/acceptance/bigquery/advanced_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/advanced_test.rb
@@ -20,10 +20,14 @@ describe Google::Cloud::Bigquery, :advanced, :bigquery do
   let(:table_id) { "examples_table" }
   let(:table) { @table }
 
-  let(:string_numeric) { "0.123456789" }
-  let(:string_bignumeric) { "0.12345678901234567890123456789012345678" }
+  let(:string_numeric) { "1.123456789" }
+  let(:string_bignumeric) { "1.1234567890123456789012345678901234567" }
   let(:max_length_string) { 50 }
   let(:max_length_bytes) { 1024 }
+  let(:precision_numeric) { 10 }
+  let(:precision_bignumeric) { 38 }
+  let(:scale_numeric) { 9 }
+  let(:scale_bignumeric) { 37 }
 
   before do
     @table = get_or_create_example_table dataset, table_id
@@ -191,6 +195,15 @@ describe Google::Cloud::Bigquery, :advanced, :bigquery do
     _(table.schema.field("spells").field("icon").max_length).must_equal max_length_bytes
   end
 
+  it "knows its schema precision and scale for numeric and bignumeric fields" do
+    _(table.schema.field("age").precision).must_be :nil?
+    _(table.schema.field("age").scale).must_be :nil?
+    _(table.schema.field("my_numeric").precision).must_equal precision_numeric
+    _(table.schema.field("my_numeric").scale).must_equal scale_numeric
+    _(table.schema.field("my_bignumeric").precision).must_equal precision_bignumeric
+    _(table.schema.field("my_bignumeric").scale).must_equal scale_bignumeric
+  end
+
   def assert_rows_equal returned_row, example_row
     _(returned_row[:id]).must_equal example_row[:id]
     _(returned_row[:name]).must_equal example_row[:name]
@@ -219,8 +232,8 @@ describe Google::Cloud::Bigquery, :advanced, :bigquery do
         schema.string "name", mode: :nullable, max_length: max_length_string
         schema.integer "age", mode: :nullable
         schema.float "weight", mode: :nullable
-        schema.numeric "my_numeric", mode: :nullable
-        schema.bignumeric "my_bignumeric", mode: :nullable
+        schema.numeric "my_numeric", mode: :nullable, precision: precision_numeric, scale: scale_numeric
+        schema.bignumeric "my_bignumeric", mode: :nullable, precision: precision_bignumeric, scale: scale_bignumeric
         schema.boolean "is_magic", mode: :nullable
         schema.float "scores", mode: :repeated
         schema.record "spells", mode: :repeated do |spells|

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
@@ -755,6 +755,8 @@ module Google
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #   At most 1 policy tag is currently allowed.
+          # @param [Integer] max_length The maximum UTF-8 length of strings
+          #   allowed in the field.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -766,8 +768,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def string name, description: nil, mode: :nullable, policy_tags: nil
-            schema.string name, description: description, mode: mode, policy_tags: policy_tags
+          def string name, description: nil, mode: :nullable, policy_tags: nil, max_length: nil
+            schema.string name, description: description, mode: mode, policy_tags: policy_tags, max_length: max_length
           end
 
           ##
@@ -862,6 +864,16 @@ module Google
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #   At most 1 policy tag is currently allowed.
+          # @param [Integer] precision The precision (maximum number of total
+          #   digits) for the field. Acceptable values for precision must be:
+          #   `1 ≤ (precision - scale) ≤ 29`. Values for scale must be:
+          #   `0 ≤ scale ≤ 9`. If the scale value is set, the precision value
+          #   must be set as well.
+          # @param [Integer] scale The scale (maximum number of digits in the
+          #   fractional part) for the field. Acceptable values for precision
+          #   must be: `1 ≤ (precision - scale) ≤ 29`. Values for scale must
+          #   be: `0 ≤ scale ≤ 9`. If the scale value is set, the precision
+          #   value must be set as well.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -873,8 +885,13 @@ module Google
           #   end
           #
           # @!group Schema
-          def numeric name, description: nil, mode: :nullable, policy_tags: nil
-            schema.numeric name, description: description, mode: mode, policy_tags: policy_tags
+          def numeric name, description: nil, mode: :nullable, policy_tags: nil, precision: nil, scale: nil
+            schema.numeric name,
+                           description: description,
+                           mode: mode,
+                           policy_tags: policy_tags,
+                           precision: precision,
+                           scale: scale
           end
 
           ##
@@ -905,6 +922,16 @@ module Google
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #   At most 1 policy tag is currently allowed.
+          # @param [Integer] precision The precision (maximum number of total
+          #   digits) for the field. Acceptable values for precision must be:
+          #   `1 ≤ (precision - scale) ≤ 38`. Values for scale must be:
+          #   `0 ≤ scale ≤ 38`. If the scale value is set, the precision value
+          #   must be set as well.
+          # @param [Integer] scale The scale (maximum number of digits in the
+          #   fractional part) for the field. Acceptable values for precision
+          #   must be: `1 ≤ (precision - scale) ≤ 38`. Values for scale must
+          #   be: `0 ≤ scale ≤ 38`. If the scale value is set, the precision
+          #   value must be set as well.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -916,8 +943,13 @@ module Google
           #   end
           #
           # @!group Schema
-          def bignumeric name, description: nil, mode: :nullable, policy_tags: nil
-            schema.bignumeric name, description: description, mode: mode, policy_tags: policy_tags
+          def bignumeric name, description: nil, mode: :nullable, policy_tags: nil, precision: nil, scale: nil
+            schema.bignumeric name,
+                              description: description,
+                              mode: mode,
+                              policy_tags: policy_tags,
+                              precision: precision,
+                              scale: scale
           end
 
           ##
@@ -969,6 +1001,8 @@ module Google
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #   At most 1 policy tag is currently allowed.
+          # @param [Integer] max_length The maximum the maximum number of
+          #   bytes in the field.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -980,8 +1014,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def bytes name, description: nil, mode: :nullable, policy_tags: nil
-            schema.bytes name, description: description, mode: mode, policy_tags: policy_tags
+          def bytes name, description: nil, mode: :nullable, policy_tags: nil, max_length: nil
+            schema.bytes name, description: description, mode: mode, policy_tags: policy_tags, max_length: max_length
           end
 
           ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
@@ -376,9 +376,25 @@ module Google
         #   single policy tag for the field. Policy tag identifiers are of
         #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #   At most 1 policy tag is currently allowed.
+        # @param [Integer] precision The precision (maximum number of total
+        #   digits) for the field. Acceptable values for precision must be:
+        #   `1 ≤ (precision - scale) ≤ 29`. Values for scale must be:
+        #   `0 ≤ scale ≤ 9`. If the scale value is set, the precision value
+        #   must be set as well.
+        # @param [Integer] scale The scale (maximum number of digits in the
+        #   fractional part) for the field. Acceptable values for precision
+        #   must be: `1 ≤ (precision - scale) ≤ 29`. Values for scale must
+        #   be: `0 ≤ scale ≤ 9`. If the scale value is set, the precision
+        #   value must be set as well.
         #
-        def numeric name, description: nil, mode: :nullable, policy_tags: nil
-          add_field name, :numeric, description: description, mode: mode, policy_tags: policy_tags
+        def numeric name, description: nil, mode: :nullable, policy_tags: nil, precision: nil, scale: nil
+          add_field name,
+                    :numeric,
+                    description: description,
+                    mode: mode,
+                    policy_tags: policy_tags,
+                    precision: precision,
+                    scale: scale
         end
 
         ##
@@ -407,9 +423,25 @@ module Google
         #   single policy tag for the field. Policy tag identifiers are of
         #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #   At most 1 policy tag is currently allowed.
+        # @param [Integer] precision The precision (maximum number of total
+        #   digits) for the field. Acceptable values for precision must be:
+        #   `1 ≤ (precision - scale) ≤ 38`. Values for scale must be:
+        #   `0 ≤ scale ≤ 38`. If the scale value is set, the precision value
+        #   must be set as well.
+        # @param [Integer] scale The scale (maximum number of digits in the
+        #   fractional part) for the field. Acceptable values for precision
+        #   must be: `1 ≤ (precision - scale) ≤ 38`. Values for scale must
+        #   be: `0 ≤ scale ≤ 38`. If the scale value is set, the precision
+        #   value must be set as well.
         #
-        def bignumeric name, description: nil, mode: :nullable, policy_tags: nil
-          add_field name, :bignumeric, description: description, mode: mode, policy_tags: policy_tags
+        def bignumeric name, description: nil, mode: :nullable, policy_tags: nil, precision: nil, scale: nil
+          add_field name,
+                    :bignumeric,
+                    description: description,
+                    mode: mode,
+                    policy_tags: policy_tags,
+                    precision: precision,
+                    scale: scale
         end
 
         ##
@@ -614,7 +646,14 @@ module Google
           raise ArgumentError, "Cannot modify a frozen schema"
         end
 
-        def add_field name, type, description: nil, mode: :nullable, policy_tags: nil, max_length: nil
+        def add_field name,
+                      type,
+                      description: nil,
+                      mode: :nullable,
+                      policy_tags: nil,
+                      max_length: nil,
+                      precision: nil,
+                      scale: nil
           frozen_check!
 
           new_gapi = Google::Apis::BigqueryV2::TableFieldSchema.new(
@@ -629,6 +668,8 @@ module Google
             new_gapi.policy_tags = Google::Apis::BigqueryV2::TableFieldSchema::PolicyTags.new names: policy_tags
           end
           new_gapi.max_length = max_length if max_length
+          new_gapi.precision = precision if precision
+          new_gapi.scale = scale if scale
           # Remove any existing field of this name
           @gapi.fields ||= []
           @gapi.fields.reject! { |f| f.name == new_gapi.name }

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema.rb
@@ -298,9 +298,16 @@ module Google
         #   single policy tag for the field. Policy tag identifiers are of
         #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #   At most 1 policy tag is currently allowed.
+        # @param [Integer] max_length The maximum UTF-8 length of strings
+        #   allowed in the field.
         #
-        def string name, description: nil, mode: :nullable, policy_tags: nil
-          add_field name, :string, description: description, mode: mode, policy_tags: policy_tags
+        def string name, description: nil, mode: :nullable, policy_tags: nil, max_length: nil
+          add_field name,
+                    :string,
+                    description: description,
+                    mode: mode,
+                    policy_tags: policy_tags,
+                    max_length: max_length
         end
 
         ##
@@ -440,9 +447,11 @@ module Google
         #   single policy tag for the field. Policy tag identifiers are of
         #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
         #   At most 1 policy tag is currently allowed.
+        # @param [Integer] max_length The maximum the maximum number of
+        #   bytes in the field.
         #
-        def bytes name, description: nil, mode: :nullable, policy_tags: nil
-          add_field name, :bytes, description: description, mode: mode, policy_tags: policy_tags
+        def bytes name, description: nil, mode: :nullable, policy_tags: nil, max_length: nil
+          add_field name, :bytes, description: description, mode: mode, policy_tags: policy_tags, max_length: max_length
         end
 
         ##
@@ -605,7 +614,7 @@ module Google
           raise ArgumentError, "Cannot modify a frozen schema"
         end
 
-        def add_field name, type, description: nil, mode: :nullable, policy_tags: nil
+        def add_field name, type, description: nil, mode: :nullable, policy_tags: nil, max_length: nil
           frozen_check!
 
           new_gapi = Google::Apis::BigqueryV2::TableFieldSchema.new(
@@ -619,6 +628,7 @@ module Google
             policy_tags = Array(policy_tags)
             new_gapi.policy_tags = Google::Apis::BigqueryV2::TableFieldSchema::PolicyTags.new names: policy_tags
           end
+          new_gapi.max_length = max_length if max_length
           # Remove any existing field of this name
           @gapi.fields ||= []
           @gapi.fields.reject! { |f| f.name == new_gapi.name }

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
@@ -221,6 +221,18 @@ module Google
           end
 
           ##
+          # The maximum length of values of this field for {#string?} or {bytes?} fields. If `max_length` is not
+          # specified, no maximum length constraint is imposed on this field. If type = `STRING`, then `max_length`
+          # represents the maximum UTF-8 length of strings in this field. If type = `BYTES`, then `max_length`
+          # represents the maximum number of bytes in this field.
+          #
+          # @return [Integer, nil] The maximum length of values of this field, or `nil`.
+          #
+          def max_length
+            @gapi.max_length
+          end
+
+          ##
           # Checks if the type of the field is `STRING`.
           #
           # @return [Boolean] `true` when `STRING`, `false` otherwise.
@@ -416,11 +428,18 @@ module Google
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #   At most 1 policy tag is currently allowed.
+          # @param [Integer] max_length The maximum UTF-8 length of strings
+          #   allowed in the field.
           #
-          def string name, description: nil, mode: :nullable, policy_tags: nil
+          def string name, description: nil, mode: :nullable, policy_tags: nil, max_length: nil
             record_check!
 
-            add_field name, :string, description: description, mode: mode, policy_tags: policy_tags
+            add_field name,
+                      :string,
+                      description: description,
+                      mode: mode,
+                      policy_tags: policy_tags,
+                      max_length: max_length
           end
 
           ##
@@ -583,11 +602,18 @@ module Google
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #   At most 1 policy tag is currently allowed.
+          # @param [Integer] max_length The maximum the maximum number of
+          #   bytes in the field.
           #
-          def bytes name, description: nil, mode: :nullable, policy_tags: nil
+          def bytes name, description: nil, mode: :nullable, policy_tags: nil, max_length: nil
             record_check!
 
-            add_field name, :bytes, description: description, mode: mode, policy_tags: policy_tags
+            add_field name,
+                      :bytes,
+                      description: description,
+                      mode: mode,
+                      policy_tags: policy_tags,
+                      max_length: max_length
           end
 
           ##
@@ -779,7 +805,7 @@ module Google
                   "Cannot add fields to a non-RECORD field (#{type})"
           end
 
-          def add_field name, type, description: nil, mode: :nullable, policy_tags: nil
+          def add_field name, type, description: nil, mode: :nullable, policy_tags: nil, max_length: nil
             frozen_check!
 
             new_gapi = Google::Apis::BigqueryV2::TableFieldSchema.new(
@@ -793,6 +819,7 @@ module Google
               policy_tags = Array(policy_tags)
               new_gapi.policy_tags = Google::Apis::BigqueryV2::TableFieldSchema::PolicyTags.new names: policy_tags
             end
+            new_gapi.max_length = max_length if max_length
             # Remove any existing field of this name
             @gapi.fields ||= []
             @gapi.fields.reject! { |f| f.name == new_gapi.name }

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
@@ -233,6 +233,32 @@ module Google
           end
 
           ##
+          # The precision (maximum number of total digits) for `NUMERIC` or `BIGNUMERIC` types. For {#numeric?} fields,
+          # acceptable values for precision must be `1 ≤ (precision - scale) ≤ 29` and values for scale must be `0 ≤
+          # scale ≤ 9`. For {#bignumeric?} fields, acceptable values for precision must be `1 ≤ (precision - scale) ≤
+          # 38` and values for scale must be `0 ≤ scale ≤ 38`. If the scale value is set, the precision value must be
+          # set as well.
+          #
+          # @return [Integer, nil] The precision for the field, or `nil`.
+          #
+          def precision
+            @gapi.precision
+          end
+
+          ##
+          # The scale (maximum number of digits in the fractional part) for `NUMERIC` or `BIGNUMERIC` types. For
+          # {#numeric?} fields, acceptable values for precision must be `1 ≤ (precision - scale) ≤ 29` and values for
+          # scale must be `0 ≤ scale ≤ 9`. For {#bignumeric?} fields, acceptable values for precision must be `1 ≤
+          # (precision - scale) ≤ 38` and values for scale must be `0 ≤ scale ≤ 38`. If the scale value is set, the
+          # precision value must be set as well.
+          #
+          # @return [Integer, nil] The scale for the field, or `nil`.
+          #
+          def scale
+            @gapi.scale
+          end
+
+          ##
           # Checks if the type of the field is `STRING`.
           #
           # @return [Boolean] `true` when `STRING`, `false` otherwise.
@@ -519,11 +545,27 @@ module Google
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #   At most 1 policy tag is currently allowed.
+          # @param [Integer] precision The precision (maximum number of total
+          #   digits) for the field. Acceptable values for precision must be:
+          #   `1 ≤ (precision - scale) ≤ 29`. Values for scale must be:
+          #   `0 ≤ scale ≤ 9`. If the scale value is set, the precision value
+          #   must be set as well.
+          # @param [Integer] scale The scale (maximum number of digits in the
+          #   fractional part) for the field. Acceptable values for precision
+          #   must be: `1 ≤ (precision - scale) ≤ 29`. Values for scale must
+          #   be: `0 ≤ scale ≤ 9`. If the scale value is set, the precision
+          #   value must be set as well.
           #
-          def numeric name, description: nil, mode: :nullable, policy_tags: nil
+          def numeric name, description: nil, mode: :nullable, policy_tags: nil, precision: nil, scale: nil
             record_check!
 
-            add_field name, :numeric, description: description, mode: mode, policy_tags: policy_tags
+            add_field name,
+                      :numeric,
+                      description: description,
+                      mode: mode,
+                      policy_tags: policy_tags,
+                      precision: precision,
+                      scale: scale
           end
 
           ##
@@ -554,11 +596,27 @@ module Google
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #   At most 1 policy tag is currently allowed.
+          # @param [Integer] precision The precision (maximum number of total
+          #   digits) for the field. Acceptable values for precision must be:
+          #   `1 ≤ (precision - scale) ≤ 38`. Values for scale must be:
+          #   `0 ≤ scale ≤ 38`. If the scale value is set, the precision value
+          #   must be set as well.
+          # @param [Integer] scale The scale (maximum number of digits in the
+          #   fractional part) for the field. Acceptable values for precision
+          #   must be: `1 ≤ (precision - scale) ≤ 38`. Values for scale must
+          #   be: `0 ≤ scale ≤ 38`. If the scale value is set, the precision
+          #   value must be set as well.
           #
-          def bignumeric name, description: nil, mode: :nullable, policy_tags: nil
+          def bignumeric name, description: nil, mode: :nullable, policy_tags: nil, precision: nil, scale: nil
             record_check!
 
-            add_field name, :bignumeric, description: description, mode: mode, policy_tags: policy_tags
+            add_field name,
+                      :bignumeric,
+                      description: description,
+                      mode: mode,
+                      policy_tags: policy_tags,
+                      precision: precision,
+                      scale: scale
           end
 
           ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -3351,6 +3351,16 @@ module Google
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #   At most 1 policy tag is currently allowed.
+          # @param [Integer] precision The precision (maximum number of total
+          #   digits) for the field. Acceptable values for precision must be:
+          #   `1 ≤ (precision - scale) ≤ 29`. Values for scale must be:
+          #   `0 ≤ scale ≤ 9`. If the scale value is set, the precision value
+          #   must be set as well.
+          # @param [Integer] scale The scale (maximum number of digits in the
+          #   fractional part) for the field. Acceptable values for precision
+          #   must be: `1 ≤ (precision - scale) ≤ 29`. Values for scale must
+          #   be: `0 ≤ scale ≤ 9`. If the scale value is set, the precision
+          #   value must be set as well.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -3362,8 +3372,13 @@ module Google
           #   end
           #
           # @!group Schema
-          def numeric name, description: nil, mode: :nullable, policy_tags: nil
-            schema.numeric name, description: description, mode: mode, policy_tags: policy_tags
+          def numeric name, description: nil, mode: :nullable, policy_tags: nil, precision: nil, scale: nil
+            schema.numeric name,
+                           description: description,
+                           mode: mode,
+                           policy_tags: policy_tags,
+                           precision: precision,
+                           scale: scale
           end
 
           ##
@@ -3394,6 +3409,16 @@ module Google
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #   At most 1 policy tag is currently allowed.
+          # @param [Integer] precision The precision (maximum number of total
+          #   digits) for the field. Acceptable values for precision must be:
+          #   `1 ≤ (precision - scale) ≤ 38`. Values for scale must be:
+          #   `0 ≤ scale ≤ 38`. If the scale value is set, the precision value
+          #   must be set as well.
+          # @param [Integer] scale The scale (maximum number of digits in the
+          #   fractional part) for the field. Acceptable values for precision
+          #   must be: `1 ≤ (precision - scale) ≤ 38`. Values for scale must
+          #   be: `0 ≤ scale ≤ 38`. If the scale value is set, the precision
+          #   value must be set as well.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -3405,8 +3430,13 @@ module Google
           #   end
           #
           # @!group Schema
-          def bignumeric name, description: nil, mode: :nullable, policy_tags: nil
-            schema.bignumeric name, description: description, mode: mode, policy_tags: policy_tags
+          def bignumeric name, description: nil, mode: :nullable, policy_tags: nil, precision: nil, scale: nil
+            schema.bignumeric name,
+                              description: description,
+                              mode: mode,
+                              policy_tags: policy_tags,
+                              precision: precision,
+                              scale: scale
           end
 
           ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -3242,6 +3242,8 @@ module Google
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #   At most 1 policy tag is currently allowed.
+          # @param [Integer] max_length The maximum UTF-8 length of strings
+          #   allowed in the field.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -3253,8 +3255,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def string name, description: nil, mode: :nullable, policy_tags: nil
-            schema.string name, description: description, mode: mode, policy_tags: policy_tags
+          def string name, description: nil, mode: :nullable, policy_tags: nil, max_length: nil
+            schema.string name, description: description, mode: mode, policy_tags: policy_tags, max_length: max_length
           end
 
           ##
@@ -3456,6 +3458,8 @@ module Google
           #   single policy tag for the field. Policy tag identifiers are of
           #   the form `projects/*/locations/*/taxonomies/*/policyTags/*`.
           #   At most 1 policy tag is currently allowed.
+          # @param [Integer] max_length The maximum the maximum number of
+          #   bytes in the field.
           #
           # @example
           #   require "google/cloud/bigquery"
@@ -3467,8 +3471,8 @@ module Google
           #   end
           #
           # @!group Schema
-          def bytes name, description: nil, mode: :nullable, policy_tags: nil
-            schema.bytes name, description: description, mode: mode, policy_tags: policy_tags
+          def bytes name, description: nil, mode: :nullable, policy_tags: nil, max_length: nil
+            schema.bytes name, description: description, mode: mode, policy_tags: policy_tags, max_length: max_length
           end
 
           ##

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_schema_test.rb
@@ -35,12 +35,6 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :schema, :mock_bigquery do
 
   let(:table_name) { "My Table" }
   let(:table_description) { "This is my table" }
-
-  let(:policy_tag) { "projects/#{project}/locations/us/taxonomies/1/policyTags/1" }
-  let(:policy_tag_2) { "projects/#{project}/locations/us/taxonomies/1/policyTags/2" }
-  let(:policy_tags) { [ policy_tag, policy_tag_2 ] }
-  let(:policy_tags_gapi) { Google::Apis::BigqueryV2::TableFieldSchema::PolicyTags.new names: policy_tags }
-
   let(:table_schema) {
     {
       fields: [
@@ -227,10 +221,8 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :schema, :mock_bigquery do
 
   it "can specify a schema both as an option and in a block during load" do
     mock = Minitest::Mock.new
-    schema_gapi_with_policy_tags = table_schema_gapi.dup
-    schema_gapi_with_policy_tags.fields.last.policy_tags = policy_tags_gapi
     job_gapi = load_job_url_gapi table_reference, load_url
-    job_gapi.configuration.load.schema = schema_gapi_with_policy_tags
+    job_gapi.configuration.load.schema = table_schema_gapi
     job_gapi.configuration.load.create_disposition = "CREATE_IF_NEEDED"
     job_gapi.configuration.load.schema_update_options = schema_update_options
 
@@ -249,7 +241,7 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :schema, :mock_bigquery do
       schema.bignumeric "my_bignumeric"
       schema.boolean "active"
       schema.bytes "avatar"
-      schema.timestamp "dob", mode: :required, policy_tags: policy_tags
+      schema.timestamp "dob", mode: :required
       schema.schema_update_options = schema_update_options
     end
     _(job).must_be_kind_of Google::Cloud::Bigquery::LoadJob

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
@@ -48,11 +48,11 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
   let(:table_schema_gapi) do
     Google::Apis::BigqueryV2::TableSchema.new(
       fields: [
-        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "REQUIRED", name: "name", type: "STRING", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "REQUIRED", name: "name", type: "STRING", description: nil, fields: [], max_length: max_length_string),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "age", type: "INTEGER", description: nil, fields: [], policy_tags: policy_tags_gapi),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "score", type: "FLOAT", description: "A score from 0.0 to 10.0", fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "active", type: "BOOLEAN", description: nil, fields: []),
-        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "avatar", type: "BYTES", description: nil, fields: [])
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "avatar", type: "BYTES", description: nil, fields: [], max_length: max_length_bytes)
       ]
     )
   end
@@ -68,6 +68,8 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
   let(:dataset_hash) { random_dataset_hash dataset_id, dataset_name, dataset_description, default_expiration }
   let(:dataset_gapi) { Google::Apis::BigqueryV2::Dataset.from_json dataset_hash.to_json }
   let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi, bigquery.service }
+  let(:max_length_string) { 50 }
+  let(:max_length_bytes) { 1024 }
 
   it "knows its attributes" do
     _(dataset.name).must_equal dataset_name
@@ -315,11 +317,11 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     table = dataset.create_table table_id do |t|
       t.name = table_name
       t.description = table_description
-      t.schema.string "name", mode: :required
+      t.schema.string "name", mode: :required, max_length: max_length_string
       t.schema.integer "age", policy_tags: policy_tags
       t.schema.float "score", description: "A score from 0.0 to 10.0"
       t.schema.boolean "active"
-      t.schema.bytes "avatar"
+      t.schema.bytes "avatar", max_length: max_length_bytes
     end
 
     mock.verify
@@ -341,13 +343,13 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
       table_reference: Google::Apis::BigqueryV2::TableReference.new(
         project_id: project, dataset_id: dataset_id, table_id: table_id),
       schema: Google::Apis::BigqueryV2::TableSchema.new(fields: [
-        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "REQUIRED", name: "name",          type: "STRING", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "REQUIRED", name: "name",          type: "STRING", description: nil, fields: [], max_length: max_length_string),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "age",           type: "INTEGER", policy_tags: policy_tags_gapi, description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "score",         type: "FLOAT", description: "A score from 0.0 to 10.0", fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "cost",          type: "NUMERIC", description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "my_bignumeric", type: "BIGNUMERIC", description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "active",        type: "BOOLEAN", description: nil, fields: []),
-        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "avatar",        type: "BYTES", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "avatar",        type: "BYTES", description: nil, fields: [], max_length: max_length_bytes),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "creation_date", type: "TIMESTAMP", description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "duration",      type: "TIME", description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "target_end",    type: "DATETIME", description: nil, fields: []),
@@ -362,13 +364,13 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
     dataset.service.mocked_service = mock
 
     table = dataset.create_table table_id do |schema|
-      schema.string "name", mode: :required
+      schema.string "name", mode: :required, max_length: max_length_string
       schema.integer "age", policy_tags: policy_tags
       schema.float "score", description: "A score from 0.0 to 10.0"
       schema.numeric "cost"
       schema.bignumeric "my_bignumeric"
       schema.boolean "active"
-      schema.bytes "avatar"
+      schema.bytes "avatar", max_length: max_length_bytes
       schema.timestamp "creation_date"
       schema.time "duration"
       schema.datetime "target_end"
@@ -409,11 +411,11 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
       t.name = table_name
       t.description = table_description
       t.schema do |s|
-        s.string "name", mode: :required
+        s.string "name", mode: :required, max_length: max_length_string
         s.integer "age", policy_tags: policy_tags
         s.float "score", description: "A score from 0.0 to 10.0"
         s.boolean "active"
-        s.bytes "avatar"
+        s.bytes "avatar", max_length: max_length_bytes
       end
     end
 

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_test.rb
@@ -70,6 +70,10 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
   let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi, bigquery.service }
   let(:max_length_string) { 50 }
   let(:max_length_bytes) { 1024 }
+  let(:precision_numeric) { 10 }
+  let(:precision_bignumeric) { 38 }
+  let(:scale_numeric) { 9 }
+  let(:scale_bignumeric) { 37 }
 
   it "knows its attributes" do
     _(dataset.name).must_equal dataset_name
@@ -346,8 +350,8 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "REQUIRED", name: "name",          type: "STRING", description: nil, fields: [], max_length: max_length_string),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "age",           type: "INTEGER", policy_tags: policy_tags_gapi, description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "score",         type: "FLOAT", description: "A score from 0.0 to 10.0", fields: []),
-        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "cost",          type: "NUMERIC", description: nil, fields: []),
-        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "my_bignumeric", type: "BIGNUMERIC", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "cost",          type: "NUMERIC", description: nil, fields: [], precision: precision_numeric, scale: scale_numeric),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "my_bignumeric", type: "BIGNUMERIC", description: nil, fields: [], precision: precision_bignumeric, scale: scale_bignumeric),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "active",        type: "BOOLEAN", description: nil, fields: []),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "avatar",        type: "BYTES", description: nil, fields: [], max_length: max_length_bytes),
         Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "creation_date", type: "TIMESTAMP", description: nil, fields: []),
@@ -367,8 +371,8 @@ describe Google::Cloud::Bigquery::Dataset, :mock_bigquery do
       schema.string "name", mode: :required, max_length: max_length_string
       schema.integer "age", policy_tags: policy_tags
       schema.float "score", description: "A score from 0.0 to 10.0"
-      schema.numeric "cost"
-      schema.bignumeric "my_bignumeric"
+      schema.numeric "cost", precision: precision_numeric, scale: scale_numeric
+      schema.bignumeric "my_bignumeric", precision: precision_bignumeric, scale: scale_bignumeric
       schema.boolean "active"
       schema.bytes "avatar", max_length: max_length_bytes
       schema.timestamp "creation_date"

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
@@ -40,12 +40,16 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
   let(:policy_tags_gapi) { Google::Apis::BigqueryV2::TableFieldSchema::PolicyTags.new names: policy_tags }
   let(:max_length_string) { 50 }
   let(:max_length_bytes) { 1024 }
+  let(:precision_numeric) { 10 }
+  let(:precision_bignumeric) { 38 }
+  let(:scale_numeric) { 9 }
+  let(:scale_bignumeric) { 37 }
 
   let(:field_string_required_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "first_name", type: "STRING", mode: "REQUIRED", description: nil, fields: [], max_length: max_length_string }
   let(:field_integer_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "rank", type: "INTEGER", description: "An integer value from 1 to 100", mode: "NULLABLE", fields: [] }
   let(:field_float_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "accuracy", type: "FLOAT", mode: "NULLABLE", description: nil, fields: [] }
-  let(:field_numeric_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "pi", type: "NUMERIC", mode: "NULLABLE", description: nil, fields: [] }
-  let(:field_bignumeric_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "my_bignumeric", type: "BIGNUMERIC", mode: "NULLABLE", description: nil, fields: [] }
+  let(:field_numeric_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "pi", type: "NUMERIC", mode: "NULLABLE", description: nil, fields: [], precision: precision_numeric, scale: scale_numeric }
+  let(:field_bignumeric_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "my_bignumeric", type: "BIGNUMERIC", mode: "NULLABLE", description: nil, fields: [], precision: precision_bignumeric, scale: scale_bignumeric }
   let(:field_boolean_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "approved", type: "BOOLEAN", mode: "NULLABLE", description: nil, fields: [] }
   let(:field_bytes_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "avatar", type: "BYTES", mode: "NULLABLE", description: nil, fields: [], max_length: max_length_bytes }
   let(:field_timestamp_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "started_at", type: "TIMESTAMP", mode: "NULLABLE", policy_tags: policy_tags_gapi, description: nil, fields: [] }
@@ -170,8 +174,8 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
       schema.string "first_name", mode: :required, max_length: max_length_string
       schema.integer "rank", description: "An integer value from 1 to 100"
       schema.float "accuracy"
-      schema.numeric "pi"
-      schema.bignumeric "my_bignumeric"
+      schema.numeric "pi", precision: precision_numeric, scale: scale_numeric
+      schema.bignumeric "my_bignumeric", precision: precision_bignumeric, scale: scale_bignumeric
       schema.boolean "approved"
       schema.bytes "avatar", max_length: max_length_bytes
       schema.timestamp "started_at", policy_tags: policy_tags
@@ -180,9 +184,15 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
       schema.date "birthday"
     end
 
-    _(table.schema.field("first_name").max_length).must_equal max_length_string
     _(table.schema.field("rank").max_length).must_be :nil?
+    _(table.schema.field("first_name").max_length).must_equal max_length_string
     _(table.schema.field("avatar").max_length).must_equal max_length_bytes
+    _(table.schema.field("rank").precision).must_be :nil?
+    _(table.schema.field("rank").scale).must_be :nil?
+    _(table.schema.field("pi").precision).must_equal precision_numeric
+    _(table.schema.field("pi").scale).must_equal scale_numeric
+    _(table.schema.field("my_bignumeric").precision).must_equal precision_bignumeric
+    _(table.schema.field("my_bignumeric").scale).must_equal scale_bignumeric
 
     mock.verify
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
@@ -38,14 +38,16 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
   let(:policy_tag_2) { "projects/#{project}/locations/us/taxonomies/1/policyTags/2" }
   let(:policy_tags) { [ policy_tag, policy_tag_2 ] }
   let(:policy_tags_gapi) { Google::Apis::BigqueryV2::TableFieldSchema::PolicyTags.new names: policy_tags }
+  let(:max_length_string) { 50 }
+  let(:max_length_bytes) { 1024 }
 
-  let(:field_string_required_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "first_name", type: "STRING", mode: "REQUIRED", description: nil, fields: [] }
+  let(:field_string_required_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "first_name", type: "STRING", mode: "REQUIRED", description: nil, fields: [], max_length: max_length_string }
   let(:field_integer_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "rank", type: "INTEGER", description: "An integer value from 1 to 100", mode: "NULLABLE", fields: [] }
   let(:field_float_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "accuracy", type: "FLOAT", mode: "NULLABLE", description: nil, fields: [] }
   let(:field_numeric_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "pi", type: "NUMERIC", mode: "NULLABLE", description: nil, fields: [] }
   let(:field_bignumeric_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "my_bignumeric", type: "BIGNUMERIC", mode: "NULLABLE", description: nil, fields: [] }
   let(:field_boolean_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "approved", type: "BOOLEAN", mode: "NULLABLE", description: nil, fields: [] }
-  let(:field_bytes_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "avatar", type: "BYTES", mode: "NULLABLE", description: nil, fields: [] }
+  let(:field_bytes_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "avatar", type: "BYTES", mode: "NULLABLE", description: nil, fields: [], max_length: max_length_bytes }
   let(:field_timestamp_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "started_at", type: "TIMESTAMP", mode: "NULLABLE", policy_tags: policy_tags_gapi, description: nil, fields: [] }
   let(:field_time_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "duration", type: "TIME", mode: "NULLABLE", description: nil, fields: [] }
   let(:field_datetime_gapi) { Google::Apis::BigqueryV2::TableFieldSchema.new name: "target_end", type: "DATETIME", mode: "NULLABLE", description: nil, fields: [] }
@@ -165,18 +167,22 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     table.service.mocked_service = mock
 
     table.schema replace: true do |schema|
-      schema.string "first_name", mode: :required
+      schema.string "first_name", mode: :required, max_length: max_length_string
       schema.integer "rank", description: "An integer value from 1 to 100"
       schema.float "accuracy"
       schema.numeric "pi"
       schema.bignumeric "my_bignumeric"
       schema.boolean "approved"
-      schema.bytes "avatar"
+      schema.bytes "avatar", max_length: max_length_bytes
       schema.timestamp "started_at", policy_tags: policy_tags
       schema.time "duration"
       schema.datetime "target_end"
       schema.date "birthday"
     end
+
+    _(table.schema.field("first_name").max_length).must_equal max_length_string
+    _(table.schema.field("rank").max_length).must_be :nil?
+    _(table.schema.field("avatar").max_length).must_equal max_length_bytes
 
     mock.verify
   end
@@ -261,7 +267,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     table.service.mocked_service = mock
 
     table.schema replace: true do |schema|
-      schema.string "first_name", mode: :required
+      schema.string "first_name", mode: :required, max_length: max_length_string
       schema.record "cities_lived", mode: :repeated do |nested|
         nested.integer "rank", description: "An integer value from 1 to 100"
         nested.timestamp "started_at", policy_tags: policy_tags
@@ -288,7 +294,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     table.service.mocked_service = mock
 
     table.schema replace: true do |schema|
-      schema.string "first_name", mode: :required
+      schema.string "first_name", mode: :required, max_length: max_length_string
       schema.record "cities_lived", mode: :repeated do |nested|
         nested.integer "rank", description: "An integer value from 1 to 100"
         nested.timestamp "started_at", policy_tags: policy_tags
@@ -313,7 +319,7 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
       _(schema.field("first_name").mode).must_equal "REQUIRED"
       schema.field "cities_lived" do |nested|
         # Add a new field to the existing record
-        nested.string "first_name", mode: :required
+        nested.string "first_name", mode: :required, max_length: max_length_string
       end
     end
 


### PR DESCRIPTION
This PR replaces #12533.

* Add `max_length` to `LoadJob::Updater#bytes`
* Add `max_length` to `LoadJob::Updater#string`
* Add `max_length` to `Schema#bytes`
* Add `max_length` to `Schema#string`
* Add `max_length` to `Schema::Field#bytes`
* Add `max_length` to `Schema::Field#string`
* Add `max_length` to `Table::Updater#bytes`
* Add `max_length` to `Table::Updater#string`
* Add `precision` and `scale` to `LoadJob::Updater#bignumeric`
* Add `precision` and `scale` to `LoadJob::Updater#numeric`
* Add `precision` and `scale` to `Schema#bignumeric`
* Add `precision` and `scale` to `Schema#numeric`
* Add `precision` and `scale` to `Schema::Field#bignumeric`
* Add `precision` and `scale` to `Schema::Field#numeric`
* Add `precision` and `scale` to `Table::Updater#bignumeric`
* Add `precision` and `scale` to `Table::Updater#numeric`
* Add `Schema::Field#max_length`
* Add `Schema::Field#precision`
* Add `Schema::Field#scale`

closes: #11673