### PR TITLE
fix: Honor quota project in auxiliary operations clients

### DIFF
--- a/google-cloud-api_gateway-v1/lib/google/cloud/api_gateway/v1/api_gateway_service/client.rb
+++ b/google-cloud-api_gateway-v1/lib/google/cloud/api_gateway/v1/api_gateway_service/client.rb
@@ -180,6 +180,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-app_engine-v1/lib/google/cloud/app_engine/v1/applications/client.rb
+++ b/google-cloud-app_engine-v1/lib/google/cloud/app_engine/v1/applications/client.rb
@@ -133,6 +133,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-app_engine-v1/lib/google/cloud/app_engine/v1/domain_mappings/client.rb
+++ b/google-cloud-app_engine-v1/lib/google/cloud/app_engine/v1/domain_mappings/client.rb
@@ -133,6 +133,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-app_engine-v1/lib/google/cloud/app_engine/v1/instances/client.rb
+++ b/google-cloud-app_engine-v1/lib/google/cloud/app_engine/v1/instances/client.rb
@@ -133,6 +133,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-app_engine-v1/lib/google/cloud/app_engine/v1/services/client.rb
+++ b/google-cloud-app_engine-v1/lib/google/cloud/app_engine/v1/services/client.rb
@@ -133,6 +133,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-app_engine-v1/lib/google/cloud/app_engine/v1/versions/client.rb
+++ b/google-cloud-app_engine-v1/lib/google/cloud/app_engine/v1/versions/client.rb
@@ -133,6 +133,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-artifact_registry-v1beta2/lib/google/cloud/artifact_registry/v1beta2/artifact_registry/client.rb
+++ b/google-cloud-artifact_registry-v1beta2/lib/google/cloud/artifact_registry/v1beta2/artifact_registry/client.rb
@@ -232,6 +232,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-asset-v1/lib/google/cloud/asset/v1/asset_service/client.rb
+++ b/google-cloud-asset-v1/lib/google/cloud/asset/v1/asset_service/client.rb
@@ -183,6 +183,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-assured_workloads-v1/lib/google/cloud/assured_workloads/v1/assured_workloads_service/client.rb
+++ b/google-cloud-assured_workloads-v1/lib/google/cloud/assured_workloads/v1/assured_workloads_service/client.rb
@@ -137,6 +137,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-assured_workloads-v1beta1/lib/google/cloud/assured_workloads/v1beta1/assured_workloads_service/client.rb
+++ b/google-cloud-assured_workloads-v1beta1/lib/google/cloud/assured_workloads/v1beta1/assured_workloads_service/client.rb
@@ -154,6 +154,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-automl-v1/lib/google/cloud/automl/v1/automl/client.rb
+++ b/google-cloud-automl-v1/lib/google/cloud/automl/v1/automl/client.rb
@@ -211,6 +211,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-automl-v1/lib/google/cloud/automl/v1/prediction_service/client.rb
+++ b/google-cloud-automl-v1/lib/google/cloud/automl/v1/prediction_service/client.rb
@@ -142,6 +142,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-automl-v1beta1/lib/google/cloud/automl/v1beta1/automl/client.rb
+++ b/google-cloud-automl-v1beta1/lib/google/cloud/automl/v1beta1/automl/client.rb
@@ -232,6 +232,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-automl-v1beta1/lib/google/cloud/automl/v1beta1/prediction_service/client.rb
+++ b/google-cloud-automl-v1beta1/lib/google/cloud/automl/v1beta1/prediction_service/client.rb
@@ -142,6 +142,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-bigtable-admin-v2/lib/google/cloud/bigtable/admin/v2/bigtable_instance_admin/client.rb
+++ b/google-cloud-bigtable-admin-v2/lib/google/cloud/bigtable/admin/v2/bigtable_instance_admin/client.rb
@@ -217,6 +217,7 @@ module Google
 
                 @operations_client = Operations.new do |config|
                   config.credentials = credentials
+                  config.quota_project = @quota_project_id
                   config.endpoint = @config.endpoint
                 end
 

