### PR TITLE
feat(bigquery): Add session support

### DIFF
--- a/google-cloud-bigquery/.rubocop.yml
+++ b/google-cloud-bigquery/.rubocop.yml
@@ -14,7 +14,7 @@ Style/Documentation:
 Lint/MixedRegexpCaptureTypes:
   Enabled: false
 Metrics/AbcSize:
-  Max: 50
+  Max: 55
 Metrics/BlockLength:
   Exclude:
     - "google-cloud-bigquery.gemspec"

--- a/google-cloud-bigquery/acceptance/bigquery/dataset_reference_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/dataset_reference_test.rb
@@ -218,6 +218,7 @@ describe Google::Cloud::Bigquery::Dataset, :reference, :bigquery do
     query_job = dataset.query_job query, job_id: job_id
     _(query_job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
     _(query_job.job_id).must_equal job_id
+    _(query_job.session_id).must_be :nil?
     query_job.wait_until_done!
     _(query_job.done?).must_equal true
     _(query_job.data.total).wont_be_nil

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -1244,6 +1244,8 @@ module Google
         #   Flattens all nested and repeated fields in the query results. The
         #   default value is `true`. `large_results` parameter must be `true` if
         #   this is set to `false`.
+        # @param [Integer] maximum_billing_tier Deprecated: Change the billing
+        #   tier to allow high-compute queries.
         # @param [Integer] maximum_bytes_billed Limits the bytes billed for this
         #   job. Queries that will have bytes billed beyond this limit will fail
         #   (without incurring a charge). Optional. If unspecified, this will be
@@ -1294,8 +1296,12 @@ module Google
         #   For additional information on migrating, see: [Migrating to
         #   standard SQL - Differences in user-defined JavaScript
         #   functions](https://cloud.google.com/bigquery/docs/reference/standard-sql/migrating-from-legacy-sql#differences_in_user-defined_javascript_functions)
-        # @param [Integer] maximum_billing_tier Deprecated: Change the billing
-        #   tier to allow high-compute queries.
+        # @param [Boolean] create_session If true, creates a new session, where the
+        #   session ID will be a server generated random id. If false, runs query
+        #   with an existing session ID when one is provided in the `session_id`
+        #   param, otherwise runs query in non-session mode. See {Job#session_id}.
+        # @param [String] session_id The ID of an existing session. See also the
+        #   `create_session` param and {Job#session_id}.
         # @yield [job] a job configuration object
         # @yieldparam [Google::Cloud::Bigquery::QueryJob::Updater] job a job
         #   configuration object for setting additional options for the query.
@@ -1435,16 +1441,52 @@ module Google
         #
         # @!group Data
         #
-        def query_job query, params: nil, types: nil, external: nil, priority: "INTERACTIVE", cache: true, table: nil,
-                      create: nil, write: nil, dryrun: nil, standard_sql: nil, legacy_sql: nil, large_results: nil,
-                      flatten: nil, maximum_billing_tier: nil, maximum_bytes_billed: nil, job_id: nil, prefix: nil,
-                      labels: nil, udfs: nil
+        def query_job query,
+                      params: nil,
+                      types: nil,
+                      external: nil,
+                      priority: "INTERACTIVE",
+                      cache: true,
+                      table: nil,
+                      create: nil,
+                      write: nil,
+                      dryrun: nil,
+                      standard_sql: nil,
+                      legacy_sql: nil,
+                      large_results: nil,
+                      flatten: nil,
+                      maximum_billing_tier: nil,
+                      maximum_bytes_billed: nil,
+                      job_id: nil,
+                      prefix: nil,
+                      labels: nil,
+                      udfs: nil,
+                      create_session: nil,
+                      session_id: nil
           ensure_service!
-          options = { params: params, types: types, external: external, priority: priority, cache: cache, table: table,
-                      create: create, write: write, dryrun: dryrun, standard_sql: standard_sql, legacy_sql: legacy_sql,
-                      large_results: large_results, flatten: flatten, maximum_billing_tier: maximum_billing_tier,
-                      maximum_bytes_billed: maximum_bytes_billed, job_id: job_id, prefix: prefix, labels: labels,
-                      udfs: udfs }
+          options = {
+            params: params,
+            types: types,
+            external: external,
+            priority: priority,
+            cache: cache,
+            table: table,
+            create: create,
+            write: write,
+            dryrun: dryrun,
+            standard_sql: standard_sql,
+            legacy_sql: legacy_sql,
+            large_results: large_results,
+            flatten: flatten,
+            maximum_billing_tier: maximum_billing_tier,
+            maximum_bytes_billed: maximum_bytes_billed,
+            job_id: job_id,
+            prefix: prefix,
+            labels: labels,
+            udfs: udfs,
+            create_session: create_session,
+            session_id: session_id
+          }
 
           updater = QueryJob::Updater.from_options service, query, options
           updater.dataset = self
@@ -1566,6 +1608,8 @@ module Google
         #   When set to false, the values of `large_results` and `flatten` are
         #   ignored; the query will be run as if `large_results` is true and
         #   `flatten` is false. Optional. The default value is false.
+        # @param [String] session_id The ID of an existing session. See the
+        #   `create_session` param in {#query_job} and {Job#session_id}.
         # @yield [job] a job configuration object
         # @yieldparam [Google::Cloud::Bigquery::QueryJob::Updater] job a job
         #   configuration object for setting additional options for the query.
@@ -1699,10 +1743,25 @@ module Google
         #
         # @!group Data
         #
-        def query query, params: nil, types: nil, external: nil, max: nil, cache: true,
-                  standard_sql: nil, legacy_sql: nil, &block
-          job = query_job query, params: params, types: types, external: external, cache: cache,
-                                 standard_sql: standard_sql, legacy_sql: legacy_sql, &block
+        def query query,
+                  params: nil,
+                  types: nil,
+                  external: nil,
+                  max: nil,
+                  cache: true,
+                  standard_sql: nil,
+                  legacy_sql: nil,
+                  session_id: nil,
+                  &block
+          job = query_job query,
+                          params: params,
+                          types: types,
+                          external: external,
+                          cache: cache,
+                          standard_sql: standard_sql,
+                          legacy_sql: legacy_sql,
+                          session_id: session_id,
+                          &block
           job.wait_until_done!
           ensure_job_succeeded! job
 

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -1304,6 +1304,7 @@ module Google
         #   session ID will be a server generated random id. If false, runs query
         #   with an existing session ID when one is provided in the `session_id`
         #   param, otherwise runs query in non-session mode. See {Job#session_id}.
+        #   The default value is false.
         # @param [String] session_id The ID of an existing session. See also the
         #   `create_session` param and {Job#session_id}.
         # @yield [job] a job configuration object

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -1393,8 +1393,9 @@ module Google
         #   require "google/cloud/bigquery"
         #
         #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
         #
-        #   job = bigquery.query_job "CREATE TABLE my_table (x INT64)"
+        #   job = dataset.query_job "CREATE TABLE my_table (x INT64)"
         #
         #   job.wait_until_done!
         #   if !job.failed?
@@ -1405,8 +1406,9 @@ module Google
         #   require "google/cloud/bigquery"
         #
         #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
         #
-        #   job = bigquery.query_job "UPDATE my_table " \
+        #   job = dataset.query_job "UPDATE my_table " \
         #                            "SET x = x + 1 " \
         #                            "WHERE x IS NOT NULL"
         #
@@ -1414,6 +1416,19 @@ module Google
         #   if !job.failed?
         #     puts job.num_dml_affected_rows
         #   end
+        #
+        # @example Run query in a session:
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #
+        #   job = dataset.query_job "CREATE TEMPORARY TABLE temptable AS SELECT 17 as foo", create_session: true
+        #
+        #   job.wait_until_done!
+        #
+        #   session_id = job.session_id
+        #   data = dataset.query "SELECT * FROM temptable", session_id: session_id
         #
         # @example Query using external data source, set destination:
         #   require "google/cloud/bigquery"
@@ -1701,8 +1716,9 @@ module Google
         #   require "google/cloud/bigquery"
         #
         #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
         #
-        #   data = bigquery.query "CREATE TABLE my_table (x INT64)"
+        #   data = dataset.query "CREATE TABLE my_table (x INT64)"
         #
         #   table_ref = data.ddl_target_table # Or ddl_target_routine for CREATE/DROP FUNCTION/PROCEDURE
         #
@@ -1710,12 +1726,24 @@ module Google
         #   require "google/cloud/bigquery"
         #
         #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
         #
-        #   data = bigquery.query "UPDATE my_table " \
-        #                         "SET x = x + 1 " \
-        #                         "WHERE x IS NOT NULL"
+        #   data = dataset.query "UPDATE my_table SET x = x + 1 WHERE x IS NOT NULL"
         #
         #   puts data.num_dml_affected_rows
+        #
+        # @example Run query in a session:
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #
+        #   job = dataset.query_job "CREATE TEMPORARY TABLE temptable AS SELECT 17 as foo", create_session: true
+        #
+        #   job.wait_until_done!
+        #
+        #   session_id = job.session_id
+        #   data = dataset.query "SELECT * FROM temptable", session_id: session_id
         #
         # @example Query using external data source, set destination:
         #   require "google/cloud/bigquery"

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -1244,8 +1244,12 @@ module Google
         #   Flattens all nested and repeated fields in the query results. The
         #   default value is `true`. `large_results` parameter must be `true` if
         #   this is set to `false`.
-        # @param [Integer] maximum_billing_tier Deprecated: Change the billing
-        #   tier to allow high-compute queries.
+        # @param [Integer] maximum_billing_tier Limits the billing tier for this
+        #   job. Queries that have resource usage beyond this tier will fail
+        #   (without incurring a charge). WARNING: The billed byte amount can be
+        #   multiplied by an amount up to this number! Most users should not need
+        #   to alter this setting, and we recommend that you avoid introducing new
+        #   uses of it. Deprecated.
         # @param [Integer] maximum_bytes_billed Limits the bytes billed for this
         #   job. Queries that will have bytes billed beyond this limit will fail
         #   (without incurring a charge). Optional. If unspecified, this will be

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -1377,8 +1377,7 @@ module Google
         #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
-        #   job = dataset.query_job "SELECT name FROM my_table " \
-        #                           "WHERE id IN UNNEST(@ids)",
+        #   job = dataset.query_job "SELECT name FROM my_table WHERE id IN UNNEST(@ids)",
         #                           params: { ids: [] },
         #                           types: { ids: [:INT64] }
         #
@@ -1408,9 +1407,7 @@ module Google
         #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
-        #   job = dataset.query_job "UPDATE my_table " \
-        #                            "SET x = x + 1 " \
-        #                            "WHERE x IS NOT NULL"
+        #   job = dataset.query_job "UPDATE my_table SET x = x + 1 WHERE x IS NOT NULL"
         #
         #   job.wait_until_done!
         #   if !job.failed?
@@ -1700,8 +1697,7 @@ module Google
         #   bigquery = Google::Cloud::Bigquery.new
         #   dataset = bigquery.dataset "my_dataset"
         #
-        #   data = dataset.query "SELECT name FROM my_table " \
-        #                        "WHERE id IN UNNEST(@ids)",
+        #   data = dataset.query "SELECT name FROM my_table WHERE id IN UNNEST(@ids)",
         #                        params: { ids: [] },
         #                        types: { ids: [:INT64] }
         #

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/job.rb
@@ -227,6 +227,16 @@ module Google
         end
 
         ##
+        # The ID of the session if this job is part of one. See the `create_session` param in {Project#query_job} and
+        # {Dataset#query_job}.
+        #
+        # @return [String, nil] The session ID, or `nil` if not associated with a session.
+        #
+        def session_id
+          @gapi.statistics.session_info&.session_id
+        end
+
+        ##
         # The ID of a multi-statement transaction.
         #
         # @return [String, nil] The transaction ID, or `nil` if not associated with a transaction.

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -474,8 +474,7 @@ module Google
         #
         #   bigquery = Google::Cloud::Bigquery.new
         #
-        #   job = bigquery.query_job "SELECT name FROM " \
-        #                            "`my_project.my_dataset.my_table`"
+        #   job = bigquery.query_job "SELECT name FROM `my_project.my_dataset.my_table`"
         #
         #   job.wait_until_done!
         #   if !job.failed?
@@ -489,8 +488,7 @@ module Google
         #
         #   bigquery = Google::Cloud::Bigquery.new
         #
-        #   job = bigquery.query_job "SELECT name FROM " \
-        #                            " [my_project:my_dataset.my_table]",
+        #   job = bigquery.query_job "SELECT name FROM [my_project:my_dataset.my_table]",
         #                            legacy_sql: true
         #
         #   job.wait_until_done!
@@ -505,9 +503,7 @@ module Google
         #
         #   bigquery = Google::Cloud::Bigquery.new
         #
-        #   job = bigquery.query_job "SELECT name FROM " \
-        #                            "`my_dataset.my_table` " \
-        #                            "WHERE id = ?",
+        #   job = bigquery.query_job "SELECT name FROM `my_dataset.my_table` WHERE id = ?",
         #                            params: [1]
         #
         #   job.wait_until_done!
@@ -522,9 +518,7 @@ module Google
         #
         #   bigquery = Google::Cloud::Bigquery.new
         #
-        #   job = bigquery.query_job "SELECT name FROM " \
-        #                            "`my_dataset.my_table` " \
-        #                            "WHERE id = @id",
+        #   job = bigquery.query_job "SELECT name FROM `my_dataset.my_table` WHERE id = @id",
         #                            params: { id: 1 }
         #
         #   job.wait_until_done!
@@ -539,9 +533,7 @@ module Google
         #
         #   bigquery = Google::Cloud::Bigquery.new
         #
-        #   job = bigquery.query_job "SELECT name FROM " \
-        #                            "`my_dataset.my_table` " \
-        #                            "WHERE id IN UNNEST(@ids)",
+        #   job = bigquery.query_job "SELECT name FROM `my_dataset.my_table` WHERE id IN UNNEST(@ids)",
         #                            params: { ids: [] },
         #                            types: { ids: [:INT64] }
         #
@@ -557,9 +549,7 @@ module Google
         #
         #   bigquery = Google::Cloud::Bigquery.new
         #
-        #   job = bigquery.query_job "CREATE TABLE " \
-        #                            "`my_dataset.my_table` " \
-        #                            "(x INT64)"
+        #   job = bigquery.query_job "CREATE TABLE`my_dataset.my_table` (x INT64)"
         #
         #   job.wait_until_done!
         #   if !job.failed?
@@ -571,10 +561,7 @@ module Google
         #
         #   bigquery = Google::Cloud::Bigquery.new
         #
-        #   job = bigquery.query_job "UPDATE " \
-        #                            "`my_dataset.my_table` " \
-        #                            "SET x = x + 1 " \
-        #                            "WHERE x IS NOT NULL"
+        #   job = bigquery.query_job "UPDATE `my_dataset.my_table` SET x = x + 1 WHERE x IS NOT NULL"
         #
         #   job.wait_until_done!
         #   if !job.failed?
@@ -829,9 +816,7 @@ module Google
         #
         #   bigquery = Google::Cloud::Bigquery.new
         #
-        #   data = bigquery.query "SELECT name " \
-        #                         "FROM `my_dataset.my_table` " \
-        #                         "WHERE id = ?",
+        #   data = bigquery.query "SELECT name FROM `my_dataset.my_table` WHERE id = ?",
         #                         params: [1]
         #
         #   # Iterate over the first page of results
@@ -846,9 +831,7 @@ module Google
         #
         #   bigquery = Google::Cloud::Bigquery.new
         #
-        #   data = bigquery.query "SELECT name " \
-        #                         "FROM `my_dataset.my_table` " \
-        #                         "WHERE id = @id",
+        #   data = bigquery.query "SELECT name FROM `my_dataset.my_table` WHERE id = @id",
         #                         params: { id: 1 }
         #
         #   # Iterate over the first page of results
@@ -863,9 +846,7 @@ module Google
         #
         #   bigquery = Google::Cloud::Bigquery.new
         #
-        #   data = bigquery.query "SELECT name FROM " \
-        #                         "`my_dataset.my_table` " \
-        #                         "WHERE id IN UNNEST(@ids)",
+        #   data = bigquery.query "SELECT name FROM `my_dataset.my_table` WHERE id IN UNNEST(@ids)",
         #                         params: { ids: [] },
         #                         types: { ids: [:INT64] }
         #
@@ -890,9 +871,7 @@ module Google
         #
         #   bigquery = Google::Cloud::Bigquery.new
         #
-        #   data = bigquery.query "UPDATE `my_dataset.my_table` " \
-        #                         "SET x = x + 1 " \
-        #                         "WHERE x IS NOT NULL"
+        #   data = bigquery.query "UPDATE `my_dataset.my_table` SET x = x + 1 WHERE x IS NOT NULL"
         #
         #   puts data.num_dml_affected_rows
         #
@@ -1392,9 +1371,7 @@ module Google
         #   bigquery = Google::Cloud::Bigquery.new
         #
         #   fourpm = bigquery.time 16, 0, 0
-        #   data = bigquery.query "SELECT name " \
-        #                         "FROM `my_dataset.my_table`" \
-        #                         "WHERE time_of_date = @time",
+        #   data = bigquery.query "SELECT name FROM `my_dataset.my_table` WHERE time_of_date = @time",
         #                         params: { time: fourpm }
         #
         #   # Iterate over the first page of results
@@ -1410,9 +1387,7 @@ module Google
         #   bigquery = Google::Cloud::Bigquery.new
         #
         #   precise_time = bigquery.time 16, 35, 15.376541
-        #   data = bigquery.query "SELECT name " \
-        #                         "FROM `my_dataset.my_table`" \
-        #                         "WHERE time_of_date >= @time",
+        #   data = bigquery.query "SELECT name FROM `my_dataset.my_table` WHERE time_of_date >= @time",
         #                         params: { time: precise_time }
         #
         #   # Iterate over the first page of results

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -402,6 +402,8 @@ module Google
         #   Flattens all nested and repeated fields in the query results. The
         #   default value is `true`. `large_results` parameter must be `true` if
         #   this is set to `false`.
+        # @param [Integer] maximum_billing_tier Deprecated: Change the billing
+        #   tier to allow high-compute queries.
         # @param [Integer] maximum_bytes_billed Limits the bytes billed for this
         #   job. Queries that will have bytes billed beyond this limit will fail
         #   (without incurring a charge). Optional. If unspecified, this will be
@@ -455,8 +457,12 @@ module Google
         #   For additional information on migrating, see: [Migrating to
         #   standard SQL - Differences in user-defined JavaScript
         #   functions](https://cloud.google.com/bigquery/docs/reference/standard-sql/migrating-from-legacy-sql#differences_in_user-defined_javascript_functions)
-        # @param [Integer] maximum_billing_tier Deprecated: Change the billing
-        #   tier to allow high-compute queries.
+        # @param [Boolean] create_session If true, creates a new session, where the
+        #   session ID will be a server generated random id. If false, runs query
+        #   with an existing session ID when one is provided in the `session_id`
+        #   param, otherwise runs query in non-session mode. See {Job#session_id}.
+        # @param [String] session_id The ID of an existing session. See also the
+        #   `create_session` param and {Job#session_id}.
         # @yield [job] a job configuration object
         # @yieldparam [Google::Cloud::Bigquery::QueryJob::Updater] job a job
         #   configuration object for setting query options.
@@ -599,17 +605,56 @@ module Google
         #     end
         #   end
         #
-        def query_job query, params: nil, types: nil, external: nil, priority: "INTERACTIVE", cache: true, table: nil,
-                      create: nil, write: nil, dryrun: nil, dataset: nil, project: nil, standard_sql: nil,
-                      legacy_sql: nil, large_results: nil, flatten: nil, maximum_billing_tier: nil,
-                      maximum_bytes_billed: nil, job_id: nil, prefix: nil, labels: nil, udfs: nil
+        def query_job query,
+                      params: nil,
+                      types: nil,
+                      external: nil,
+                      priority: "INTERACTIVE",
+                      cache: true,
+                      table: nil,
+                      create: nil,
+                      write: nil,
+                      dryrun: nil,
+                      dataset: nil,
+                      project: nil,
+                      standard_sql: nil,
+                      legacy_sql: nil,
+                      large_results: nil,
+                      flatten: nil,
+                      maximum_billing_tier: nil,
+                      maximum_bytes_billed: nil,
+                      job_id: nil,
+                      prefix: nil,
+                      labels: nil,
+                      udfs: nil,
+                      create_session: nil,
+                      session_id: nil
           ensure_service!
-          options = { params: params, types: types, external: external, priority: priority, cache: cache, table: table,
-                      create: create, write: write, dryrun: dryrun, dataset: dataset,
-                      project: (project || self.project), standard_sql: standard_sql, legacy_sql: legacy_sql,
-                      large_results: large_results, flatten: flatten, maximum_billing_tier: maximum_billing_tier,
-                      maximum_bytes_billed: maximum_bytes_billed, job_id: job_id, prefix: prefix, labels: labels,
-                      udfs: udfs }
+          options = {
+            params: params,
+            types: types,
+            external: external,
+            priority: priority,
+            cache: cache,
+            table: table,
+            create: create,
+            write: write,
+            dryrun: dryrun,
+            dataset: dataset,
+            project: (project || self.project),
+            standard_sql: standard_sql,
+            legacy_sql: legacy_sql,
+            large_results: large_results,
+            flatten: flatten,
+            maximum_billing_tier: maximum_billing_tier,
+            maximum_bytes_billed: maximum_bytes_billed,
+            job_id: job_id,
+            prefix: prefix,
+            labels: labels,
+            udfs: udfs,
+            create_session: create_session,
+            session_id: session_id
+          }
 
           updater = QueryJob::Updater.from_options service, query, options
 
@@ -730,6 +775,8 @@ module Google
         #   When set to false, the values of `large_results` and `flatten` are
         #   ignored; the query will be run as if `large_results` is true and
         #   `flatten` is false. Optional. The default value is false.
+        # @param [String] session_id The ID of an existing session. See the
+        #   `create_session` param in {#query_job} and {Job#session_id}.
         # @yield [job] a job configuration object
         # @yieldparam [Google::Cloud::Bigquery::QueryJob::Updater] job a job
         #   configuration object for setting additional options for the query.
@@ -873,10 +920,29 @@ module Google
         #   # Retrieve the next page of results
         #   data = data.next if data.next?
         #
-        def query query, params: nil, types: nil, external: nil, max: nil, cache: true, dataset: nil, project: nil,
-                  standard_sql: nil, legacy_sql: nil, &block
-          job = query_job query, params: params, types: types, external: external, cache: cache, dataset: dataset,
-                                 project: project, standard_sql: standard_sql, legacy_sql: legacy_sql, &block
+        def query query,
+                  params: nil,
+                  types: nil,
+                  external: nil,
+                  max: nil,
+                  cache: true,
+                  dataset: nil,
+                  project: nil,
+                  standard_sql: nil,
+                  legacy_sql: nil,
+                  session_id: nil,
+                  &block
+          job = query_job query,
+                          params: params,
+                          types: types,
+                          external: external,
+                          cache: cache,
+                          dataset: dataset,
+                          project: project,
+                          standard_sql: standard_sql,
+                          legacy_sql: legacy_sql,
+                          session_id: session_id,
+                          &block
           job.wait_until_done!
 
           if job.failed?

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -465,6 +465,7 @@ module Google
         #   session ID will be a server generated random id. If false, runs query
         #   with an existing session ID when one is provided in the `session_id`
         #   param, otherwise runs query in non-session mode. See {Job#session_id}.
+        #   The default value is false.
         # @param [String] session_id The ID of an existing session. See also the
         #   `create_session` param and {Job#session_id}.
         # @yield [job] a job configuration object

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -402,8 +402,12 @@ module Google
         #   Flattens all nested and repeated fields in the query results. The
         #   default value is `true`. `large_results` parameter must be `true` if
         #   this is set to `false`.
-        # @param [Integer] maximum_billing_tier Deprecated: Change the billing
-        #   tier to allow high-compute queries.
+        # @param [Integer] maximum_billing_tier Limits the billing tier for this
+        #   job. Queries that have resource usage beyond this tier will fail
+        #   (without incurring a charge). WARNING: The billed byte amount can be
+        #   multiplied by an amount up to this number! Most users should not need
+        #   to alter this setting, and we recommend that you avoid introducing new
+        #   uses of it. Deprecated.
         # @param [Integer] maximum_bytes_billed Limits the bytes billed for this
         #   job. Queries that will have bytes billed beyond this limit will fail
         #   (without incurring a charge). Optional. If unspecified, this will be

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
@@ -775,6 +775,8 @@ module Google
             updater = QueryJob::Updater.new service, req
             updater.set_params_and_types options[:params], options[:types] if options[:params]
             updater.create = options[:create]
+            updater.create_session = options[:create_session]
+            updater.session_id = options[:session_id] if options[:session_id]
             updater.write = options[:write]
             updater.table = options[:table]
             updater.dryrun = options[:dryrun]
@@ -1016,6 +1018,37 @@ module Google
           # @!group Attributes
           def create= value
             @gapi.configuration.query.create_disposition = Convert.create_disposition value
+          end
+
+          ##
+          # Sets the create_session property. If true, creates a new session,
+          # where session id will be a server generated random id. If false,
+          # runs query with an existing {#session_id=}, otherwise runs query in
+          # non-session mode. The default value is `false`.
+          #
+          # @param [Boolean] value The create_session property. The default
+          # value is `false`.
+          #
+          # @!group Attributes
+          def create_session= value
+            @gapi.configuration.query.create_session = value
+          end
+
+          ##
+          # Sets the session ID for a query run in session mode. See {#create_session=}.
+          #
+          # @param [String] value The session ID. The default value is `nil`.
+          #
+          # @!group Attributes
+          def session_id= value
+            @gapi.configuration.query.connection_properties ||= []
+            prop = @gapi.configuration.query.connection_properties.find { |cp| cp.key == "session_id" }
+            if prop
+              prop.value = value
+            else
+              prop = Google::Apis::BigqueryV2::ConnectionProperty.new key: "session_id", value: value
+              @gapi.configuration.query.connection_properties << prop
+            end
           end
 
           ##

--- a/google-cloud-bigquery/support/doctest_helper.rb
+++ b/google-cloud-bigquery/support/doctest_helper.rb
@@ -253,7 +253,16 @@ YARD::Doctest.configure do |doctest|
     mock_bigquery do |mock|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :insert_job, query_job_gapi, ["my-project", Google::Apis::BigqueryV2::Job]
-      mock.expect :get_job_query_results, query_data_gapi(token: nil), ["my-project", "1234567890", Hash]
+      mock.expect :list_table_data, table_data_gapi(token: nil).to_json, ["my-project", "target_dataset_id", "target_table_id", Hash]
+    end
+  end
+
+  doctest.before "Google::Cloud::Bigquery::Dataset#query@Run query in a session:" do
+    mock_bigquery do |mock|
+      mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
+      mock.expect :insert_job, query_job_gapi, ["my-project", Google::Apis::BigqueryV2::Job]
+      mock.expect :get_job, query_job_gapi, ["my-project", "1234567890", Hash]
+      mock.expect :insert_job, query_job_gapi, ["my-project", Google::Apis::BigqueryV2::Job]
       mock.expect :list_table_data, table_data_gapi(token: nil).to_json, ["my-project", "target_dataset_id", "target_table_id", Hash]
     end
   end
@@ -266,7 +275,16 @@ YARD::Doctest.configure do |doctest|
       mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
       mock.expect :insert_job, query_job_gapi, ["my-project", Google::Apis::BigqueryV2::Job]
       mock.expect :get_job, query_job_gapi, ["my-project", "1234567890", Hash]
-      mock.expect :get_job_query_results, query_data_gapi, ["my-project", "1234567890", Hash]
+      mock.expect :list_table_data, table_data_gapi(token: nil).to_json, ["my-project", "target_dataset_id", "target_table_id", Hash]
+    end
+  end
+
+  doctest.before "Google::Cloud::Bigquery::Dataset#query_job@Run query in a session:" do
+    mock_bigquery do |mock|
+      mock.expect :get_dataset, dataset_full_gapi, ["my-project", "my_dataset"]
+      mock.expect :insert_job, query_job_gapi, ["my-project", Google::Apis::BigqueryV2::Job]
+      mock.expect :get_job, query_job_gapi, ["my-project", "1234567890", Hash]
+      mock.expect :insert_job, query_job_gapi, ["my-project", Google::Apis::BigqueryV2::Job]
       mock.expect :list_table_data, table_data_gapi(token: nil).to_json, ["my-project", "target_dataset_id", "target_table_id", Hash]
     end
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_test.rb
@@ -26,6 +26,7 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :mock_bigquery do
                                                   bigquery.service }
   let(:labels) { { "foo" => "bar" } }
   let(:udfs) { [ "return x+1;", "gs://my-bucket/my-lib.js" ] }
