### PR TITLE
feat: GA release of google-cloud-orchestration-airflow-service

### DIFF
--- a/google-cloud-orchestration-airflow-service/CHANGELOG.md
+++ b/google-cloud-orchestration-airflow-service/CHANGELOG.md
@@ -2,6 +2,4 @@
 
 ### 0.1.0 / 2021-09-27
 
-#### Features
-
 * Initial generation of google-cloud-orchestration-airflow-service


### PR DESCRIPTION
We're going to bump the version of google-cloud-orchestration-airflow-service to 1.0. This is just a "dummy" change to trigger release-please.