--- a/google-cloud-bigtable-admin-v2/lib/google/cloud/bigtable/admin/v2/bigtable_table_admin/client.rb
+++ b/google-cloud-bigtable-admin-v2/lib/google/cloud/bigtable/admin/v2/bigtable_table_admin/client.rb
@@ -210,6 +210,7 @@ module Google
 
                 @operations_client = Operations.new do |config|
                   config.credentials = credentials
+                  config.quota_project = @quota_project_id
                   config.endpoint = @config.endpoint
                 end
 

--- a/google-cloud-build-v1/lib/google/cloud/build/v1/cloud_build/client.rb
+++ b/google-cloud-build-v1/lib/google/cloud/build/v1/cloud_build/client.rb
@@ -195,6 +195,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-channel-v1/lib/google/cloud/channel/v1/cloud_channel_service/client.rb
+++ b/google-cloud-channel-v1/lib/google/cloud/channel/v1/cloud_channel_service/client.rb
@@ -180,6 +180,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-cloud_dms-v1/lib/google/cloud/cloud_dms/v1/data_migration_service/client.rb
+++ b/google-cloud-cloud_dms-v1/lib/google/cloud/cloud_dms/v1/data_migration_service/client.rb
@@ -174,6 +174,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-contact_center_insights-v1/lib/google/cloud/contact_center_insights/v1/contact_center_insights/client.rb
+++ b/google-cloud-contact_center_insights-v1/lib/google/cloud/contact_center_insights/v1/contact_center_insights/client.rb
@@ -140,6 +140,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-data_fusion-v1/lib/google/cloud/data_fusion/v1/data_fusion/client.rb
+++ b/google-cloud-data_fusion-v1/lib/google/cloud/data_fusion/v1/data_fusion/client.rb
@@ -139,6 +139,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-data_labeling-v1beta1/lib/google/cloud/data_labeling/v1beta1/data_labeling_service/client.rb
+++ b/google-cloud-data_labeling-v1beta1/lib/google/cloud/data_labeling/v1beta1/data_labeling_service/client.rb
@@ -264,6 +264,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-dataproc-v1/lib/google/cloud/dataproc/v1/batch_controller/client.rb
+++ b/google-cloud-dataproc-v1/lib/google/cloud/dataproc/v1/batch_controller/client.rb
@@ -135,6 +135,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-dataproc-v1/lib/google/cloud/dataproc/v1/cluster_controller/client.rb
+++ b/google-cloud-dataproc-v1/lib/google/cloud/dataproc/v1/cluster_controller/client.rb
@@ -166,6 +166,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-dataproc-v1/lib/google/cloud/dataproc/v1/job_controller/client.rb
+++ b/google-cloud-dataproc-v1/lib/google/cloud/dataproc/v1/job_controller/client.rb
@@ -168,6 +168,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-dataproc-v1/lib/google/cloud/dataproc/v1/workflow_template_service/client.rb
+++ b/google-cloud-dataproc-v1/lib/google/cloud/dataproc/v1/workflow_template_service/client.rb
@@ -171,6 +171,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-datastore-admin-v1/lib/google/cloud/datastore/admin/v1/datastore_admin/client.rb
+++ b/google-cloud-datastore-admin-v1/lib/google/cloud/datastore/admin/v1/datastore_admin/client.rb
@@ -212,6 +212,7 @@ module Google
 
                 @operations_client = Operations.new do |config|
                   config.credentials = credentials
+                  config.quota_project = @quota_project_id
                   config.endpoint = @config.endpoint
                 end
 