+  let(:session_id) { "mysessionid" }
   let(:range_partitioning) do
     Google::Apis::BigqueryV2::RangePartitioning.new(
       field: "my_table_id",
@@ -338,5 +339,43 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :mock_bigquery do
 
     _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
     _(job.udfs).must_equal ["gs://my-bucket/my-lib.js"]
+  end
+
+  it "queries the data with create_session option" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    job_gapi = query_job_gapi query, create_session: true
+    job_gapi.configuration.query.default_dataset = Google::Apis::BigqueryV2::DatasetReference.new(
+      project_id: project,
+      dataset_id: dataset_id
+    )
+    job_resp_gapi = query_job_resp_gapi query, session_id: session_id
+    mock.expect :insert_job, job_resp_gapi, [project, job_gapi]
+
+    job = dataset.query_job query, create_session: true
+    mock.verify
+
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job.session_id).must_equal session_id
+  end
+
+  it "queries the data with session_id option" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    job_gapi = query_job_gapi query, session_id: session_id
+    job_gapi.configuration.query.default_dataset = Google::Apis::BigqueryV2::DatasetReference.new(
+      project_id: project,
+      dataset_id: dataset_id
+    )
+    job_resp_gapi = query_job_resp_gapi query, session_id: session_id
+    mock.expect :insert_job, job_resp_gapi, [project, job_gapi]
+
+    job = dataset.query_job query, session_id: session_id
+    mock.verify
+
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job.session_id).must_equal session_id
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_query_job_test.rb
@@ -360,6 +360,27 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :mock_bigquery do
     _(job.session_id).must_equal session_id
   end
 
