### PR TITLE
fix(spanner): pass quota_project_id from credentials

### DIFF
--- a/google-cloud-spanner/lib/google/cloud/spanner.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner.rb
@@ -120,7 +120,7 @@ module Google
 
         Spanner::Project.new(
           Spanner::Service.new(
-            project_id, credentials,
+            project_id, credentials, quota_project: configure.quota_project,
             host: endpoint, timeout: timeout, lib_name: lib_name,
             lib_version: lib_version
           ),

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database.rb
@@ -117,8 +117,11 @@ module Google
             project_id = project_id.to_s # Always cast to a string
             raise ArgumentError, "project_id is missing" if project_id.empty?
 
+            configure.quota_project ||= credentials.quota_project_id if credentials.respond_to? :quota_project_id
+
             Admin::Database::V1::DatabaseAdmin::Client.new do |config|
               config.credentials = channel endpoint, credentials
+              config.quota_project = configure.quota_project
               config.timeout = timeout if timeout
               config.endpoint = endpoint if endpoint
               config.lib_name = lib_name_with_prefix lib_name, lib_version

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance.rb
@@ -117,8 +117,11 @@ module Google
             project_id = project_id.to_s # Always cast to a string
             raise ArgumentError, "project_id is missing" if project_id.empty?
 
+            configure.quota_project ||= credentials.quota_project_id if credentials.respond_to? :quota_project_id
+
             Admin::Instance::V1::InstanceAdmin::Client.new do |config|
               config.credentials = channel endpoint, credentials
+              config.quota_project = configure.quota_project
               config.timeout = timeout if timeout
               config.endpoint = endpoint if endpoint
               config.lib_name = lib_name_with_prefix lib_name, lib_version

--- a/google-cloud-spanner/lib/google/cloud/spanner/service.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/service.rb
@@ -34,6 +34,7 @@ module Google
         attr_accessor :host
         attr_accessor :lib_name
         attr_accessor :lib_version
+        attr_accessor :quota_project
 
         ##
         # Creates a new Service instance.
@@ -41,7 +42,7 @@ module Google
                        host: nil, timeout: nil, lib_name: nil, lib_version: nil
           @project = project
           @credentials = credentials
-          @quota_project_id = quota_project || credentials.quota_project_id if credentials.respond_to? :quota_project_id
+          @quota_project = quota_project || (credentials.quota_project_id if credentials.respond_to? :quota_project_id)
           @host = host
           @timeout = timeout
           @lib_name = lib_name
@@ -69,7 +70,7 @@ module Google
           @service ||= \
             V1::Spanner::Client.new do |config|
               config.credentials = channel
-              config.quota_project = @quota_project_id
+              config.quota_project = @quota_project
               config.timeout = timeout if timeout
               config.endpoint = host if host
               config.lib_name = lib_name_with_prefix
@@ -84,7 +85,7 @@ module Google
           @instances ||= \
             Admin::Instance::V1::InstanceAdmin::Client.new do |config|
               config.credentials = channel
-              config.quota_project = @quota_project_id
+              config.quota_project = @quota_project
               config.timeout = timeout if timeout
               config.endpoint = host if host
               config.lib_name = lib_name_with_prefix
@@ -99,7 +100,7 @@ module Google
           @databases ||= \
             Admin::Database::V1::DatabaseAdmin::Client.new do |config|
               config.credentials = channel
-              config.quota_project = @quota_project_id
+              config.quota_project = @quota_project
               config.timeout = timeout if timeout
               config.endpoint = host if host
               config.lib_name = lib_name_with_prefix

--- a/google-cloud-spanner/lib/google/cloud/spanner/service.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/service.rb
@@ -37,10 +37,11 @@ module Google
 
         ##
         # Creates a new Service instance.
-        def initialize project, credentials,
+        def initialize project, credentials, quota_project: nil,
                        host: nil, timeout: nil, lib_name: nil, lib_version: nil
           @project = project
           @credentials = credentials
+          @quota_project_id = quota_project || credentials.quota_project_id if credentials.respond_to? :quota_project_id
           @host = host
           @timeout = timeout
           @lib_name = lib_name
@@ -68,6 +69,7 @@ module Google
           @service ||= \
             V1::Spanner::Client.new do |config|
               config.credentials = channel
+              config.quota_project = @quota_project_id
               config.timeout = timeout if timeout
               config.endpoint = host if host
               config.lib_name = lib_name_with_prefix
@@ -82,6 +84,7 @@ module Google
           @instances ||= \
             Admin::Instance::V1::InstanceAdmin::Client.new do |config|
               config.credentials = channel
+              config.quota_project = @quota_project_id
               config.timeout = timeout if timeout
               config.endpoint = host if host
               config.lib_name = lib_name_with_prefix
@@ -96,6 +99,7 @@ module Google
           @databases ||= \
             Admin::Database::V1::DatabaseAdmin::Client.new do |config|
               config.credentials = channel
+              config.quota_project = @quota_project_id
               config.timeout = timeout if timeout
               config.endpoint = host if host
               config.lib_name = lib_name_with_prefix

--- a/google-cloud-spanner/test/google/cloud/spanner/service_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/service_test.rb
@@ -1,0 +1,19 @@
+describe Google::Cloud::Spanner::Service do
+    describe ".new" do
+        it "sets quota_project with given value" do
+            expected_quota_project = "test_quota_project"
+            service = Google::Cloud::Spanner::Service.new(
+                "test_project", nil, quota_project: expected_quota_project
+              )
+            assert_equal expected_quota_project, service.quota_project
+        end
+
+        it "sets quota_project from credentials if not given from config" do 
+            expected_quota_project = "test_quota_project"
+            service = Google::Cloud::Spanner::Service.new(
+                "test_project", OpenStruct.new(quota_project_id: expected_quota_project)
+              )
+            assert_equal expected_quota_project, service.quota_project
+        end
+    end
+end

--- a/google-cloud-spanner/test/google/cloud/spanner_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner_test.rb
@@ -276,7 +276,7 @@ describe Google::Cloud do
         _(project).must_equal "project-id"
         _(credentials).must_be_kind_of OpenStruct
         _(timeout).must_be :nil?
-        _(quota_project).must_equal "quota_project"
+        _(credentials.quota_project_id).must_equal "quota_project_id"
         _(keyword_args.key?(:lib_name)).must_equal true
         _(keyword_args.key?(:lib_version)).must_equal true
         _(keyword_args[:lib_name]).must_be :nil?

--- a/google-cloud-spanner/test/google/cloud/spanner_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner_test.rb
@@ -244,6 +244,61 @@ describe Google::Cloud do
       end
     end
 
+    it "uses quota_project from config" do
+      stubbed_service = ->(project, credentials, quota_project: nil, timeout: nil, **keyword_args) {
+        _(project).must_equal "project-id"
+        _(credentials).must_equal default_credentials
+        _(timeout).must_be :nil?
+        _(quota_project).must_equal "quota_project"
+        _(keyword_args.key?(:lib_name)).must_equal true
+        _(keyword_args.key?(:lib_version)).must_equal true
+        _(keyword_args[:lib_name]).must_be :nil?
+        _(keyword_args[:lib_version]).must_be :nil?
+        OpenStruct.new project: project
+      }
+
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        Google::Cloud::Spanner::Service.stub :new, stubbed_service do
+          Google::Cloud::Spanner.configure do |config|
+              config.quota_project  = "quota_project"
+          end
+          spanner = Google::Cloud::Spanner.new project: "project-id", credentials: default_credentials
+          _(spanner).must_be_kind_of Google::Cloud::Spanner::Project
+          _(spanner.project).must_equal "project-id"
+          _(spanner.service).must_be_kind_of OpenStruct
+        end
+      end
+    end
+
+    it "uses quota_project from credentials" do
+      stubbed_service = ->(project, credentials, quota_project: nil, timeout: nil, **keyword_args) {
+        _(project).must_equal "project-id"
+        _(credentials).must_be_kind_of OpenStruct
+        _(timeout).must_be :nil?
+        _(quota_project).must_equal "quota_project"
+        _(keyword_args.key?(:lib_name)).must_equal true
+        _(keyword_args.key?(:lib_version)).must_equal true
+        _(keyword_args[:lib_name]).must_be :nil?
+        _(keyword_args[:lib_version]).must_be :nil?
+        OpenStruct.new project: project
+      }
+
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        Google::Cloud::Spanner::Service.stub :new, stubbed_service do
+          quota_project_credentials = OpenStruct.new(quota_project_id: "quota_project_id")
+          def quota_project_credentials.is_a? target
+              target == Google::Auth::Credentials
+          end
+          spanner = Google::Cloud::Spanner.new project: "project-id", credentials: quota_project_credentials
+          _(spanner).must_be_kind_of Google::Cloud::Spanner::Project
+          _(spanner.project).must_equal "project-id"
+          _(spanner.service).must_be_kind_of OpenStruct
+        end
+      end
+    end
+
     it "uses provided project and keyfile aliases" do
       stubbed_credentials = ->(keyfile, scope: nil) {
         _(keyfile).must_equal "path/to/keyfile.json"


### PR DESCRIPTION
- quota_project is set from the config or credentials in generated libs like https://github.com/googleapis/google-cloud-ruby/blob/9291b1072dd7ada449a5adf16339d8f1c16d7e48/google-cloud-spanner-v1/lib/google/cloud/spanner/v1/spanner/client.rb#L206
- wrapper passes grpc channel as credentails, hence set the config with quota_project from credentials while creating clients

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-ruby/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea.
- [ ] Follow the instructions in [CONTRIBUTING](CONTRIBUTING.md). Most importantly, ensure the tests and linter pass by running `bundle exec rake ci` in the gem subdirectory.
- [ ] Update code documentation if necessary.

closes: #<issue_number_goes_here>