### PR TITLE
chore: Release-please searches for gem version file if one is not found

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -33,7 +33,7 @@ jobs:
         run: "gem install --no-document toys && npm install release-please"
       - name: execute
         run: |
-          toys release please --fork \
+          toys release please -v --fork \
             --github-event-name=${{ github.event_name }} \
             --release-type=ruby-yoshi \
             ${{ github.event.inputs.args }} -- ${{ github.event.inputs.gem }}


### PR DESCRIPTION
Also refactors the release perform script so it does less work if the gem version is already present on rubygems, in preparation to switch apiary generated library releases to this version of the script.