### PR TITLE
feat(kms): add samples for new KMS RNG APIs

### DIFF
--- a/google-cloud-kms/samples/Rakefile
+++ b/google-cloud-kms/samples/Rakefile
@@ -117,6 +117,14 @@ namespace :fixtures do
                              "asymmetric_decrypt_key",
                              :ASYMMETRIC_DECRYPT,
                              :RSA_DECRYPT_OAEP_2048_SHA256
+
+    get_or_create_crypto_key client,
+                             project_id,
+                             location_id,
+                             key_ring_id,
+                             "mac_key",
+                             :MAC,
+                             :HMAC_SHA256
   end
 end
 


### PR DESCRIPTION
This is based on https://github.com/googleapis/google-cloud-ruby/pull/13603 (I'll rebase once that's merged). Unfortunately the tests won't run or pass without it.

This adds new samples for the Cloud KMS RNG APIs.