### PR TITLE
fix(pubsub): Change IAM and Schema client metadata hash keys to symbols

### DIFF
--- a/google-cloud-pubsub/acceptance/pubsub/service_test.rb
+++ b/google-cloud-pubsub/acceptance/pubsub/service_test.rb
@@ -18,21 +18,48 @@
 require "pubsub_helper"
 
 describe Google::Cloud::PubSub::Service, :pubsub do
+  let(:endpoint) { "pubsub.googleapis.com" }
   let(:config_metadata) { { "google-cloud-resource-prefix": "projects/#{pubsub.project_id}" } }
 
-  it "passes the correct configuration to its v1 subscriber client" do
+  it "configures the V1::Subscriber::Client" do
     _(pubsub.project_id).wont_be :empty?
     config = pubsub.service.subscriber.configure
     _(config).must_be_kind_of Google::Cloud::PubSub::V1::Subscriber::Client::Configuration
+    _(config.timeout).must_be :nil?
+    _(config.endpoint).must_equal endpoint
     _(config.lib_name).must_equal "gccl"
     _(config.lib_version).must_equal Google::Cloud::PubSub::VERSION
     _(config.metadata).must_equal config_metadata
   end
 
-  it "passes the correct configuration to its v1 publisher client" do
+  it "configures the V1::Publisher::Client" do
     _(pubsub.project_id).wont_be :empty?
     config = pubsub.service.publisher.configure
     _(config).must_be_kind_of Google::Cloud::PubSub::V1::Publisher::Client::Configuration
+    _(config.timeout).must_be :nil?
+    _(config.endpoint).must_equal endpoint
+    _(config.lib_name).must_equal "gccl"
+    _(config.lib_version).must_equal Google::Cloud::PubSub::VERSION
+    _(config.metadata).must_equal config_metadata
+  end
+
+  it "configures the V1::IAMPolicy::Client" do
+    _(pubsub.project_id).wont_be :empty?
+    config = pubsub.service.iam.configure
+    _(config).must_be_kind_of Google::Cloud::PubSub::V1::IAMPolicy::Client::Configuration
+    _(config.timeout).must_be :nil?
+    _(config.endpoint).must_equal endpoint
+    _(config.lib_name).must_equal "gccl"
+    _(config.lib_version).must_equal Google::Cloud::PubSub::VERSION
+    _(config.metadata).must_equal config_metadata
+  end
+
+  it "configures the V1::SchemaService::Client" do
+    _(pubsub.project_id).wont_be :empty?
+    config = pubsub.service.schemas.configure
+    _(config).must_be_kind_of Google::Cloud::PubSub::V1::SchemaService::Client::Configuration
+    _(config.timeout).must_be :nil?
+    _(config.endpoint).must_equal endpoint
     _(config.lib_name).must_equal "gccl"
     _(config.lib_version).must_equal Google::Cloud::PubSub::VERSION
     _(config.metadata).must_equal config_metadata

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
@@ -81,7 +81,7 @@ module Google
             config.endpoint = host if host
             config.lib_name = "gccl"
             config.lib_version = Google::Cloud::PubSub::VERSION
-            config.metadata = { "google-cloud-resource-prefix" => "projects/#{@project}" }
+            config.metadata = { "google-cloud-resource-prefix": "projects/#{@project}" }
           end
         end
         attr_accessor :mocked_iam
@@ -94,7 +94,7 @@ module Google
             config.endpoint = host if host
             config.lib_name = "gccl"
             config.lib_version = Google::Cloud::PubSub::VERSION
-            config.metadata = { "google-cloud-resource-prefix" => "projects/#{@project}" }
+            config.metadata = { "google-cloud-resource-prefix": "projects/#{@project}" }
           end
         end
         attr_accessor :mocked_schemas

--- a/google-cloud-pubsub/test/google/cloud/pubsub/service_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/service_test.rb
@@ -1,0 +1,101 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+require "gapic/grpc/service_stub"
+
+describe Google::Cloud::PubSub::Service do
+  let(:project) { "test" }
+  let(:credentials) { OpenStruct.new(project_id: "project-id") }
+  let(:endpoint) { "pubsub.googleapis.com" }
+  let(:lib_name) { "gccl" }
+  let(:lib_version) { Google::Cloud::PubSub::VERSION }
+  let(:metadata) { { "google-cloud-resource-prefix": "projects/#{project}" } }
+
+  it "configures the V1::Subscriber::Client" do
+    # Clear all environment variables
+    ENV.stub :[], nil do
+      Google::Auth::Credentials.stub :default, credentials do
+        Gapic::ServiceStub.stub :new, nil do
+          service = Google::Cloud::PubSub::Service.new project, nil
+          _(service.project).must_equal project
+          config = service.subscriber.configure
+          _(config).must_be_kind_of Google::Cloud::PubSub::V1::Subscriber::Client::Configuration
+          _(config.timeout).must_be :nil?
+          _(config.endpoint).must_equal endpoint
+          _(config.lib_name).must_equal lib_name
+          _(config.lib_version).must_equal lib_version
+          _(config.metadata).must_equal metadata
+        end
+      end
+    end
+  end
+
+  it "configures the V1::Publisher::Client" do
+    # Clear all environment variables
+    ENV.stub :[], nil do
+      Google::Auth::Credentials.stub :default, credentials do
+        Gapic::ServiceStub.stub :new, nil do
+          service = Google::Cloud::PubSub::Service.new project, nil
+          _(service.project).must_equal project
+          config = service.publisher.configure
+          _(config).must_be_kind_of Google::Cloud::PubSub::V1::Publisher::Client::Configuration
+          _(config.timeout).must_be :nil?
+          _(config.endpoint).must_equal endpoint
+          _(config.lib_name).must_equal lib_name
+          _(config.lib_version).must_equal lib_version
+          _(config.metadata).must_equal metadata
+        end
+      end
+    end
+  end
+
+  it "configures the V1::IAMPolicy::Client" do
+    # Clear all environment variables
+    ENV.stub :[], nil do
+      Google::Auth::Credentials.stub :default, credentials do
+        Gapic::ServiceStub.stub :new, nil do
+          service = Google::Cloud::PubSub::Service.new project, nil
+          _(service.project).must_equal project
+          config = service.iam.configure
+          _(config).must_be_kind_of Google::Cloud::PubSub::V1::IAMPolicy::Client::Configuration
+          _(config.timeout).must_be :nil?
+          _(config.endpoint).must_equal endpoint
+          _(config.lib_name).must_equal lib_name
+          _(config.lib_version).must_equal lib_version
+          _(config.metadata).must_equal metadata
+        end
+      end
+    end
+  end
+
+  it "configures the V1::SchemaService::Client" do
+    # Clear all environment variables
+    ENV.stub :[], nil do
+      Google::Auth::Credentials.stub :default, credentials do
+        Gapic::ServiceStub.stub :new, nil do
+          service = Google::Cloud::PubSub::Service.new project, nil
+          _(service.project).must_equal project
+          config = service.schemas.configure
+          _(config).must_be_kind_of Google::Cloud::PubSub::V1::SchemaService::Client::Configuration
+          _(config.timeout).must_be :nil?
+          _(config.endpoint).must_equal endpoint
+          _(config.lib_name).must_equal lib_name
+          _(config.lib_version).must_equal lib_version
+          _(config.metadata).must_equal metadata
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
refs: #7138
refs: #7131

As explained in #7131 

> changed the keys to symbols, because it's kinda preferred. The other metadata keys, as set in the generated clients, are symbols. It doesn't really matter—gRPC will take either symbols or strings—but for consistency we'll use symbols.