### PR TITLE
feat: GA release of google-cloud-data_fusion

### DIFF
--- a/google-cloud-data_fusion/CHANGELOG.md
+++ b/google-cloud-data_fusion/CHANGELOG.md
@@ -2,6 +2,4 @@
 
 ### 0.1.0 / 2021-07-27
 
-#### Features
-
 * Initial generation of google-cloud-data_fusion


### PR DESCRIPTION
We're going to bump the version of google-cloud-data_fusion to 1.0. This is just a "dummy" change to trigger release-please.