### PR TITLE
fix(bigquery): Add precision and scale to Field#add_field

### DIFF
--- a/google-cloud-bigquery/acceptance/bigquery/advanced_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/advanced_test.rb
@@ -232,10 +232,16 @@ describe Google::Cloud::Bigquery, :advanced, :bigquery do
   it "knows its schema precision and scale for numeric and bignumeric fields" do
     _(table.schema.field("age").precision).must_be :nil?
     _(table.schema.field("age").scale).must_be :nil?
+
     _(table.schema.field("my_numeric").precision).must_equal precision_numeric
     _(table.schema.field("my_numeric").scale).must_equal scale_numeric
     _(table.schema.field("my_bignumeric").precision).must_equal precision_bignumeric
     _(table.schema.field("my_bignumeric").scale).must_equal scale_bignumeric
+
+    _(table.schema.field("spells").field("my_nested_numeric").precision).must_equal precision_numeric
+    _(table.schema.field("spells").field("my_nested_numeric").scale).must_equal scale_numeric
+    _(table.schema.field("spells").field("my_nested_bignumeric").precision).must_equal precision_bignumeric
+    _(table.schema.field("spells").field("my_nested_bignumeric").scale).must_equal scale_bignumeric
   end
 
   def assert_rows_equal returned_row, example_row
@@ -279,6 +285,8 @@ describe Google::Cloud::Bigquery, :advanced, :bigquery do
           end
           spells.bytes "icon", mode: :nullable, max_length: max_length_bytes
           spells.timestamp "last_used", mode: :nullable
+          spells.numeric "my_nested_numeric", mode: :nullable, precision: precision_numeric, scale: scale_numeric
+          spells.bignumeric "my_nested_bignumeric", mode: :nullable, precision: precision_bignumeric, scale: scale_bignumeric
         end
         schema.time "tea_time", mode: :nullable
         schema.date "next_vacation", mode: :nullable
@@ -321,7 +329,9 @@ describe Google::Cloud::Bigquery, :advanced, :bigquery do
               { name: "Explodey", power: 11.0 }
             ],
             icon: File.open("acceptance/data/kitten-test-data.json", "rb"),
-            last_used: Time.parse("2015-10-31 23:59:56 UTC")
+            last_used: Time.parse("2015-10-31 23:59:56 UTC"),
+            my_nested_numeric: BigDecimal(string_numeric),
+            my_nested_bignumeric: string_bignumeric, # BigDecimal would be rounded, use String instead!
           }
         ],
         tea_time: Google::Cloud::Bigquery::Time.new("15:00:00"),

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/schema/field.rb
@@ -939,7 +939,14 @@ module Google
                   "Cannot add fields to a non-RECORD field (#{type})"
           end
 
-          def add_field name, type, description: nil, mode: :nullable, policy_tags: nil, max_length: nil
+          def add_field name,
+                        type,
+                        description: nil,
+                        mode: :nullable,
+                        policy_tags: nil,
+                        max_length: nil,
+                        precision: nil,
+                        scale: nil
             frozen_check!
 
             new_gapi = Google::Apis::BigqueryV2::TableFieldSchema.new(
@@ -954,6 +961,8 @@ module Google
               new_gapi.policy_tags = Google::Apis::BigqueryV2::TableFieldSchema::PolicyTags.new names: policy_tags
             end
             new_gapi.max_length = max_length if max_length
+            new_gapi.precision = precision if precision
+            new_gapi.scale = scale if scale
             # Remove any existing field of this name
             @gapi.fields ||= []
             @gapi.fields.reject! { |f| f.name == new_gapi.name }

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_load_job_schema_test.rb
@@ -50,9 +50,11 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :schema, :mock_bigquery do
       Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "birthday",      type: "DATE", description: nil, fields: []),
       Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "home",          type: "GEOGRAPHY", description: nil, fields: []),
       Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "REPEATED", name: "cities_lived",  type: "RECORD", description: nil, fields: [
-        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "place",           type: "STRING",  description: nil, fields: []),
-        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "location",        type: "GEOGRAPHY",  description: nil, fields: []),
-        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "number_of_years", type: "INTEGER", description: nil, fields: [])
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "place",                type: "STRING",  description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "location",             type: "GEOGRAPHY",  description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "number_of_years",      type: "INTEGER", description: nil, fields: []),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "my_nested_numeric",    type: "NUMERIC", description: nil, fields: [], precision: precision_numeric, scale: scale_numeric),
+        Google::Apis::BigqueryV2::TableFieldSchema.new(mode: "NULLABLE", name: "my_nested_bignumeric", type: "BIGNUMERIC", description: nil, fields: [], precision: precision_bignumeric, scale: scale_bignumeric)
       ])
     ]
   end