+  it "queries the data with create_session in block" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    job_gapi = query_job_gapi query, create_session: true
+    job_gapi.configuration.query.default_dataset = Google::Apis::BigqueryV2::DatasetReference.new(
+      project_id: project,
+      dataset_id: dataset_id
+    )
+    job_resp_gapi = query_job_resp_gapi query, session_id: session_id
+    mock.expect :insert_job, job_resp_gapi, [project, job_gapi]
+
+    job = dataset.query_job query do |j|
+      j.create_session = true
+    end
+    mock.verify
+
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job.session_id).must_equal session_id
+  end
+
   it "queries the data with session_id option" do
     mock = Minitest::Mock.new
     bigquery.service.mocked_service = mock
@@ -373,6 +394,29 @@ describe Google::Cloud::Bigquery::Dataset, :query_job, :mock_bigquery do
     mock.expect :insert_job, job_resp_gapi, [project, job_gapi]
 
     job = dataset.query_job query, session_id: session_id
+    mock.verify
+
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job.session_id).must_equal session_id
+  end
+
+  it "queries the data with session_id in block" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    job_gapi = query_job_gapi query, session_id: session_id
+    job_gapi.configuration.query.default_dataset = Google::Apis::BigqueryV2::DatasetReference.new(
+      project_id: project,
+      dataset_id: dataset_id
+    )
+    job_resp_gapi = query_job_resp_gapi query, session_id: session_id
+    mock.expect :insert_job, job_resp_gapi, [project, job_gapi]
+
+    job = dataset.query_job query do |j|
+      j.session_id = session_id
+      j.session_id = nil
+      j.session_id = session_id
+    end
     mock.verify
 
     _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob

--- a/google-cloud-bigquery/test/google/cloud/bigquery/job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/job_test.rb
@@ -20,7 +20,8 @@ describe Google::Cloud::Bigquery::Job, :mock_bigquery do
   # Create a job object with the project's mocked connection object
   let(:region) { "US" }
   let(:labels) { { "foo" => "bar" } }
-  let(:job_hash) { random_job_hash location: region, transaction_id: "123456789" }
+  let(:session_id) { "mysessionid" }
+  let(:job_hash) { random_job_hash location: region, transaction_id: "123456789", session_id: session_id }
   let(:job_gapi) do
     job_gapi = Google::Apis::BigqueryV2::Job.from_json job_hash.to_json
     job_gapi.configuration.labels = labels
@@ -60,6 +61,7 @@ describe Google::Cloud::Bigquery::Job, :mock_bigquery do
     _(job.user_email).must_equal "user@example.com"
     _(job.num_child_jobs).must_equal 2
     _(job.parent_job_id).must_equal "2222222222"
+    _(job.session_id).must_equal session_id
   end
 
   it "knows its state" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_test.rb
@@ -263,6 +263,23 @@ describe Google::Cloud::Bigquery::Project, :query_job, :mock_bigquery do
     _(job.session_id).must_equal session_id
   end
 
