### PR TITLE
chore(dialogflow): Update synth file to add a note about ES to the gem description

### DIFF
--- a/google-cloud-dialogflow/synth.py
+++ b/google-cloud-dialogflow/synth.py
@@ -27,7 +27,7 @@ library = gapic.ruby_library(
     generator_args={
         "ruby-cloud-gem-name": "google-cloud-dialogflow",
         "ruby-cloud-title": "Dialogflow",
-        "ruby-cloud-description": "Dialogflow is an end-to-end, build-once deploy-everywhere development suite for creating conversational interfaces for websites, mobile applications, popular messaging platforms, and IoT devices. You can use it to build interfaces (such as chatbots and conversational IVR) that enable natural and rich interactions between your users and your business.",
+        "ruby-cloud-description": "Dialogflow is an end-to-end, build-once deploy-everywhere development suite for creating conversational interfaces for websites, mobile applications, popular messaging platforms, and IoT devices. You can use it to build interfaces (such as chatbots and conversational IVR) that enable natural and rich interactions between your users and your business. This client is for Dialogflow ES, providing the standard agent type suitable for small and simple agents.",
         "ruby-cloud-env-prefix": "DIALOGFLOW",
         "ruby-cloud-wrapper-of": "v2:0.8",
         "ruby-cloud-product-url": "https://cloud.google.com/dialogflow",


### PR DESCRIPTION
This will add the appropriate sentence to the gem description when this wrapper is regenerated, as noted in https://github.com/googleapis/google-cloud-ruby/pull/13663#discussion_r693415156.

Also see https://github.com/googleapis/google-cloud-ruby/pull/13670/files#diff-dda76d3c2b9914c963706fc9e51bbad9a5f85fc19b3719e17759cf743501f0b4 which does the initial generation of the CX wrapper, and includes the corresponding note about CX.

For the versioned libraries, this parameter is set in the BUILD.bazel file upstream, and will be updated in the internal change cl/392283751.