### PR TITLE
docs: added comment to explain project_id param

### DIFF
--- a/google-cloud-firestore/samples/quickstart.rb
+++ b/google-cloud-firestore/samples/quickstart.rb
@@ -18,6 +18,9 @@ def initialize_firestore_client project_id:
   # [START firestore_setup_client_create]
   require "google/cloud/firestore"
 
+  # The `project_id` parameter is optional and represents which project the
+  # client will act on behalf of. If not supplied, the client falls back to the
+  # default project inferred from the environment.
   firestore = Google::Cloud::Firestore.new project_id: project_id
 
   puts "Created Cloud Firestore client with given project ID."


### PR DESCRIPTION
This comes as part of an effort to consolidate the [`firestore_setup_client_create`](https://cloud.google.com/firestore/docs/samples/firestore-setup-client-create#firestore_setup_client_create-ruby) and [`firestore_setup_client_create_with_project_id`](https://cloud.google.com/firestore/docs/samples/firestore-setup-client-create-with-project-id) regions.