--- a/google-cloud-datastream-v1alpha1/lib/google/cloud/datastream/v1alpha1/datastream/client.rb
+++ b/google-cloud-datastream-v1alpha1/lib/google/cloud/datastream/v1alpha1/datastream/client.rb
@@ -160,6 +160,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-deploy-v1/lib/google/cloud/deploy/v1/cloud_deploy/client.rb
+++ b/google-cloud-deploy-v1/lib/google/cloud/deploy/v1/cloud_deploy/client.rb
@@ -199,6 +199,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-dialogflow-cx-v3/lib/google/cloud/dialogflow/cx/v3/agents/client.rb
+++ b/google-cloud-dialogflow-cx-v3/lib/google/cloud/dialogflow/cx/v3/agents/client.rb
@@ -141,6 +141,7 @@ module Google
 
                 @operations_client = Operations.new do |config|
                   config.credentials = credentials
+                  config.quota_project = @quota_project_id
                   config.endpoint = @config.endpoint
                 end
 

--- a/google-cloud-dialogflow-cx-v3/lib/google/cloud/dialogflow/cx/v3/environments/client.rb
+++ b/google-cloud-dialogflow-cx-v3/lib/google/cloud/dialogflow/cx/v3/environments/client.rb
@@ -141,6 +141,7 @@ module Google
 
                 @operations_client = Operations.new do |config|
                   config.credentials = credentials
+                  config.quota_project = @quota_project_id
                   config.endpoint = @config.endpoint
                 end
 

--- a/google-cloud-dialogflow-cx-v3/lib/google/cloud/dialogflow/cx/v3/flows/client.rb
+++ b/google-cloud-dialogflow-cx-v3/lib/google/cloud/dialogflow/cx/v3/flows/client.rb
@@ -141,6 +141,7 @@ module Google
 
                 @operations_client = Operations.new do |config|
                   config.credentials = credentials
+                  config.quota_project = @quota_project_id
                   config.endpoint = @config.endpoint
                 end
 

--- a/google-cloud-dialogflow-cx-v3/lib/google/cloud/dialogflow/cx/v3/test_cases/client.rb
+++ b/google-cloud-dialogflow-cx-v3/lib/google/cloud/dialogflow/cx/v3/test_cases/client.rb
@@ -142,6 +142,7 @@ module Google
 
                 @operations_client = Operations.new do |config|
                   config.credentials = credentials
+                  config.quota_project = @quota_project_id
                   config.endpoint = @config.endpoint
                 end
 

--- a/google-cloud-dialogflow-cx-v3/lib/google/cloud/dialogflow/cx/v3/versions/client.rb
+++ b/google-cloud-dialogflow-cx-v3/lib/google/cloud/dialogflow/cx/v3/versions/client.rb
@@ -141,6 +141,7 @@ module Google
 
                 @operations_client = Operations.new do |config|
                   config.credentials = credentials
+                  config.quota_project = @quota_project_id
                   config.endpoint = @config.endpoint
                 end
 

--- a/google-cloud-dialogflow-v2/lib/google/cloud/dialogflow/v2/agents/client.rb
+++ b/google-cloud-dialogflow-v2/lib/google/cloud/dialogflow/v2/agents/client.rb
@@ -140,6 +140,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-dialogflow-v2/lib/google/cloud/dialogflow/v2/documents/client.rb
+++ b/google-cloud-dialogflow-v2/lib/google/cloud/dialogflow/v2/documents/client.rb
@@ -140,6 +140,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-dialogflow-v2/lib/google/cloud/dialogflow/v2/entity_types/client.rb
+++ b/google-cloud-dialogflow-v2/lib/google/cloud/dialogflow/v2/entity_types/client.rb
@@ -140,6 +140,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-dialogflow-v2/lib/google/cloud/dialogflow/v2/intents/client.rb
+++ b/google-cloud-dialogflow-v2/lib/google/cloud/dialogflow/v2/intents/client.rb
@@ -140,6 +140,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-document_ai-v1/lib/google/cloud/document_ai/v1/document_processor_service/client.rb
+++ b/google-cloud-document_ai-v1/lib/google/cloud/document_ai/v1/document_processor_service/client.rb
@@ -153,6 +153,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-document_ai-v1beta3/lib/google/cloud/document_ai/v1beta3/document_processor_service/client.rb
+++ b/google-cloud-document_ai-v1beta3/lib/google/cloud/document_ai/v1beta3/document_processor_service/client.rb
@@ -153,6 +153,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-domains-v1beta1/lib/google/cloud/domains/v1beta1/domains/client.rb
+++ b/google-cloud-domains-v1beta1/lib/google/cloud/domains/v1beta1/domains/client.rb
@@ -135,6 +135,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-eventarc-v1/lib/google/cloud/eventarc/v1/eventarc/client.rb
+++ b/google-cloud-eventarc-v1/lib/google/cloud/eventarc/v1/eventarc/client.rb
@@ -136,6 +136,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-filestore-v1/lib/google/cloud/filestore/v1/cloud_filestore_manager/client.rb
+++ b/google-cloud-filestore-v1/lib/google/cloud/filestore/v1/cloud_filestore_manager/client.rb
@@ -187,6 +187,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-firestore-admin-v1/lib/google/cloud/firestore/admin/v1/firestore_admin/client.rb
+++ b/google-cloud-firestore-admin-v1/lib/google/cloud/firestore/admin/v1/firestore_admin/client.rb
@@ -196,6 +196,7 @@ module Google
 
                 @operations_client = Operations.new do |config|
                   config.credentials = credentials
