### PR TITLE
feat: GA release of google-identity-access_context_manager

### DIFF
--- a/google-identity-access_context_manager/CHANGELOG.md
+++ b/google-identity-access_context_manager/CHANGELOG.md
@@ -2,6 +2,4 @@
 
 ### 0.1.0 / 2021-09-23
 
-#### Features
-
 * Initial generation of google-identity-access_context_manager


### PR DESCRIPTION
We're going to bump the version of google-identity-acess_context_manager to 1.0. This is just a "dummy" change to trigger release-please.