@@ -124,6 +126,8 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :schema, :mock_bigquery do
         nested_schema.string "place"
         nested_schema.geography "location"
         nested_schema.integer "number_of_years"
+        nested_schema.numeric "my_nested_numeric", precision: precision_numeric, scale: scale_numeric
+        nested_schema.bignumeric "my_nested_bignumeric", precision: precision_bignumeric, scale: scale_bignumeric
       end
       job.schema_update_options = schema_update_options
       job.range_partitioning_field = "age"
@@ -182,6 +186,8 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :schema, :mock_bigquery do
         nested_schema.string "place"
         nested_schema.geography "location"
         nested_schema.integer "number_of_years"
+        nested_schema.numeric "my_nested_numeric", precision: precision_numeric, scale: scale_numeric
+        nested_schema.bignumeric "my_nested_bignumeric", precision: precision_bignumeric, scale: scale_bignumeric
       end
       job.schema_update_options = schema_update_options
       job.time_partitioning_type = "DAY"
@@ -235,6 +241,8 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :schema, :mock_bigquery do
       nested_schema.string "place"
       nested_schema.geography "location"
       nested_schema.integer "number_of_years"
+      nested_schema.numeric "my_nested_numeric", precision: precision_numeric, scale: scale_numeric
+      nested_schema.bignumeric "my_nested_bignumeric", precision: precision_bignumeric, scale: scale_bignumeric
     end
 
     job = dataset.load_job table_id, load_file, create: :needed, schema: schema
@@ -290,6 +298,8 @@ describe Google::Cloud::Bigquery::Dataset, :load_job, :schema, :mock_bigquery do
         nested_schema.string "place"
         nested_schema.geography "location"
         nested_schema.integer "number_of_years"
+        nested_schema.numeric "my_nested_numeric", precision: precision_numeric, scale: scale_numeric
+        nested_schema.bignumeric "my_nested_bignumeric", precision: precision_bignumeric, scale: scale_bignumeric
       end
       schema.schema_update_options = schema_update_options
     end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
@@ -357,7 +357,9 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
         { name: "first_name", type: "STRING", mode: "REQUIRED", description: nil, fields: [] },
         { name: "countries_lived", type: "RECORD", mode: "REPEATED", description: nil, fields: [
             { name: "cities_lived", type: "RECORD", mode: "REPEATED", description: nil, fields: [
-                { mode: "NULLABLE", name: "rank", type: "INTEGER", description: "An integer value from 1 to 100", fields: [] }
+                { mode: "NULLABLE", name: "rank", type: "INTEGER", description: "An integer value from 1 to 100", fields: [] },
+                { mode: "NULLABLE", name: "my_nested_numeric", type: "NUMERIC", description: nil, fields: [], precision: precision_numeric, scale: scale_numeric },
+                { mode: "NULLABLE", name: "my_nested_bignumeric", type: "BIGNUMERIC", description: nil, fields: [], precision: precision_bignumeric, scale: scale_bignumeric }
               ]
             }
           ]
@@ -378,6 +380,8 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
       schema.record "countries_lived", mode: :repeated do |nested|
         nested.record "cities_lived", mode: :repeated do |nested_2|
           nested_2.integer "rank", description: "An integer value from 1 to 100"
+          nested_2.numeric "my_nested_numeric", precision: precision_numeric, scale: scale_numeric
+          nested_2.bignumeric "my_nested_bignumeric", precision: precision_bignumeric, scale: scale_bignumeric
         end
       end
     end


### PR DESCRIPTION
Although I correctly added `precision` and `scale` to the public methods`Field#numeric` and `#bignumeric` in #13102, I missed adding the same keyword args to the protected method `Field#add_field` in that PR. This change fixes the bug and adds tests.

Much thanks to @inz for reporting this issue!

refs: #13102
closes: #13987