+                  config.quota_project = @quota_project_id
                   config.endpoint = @config.endpoint
                 end
 

--- a/google-cloud-functions-v1/lib/google/cloud/functions/v1/cloud_functions_service/client.rb
+++ b/google-cloud-functions-v1/lib/google/cloud/functions/v1/cloud_functions_service/client.rb
@@ -159,6 +159,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-gaming-v1/lib/google/cloud/gaming/v1/game_server_clusters_service/client.rb
+++ b/google-cloud-gaming-v1/lib/google/cloud/gaming/v1/game_server_clusters_service/client.rb
@@ -167,6 +167,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-gaming-v1/lib/google/cloud/gaming/v1/game_server_configs_service/client.rb
+++ b/google-cloud-gaming-v1/lib/google/cloud/gaming/v1/game_server_configs_service/client.rb
@@ -149,6 +149,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-gaming-v1/lib/google/cloud/gaming/v1/game_server_deployments_service/client.rb
+++ b/google-cloud-gaming-v1/lib/google/cloud/gaming/v1/game_server_deployments_service/client.rb
@@ -169,6 +169,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-gaming-v1/lib/google/cloud/gaming/v1/realms_service/client.rb
+++ b/google-cloud-gaming-v1/lib/google/cloud/gaming/v1/realms_service/client.rb
@@ -157,6 +157,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-gke_hub-v1/lib/google/cloud/gke_hub/v1/gke_hub/client.rb
+++ b/google-cloud-gke_hub-v1/lib/google/cloud/gke_hub/v1/gke_hub/client.rb
@@ -153,6 +153,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-gke_hub-v1beta1/lib/google/cloud/gke_hub/v1beta1/gke_hub_membership_service/client.rb
+++ b/google-cloud-gke_hub-v1beta1/lib/google/cloud/gke_hub/v1beta1/gke_hub_membership_service/client.rb
@@ -147,6 +147,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-ids-v1/lib/google/cloud/ids/v1/ids/client.rb
+++ b/google-cloud-ids-v1/lib/google/cloud/ids/v1/ids/client.rb
@@ -149,6 +149,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-life_sciences-v2beta/lib/google/cloud/life_sciences/v2beta/workflows_service/client.rb
+++ b/google-cloud-life_sciences-v2beta/lib/google/cloud/life_sciences/v2beta/workflows_service/client.rb
@@ -136,6 +136,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-managed_identities-v1/lib/google/cloud/managed_identities/v1/managed_identities_service/client.rb
+++ b/google-cloud-managed_identities-v1/lib/google/cloud/managed_identities/v1/managed_identities_service/client.rb
@@ -186,6 +186,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-memcache-v1/lib/google/cloud/memcache/v1/cloud_memcache/client.rb
+++ b/google-cloud-memcache-v1/lib/google/cloud/memcache/v1/cloud_memcache/client.rb
@@ -163,6 +163,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-memcache-v1beta2/lib/google/cloud/memcache/v1beta2/cloud_memcache/client.rb
+++ b/google-cloud-memcache-v1beta2/lib/google/cloud/memcache/v1beta2/cloud_memcache/client.rb
@@ -165,6 +165,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-metastore-v1/lib/google/cloud/metastore/v1/dataproc_metastore/client.rb
+++ b/google-cloud-metastore-v1/lib/google/cloud/metastore/v1/dataproc_metastore/client.rb
@@ -174,6 +174,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-metastore-v1beta/lib/google/cloud/metastore/v1beta/dataproc_metastore/client.rb
+++ b/google-cloud-metastore-v1beta/lib/google/cloud/metastore/v1beta/dataproc_metastore/client.rb
@@ -174,6 +174,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-monitoring-metrics_scope-v1/lib/google/cloud/monitoring/metrics_scope/v1/metrics_scopes/client.rb
+++ b/google-cloud-monitoring-metrics_scope-v1/lib/google/cloud/monitoring/metrics_scope/v1/metrics_scopes/client.rb
@@ -137,6 +137,7 @@ module Google
 
                 @operations_client = Operations.new do |config|
                   config.credentials = credentials
