### PR TITLE
feat: GA release of google-cloud-contact_center_insights

### DIFF
--- a/google-cloud-contact_center_insights/CHANGELOG.md
+++ b/google-cloud-contact_center_insights/CHANGELOG.md
@@ -2,6 +2,4 @@
 
 ### 0.1.0 / 2021-08-23
 
-#### Features
-
 * Initial generation of google-cloud-contact_center_insights


### PR DESCRIPTION
We're going to bump the version of google-cloud-contact_center_insights to 1.0. This is just a "dummy" change to trigger release-please.