### PR TITLE
Rebecca pete patch ruby 1

### DIFF
--- a/google-cloud-storage/samples/storage_change_file_storage_class.rb
+++ b/google-cloud-storage/samples/storage_change_file_storage_class.rb
@@ -23,7 +23,7 @@ def change_file_storage_class bucket_name:, file_name:
   require "google/cloud/storage"
 
   storage = Google::Cloud::Storage.new
-  bucket = storage.bucket bucket_name
+  bucket = storage.bucket bucket_name, skip_lookup: true
 
   file = bucket.file file_name
 

--- a/google-cloud-storage/samples/storage_compose_file.rb
+++ b/google-cloud-storage/samples/storage_compose_file.rb
@@ -29,7 +29,7 @@ def compose_file bucket_name:, first_file_name:, second_file_name:, destination_
   require "google/cloud/storage"
 
   storage = Google::Cloud::Storage.new
-  bucket = storage.bucket bucket_name
+  bucket = storage.bucket bucket_name, skip_lookup: true
 
   destination = bucket.compose [first_file_name, second_file_name], destination_file_name do |f|
     f.content_type = "text/plain"

--- a/google-cloud-storage/samples/storage_copy_file.rb
+++ b/google-cloud-storage/samples/storage_copy_file.rb
@@ -29,7 +29,7 @@ def copy_file source_bucket_name:, source_file_name:, destination_bucket_name:, 
   require "google/cloud/storage"
 
   storage = Google::Cloud::Storage.new
-  bucket  = storage.bucket source_bucket_name
+  bucket  = storage.bucket source_bucket_name, skip_lookup: true
   file    = bucket.file source_file_name
 
   destination_bucket = storage.bucket destination_bucket_name

--- a/google-cloud-storage/samples/storage_copy_file_archived_generation.rb
+++ b/google-cloud-storage/samples/storage_copy_file_archived_generation.rb
@@ -37,9 +37,9 @@ def copy_file_archived_generation source_bucket_name:,
 
   storage = Google::Cloud::Storage.new
 
-  source_bucket = storage.bucket source_bucket_name
+  source_bucket = storage.bucket source_bucket_name, skip_lookup: true
   source_file = source_bucket.file source_file_name
-  destination_bucket = storage.bucket destination_bucket_name
+  destination_bucket = storage.bucket destination_bucket_name, skip_lookup: true
 
   destination_file = source_file.copy destination_bucket, destination_file_name, generation: generation
 

--- a/google-cloud-storage/samples/storage_delete_file.rb
+++ b/google-cloud-storage/samples/storage_delete_file.rb
@@ -23,7 +23,7 @@ def delete_file bucket_name:, file_name:
   require "google/cloud/storage"
 
   storage = Google::Cloud::Storage.new
-  bucket  = storage.bucket bucket_name
+  bucket  = storage.bucket bucket_name, skip_lookup: true
   file    = bucket.file file_name
 
   file.delete

--- a/google-cloud-storage/samples/storage_delete_file_archived_generation.rb
+++ b/google-cloud-storage/samples/storage_delete_file_archived_generation.rb
@@ -26,7 +26,7 @@ def delete_file_archived_generation bucket_name:, file_name:, generation:
   require "google/cloud/storage"
 
   storage = Google::Cloud::Storage.new
-  bucket = storage.bucket bucket_name
+  bucket = storage.bucket bucket_name, skip_lookup: true
 
   file = bucket.file file_name
 

--- a/google-cloud-storage/samples/storage_download_encrypted_file.rb
+++ b/google-cloud-storage/samples/storage_download_encrypted_file.rb
@@ -30,7 +30,7 @@ def download_encrypted_file bucket_name:, file_name:, local_file_path:, encrypti
 
   storage = Google::Cloud::Storage.new
 
-  bucket = storage.bucket bucket_name
+  bucket = storage.bucket bucket_name, skip_lookup: true
 
   file = bucket.file file_name, encryption_key: encryption_key
   file.download local_file_path, encryption_key: encryption_key