+                  config.quota_project = @quota_project_id
                   config.endpoint = @config.endpoint
                 end
 

--- a/google-cloud-network_connectivity-v1/lib/google/cloud/network_connectivity/v1/hub_service/client.rb
+++ b/google-cloud-network_connectivity-v1/lib/google/cloud/network_connectivity/v1/hub_service/client.rb
@@ -154,6 +154,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-network_connectivity-v1alpha1/lib/google/cloud/network_connectivity/v1alpha1/hub_service/client.rb
+++ b/google-cloud-network_connectivity-v1alpha1/lib/google/cloud/network_connectivity/v1alpha1/hub_service/client.rb
@@ -155,6 +155,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-network_management-v1/lib/google/cloud/network_management/v1/reachability_service/client.rb
+++ b/google-cloud-network_management-v1/lib/google/cloud/network_management/v1/reachability_service/client.rb
@@ -144,6 +144,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-network_security-v1beta1/lib/google/cloud/network_security/v1beta1/network_security/client.rb
+++ b/google-cloud-network_security-v1beta1/lib/google/cloud/network_security/v1beta1/network_security/client.rb
@@ -139,6 +139,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-notebooks-v1beta1/lib/google/cloud/notebooks/v1beta1/notebook_service/client.rb
+++ b/google-cloud-notebooks-v1beta1/lib/google/cloud/notebooks/v1beta1/notebook_service/client.rb
@@ -178,6 +178,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-orchestration-airflow-service-v1/lib/google/cloud/orchestration/airflow/service/v1/environments/client.rb
+++ b/google-cloud-orchestration-airflow-service-v1/lib/google/cloud/orchestration/airflow/service/v1/environments/client.rb
@@ -137,6 +137,7 @@ module Google
 
                   @operations_client = Operations.new do |config|
                     config.credentials = credentials
+                    config.quota_project = @quota_project_id
                     config.endpoint = @config.endpoint
                   end
 

