### PR TITLE
Update storage_download_file.rb

### DIFF
--- a/google-cloud-storage/samples/storage_download_file.rb
+++ b/google-cloud-storage/samples/storage_download_file.rb
@@ -26,12 +26,12 @@ def download_file bucket_name:, file_name:, local_file_path:
   require "google/cloud/storage"
 
   storage = Google::Cloud::Storage.new
-  bucket  = storage.bucket bucket_name
+  bucket  = storage.bucket bucket_name, skip_lookup: true
   file    = bucket.file file_name
 
   file.download local_file_path
 
-  puts "Downloaded #{file.name} to #{local_file_path}"
+  puts "Downloaded #{file_name} to #{local_file_path}"
 end
 # [END storage_download_file]
 

--- a/google-cloud-storage/samples/storage_download_file.rb
+++ b/google-cloud-storage/samples/storage_download_file.rb
@@ -31,7 +31,7 @@ def download_file bucket_name:, file_name:, local_file_path:
 
   file.download local_file_path
 
-  puts "Downloaded #{file_name} to #{local_file_path}"
+  puts "Downloaded #{file.name} to #{local_file_path}"
 end
 # [END storage_download_file]
 


### PR DESCRIPTION
@frankyn
As currently written, the sample makes a separate request to retrieve bucket metadata. This behavior would require unnecessary, additional IAM permissions.

Also, does line 32 (`file.download`) make a separate request to the API? Is this necessary? Can `file.download` be made `file_download`? Thanks!

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-ruby/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea.
- [ ] Follow the instructions in [CONTRIBUTING](CONTRIBUTING.md). Most importantly, ensure the tests and linter pass by running `bundle exec rake ci` in the gem subdirectory.
- [ ] Update code documentation if necessary.

closes: #<issue_number_goes_here>