+  it "queries the data with create_session option in a block" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    job_gapi = query_job_gapi query, location: nil, create_session: true
+    job_resp_gapi = query_job_resp_gapi query, session_id: session_id
+    mock.expect :insert_job, job_resp_gapi, [project, job_gapi]
+
+    job = bigquery.query_job query do |j|
+      j.create_session = true
+    end
+    mock.verify
+
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job.session_id).must_equal session_id
+  end
+
   it "queries the data with session_id option" do
     mock = Minitest::Mock.new
     bigquery.service.mocked_service = mock
@@ -272,6 +289,25 @@ describe Google::Cloud::Bigquery::Project, :query_job, :mock_bigquery do
     mock.expect :insert_job, job_resp_gapi, [project, job_gapi]
 
     job = bigquery.query_job query, session_id: session_id
+    mock.verify
+
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job.session_id).must_equal session_id
+  end
+
+  it "queries the data with session_id option in a block" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    job_gapi = query_job_gapi query, location: nil, session_id: session_id
+    job_resp_gapi = query_job_resp_gapi query, session_id: session_id
+    mock.expect :insert_job, job_resp_gapi, [project, job_gapi]
+
+    job = bigquery.query_job query do |j|
+      j.session_id = session_id
+      j.session_id = nil
+      j.session_id = session_id
+    end
     mock.verify
 
     _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_job_test.rb
