### PR TITLE
chore(firestore): Add custom type samples

### DIFF
--- a/google-cloud-firestore/samples/.rubocop.yml
+++ b/google-cloud-firestore/samples/.rubocop.yml
@@ -24,3 +24,5 @@ Lint/UselessAssignment:
     - "paginate_data.rb"
     - "query_data.rb"
     - "quickstart.rb"
+Style/AccessorGrouping:
+  Enabled: false

--- a/google-cloud-firestore/samples/acceptance/add_data_test.rb
+++ b/google-cloud-firestore/samples/acceptance/add_data_test.rb
@@ -46,6 +46,13 @@ describe "Google Cloud Firestore API samples - Add Data" do
     assert_includes out, "Set multiple data-type data for the one document in the data collection."
   end
 
+  it "data_set_from_custom_type" do
+    out, _err = capture_io do
+      data_set_from_custom_type project_id: @firestore_project, collection_path: @collection_path
+    end
+    assert_includes out, "Set custom type data for the LA document in the cities collection."
+  end
+
   it "set_requires_id" do
     out, _err = capture_io do
       set_requires_id project_id: @firestore_project, collection_path: @collection_path

--- a/google-cloud-firestore/samples/add_data.rb
+++ b/google-cloud-firestore/samples/add_data.rb
@@ -87,22 +87,22 @@ class City
 
   def self.from_h source
     city = new source[:name], source[:state], source[:country]
-    city.capital = source[:capital] if source[:capital]
-    city.population = source[:population] if source[:population]
-    city.regions = source[:regions] if source[:regions]
+    city.capital = source[:capital] if source.key? :capital
+    city.population = source[:population] if source.key? :population
+    city.regions = source[:regions] if source.key? :regions
     city
   end
 
   def to_h
-    hsh = {
+    # Serialize to sparse hash that omits nil values for optional fields.
+    {
       name: name,
       state: state,
-      country: country
-    }
-    hsh[:capital] = capital if capital
-    hsh[:population] = population if population
-    hsh[:regions] = regions if regions
-    hsh
+      country: country,
+      capital: capital,
+      population: population,
+      regions: regions
+    }.delete_if { |_, v| v.nil? }
   end
 end
 # [END firestore_data_custom_type_definition]

--- a/google-cloud-firestore/samples/add_data.rb
+++ b/google-cloud-firestore/samples/add_data.rb
@@ -72,6 +72,54 @@ def set_document_data_types project_id:, collection_path: "data"
   puts "Set multiple data-type data for the one document in the data collection."
 end
 
+# [START firestore_data_custom_type_definition]
+class City
+  attr_accessor :name, :state, :country, :capital, :population, :regions
+
+  def initialize name, state, country, capital: false, population: 0, regions: []
+    @name = name
+    @state = state
+    @country = country
+    @capital = capital
+    @population = population
+    @regions = regions
+  end
+
+  def self.from_h source
+    city = new source[:name], source[:state], source[:country]
+    city.capital = source[:capital] if source[:capital]
+    city.population = source[:population] if source[:population]
+    city.regions = source[:regions] if source[:regions]
+    city
+  end
+
+  def to_h
+    hsh = {
+      name: name,
+      state: state,
+      country: country
+    }
+    hsh[:capital] = capital if capital
+    hsh[:population] = population if population
+    hsh[:regions] = regions if regions
+    hsh
+  end
+end
+# [END firestore_data_custom_type_definition]
+
+def data_set_from_custom_type project_id:, collection_path: "cities"
+  # project_id = "Your Google Cloud Project ID"
+  # collection_path = "cities"
+
+  firestore = Google::Cloud::Firestore.new project_id: project_id
+  # [START firestore_data_set_from_custom_type]
+  city = City.new "Los Angeles", "CA", "USA"
+
+  firestore.col(collection_path).doc("LA").set(city.to_h)
+  # [END firestore_data_set_from_custom_type]
+  puts "Set custom type data for the LA document in the cities collection."
+end
+
 def set_requires_id project_id:, collection_path: "cities"
   # project_id = "Your Google Cloud Project ID"
   # collection_path = "cities"


### PR DESCRIPTION
Adapted from Python samples [firestore_data_custom_type_definition](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/02fca3921587f426fbb0eb26e86cb743eb13f354/firestore/cloud-client/snippets.py#L109-L165) and [firestore_data_set_from_custom_type](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/02fca3921587f426fbb0eb26e86cb743eb13f354/firestore/cloud-client/snippets.py#L196-L197), without however using `EXCLUDE` blocks as in the Python custom class methods.

* Add `firestore_data_custom_type_definition`
* Add `firestore_data_set_from_custom_type`

refs: #14020