### PR TITLE
chore: Add Rake task for running rubocop against inline doc samples

### DIFF
--- a/google-cloud-bigtable/.gitignore
+++ b/google-cloud-bigtable/.gitignore
@@ -17,3 +17,4 @@ jsondoc/*
 tmp/*
 .byebug_history
 .DS_Store
+rubocop_yard_examples/*

--- a/google-cloud-bigtable/.rubocop_yard_examples.yml
+++ b/google-cloud-bigtable/.rubocop_yard_examples.yml
@@ -1,0 +1,8 @@
+inherit_from: .rubocop.yml
+
+Layout/TrailingEmptyLines:
+  Enabled: false
+Lint/UselessAssignment:
+  Enabled: false
+Style/CommentedKeyword:
+  Enabled: false

--- a/google-cloud-bigtable/Rakefile
+++ b/google-cloud-bigtable/Rakefile
@@ -181,15 +181,11 @@ task :rubocop_yard_examples do
   examples = registry.all.map { |object| object.tags(:example) }.flatten
 
   dir_name = "rubocop_yard_examples"
-  rm_rf dir_name if File.exist? dir_name
+  rm_rf dir_name
   mkdir_p dir_name
   hsh = examples.each_with_object({}) do |e, h|
     obj = e.object
-    # puts "\n\n"
-    # puts "location: #{obj.file}:#{obj.line}"
-    # puts "example: #{e.name}" if e.name&.length > 0
-    # puts "\n\n"
-    name = "#{obj.file.gsub %r{(\.|/|-)}, '_'}_#{obj.line}"
+    name = "#{obj.file.gsub(/\W/, '_')}_#{obj.line}"
     h[name] ||= []
     h[name] << e.text
   end

--- a/google-cloud-bigtable/Rakefile
+++ b/google-cloud-bigtable/Rakefile
@@ -174,6 +174,34 @@ task :doctest do
   sh "bundle exec yard config load_plugins true && bundle exec yard doctest"
 end
 
+desc "Run rubocop on yard examples."
+task :rubocop_yard_examples do
+  YARD.parse "lib/**/*.rb"
+  registry = YARD::Registry.load_all
+  examples = registry.all.map { |object| object.tags(:example) }.flatten
+
+  dir_name = "rubocop_yard_examples"
+  rm_rf dir_name if File.exist? dir_name
+  mkdir_p dir_name
+  hsh = examples.each_with_object({}) do |e, h|
+    obj = e.object
+    # puts "\n\n"
+    # puts "location: #{obj.file}:#{obj.line}"
+    # puts "example: #{e.name}" if e.name&.length > 0
+    # puts "\n\n"
+    name = "#{obj.file.gsub %r{(\.|/|-)}, '_'}_#{obj.line}"
+    h[name] ||= []
+    h[name] << e.text
+  end
+  hsh.each_pair do |k, v|
+    v.each_with_index do |text, i|
+      file_name = i.positive? ? "#{k}_#{i + 1}" : k # "foo", "foo_2", "foo_3", ...
+      File.write "#{dir_name}/#{file_name}.rb", text
+    end
+  end
+  sh "bundle exec rubocop #{dir_name} --config .rubocop_yard_examples.yml"
+end
+
 desc "Start an interactive shell."
 task :console do
   require "irb"


### PR DESCRIPTION
closes: #13278

This PR provides a WIP rake task to run rubocop over the `@example` tag contents in a library's inline docs.

Currently, the intermediate file output appears as follows. The file paths and line numbers in the naming of these files is the only way to trace back rubocop failures to their source code locations.

```
lib_google_cloud_bigtable_project_rb_103.rb
lib_google_cloud_bigtable_project_rb_126.rb
lib_google_cloud_bigtable_project_rb_226.rb
lib_google_cloud_bigtable_project_rb_226_2.rb
lib_google_cloud_bigtable_project_rb_260.rb
lib_google_cloud_bigtable_project_rb_283.rb
lib_google_cloud_bigtable_project_rb_342.rb
lib_google_cloud_bigtable_project_rb_342_2.rb
lib_google_cloud_bigtable_project_rb_342_3.rb
lib_google_cloud_bigtable_project_rb_427.rb
lib_google_cloud_bigtable_project_rb_427_2.rb
lib_google_cloud_bigtable_project_rb_455.rb
lib_google_cloud_bigtable_project_rb_52.rb
lib_google_cloud_bigtable_project_rb_79.rb
```