@@ -26,6 +26,7 @@ describe Google::Cloud::Bigquery::Project, :query_job, :mock_bigquery do
                                                   bigquery.service }
   let(:labels) { { "foo" => "bar" } }
   let(:udfs) { [ "return x+1;", "gs://my-bucket/my-lib.js" ] }
+  let(:session_id) { "mysessionid" }
 
   it "queries the data" do
     mock = Minitest::Mock.new
@@ -245,5 +246,35 @@ describe Google::Cloud::Bigquery::Project, :query_job, :mock_bigquery do
 
     _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
     _(job.udfs).must_equal ["gs://my-bucket/my-lib.js"]
+  end
+
+  it "queries the data with create_session option" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    job_gapi = query_job_gapi query, location: nil, create_session: true
+    job_resp_gapi = query_job_resp_gapi query, session_id: session_id
+    mock.expect :insert_job, job_resp_gapi, [project, job_gapi]
+
+    job = bigquery.query_job query, create_session: true
+    mock.verify
+
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job.session_id).must_equal session_id
+  end
+
+  it "queries the data with session_id option" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    job_gapi = query_job_gapi query, location: nil, session_id: session_id
+    job_resp_gapi = query_job_resp_gapi query, session_id: session_id
+    mock.expect :insert_job, job_resp_gapi, [project, job_gapi]
+
+    job = bigquery.query_job query, session_id: session_id
+    mock.verify
+
+    _(job).must_be_kind_of Google::Cloud::Bigquery::QueryJob
+    _(job.session_id).must_equal session_id
   end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/project_query_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/project_query_test.rb
