### PR TITLE
chore: Fix descriptions in synth files for analytics wrappers

### DIFF
--- a/google-analytics-admin/synth.py
+++ b/google-analytics-admin/synth.py
@@ -28,7 +28,7 @@ library = gapic.ruby_library(
     generator_args={
         "ruby-cloud-gem-name": "google-analytics-admin",
         "ruby-cloud-title": "Google Analytics Admin",
-        "ruby-cloud-description": "The Analytics Admin API allows for programmatic access to the Google Analytics App+Web configuration data. You can use the Google Analytics Admin API to manage accounts and App+Web properties. Note that google-analytics-admin-v1alpha is a version-specific client library. For most uses, we recommend installing the main client library google-analytics-admin instead. See the readme for more details.",
+        "ruby-cloud-description": "The Analytics Admin API allows for programmatic access to the Google Analytics App+Web configuration data. You can use the Google Analytics Admin API to manage accounts and App+Web properties.",
         "ruby-cloud-env-prefix": "ANALYTICS_ADMIN",
         "ruby-cloud-wrapper-of": "v1alpha:0.0",
         "ruby-cloud-api-id": "analyticsadmin.googleapis.com",

--- a/google-analytics-data/synth.py
+++ b/google-analytics-data/synth.py
@@ -28,7 +28,7 @@ library = gapic.ruby_library(
     generator_args={
         "ruby-cloud-gem-name": "google-analytics-data",
         "ruby-cloud-title": "Google Analytics Data",
-        "ruby-cloud-description": "The Google Analytics Data API provides programmatic methods to access report data in Google Analytics 4 (GA4) properties. Google Analytics 4 helps you understand how people use your web, iOS, or Android app. Note that google-analytics-data-v1beta is a version-specific client library. For most uses, we recommend installing the main client library google-analytics-data instead. See the readme for more details.",
+        "ruby-cloud-description": "The Google Analytics Data API provides programmatic methods to access report data in Google Analytics 4 (GA4) properties. Google Analytics 4 helps you understand how people use your web, iOS, or Android app.",
         "ruby-cloud-env-prefix": "ANALYTICS_DATA",
         "ruby-cloud-wrapper-of": "v1beta:0.0;v1alpha:0.0",
         "ruby-cloud-product-url": "https://developers.google.com/analytics/devguides/reporting/data/v1",


### PR DESCRIPTION
These two libraries are wrappers and should not have the non-wrapper specific note in their description.