### PR TITLE
Fix a failing spec in a storage sample

### DIFF
--- a/google-cloud-storage/samples/acceptance/acls_test.rb
+++ b/google-cloud-storage/samples/acceptance/acls_test.rb
@@ -112,7 +112,7 @@ describe "ACL Snippets" do
     readers = bucket.file(remote_file_name).acl.readers
 
     out, _err = capture_io do
-      StoragePrintFileACL.new print_file_acl bucket_name: bucket.name,
+      StoragePrintFileACL.new.print_file_acl bucket_name: bucket.name,
                                              file_name:   remote_file_name
     end
 


### PR DESCRIPTION
This PR fixes a failing spec introduced in #17597 