### PR TITLE
chore: Updates to peek-client tool

### DIFF
--- a/.toys/peek-client.rb
+++ b/.toys/peek-client.rb
@@ -18,22 +18,91 @@ require "tmpdir"
 
 required_arg :piper_client
 required_arg :library_path
-required_arg :bazel_target
 flag :output_dir, "--output=PATH", "-o PATH"
+flag :bazel_target, "--bazel-target=TARGET"
+flag :owl_bot
+flag :test
+flag :pull
+flag :postprocessor_tag, "--postprocessor-tag=TAG", default: "latest"
 
 include :exec, e: true
 include :fileutils
 include :terminal
 
+static :postprocessor_image, "gcr.io/cloud-devrel-public-resources/owlbot-ruby"
+
 def run
-  piper_client_dir = capture("p4 g4d #{piper_client}").strip
-  bazel_base_dir = File.join piper_client_dir, "third_party", "googleapis", "stable"
-  generated_dir = File.join bazel_base_dir, "bazel-bin", library_path, bazel_target
+  set :bazel_target, default_bazel_target unless bazel_target
+  set :output_dir, default_output_dir unless output_dir
+  run_bazel
+  final_dir = output_dir
+  final_dir = run_owl_bot if owl_bot
+  run_test final_dir if test
+  puts final_dir, :bold
+end
+
+def run_bazel
   exec ["bazel", "build", "#{library_path}:#{bazel_target}"], chdir: bazel_base_dir
-  set :output_dir, File.join(Dir.mktmpdir, "client") unless output_dir
   rm_rf output_dir
   cp_r generated_dir, output_dir
-  exec ["bundle", "install"], chdir: output_dir
-  exec ["bundle", "exec", "rake", "ci"], chdir: output_dir
-  puts output_dir, :bold
+end
+
+def run_owl_bot
+  gemspecs = Dir.glob "*.gemspec", base: output_dir
+  error "Unable to find gemspec in #{output_dir}" unless gemspecs.size == 1
+  gem_name = File.basename gemspecs.first
+  staging_base_dir = File.join context_directory, "owl-bot-staging"
+  staging_dir = File.join staging_base_dir, gem_name
+  rm_rf staging_base_dir
+  mkdir_p staging_base_dir
+  mv output_dir, staging_dir
+  exec ["docker", "pull", "#{postprocessor_image}:#{postprocessor_tag}"] if pull
+  docker_run "#{postprocessor_image}:#{postprocessor_tag}", "--gem", gem_name
+  File.join context_directory, gem_name
+end
+
+def run_test dir
+  exec ["bundle", "install"], chdir: dir
+  exec ["bundle", "exec", "rake", "ci"], chdir: dir
+end
+
+def piper_client_dir
+  @piper_client_dir ||= capture("p4 g4d #{piper_client}").strip
+end
+
+def bazel_base_dir
+  @bazel_base_dir ||= File.join piper_client_dir, "third_party", "googleapis", "stable"
+end
+
+def generated_dir
+  @generated_dir ||= File.join bazel_base_dir, "bazel-bin", library_path, bazel_target
+end
+
+def default_bazel_target
+  build_file_path = File.join bazel_base_dir, library_path, "BUILD.bazel"
+  error "Unable to find #{build_file_path}" unless File.file? build_file_path
+  build_content = File.read build_file_path
+  match = /ruby_gapic_assembly_pkg\(\n\s+name\s*=\s*"([\w-]+-ruby)",/.match build_content
+  error "Unable to find ruby build rule in #{build_file_path}" unless match
+  match[1]
+end
+
+def default_output_dir
+  File.join context_directory, "tmp", "owl-bot-staging"
+end
+
+def docker_run *args
+  cmd = [
+    "docker", "run",
+    "--rm",
+    "--user", "#{Process.uid}:#{Process.gid}",
+    "-v", "#{context_directory}:/repo",
+    "-w", "/repo"
+  ] + args
+  exec cmd
+end
+
+def error msg
+  puts msg, :red, :bold
+  exit 1
 end


### PR DESCRIPTION
* Generates into `tmp/owl-bot-staging` by default.
* Automatically determines the bazel target.
* Adds an option to run the owlbot postprocessor.
