### PR TITLE
test(bigtable): Fix acceptance test fixture name

### DIFF
--- a/google-cloud-bigtable/acceptance/bigtable_helper.rb
+++ b/google-cloud-bigtable/acceptance/bigtable_helper.rb
@@ -189,7 +189,7 @@ def bigtable_cluster_id
 end
 
 def bigtable_cluster_id_2
-  "#{$bigtable_instance_id}-clstr2"
+  "#{bigtable_instance_id}-clstr2"
 end
 
 def bigtable_kms_key


### PR DESCRIPTION
This error only occurs when setting up permanent test fixtures for the first time in a new project.

```
/Users/quartzmo/code/google/codez/google-cloud-ruby/google-cloud-bigtable-admin-v2/lib/google/cloud/bigtable/admin/v2/bigtable_instance_admin/client.rb:316:in `rescue in create_instance': 3:Error in field 'clusters' : Cluster Id : Invalid id for collection clusters : Should match [a-z][a-z0-9\\-]+[a-z0-9] but found '-clstr2'. debug_error_string:{"created":"@1629931849.107748000","description":"Error received from peer ipv4:142.250.188.234:443","file":"src/core/lib/surface/call.cc","file_line":1067,"grpc_message":"Error in field 'clusters' : Cluster Id : Invalid id for collection clusters : Should match [a-z][a-z0-9\\-]+[a-z0-9] but found '-clstr2'","grpc_status":3} (Google::Cloud::InvalidArgumentError)
	from /Users/quartzmo/code/google/codez/google-cloud-ruby/google-cloud-bigtable-admin-v2/lib/google/cloud/bigtable/admin/v2/bigtable_instance_admin/client.rb:279:in `create_instance'
	from /Users/quartzmo/code/google/codez/google-cloud-ruby/google-cloud-bigtable/lib/google/cloud/bigtable/service.rb:115:in `create_instance'
	from /Users/quartzmo/code/google/codez/google-cloud-ruby/google-cloud-bigtable/lib/google/cloud/bigtable/project.rb:238:in `create_instance'
	from /Users/quartzmo/code/google/codez/google-cloud-ruby/google-cloud-bigtable/acceptance/bigtable_helper.rb:105:in `create_test_instance'
	from /Users/quartzmo/code/google/codez/google-cloud-ruby/google-cloud-bigtable/acceptance/bigtable_helper.rb:207:in `<top (required)>'
	from /Users/quartzmo/code/google/codez/google-cloud-ruby/google-cloud-bigtable/acceptance/bigtable/app_profile_test.rb:18:in `require'
	from /Users/quartzmo/code/google/codez/google-cloud-ruby/google-cloud-bigtable/acceptance/bigtable/app_profile_test.rb:18:in `<top (required)>'
```