### PR TITLE
chore: remove owlbot staging directory from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,4 @@ package-lock.json
 # Ignore RubyMine project files
 .idea
 
-/owl-bot-staging
 /tmp


### PR DESCRIPTION
owlbot needs to create a PR with changes in the staging directory before the postprocessor runs