### PR TITLE
chore(firestore): Fix rubocop warning

### DIFF
--- a/google-cloud-firestore/lib/google/cloud/firestore/service.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/service.rb
@@ -189,7 +189,7 @@ module Google
         def document_mask mask
           return nil if mask.nil?
 
-          mask = Array(mask).map(&:to_s).reject(&:nil?).reject(&:empty?)
+          mask = Array(mask).map(&:to_s).reject(&:empty?)
           return nil if mask.empty?
 
           Google::Cloud::Firestore::V1::DocumentMask.new field_paths: mask


### PR DESCRIPTION
Fixes the following warning we're getting in recent versions of rubocop:

```
lib/google/cloud/firestore/service.rb:192:42: C: [Correctable] Style/CollectionCompact: Use compact instead of reject(&:nil?).
          mask = Array(mask).map(&:to_s).reject(&:nil?).reject(&:empty?)
                                         ^^^^^^^^^^^^^^
```

(Turns out we don't even need `compact` because the previous map guarantees that all items are strings and not nil.)