@@ -24,12 +24,11 @@ describe Google::Cloud::Bigquery::Project, :query, :mock_bigquery do
   let(:job_id) { "job_9876543210" }
   let(:dataset_id) { "my_dataset" }
   let(:dataset_gapi) { random_dataset_gapi dataset_id }
-  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi,
-                                                      bigquery.service }
+  let(:dataset) { Google::Cloud::Bigquery::Dataset.from_gapi dataset_gapi, bigquery.service }
   let(:table_id) { "my_table" }
   let(:table_gapi) { random_table_gapi dataset_id, table_id }
-  let(:table) { Google::Cloud::Bigquery::Table.from_gapi table_gapi,
-                                                  bigquery.service }
+  let(:table) { Google::Cloud::Bigquery::Table.from_gapi table_gapi, bigquery.service }
+  let(:session_id) { "mysessionid" }
 
   it "queries the data" do
     mock = Minitest::Mock.new
@@ -279,6 +278,25 @@ describe Google::Cloud::Bigquery::Project, :query, :mock_bigquery do
 
 
     data = bigquery.query query, cache: false
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
+    _(data.count).must_equal 3
+    mock.verify
+  end
+
+  it "queries the data with session_id option" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    job_gapi = query_job_gapi query, location: nil, session_id: session_id
+    mock.expect :insert_job, query_job_resp_gapi(query, job_id: job_id), [project, job_gapi]
+    mock.expect :get_job_query_results,
+                query_data_gapi,
+                [project, job_id, {location: "US", max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil}]
+    mock.expect :list_table_data,
+                table_data_gapi.to_json,
+                [project, "target_dataset_id", "target_table_id", {  max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true} }]
+
+    data = bigquery.query query, session_id: session_id
     _(data.class).must_equal Google::Cloud::Bigquery::Data
     _(data.count).must_equal 3
     mock.verify


### PR DESCRIPTION
* Add `create_session` and `session_id` params to `Project#query_job`
* Add `session_id` param to `Project#query`
* Add `create_session` and `session_id` params to `Dataset#query_job`
* Add `session_id` param to `Dataset#query`
* Add `Job#session_id`
* Add `QueryJob::Updater#create_session=`
* Add `QueryJob::Updater#session_id=`

closes: #15553