### PR TITLE
test(kms): fix acceptance test in google-cloud-kms.

### DIFF
--- a/google-cloud-kms/acceptance/google/cloud/kms/v1/smoke_test.rb
+++ b/google-cloud-kms/acceptance/google/cloud/kms/v1/smoke_test.rb
@@ -20,7 +20,7 @@ require "google/cloud/kms"
 class KmsServiceSmokeTest < Minitest::Test
   def test_list_key_rings
     kms = Google::Cloud::Kms.key_management_service version: :v1
-    key_ring_parent = kms.class.location_path ENV["KMS_PROJECT"], "us-central1"
+    key_ring_parent = kms.location_path project: ENV["KMS_PROJECT"], location: "us-central1"
     key_rings = kms.list_key_rings(parent: key_ring_parent).to_a
     key_rings.size.must_equal 1
     key_rings[0].name.must_match %r{keyRings/ruby-test$}

--- a/google-cloud-kms/acceptance/google/cloud/kms/v1/smoke_test.rb
+++ b/google-cloud-kms/acceptance/google/cloud/kms/v1/smoke_test.rb
@@ -17,12 +17,12 @@ require "minitest/autorun"
 
 require "google/cloud/kms"
 
-class KmsServiceSmokeTest < Minitest::Test
+class KmsServiceSmokeTest < Minitest::Spec
   def test_list_key_rings
     kms = Google::Cloud::Kms.key_management_service version: :v1
     key_ring_parent = kms.location_path project: ENV["KMS_PROJECT"], location: "us-central1"
     key_rings = kms.list_key_rings(parent: key_ring_parent).to_a
-    key_rings.size.must_equal 1
-    key_rings[0].name.must_match %r{keyRings/ruby-test$}
+	_(key_rings.size).must_equal 1
+    _(key_rings[0].name).must_match %r{keyRings/ruby-test$}
   end
 end

--- a/google-cloud-kms/acceptance/google/cloud/kms/v1/smoke_test.rb
+++ b/google-cloud-kms/acceptance/google/cloud/kms/v1/smoke_test.rb
@@ -22,7 +22,7 @@ class KmsServiceSmokeTest < Minitest::Spec
     kms = Google::Cloud::Kms.key_management_service version: :v1
     key_ring_parent = kms.location_path project: ENV["KMS_PROJECT"], location: "us-central1"
     key_rings = kms.list_key_rings(parent: key_ring_parent).to_a
-	_(key_rings.size).must_equal 1
+    _(key_rings.size).must_equal 1
     _(key_rings[0].name).must_match %r{keyRings/ruby-test$}
   end
 end


### PR DESCRIPTION
One of the issues in [#12535](https://github.com/googleapis/google-cloud-ruby/issues/12535) is that the acceptance test is failing in google-cloud-kms. This PR is to fix that issue.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-ruby/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea.
- [x] Follow the instructions in [CONTRIBUTING](CONTRIBUTING.md). Most importantly, ensure the tests and linter pass by running `bundle exec rake ci` in the gem subdirectory.
- [ ] Update code documentation if necessary.