### PR TITLE
chore: Handle aliases and attributes better in CloudRAD

### DIFF
--- a/template/default/layout/yaml/_method.erb
+++ b/template/default/layout/yaml/_method.erb
@@ -11,6 +11,7 @@
   syntax:
     description: "<%= pre_format @method.docstring, min_header: 4 %>"
     content: "<%= method_signature %>"
+<%= alias_text %>
 <%= param_text %>
 <%= yield_text %>
 <%= yield_param_text %>


### PR DESCRIPTION
* Show parameters properly in methods that are defined as aliases. Fixes #16051 
* Include aliases and alias-of in the output, so the doc-template can later render it.
* attr_writer methods now display the parameter correctly. Implemented as an alternative to #13617 which we still might do later but we're deferring for now.
