### PR TITLE
chore(pubsub): Fix samples schema test

### DIFF
--- a/google-cloud-pubsub/samples/acceptance/schemas_test.rb
+++ b/google-cloud-pubsub/samples/acceptance/schemas_test.rb
@@ -53,9 +53,8 @@ describe "schemas" do
     # pubsub_delete_schema
     assert_output "Schema #{schema_id} deleted.\n" do
       delete_schema schema_id: schema_id
+      @schema = nil
     end
-    @schema = pubsub.schema schema_id
-    refute @schema
   end
 
   describe "AVRO" do


### PR DESCRIPTION
Eventual consistency of the deleted state of the schema makes it unreliable to immediately assert that the deletion happened.

closes: #13691