### PR TITLE
Update storage_delete_bucket.rb

### DIFF
--- a/google-cloud-storage/samples/storage_delete_bucket.rb
+++ b/google-cloud-storage/samples/storage_delete_bucket.rb
@@ -20,7 +20,7 @@ def delete_bucket bucket_name:
   require "google/cloud/storage"
 
   storage = Google::Cloud::Storage.new
-  bucket  = storage.bucket bucket_name
+  bucket  = storage.bucket bucket_name, skip_lookup: true
 
   bucket.delete
 


### PR DESCRIPTION
@frankyn
As currently written, the sample makes a separate request to retrieve bucket metadata. This behavior would require unnecessary, additional IAM permissions.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-ruby/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea.
- [ ] Follow the instructions in [CONTRIBUTING](CONTRIBUTING.md). Most importantly, ensure the tests and linter pass by running `bundle exec rake ci` in the gem subdirectory.
- [ ] Update code documentation if necessary.

closes: #<issue_number_goes_here>