--- a/google-cloud-storage/samples/storage_get_metadata.rb
+++ b/google-cloud-storage/samples/storage_get_metadata.rb
@@ -23,7 +23,7 @@ def get_metadata bucket_name:, file_name:
   require "google/cloud/storage"
 
   storage = Google::Cloud::Storage.new
-  bucket  = storage.bucket bucket_name
+  bucket  = storage.bucket bucket_name, skip_lookup: true
   file    = bucket.file file_name
 
   puts "Name: #{file.name}"

--- a/google-cloud-storage/samples/storage_make_public.rb
+++ b/google-cloud-storage/samples/storage_make_public.rb
@@ -23,7 +23,7 @@ def make_public bucket_name:, file_name:
   require "google/cloud/storage"
 
   storage = Google::Cloud::Storage.new
-  bucket  = storage.bucket bucket_name
+  bucket  = storage.bucket bucket_name, skip_lookup: true
   file    = bucket.file file_name
 
   file.acl.public!

--- a/google-cloud-storage/samples/storage_move_file.rb
+++ b/google-cloud-storage/samples/storage_move_file.rb
@@ -26,7 +26,7 @@ def move_file bucket_name:, file_name:, new_name:
   require "google/cloud/storage"
 
   storage = Google::Cloud::Storage.new
-  bucket  = storage.bucket bucket_name
+  bucket  = storage.bucket bucket_name, skip_lookup: true
   file    = bucket.file file_name
 
   renamed_file = file.copy new_name

--- a/google-cloud-storage/samples/storage_object_csek_to_cmek.rb
+++ b/google-cloud-storage/samples/storage_object_csek_to_cmek.rb
@@ -29,7 +29,7 @@ def object_csek_to_cmek bucket_name:, file_name:, encryption_key:, kms_key_name:
   require "google/cloud/storage"
 
   storage = Google::Cloud::Storage.new
-  bucket = storage.bucket bucket_name
+  bucket = storage.bucket bucket_name, skip_lookup: true
 
   file = bucket.file file_name, encryption_key: encryption_key
 

--- a/google-cloud-storage/samples/storage_release_event_based_hold.rb
+++ b/google-cloud-storage/samples/storage_release_event_based_hold.rb
@@ -23,7 +23,7 @@ def release_event_based_hold bucket_name:, file_name:
   require "google/cloud/storage"
 
   storage = Google::Cloud::Storage.new
-  bucket  = storage.bucket bucket_name
+  bucket  = storage.bucket bucket_name, skip_lookup: true
   file    = bucket.file file_name
 
   file.release_event_based_hold!

--- a/google-cloud-storage/samples/storage_release_temporary_hold.rb
+++ b/google-cloud-storage/samples/storage_release_temporary_hold.rb
@@ -23,7 +23,7 @@ def release_temporary_hold bucket_name:, file_name:
   require "google/cloud/storage"
 
   storage = Google::Cloud::Storage.new
-  bucket  = storage.bucket bucket_name
+  bucket  = storage.bucket bucket_name, skip_lookup: true
   file    = bucket.file file_name
 
   file.release_temporary_hold!

--- a/google-cloud-storage/samples/storage_rotate_encryption_key.rb
+++ b/google-cloud-storage/samples/storage_rotate_encryption_key.rb
@@ -31,7 +31,7 @@ def rotate_encryption_key bucket_name:, file_name:, current_encryption_key:, new
   require "google/cloud/storage"
 
   storage = Google::Cloud::Storage.new
-  bucket  = storage.bucket bucket_name
+  bucket  = storage.bucket bucket_name, skip_lookup: true
   file    = bucket.file file_name, encryption_key: current_encryption_key
 
   file.rotate encryption_key:     current_encryption_key,

--- a/google-cloud-storage/samples/storage_set_bucket_default_kms_key.rb
+++ b/google-cloud-storage/samples/storage_set_bucket_default_kms_key.rb
@@ -25,7 +25,7 @@ def set_bucket_default_kms_key bucket_name:, default_kms_key:
   storage = Google::Cloud::Storage.new
   bucket  = storage.bucket bucket_name
 
