### PR TITLE
Determine ALTER TABLE to be a DDL statement in google-cloud-bigquery

### DIFF
--- a/google-cloud-bigquery/lib/google/cloud/bigquery/data.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/data.rb
@@ -276,8 +276,16 @@ module Google
         #   data.ddl? #=> true
         #
         def ddl?
-          ["CREATE_MODEL", "CREATE_TABLE", "CREATE_TABLE_AS_SELECT", "CREATE_VIEW", "\n", "DROP_MODEL", "DROP_TABLE",
-           "DROP_VIEW"].include? statement_type
+          [
+            "CREATE_MODEL",
+            "CREATE_TABLE",
+            "CREATE_TABLE_AS_SELECT",
+            "CREATE_VIEW",
+            "\n",
+            "DROP_MODEL",
+            "DROP_TABLE",
+            "DROP_VIEW"
+          ].include? statement_type
         end
 
         ##

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/data.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/data.rb
@@ -232,6 +232,8 @@ module Google
         # The type of query statement, if valid. Possible values (new values
         # might be added in the future):
         #
+        # * "ALTER_TABLE": DDL statement, see [Using Data Definition Language
+        #   Statements](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language)
         # * "CREATE_MODEL": DDL statement, see [Using Data Definition Language
         #   Statements](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language)
         # * "CREATE_TABLE": DDL statement, see [Using Data Definition Language
@@ -277,6 +279,7 @@ module Google
         #
         def ddl?
           [
+            "ALTER_TABLE",
             "CREATE_MODEL",
             "CREATE_TABLE",
             "CREATE_TABLE_AS_SELECT",

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
@@ -250,6 +250,8 @@ module Google
         # The type of query statement, if valid. Possible values (new values
         # might be added in the future):
         #
+        # * "ALTER_TABLE": DDL statement, see [Using Data Definition Language
+        #   Statements](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language)
         # * "CREATE_MODEL": DDL statement, see [Using Data Definition Language
         #   Statements](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language)
         # * "CREATE_TABLE": DDL statement, see [Using Data Definition Language
@@ -296,6 +298,7 @@ module Google
         #
         def ddl?
           [
+            "ALTER_TABLE",
             "CREATE_MODEL",
             "CREATE_TABLE",
             "CREATE_TABLE_AS_SELECT",

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
@@ -295,8 +295,16 @@ module Google
         #   query_job.ddl? #=> true
         #
         def ddl?
-          ["CREATE_MODEL", "CREATE_TABLE", "CREATE_TABLE_AS_SELECT", "CREATE_VIEW", "\n", "DROP_MODEL", "DROP_TABLE",
-           "DROP_VIEW"].include? statement_type
+          [
+            "CREATE_MODEL",
+            "CREATE_TABLE",
+            "CREATE_TABLE_AS_SELECT",
+            "CREATE_VIEW",
+            "\n",
+            "DROP_MODEL",
+            "DROP_TABLE",
+            "DROP_VIEW"
+          ].include? statement_type
         end
 
         ##


### PR DESCRIPTION
Resolves https://github.com/googleapis/google-cloud-ruby/issues/16097.

After making this change to determine `ALTER TABLE` to be a DDL statement, we have not seen the failure after running our migrations in a loop for a couple of hours (delete dataset, migrate, repeat).

Oddly, the method is defined twice (one does not seem to be used?), so we made the change to both.