--- a/google-cloud-os_config-v1/lib/google/cloud/os_config/v1/os_config_zonal_service/client.rb
+++ b/google-cloud-os_config-v1/lib/google/cloud/os_config/v1/os_config_zonal_service/client.rb
@@ -143,6 +143,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-os_config-v1alpha/lib/google/cloud/os_config/v1alpha/os_config_zonal_service/client.rb
+++ b/google-cloud-os_config-v1alpha/lib/google/cloud/os_config/v1alpha/os_config_zonal_service/client.rb
@@ -143,6 +143,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-recommendation_engine-v1beta1/lib/google/cloud/recommendation_engine/v1beta1/catalog_service/client.rb
+++ b/google-cloud-recommendation_engine-v1beta1/lib/google/cloud/recommendation_engine/v1beta1/catalog_service/client.rb
@@ -165,6 +165,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-recommendation_engine-v1beta1/lib/google/cloud/recommendation_engine/v1beta1/user_event_service/client.rb
+++ b/google-cloud-recommendation_engine-v1beta1/lib/google/cloud/recommendation_engine/v1beta1/user_event_service/client.rb
@@ -160,6 +160,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-redis-v1/lib/google/cloud/redis/v1/cloud_redis/client.rb
+++ b/google-cloud-redis-v1/lib/google/cloud/redis/v1/cloud_redis/client.rb
@@ -167,6 +167,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-redis-v1beta1/lib/google/cloud/redis/v1beta1/cloud_redis/client.rb
+++ b/google-cloud-redis-v1beta1/lib/google/cloud/redis/v1beta1/cloud_redis/client.rb
@@ -167,6 +167,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-resource_manager-v3/lib/google/cloud/resource_manager/v3/folders/client.rb
+++ b/google-cloud-resource_manager-v3/lib/google/cloud/resource_manager/v3/folders/client.rb
@@ -166,6 +166,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-resource_manager-v3/lib/google/cloud/resource_manager/v3/projects/client.rb
+++ b/google-cloud-resource_manager-v3/lib/google/cloud/resource_manager/v3/projects/client.rb
@@ -164,6 +164,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-resource_manager-v3/lib/google/cloud/resource_manager/v3/tag_bindings/client.rb
+++ b/google-cloud-resource_manager-v3/lib/google/cloud/resource_manager/v3/tag_bindings/client.rb
@@ -145,6 +145,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-resource_manager-v3/lib/google/cloud/resource_manager/v3/tag_keys/client.rb
+++ b/google-cloud-resource_manager-v3/lib/google/cloud/resource_manager/v3/tag_keys/client.rb
@@ -158,6 +158,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-resource_manager-v3/lib/google/cloud/resource_manager/v3/tag_values/client.rb
+++ b/google-cloud-resource_manager-v3/lib/google/cloud/resource_manager/v3/tag_values/client.rb
@@ -158,6 +158,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-retail-v2/lib/google/cloud/retail/v2/completion_service/client.rb
+++ b/google-cloud-retail-v2/lib/google/cloud/retail/v2/completion_service/client.rb
@@ -144,6 +144,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-retail-v2/lib/google/cloud/retail/v2/product_service/client.rb
+++ b/google-cloud-retail-v2/lib/google/cloud/retail/v2/product_service/client.rb
@@ -146,6 +146,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-retail-v2/lib/google/cloud/retail/v2/user_event_service/client.rb
+++ b/google-cloud-retail-v2/lib/google/cloud/retail/v2/user_event_service/client.rb
@@ -150,6 +150,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-security-private_ca-v1beta1/lib/google/cloud/security/private_ca/v1beta1/certificate_authority_service/client.rb
+++ b/google-cloud-security-private_ca-v1beta1/lib/google/cloud/security/private_ca/v1beta1/certificate_authority_service/client.rb
@@ -142,6 +142,7 @@ module Google
 
                 @operations_client = Operations.new do |config|
                   config.credentials = credentials
+                  config.quota_project = @quota_project_id
                   config.endpoint = @config.endpoint
                 end
 

--- a/google-cloud-security_center-v1/lib/google/cloud/security_center/v1/security_center/client.rb
+++ b/google-cloud-security_center-v1/lib/google/cloud/security_center/v1/security_center/client.rb
@@ -214,6 +214,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-security_center-v1p1beta1/lib/google/cloud/security_center/v1p1beta1/security_center/client.rb
+++ b/google-cloud-security_center-v1p1beta1/lib/google/cloud/security_center/v1p1beta1/security_center/client.rb
@@ -214,6 +214,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-service_management-v1/lib/google/cloud/service_management/v1/service_manager/client.rb
+++ b/google-cloud-service_management-v1/lib/google/cloud/service_management/v1/service_manager/client.rb
@@ -133,6 +133,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-service_usage-v1/lib/google/cloud/service_usage/v1/service_usage/client.rb
+++ b/google-cloud-service_usage-v1/lib/google/cloud/service_usage/v1/service_usage/client.rb
@@ -139,6 +139,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-shell-v1/lib/google/cloud/shell/v1/cloud_shell_service/client.rb
+++ b/google-cloud-shell-v1/lib/google/cloud/shell/v1/cloud_shell_service/client.rb
@@ -154,6 +154,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-spanner-admin-database-v1/lib/google/cloud/spanner/admin/database/v1/database_admin/client.rb
+++ b/google-cloud-spanner-admin-database-v1/lib/google/cloud/spanner/admin/database/v1/database_admin/client.rb
@@ -212,6 +212,7 @@ module Google
 
                   @operations_client = Operations.new do |config|
                     config.credentials = credentials