-  bucket.default_kms_key = default_kms_key
+  bucket.default_kms_key = default_kms_key, skip_lookup: true
 
   puts "Default KMS key for #{bucket.name} was set to #{bucket.default_kms_key}"
 end

--- a/google-cloud-storage/samples/storage_set_bucket_default_kms_key.rb
+++ b/google-cloud-storage/samples/storage_set_bucket_default_kms_key.rb
@@ -25,7 +25,7 @@ def set_bucket_default_kms_key bucket_name:, default_kms_key:
   storage = Google::Cloud::Storage.new
   bucket  = storage.bucket bucket_name
 
-  bucket.default_kms_key = default_kms_key, skip_lookup: true
+  bucket.default_kms_key = default_kms_key
 
   puts "Default KMS key for #{bucket.name} was set to #{bucket.default_kms_key}"
 end

--- a/google-cloud-storage/samples/storage_set_event_based_hold.rb
+++ b/google-cloud-storage/samples/storage_set_event_based_hold.rb
@@ -23,7 +23,7 @@ def set_event_based_hold bucket_name:, file_name:
   require "google/cloud/storage"
 
   storage = Google::Cloud::Storage.new
-  bucket  = storage.bucket bucket_name
+  bucket  = storage.bucket bucket_name, skip_lookup: true
   file    = bucket.file file_name
 
   file.set_event_based_hold!

--- a/google-cloud-storage/samples/storage_set_metadata.rb
+++ b/google-cloud-storage/samples/storage_set_metadata.rb
@@ -23,7 +23,7 @@ def set_metadata bucket_name:, file_name:
   require "google/cloud/storage"
 
   storage = Google::Cloud::Storage.new
-  bucket  = storage.bucket bucket_name
+  bucket  = storage.bucket bucket_name, skip_lookup: true
   file    = bucket.file file_name
 
   file.update do |file|

--- a/google-cloud-storage/samples/storage_set_temporary_hold.rb
+++ b/google-cloud-storage/samples/storage_set_temporary_hold.rb
@@ -23,7 +23,7 @@ def set_temporary_hold bucket_name:, file_name:
   require "google/cloud/storage"
 
   storage = Google::Cloud::Storage.new
-  bucket  = storage.bucket bucket_name
+  bucket  = storage.bucket bucket_name, skip_lookup: true
   file    = bucket.file file_name
 
   file.set_temporary_hold!

--- a/google-cloud-storage/samples/storage_upload_encrypted_file.rb
+++ b/google-cloud-storage/samples/storage_upload_encrypted_file.rb
@@ -30,7 +30,7 @@ def upload_encrypted_file bucket_name:, local_file_path:, file_name: nil, encryp
 
   storage = Google::Cloud::Storage.new
 
-  bucket = storage.bucket bucket_name
+  bucket = storage.bucket bucket_name, skip_lookup: true
 
   file = bucket.create_file local_file_path, file_name, encryption_key: encryption_key
 

--- a/google-cloud-storage/samples/storage_upload_with_kms_key.rb
+++ b/google-cloud-storage/samples/storage_upload_with_kms_key.rb
@@ -30,7 +30,7 @@ def upload_with_kms_key bucket_name:, local_file_path:, file_name: nil, kms_key:
 
   storage = Google::Cloud::Storage.new
 
-  bucket = storage.bucket bucket_name
+  bucket = storage.bucket bucket_name, skip_lookup: true
 
   file = bucket.create_file local_file_path, file_name, kms_key: kms_key
 


### PR DESCRIPTION
@frankyn
As written, the samples make a separate request to retrieve bucket metadata. This behavior requires unnecessary IAM permissions which could pose a privacy risk. Per discussion with @frankyn `skip_lookup: true` offers a simple workaround (b/210692437). 

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-ruby/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea.
- [ ] Follow the instructions in [CONTRIBUTING](CONTRIBUTING.md). Most importantly, ensure the tests and linter pass by running `bundle exec rake ci` in the gem subdirectory.
- [ ] Update code documentation if necessary.

closes: #<issue_number_goes_here>