### PR TITLE
chore: Various updates to cloudrad

### DIFF
--- a/template/default/layout/yaml/_method.erb
+++ b/template/default/layout/yaml/_method.erb
@@ -5,11 +5,11 @@
     - ruby
   module: <%= ENV["CLOUDRAD_GEM_NAME"] %>
   id: "<%= @method.path[@method.path.size - (@method.name.size + 1)..-1] %>"
-  summary: "<%= demote_headers pre_format(@method.docstring), 4 %>"
+  summary: "<%= pre_format @method.docstring, min_header: 4 %>"
   type: <%= @method.type %>
   example: <%= example_text @method, "    " %>
   syntax:
-    description: "<%= demote_headers pre_format(@method.docstring), 4 %>"
+    description: "<%= pre_format @method.docstring, min_header: 4 %>"
     content: "<%= method_signature %>"
 <%= param_text %>
 <%= yield_text %>

--- a/template/default/layout/yaml/_object.erb
+++ b/template/default/layout/yaml/_object.erb
@@ -5,7 +5,7 @@
   - ruby
   module: <%= ENV["CLOUDRAD_GEM_NAME"] %>
   id: <%= @object.name %>
-  summary: "<%= pre_format @object.docstring %>"
+  summary: "<%= pre_format @object.docstring, min_header: 2, toplevel_header: true %>"
   type: "<%= @object.type %>"
   name: <%= @object.path %>
   example: <%= example_text @object, "    " %>

--- a/template/default/layout/yaml/method.rb
+++ b/template/default/layout/yaml/method.rb
@@ -32,7 +32,7 @@ def method_signature
   return_text = ""
 
   unless return_types.empty?
-    return_text += " => "
+    return_text += " -> "
     return_text += return_types.join ", "
   end
 
@@ -47,8 +47,8 @@ def method_signature
     text += "def "
     text += "self." if sign == "."
     text += @method.name.to_s
+    text += "("
     unless @method.parameters.empty?
-      text += "("
       params = @method.parameters.map do |param|
         entry = param[0]
         if param[1]
@@ -61,8 +61,8 @@ def method_signature
         entry
       end
       text += params.join ", "
-      text += ")"
     end
+    text += ")"
     text += block_text
     text += return_text
   else


### PR DESCRIPTION
Further cleanup and fixes to cloudrad formatter.

* Annotated Ruby code blocks in Markdown files for the pretty-printer. Fixes #13974
* Reversed the order of markdown and YARD processing to ensure links don't appear in code blocks.
* Refined the header-demotion logic to handle different use cases (e.g. method description vs class description), and reimplemented it as a redcarpet subclass for simplicity.
* Adjusted redcarpet parameters to enable lax spacing and suppress intra-word emphasis.
* Tweaked the signature format a bit to make it closer to RBS. It's still not RBS, though, and we still need to figure out whether or not it should be.
* Deleted a bunch of dead code.