+                    config.quota_project = @quota_project_id
                     config.endpoint = @config.endpoint
                   end
 

--- a/google-cloud-spanner-admin-instance-v1/lib/google/cloud/spanner/admin/instance/v1/instance_admin/client.rb
+++ b/google-cloud-spanner-admin-instance-v1/lib/google/cloud/spanner/admin/instance/v1/instance_admin/client.rb
@@ -195,6 +195,7 @@ module Google
 
                   @operations_client = Operations.new do |config|
                     config.credentials = credentials
+                    config.quota_project = @quota_project_id
                     config.endpoint = @config.endpoint
                   end
 

--- a/google-cloud-speech-v1/lib/google/cloud/speech/v1/speech/client.rb
+++ b/google-cloud-speech-v1/lib/google/cloud/speech/v1/speech/client.rb
@@ -147,6 +147,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-speech-v1p1beta1/lib/google/cloud/speech/v1p1beta1/speech/client.rb
+++ b/google-cloud-speech-v1p1beta1/lib/google/cloud/speech/v1p1beta1/speech/client.rb
@@ -147,6 +147,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-storage_transfer-v1/lib/google/cloud/storage_transfer/v1/storage_transfer_service/client.rb
+++ b/google-cloud-storage_transfer-v1/lib/google/cloud/storage_transfer/v1/storage_transfer_service/client.rb
@@ -137,6 +137,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-talent-v4/lib/google/cloud/talent/v4/job_service/client.rb
+++ b/google-cloud-talent-v4/lib/google/cloud/talent/v4/job_service/client.rb
@@ -164,6 +164,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-talent-v4beta1/lib/google/cloud/talent/v4beta1/job_service/client.rb
+++ b/google-cloud-talent-v4beta1/lib/google/cloud/talent/v4beta1/job_service/client.rb
@@ -164,6 +164,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-tpu-v1/lib/google/cloud/tpu/v1/tpu/client.rb
+++ b/google-cloud-tpu-v1/lib/google/cloud/tpu/v1/tpu/client.rb
@@ -139,6 +139,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-translate-v3/lib/google/cloud/translate/v3/translation_service/client.rb
+++ b/google-cloud-translate-v3/lib/google/cloud/translate/v3/translation_service/client.rb
@@ -167,6 +167,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-video_intelligence-v1/lib/google/cloud/video_intelligence/v1/video_intelligence_service/client.rb
+++ b/google-cloud-video_intelligence-v1/lib/google/cloud/video_intelligence/v1/video_intelligence_service/client.rb
@@ -138,6 +138,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-video_intelligence-v1beta2/lib/google/cloud/video_intelligence/v1beta2/video_intelligence_service/client.rb
+++ b/google-cloud-video_intelligence-v1beta2/lib/google/cloud/video_intelligence/v1beta2/video_intelligence_service/client.rb
@@ -138,6 +138,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-video_intelligence-v1p1beta1/lib/google/cloud/video_intelligence/v1p1beta1/video_intelligence_service/client.rb
+++ b/google-cloud-video_intelligence-v1p1beta1/lib/google/cloud/video_intelligence/v1p1beta1/video_intelligence_service/client.rb
@@ -138,6 +138,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-video_intelligence-v1p2beta1/lib/google/cloud/video_intelligence/v1p2beta1/video_intelligence_service/client.rb
+++ b/google-cloud-video_intelligence-v1p2beta1/lib/google/cloud/video_intelligence/v1p2beta1/video_intelligence_service/client.rb
@@ -138,6 +138,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-video_intelligence-v1p3beta1/lib/google/cloud/video_intelligence/v1p3beta1/video_intelligence_service/client.rb
+++ b/google-cloud-video_intelligence-v1p3beta1/lib/google/cloud/video_intelligence/v1p3beta1/video_intelligence_service/client.rb
@@ -138,6 +138,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-vision-v1/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/google-cloud-vision-v1/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -157,6 +157,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-vision-v1/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/google-cloud-vision-v1/lib/google/cloud/vision/v1/product_search/client.rb
@@ -243,6 +243,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-vision-v1p3beta1/lib/google/cloud/vision/v1p3beta1/image_annotator/client.rb
+++ b/google-cloud-vision-v1p3beta1/lib/google/cloud/vision/v1p3beta1/image_annotator/client.rb
@@ -147,6 +147,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-vision-v1p3beta1/lib/google/cloud/vision/v1p3beta1/product_search/client.rb
+++ b/google-cloud-vision-v1p3beta1/lib/google/cloud/vision/v1p3beta1/product_search/client.rb
@@ -238,6 +238,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-vision-v1p4beta1/lib/google/cloud/vision/v1p4beta1/image_annotator/client.rb
+++ b/google-cloud-vision-v1p4beta1/lib/google/cloud/vision/v1p4beta1/image_annotator/client.rb
@@ -157,6 +157,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-vision-v1p4beta1/lib/google/cloud/vision/v1p4beta1/product_search/client.rb
+++ b/google-cloud-vision-v1p4beta1/lib/google/cloud/vision/v1p4beta1/product_search/client.rb
@@ -242,6 +242,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-vm_migration-v1/lib/google/cloud/vm_migration/v1/vm_migration/client.rb
+++ b/google-cloud-vm_migration-v1/lib/google/cloud/vm_migration/v1/vm_migration/client.rb
@@ -143,6 +143,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-vpc_access-v1/lib/google/cloud/vpc_access/v1/vpc_access_service/client.rb
+++ b/google-cloud-vpc_access-v1/lib/google/cloud/vpc_access/v1/vpc_access_service/client.rb
@@ -150,6 +150,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-workflows-v1/lib/google/cloud/workflows/v1/workflows/client.rb
+++ b/google-cloud-workflows-v1/lib/google/cloud/workflows/v1/workflows/client.rb
@@ -137,6 +137,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-cloud-workflows-v1beta/lib/google/cloud/workflows/v1beta/workflows/client.rb
+++ b/google-cloud-workflows-v1beta/lib/google/cloud/workflows/v1beta/workflows/client.rb
@@ -137,6 +137,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 

--- a/google-iam-v1beta/lib/google/iam/v1beta/workload_identity_pools/client.rb
+++ b/google-iam-v1beta/lib/google/iam/v1beta/workload_identity_pools/client.rb
@@ -194,6 +194,7 @@ module Google
 
             @operations_client = Operations.new do |config|
               config.credentials = credentials
+              config.quota_project = @quota_project_id
               config.endpoint = @config.endpoint
             end
 

--- a/google-identity-access_context_manager-v1/lib/google/identity/access_context_manager/v1/access_context_manager/client.rb
+++ b/google-identity-access_context_manager-v1/lib/google/identity/access_context_manager/v1/access_context_manager/client.rb
@@ -147,6 +147,7 @@ module Google
 
               @operations_client = Operations.new do |config|
                 config.credentials = credentials
+                config.quota_project = @quota_project_id
                 config.endpoint = @config.endpoint
               end
 


### PR DESCRIPTION
Global regeneration with commit d3f0bc7c6c99af02b6a4198b2fc6b71e37b672ca in the generator.

Do not merge until gapic-generator-ruby 0.10.4 is released.