### PR TITLE
chore(firestore): Fix credentials for acceptance tests

### DIFF
--- a/.toys/ci.rb
+++ b/.toys/ci.rb
@@ -113,14 +113,14 @@ end
 
 def setup_auth_env
   final_project = project || ENV["GCLOUD_TEST_PROJECT"] || ENV["GOOGLE_CLOUD_PROJECT"]
-  final_keyfile = keyfile || ENV["GCLOUD_TEST_KEYFILE"] || ENV["GOOGLE_APPLICATION_CREDENTIALS"]
+  final_keyfile = keyfile || ENV["GCLOUD_TEST_KEYFILE"]
   logger.info "Project for integration tests: #{final_project.inspect}"
   logger.info "Set keyfile for integration tests." if final_keyfile
   {
     "GCLOUD_TEST_PROJECT" => final_project,
     "GOOGLE_CLOUD_PROJECT" => final_project,
     "GCLOUD_TEST_KEYFILE" => final_keyfile,
-    "GOOGLE_APPLICATION_CREDENTIALS" => final_keyfile
+    "GOOGLE_APPLICATION_CREDENTIALS" => ENV["GOOGLE_APPLICATION_CREDENTIALS"]
   }
 end
 

--- a/google-cloud-firestore/Rakefile
+++ b/google-cloud-firestore/Rakefile
@@ -52,12 +52,9 @@ task :acceptance, :project, :keyfile do |t, args|
   project = args[:project]
   project ||= ENV["FIRESTORE_TEST_PROJECT"] || ENV["GCLOUD_TEST_PROJECT"]
   keyfile = args[:keyfile]
-  keyfile ||= ENV["FIRESTORE_TEST_KEYFILE"] || ENV["GCLOUD_TEST_KEYFILE"]
-  if keyfile
-    keyfile = File.read keyfile
-  else
-    keyfile ||= ENV["FIRESTORE_TEST_KEYFILE_JSON"] || ENV["GCLOUD_TEST_KEYFILE_JSON"]
-  end
+  keyfile ||= ENV["FIRESTORE_TEST_KEYFILE"] || ENV["FIRESTORE_TEST_KEYFILE_JSON"] ||
+              ENV["GCLOUD_TEST_KEYFILE"] || ENV["GCLOUD_TEST_KEYFILE_JSON"]
+  keyfile = File.read keyfile if keyfile && !keyfile.strip.start_with?("{")
   if project.nil? || keyfile.nil?
     fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or FIRESTORE_TEST_PROJECT=test123 FIRESTORE_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
   end
@@ -91,12 +88,9 @@ namespace :acceptance do
     project = args[:project]
     project ||= ENV["FIRESTORE_TEST_PROJECT"] || ENV["GCLOUD_TEST_PROJECT"]
     keyfile = args[:keyfile]
-    keyfile ||= ENV["FIRESTORE_TEST_KEYFILE"] || ENV["GCLOUD_TEST_KEYFILE"]
-    if keyfile
-      keyfile = File.read keyfile
-    else
-      keyfile ||= ENV["FIRESTORE_TEST_KEYFILE_JSON"] || ENV["GCLOUD_TEST_KEYFILE_JSON"]
-    end
+    keyfile ||= ENV["FIRESTORE_TEST_KEYFILE"] || ENV["FIRESTORE_TEST_KEYFILE_JSON"] ||
+                ENV["GCLOUD_TEST_KEYFILE"] || ENV["GCLOUD_TEST_KEYFILE_JSON"]
+    keyfile = File.read keyfile if keyfile && !keyfile.strip.start_with?("{")
     if project.nil? || keyfile.nil?
       fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or FIRESTORE_TEST_PROJECT=test123 FIRESTORE_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
     end

--- a/google-cloud-firestore/samples/Rakefile
+++ b/google-cloud-firestore/samples/Rakefile
@@ -15,13 +15,10 @@
 require "rake/testtask"
 
 Rake::TestTask.new "test" do |t|
-  project ||= ENV["FIRESTORE_TEST_PROJECT"] || ENV["GCLOUD_TEST_PROJECT"]
-  keyfile ||= ENV["FIRESTORE_TEST_KEYFILE"] || ENV["GCLOUD_TEST_KEYFILE"]
-  if keyfile
-    keyfile = File.read keyfile
-  else
-    keyfile ||= ENV["FIRESTORE_TEST_KEYFILE_JSON"] || ENV["GCLOUD_TEST_KEYFILE_JSON"]
-  end
+  project = ENV["FIRESTORE_TEST_PROJECT"] || ENV["GCLOUD_TEST_PROJECT"]
+  keyfile = ENV["FIRESTORE_TEST_KEYFILE"] || ENV["FIRESTORE_TEST_KEYFILE_JSON"] ||
+            ENV["GCLOUD_TEST_KEYFILE"] || ENV["GCLOUD_TEST_KEYFILE_JSON"]
+  keyfile = File.read keyfile if keyfile && !keyfile.strip.start_with?("{")
   if project.nil? || keyfile.nil?
     raise "You must provide a project and keyfile. " \
           "e.g. FIRESTORE_TEST_PROJECT=test123 FIRESTORE_TEST_KEYFILE=/path/to/keyfile.json rake test"


### PR DESCRIPTION
The rakefile was using credentials based on environment variables in this priority:

* `FIRESTORE_TEST_KEYFILE`
* `GCLOUD_TEST_KEYFILE`
* `FIRESTORE_TEST_KEYFILE_JSON`
* `GCLOUD_TEST_KEYFILE_JSON`

That is, `GCLOUD_TEST_KEYFILE` was taking precedence over `FIRESTORE_TEST_KEYFILE_JSON`. This is incorrect; Firestore-specific credentials should always take precedence over generic credentials. It turns out that the test environment is setting both `GCLOUD_TEST_KEYFILE` and `FIRESTORE_TEST_KEYFILE_JSON`, and so the test was using the wrong credentials. This PR fixes the priority order.

Fixes #13688