### PR TITLE
chore(error_reporting): update the service brand name

### DIFF
--- a/google-cloud-error_reporting-v1beta1/.repo-metadata.json
+++ b/google-cloud-error_reporting-v1beta1/.repo-metadata.json
@@ -5,7 +5,7 @@
     "distribution_name": "google-cloud-error_reporting-v1beta1",
     "language": "ruby",
     "name": "clouderrorreporting",
-    "name_pretty": "Cloud Error Reporting V1beta1 API",
+    "name_pretty": "Error Reporting V1beta1 API",
     "product_documentation": "https://cloud.google.com/error-reporting",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-ruby",

--- a/google-cloud-error_reporting-v1beta1/.yardopts
+++ b/google-cloud-error_reporting-v1beta1/.yardopts
@@ -1,5 +1,5 @@
 --no-private
---title="Cloud Error Reporting V1beta1 API"
+--title="Error Reporting V1beta1 API"
 --exclude _pb\.rb$
 --markup markdown
 --markup-provider redcarpet

--- a/google-cloud-error_reporting-v1beta1/README.md
+++ b/google-cloud-error_reporting-v1beta1/README.md
@@ -1,13 +1,13 @@
-# Ruby Client for the Cloud Error Reporting V1beta1 API
+# Ruby Client for the Error Reporting V1beta1 API
 
-API Client library for the Cloud Error Reporting V1beta1 API
+API Client library for the Error Reporting V1beta1 API
 
 The Error Reporting API provides a simple endpoint to report errors from your running service, and read access to error groups and their associated errors.
 
 https://github.com/googleapis/google-cloud-ruby
 
 This gem is a _versioned_ client. It provides basic client classes for a
-specific version of the Cloud Error Reporting V1beta1 API. Most users should consider using
+specific version of the Error Reporting V1beta1 API. Most users should consider using
 the main client gem,
 [google-cloud-error_reporting](https://rubygems.org/gems/google-cloud-error_reporting).
 See the section below titled *Which client should I use?* for more information.

--- a/google-cloud-error_reporting-v1beta1/google-cloud-error_reporting-v1beta1.gemspec
+++ b/google-cloud-error_reporting-v1beta1/google-cloud-error_reporting-v1beta1.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   gem.authors       = ["Google LLC"]
   gem.email         = "googleapis-packages@google.com"
   gem.description   = "The Error Reporting API provides a simple endpoint to report errors from your running service, and read access to error groups and their associated errors. Note that google-cloud-error_reporting-v1beta1 is a version-specific client library. For most uses, we recommend installing the main client library google-cloud-error_reporting instead. See the readme for more details."
-  gem.summary       = "API Client library for the Cloud Error Reporting V1beta1 API"
+  gem.summary       = "API Client library for the Error Reporting V1beta1 API"
   gem.homepage      = "https://github.com/googleapis/google-cloud-ruby"
   gem.license       = "Apache-2.0"
 

--- a/google-cloud-error_reporting-v1beta1/proto_docs/README.md
+++ b/google-cloud-error_reporting-v1beta1/proto_docs/README.md
@@ -1,4 +1,4 @@
-# Cloud Error Reporting V1beta1 Protocol Buffer Documentation
+# Error Reporting V1beta1 Protocol Buffer Documentation
 
 These files are for the YARD documentation of the generated protobuf files.
 They are not intended to be required or loaded at runtime.

--- a/google-cloud-error_reporting/.repo-metadata.json
+++ b/google-cloud-error_reporting/.repo-metadata.json
@@ -5,7 +5,7 @@
     "distribution_name": "google-cloud-error_reporting",
     "language": "ruby",
     "name": "clouderrorreporting",
-    "name_pretty": "Cloud Error Reporting API",
+    "name_pretty": "Error Reporting API",
     "product_documentation": "https://cloud.google.com/error-reporting",
     "release_level": "preview",
     "repo": "googleapis/google-cloud-ruby",

--- a/google-cloud-error_reporting/.yardopts
+++ b/google-cloud-error_reporting/.yardopts
@@ -1,5 +1,5 @@
 --no-private
---title=Stackdriver Error Reporting
+--title=Error Reporting
 --exclude _pb\.rb$
 --markup markdown
 --markup-provider redcarpet

--- a/google-cloud-error_reporting/INSTRUMENTATION.md
+++ b/google-cloud-error_reporting/INSTRUMENTATION.md
@@ -1,4 +1,4 @@
-# Stackdriver Error Reporting Instrumentation
+# Error Reporting Instrumentation
 
 The google-cloud-error_reporting gem provides framework instrumentation features
 to make it easy to report exceptions from your application.
@@ -20,7 +20,8 @@ end
 ```
 
 ## Configuration
-The default configuration enables Stackdriver instrumentation features to run on
+
+The default configuration enables Google Cloud Error Reporting instrumentation features to run on
 Google Cloud Platform. You can easily configure the instrumentation library  if
 you want to run on a non Google Cloud environment or you want to customize  the
 default behavior.
@@ -34,13 +35,13 @@ for full configuration parameters.
 The google-cloud-error_reporting gem provides a Rack Middleware class that can
 easily integrate with Rack based application frameworks, such as Rails and
 Sinatra. When enabled, it automatically gathers application exceptions from
-requests and submits the information to the Stackdriver Error Reporting service.
+requests and submits the information to the Error Reporting service.
 On top of that, the google-cloud-error_reporting also implements a Railtie class
 that automatically enables the Rack Middleware in Rails applications when used.
 
 ### Rails Integration
 
-To use the Stackdriver Error Reporting Railtie for Ruby on Rails applications,
+To use the Error Reporting Railtie for Ruby on Rails applications,
 simply add this line to `config/application.rb`:
 
 ```ruby
@@ -62,7 +63,8 @@ use Google::Cloud::ErrorReporting::Middleware
 ```
 
 ## Report Captured Exceptions
-Captured Ruby exceptions can be reported directly to Stackdriver Error Reporting
+
+Captured Ruby exceptions can be reported directly to Error Reporting
 by using {Google::Cloud::ErrorReporting.report}:
 
 ```ruby

--- a/google-cloud-error_reporting/LOGGING.md
+++ b/google-cloud-error_reporting/LOGGING.md
@@ -6,7 +6,7 @@ that you set may be a Ruby stdlib
 [`Logger`](https://ruby-doc.org/stdlib/libdoc/logger/rdoc/Logger.html) as
 shown below, or a
 [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
-that will write logs to [Stackdriver
+that will write logs to [Cloud
 Logging](https://cloud.google.com/logging/). See
 [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
 and the gRPC

--- a/google-cloud-error_reporting/OVERVIEW.md
+++ b/google-cloud-error_reporting/OVERVIEW.md
@@ -1,11 +1,10 @@
 # Error Reporting
 
-Stackdriver Error Reporting counts, analyzes and aggregates the crashes in your
-running cloud services. The Stackdriver Error Reporting Instrumentation client
+Error Reporting counts, analyzes and aggregates the crashes in your
+running cloud services. The Error Reporting Instrumentation client
 provides a simple way to report errors from your application.
 
-For general information about Stackdriver Error Reporting, read [Stackdriver
-Error Reporting Documentation](https://cloud.google.com/error-reporting/docs/).
+For general information about Error Reporting, read [Error Reporting Documentation](https://cloud.google.com/error-reporting/docs/).
 
 The goal of google-cloud is to provide an API that is comfortable to Rubyists.
 Your authentication credentials are detected automatically in Google Cloud
@@ -17,13 +16,13 @@ connecting in the [Authentication Guide](AUTHENTICATION.md).
 
 ## How to report errors
 
-You can easily report exceptions from your applications to Stackdriver Error
+You can easily report exceptions from your applications to Error
 Reporting service:
 
 ```ruby
 require "google/cloud/error_reporting"
 
-# Configure Stackdriver ErrorReporting instrumentation
+# Configure Error Reporting instrumentation
 Google::Cloud::ErrorReporting.configure do |config|
   config.project_id = "my-project"
   config.keyfile = "/path/to/keyfile.json"
@@ -44,4 +43,4 @@ See the [Instrumentation Guide](INSTRUMENTATION.md) for more examples.
 
 ## Additional information
 
-Stackdriver Error Reporting can be configured to use gRPC's logging. To learn more, see the[Logging guide](LOGGING.md).
+Error Reporting can be configured to use gRPC's logging. To learn more, see the[Logging guide](LOGGING.md).

--- a/google-cloud-error_reporting/README.md
+++ b/google-cloud-error_reporting/README.md
@@ -1,6 +1,6 @@
 # google-cloud-error_reporting
 
-[Stackdriver Error Reporting](https://cloud.google.com/error-reporting/) counts,
+[Error Reporting](https://cloud.google.com/error-reporting/) counts,
 analyzes and aggregates errors raised in your running cloud services. A
 centralized error management interface displays the results with sorting and
 filtering capabilities. A dedicated view shows the error details: time chart,
@@ -10,7 +10,7 @@ exception stack trace. Opt-in to receive email and mobile alerts on new errors.
 - [google-cloud-error_reporting API documentation](https://googleapis.dev/ruby/google-cloud-error_reporting/latest)
 - [google-cloud-error_reporting instrumentation documentation](https://googleapis.dev/ruby/google-cloud-error_reporting/latest/file.INSTRUMENTATION.html)
 - [google-cloud-error_reporting on RubyGems](https://rubygems.org/gems/google-cloud-error_reporting)
-- [Stackdriver ErrorReporting documentation](https://cloud.google.com/error-reporting/docs/)
+- [Error Reporting documentation](https://cloud.google.com/error-reporting/docs/)
 
 ## Quick Start
 
@@ -38,17 +38,17 @@ Alternatively, check out the
 [`stackdriver`](https://googleapis.dev/ruby/stackdriver)
 gem that includes the `google-cloud-error_reporting` gem.
 
-## Enable Stackdriver Error Reporting API
+## Enable Error Reporting API
 
-The Stackdriver Error Reporting library needs the [Stackdriver Error Reporting
+The Error Reporting library needs the [Error Reporting
 API](https://console.cloud.google.com/apis/library/clouderrorreporting.googleapis.com)
 to be enabled on your Google Cloud project. Make sure it's enabled if not
 already.
 
 ## Reporting errors in Rack-based frameworks
 
-The Stackdriver Error Reporting library for Ruby makes it easy to integrate
-Stackdriver Error Reporting into popular Rack-based Ruby web frameworks such as
+The Error Reporting library for Ruby makes it easy to integrate
+Error Reporting into popular Rack-based Ruby web frameworks such as
 Ruby on Rails and Sinatra. When the library integration is enabled, it
 automatically reports exceptions captured from the application's Rack stack.
 
@@ -90,22 +90,22 @@ end
 
 ## Configuring the library
 
-You can customize the behavior of the Stackdriver Error Reporting library for
+You can customize the behavior of the Error Reporting library for
 Ruby. See the [configuration
 guide](https://googleapis.dev/ruby/stackdriver/latest/file.INSTRUMENTATION_CONFIGURATION.html)
 for a list of possible configuration options.
 
 ## Running on Google Cloud Platform
 
-The Stackdriver Error Reporting library for Ruby should work without you
+The Error Reporting library for Ruby should work without you
 manually providing authentication credentials for instances running on Google
-Cloud Platform, as long as the Stackdriver Error Reporting API access scope is
+Cloud Platform, as long as the Error Reporting API access scope is
 enabled on that instance.
 
 ### App Engine
 
-On Google App Engine, the Stackdriver Error Reporting API access scope is
-enabled by default, and the Stackdriver Error Reporting library for Ruby can be
+On Google App Engine, the Error Reporting API access scope is
+enabled by default, and the Error Reporting library for Ruby can be
 used without providing credentials or a project ID.
 
 ### Container Engine
@@ -130,9 +130,9 @@ full access to all Cloud APIs" under Access scopes.
 
 ## Running locally and elsewhere
 
-To run the Stackdriver Error Reporting outside of Google Cloud Platform, you
+To run the Error Reporting outside of Google Cloud Platform, you
 must supply your GCP project ID and appropriate service account credentials
-directly to the Stackdriver Error Reporting. This applies to running the library
+directly to the Error Reporting. This applies to running the library
 on your own workstation, on your datacenter's computers, or on the VM instances
 of another cloud provider. See the [Authentication section](#authentication) for
 instructions on how to do so.
@@ -153,7 +153,7 @@ Rails.application.configure do |config|
   # Shared parameters
   config.google_cloud.project_id = "your-project-id"
   config.google_cloud.keyfile = "/path/to/key.json"
-  # Or Stackdriver Error Reporting specific parameters
+  # Or Error Reporting specific parameters
   config.google_cloud.error_reporting.project_id = "your-project-id"
   config.google_cloud.error_reporting.keyfile = "/path/to/key.json"
 end
@@ -168,7 +168,7 @@ Google::Cloud.configure do |config|
   # Shared parameters
   config.project_id = "your-project-id"
   config.keyfile = "/path/to/key.json"
-  # Or Stackdriver Error Reporting specific parameters
+  # Or Error Reporting specific parameters
   config.error_reporting.project_id = "your-project-id"
   config.error_reporting.keyfile = "/path/to/key.json"
 end
@@ -187,8 +187,7 @@ that you set may be a Ruby stdlib
 [`Logger`](https://ruby-doc.org/stdlib/libdoc/logger/rdoc/Logger.html) as
 shown below, or a
 [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest)
-that will write logs to [Stackdriver
-Logging](https://cloud.google.com/logging/). See
+that will write logs to [Cloud Logging](https://cloud.google.com/logging/). See
 [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb)
 and the gRPC
 [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb)

--- a/google-cloud-error_reporting/google-cloud-error_reporting.gemspec
+++ b/google-cloud-error_reporting/google-cloud-error_reporting.gemspec
@@ -7,8 +7,8 @@ Gem::Specification.new do |gem|
 
   gem.authors       = ["Google Inc"]
   gem.email         = ["googleapis-packages@google.com"]
-  gem.description   = "google-cloud-error_reporting is the official library for Stackdriver Error Reporting."
-  gem.summary       = "API Client library for Stackdriver Error Reporting"
+  gem.description   = "google-cloud-error_reporting is the official library for Error Reporting."
+  gem.summary       = "API Client library for Error Reporting"
   gem.homepage      = "https://github.com/googleapis/google-cloud-ruby/tree/master/google-cloud-error_reporting"
   gem.license       = "Apache-2.0"
 

--- a/google-cloud-error_reporting/integration/common_error_reporting_test.rb
+++ b/google-cloud-error_reporting/integration/common_error_reporting_test.rb
@@ -18,7 +18,7 @@ require "google/cloud/error_reporting/v1beta1"
 
 
 describe Google::Cloud::ErrorReporting do
-  it "submits error event to Stackdriver Error Reporting service" do
+  it "submits error event to Error Reporting service" do
     token = Time.now.to_i
     response = send_request "test_error_reporting", "token=#{token}"
 

--- a/google-cloud-error_reporting/lib/google-cloud-error_reporting.rb
+++ b/google-cloud-error_reporting/lib/google-cloud-error_reporting.rb
@@ -25,7 +25,7 @@ require "googleauth"
 module Google
   module Cloud
     ##
-    # Create a new object for connecting to the Stackdriver Error Reporting
+    # Create a new object for connecting to the Error Reporting
     # service. Each call creates a new connection.
     #
     # For more information on connecting to Google Cloud see the
@@ -64,14 +64,14 @@ module Google
     end
 
     ##
-    # Create a new object for connecting to the Stackdriver Error Reporting
+    # Create a new object for connecting to the Error Reporting
     # service. Each call creates a new connection.
     #
     # For more information on connecting to Google Cloud see the
     # {file:AUTHENTICATION.md Authentication Guide}.
     #
     # @param [String] project_id Google Cloud Platform project identifier for
-    #   the Stackdriver Error Reporting service you are connecting to. If not
+    #   the Error Reporting service you are connecting to. If not
     #   present, the default project for the credentials is used.
     # @param [String, Hash, Google::Auth::Credentials] credentials The path to
     #   the keyfile as a String, the contents of the keyfile as a Hash, or a

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting.rb
@@ -27,7 +27,7 @@ module Google
     ##
     # # Error Reporting
     #
-    # Stackdriver Error Reporting counts, analyzes and aggregates the crashes in
+    # Error Reporting counts, analyzes and aggregates the crashes in
     # your running cloud services.
     #
     # See {file:OVERVIEW.md Error Reporting Overview}.
@@ -40,14 +40,14 @@ module Google
       @default_reporter_mutex = Monitor.new
 
       ##
-      # Creates a new object for connecting to the Stackdriver Error Reporting
+      # Creates a new object for connecting to the Error Reporting
       # service. Each call creates a new connection.
       #
       # For more information on connecting to Google Cloud see the
       # {file:AUTHENTICATION.md Authentication Guide}.
       #
       # @param [String] project_id Google Cloud Platform project identifier for
-      #   the Stackdriver Error Reporting service you are connecting to. If not
+      #   the Error Reporting service you are connecting to. If not
       #   present, the default project for the credentials is used.
       # @param [String, Hash, Google::Auth::Credentials] credentials The path to
       #   the keyfile as a String, the contents of the keyfile as a Hash, or a
@@ -102,11 +102,11 @@ module Google
       # client, allows the {.report} public method to reuse these
       # configured parameters.
       #
-      # The following Stackdriver ErrorReporting configuration parameters are
+      # The following ErrorReporting configuration parameters are
       # supported:
       #
       # * `project_id` - (String)  Google Cloud Platform project identifier for
-      #   the Stackdriver Error Reporting service you are connecting to. (The
+      #   the Error Reporting service you are connecting to. (The
       #   parameter `project` is considered deprecated, but may also be used.)
       # * `credentials` - (String, Hash, Google::Auth::Credentials) The path to
       #   the keyfile as a String, the contents of the keyfile as a Hash, or a
@@ -165,13 +165,13 @@ module Google
 
       ##
       # Provides an easy-to-use interface to Report a Ruby exception object to
-      # Stackdriver ErrorReporting service. This method helps users to
-      # transform the Ruby exception into an Stackdriver ErrorReporting
+      # Error Reporting service. This method helps users to
+      # transform the Ruby exception into an Error Reporting
       # ErrorEvent gRPC structure, so users don't need to. This should be the
       # prefered method to use when users wish to report captured exception in
       # applications.
       #
-      # This public method creates a default Stackdriver ErrorReporting client
+      # This public method creates a default Error Reporting client
       # and reuse that between calls. The default client is initialized with
       # parameters defined in {.configure}.
       #

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/async_error_reporter.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/async_error_reporter.rb
@@ -29,7 +29,7 @@ module Google
       class AsyncErrorReporterError < Google::Cloud::Error
         # @!attribute [r] error_event
         #   @return [Array<Google::Cloud::ErrorReporting::ErrorEvent>] The
-        #   individual error event that was not reported to Stackdriver Error
+        #   individual error event that was not reported to Error
         #   Reporting service.
         attr_reader :error_event
 
@@ -48,7 +48,7 @@ module Google
       class ErrorReporterError < Google::Cloud::Error
         # @!attribute [r] error_event
         #   @return [Array<Google::Cloud::ErrorReporting::ErrorEvent>] The
-        #   individual error event that was not reported to Stackdriver Error
+        #   individual error event that was not reported to Error
         #   Reporting service.
         attr_reader :error_event
 
@@ -63,7 +63,7 @@ module Google
       #
       # @private Used by {Google::Cloud::ErrorReporting} and
       # {Google::Cloud::ErrorReporting::Middleware} to asynchronously submit
-      # error events to Stackdriver Error Reporting service when used in
+      # error events to Error Reporting service when used in
       # Ruby applications.
       class AsyncErrorReporter
         ##

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/credentials.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/credentials.rb
@@ -22,7 +22,7 @@ module Google
       # # Credentials
       #
       # Represents the authentication and authorization used to connect to the
-      # Stackdriver Error Reporting service.
+      # Error Reporting service.
       #
       # @example
       #   require "google/cloud/error_reporting"

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/error_event.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/error_event.rb
@@ -19,13 +19,13 @@ module Google
       ##
       # # ErrorEvent
       #
-      # An individual error event to report to Stackdriver Error Reporting
+      # An individual error event to report to Error Reporting
       # service.
       #
       # Google::Cloud::ErrorReporting::ErrorEvent is able to be transformed
       # into the `Google::Cloud::ErrorReporting::V1beta1::ReportedErrorEvent`
       # gRPC structure. Once an error event is reported, the GCP
-      # Stackdriver ErrorReporting service is able to parse the message and
+      # Error Reporting service is able to parse the message and
       # backtrace, then group the error events by content.
       #
       # @see https://cloud.google.com/error-reporting/reference/rest/v1beta1/projects.events

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/middleware.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/middleware.rb
@@ -21,7 +21,7 @@ module Google
       #
       # Google::Cloud::ErrorReporting::Middleware defines a Rack Middleware
       # that can automatically catch upstream exceptions and report them
-      # to Stackdriver Error Reporting.
+      # to Error Reporting.
       #
       class Middleware
         EXCEPTION_KEYS = ["sinatra.error", "rack.exception"].freeze
@@ -65,7 +65,7 @@ module Google
         ##
         # Implements the mandatory Rack Middleware call method.
         #
-        # Catch all Exceptions from upstream and report them to Stackdriver
+        # Catch all Exceptions from upstream and report them to
         # Error Reporting. Unless the exception's class is defined to be ignored
         # by this Middleware.
         #
@@ -94,7 +94,7 @@ module Google
         end
 
         ##
-        # Report an given exception to Stackdriver Error Reporting.
+        # Report an given exception to Error Reporting.
         #
         # While it reports most of the exceptions. Certain Rails exceptions that
         # maps to a HTTP status code less than 500 will be treated as not the

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/project.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/project.rb
@@ -26,7 +26,7 @@ module Google
       #
       # Projects are top-level containers in Google Cloud Platform. They store
       # information about billing and authorized users, and they control access
-      # to Stackdriver ErrorReporting. Each project has a friendly name and a
+      # to Error Reporting. Each project has a friendly name and a
       # unique ID. Projects can be created only in the [Google Developers
       # Console](https://console.developers.google.com).
       #
@@ -111,7 +111,7 @@ module Google
         alias project project_id
 
         ##
-        # Report a {Google::Cloud::ErrorReporting::ErrorEvent} to Stackdriver
+        # Report a {Google::Cloud::ErrorReporting::ErrorEvent} to 
         # Error Reporting service.
         #
         # @example
@@ -128,7 +128,7 @@ module Google
 
         ##
         # Create a {Google::Cloud::ErrorReporting::ErrorEvent} from the
-        # given exception, and report this ErrorEvent to Stackdriver Error
+        # given exception, and report this ErrorEvent to Error
         # Reporting service.
         #
         # @param [Exception] exception A Ruby exception

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/project.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/project.rb
@@ -111,7 +111,7 @@ module Google
         alias project project_id
 
         ##
-        # Report a {Google::Cloud::ErrorReporting::ErrorEvent} to 
+        # Report a {Google::Cloud::ErrorReporting::ErrorEvent} to
         # Error Reporting service.
         #
         # @example

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/rails.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/rails.rb
@@ -24,7 +24,7 @@ module Google
       # Google::Cloud::ErrorReporting::Railtie automatically add the
       # {Google::Cloud::ErrorReporting::Middleware} to Rack in a Rails
       # environment. It will automatically capture Exceptions from the Rails app
-      # and report them to the Stackdriver Error Reporting service.
+      # and report them to the Error Reporting service.
       #
       # The Middleware is only added when certain conditions are met. See
       # `Google::Cloud.configure.use_error_reporting` for detail.

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/service.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/service.rb
@@ -53,7 +53,7 @@ module Google
         attr_accessor :mocked_error_reporting
 
         ##
-        # Report a {Google::Cloud::ErrorReporting::ErrorEvent} to Stackdriver
+        # Report a {Google::Cloud::ErrorReporting::ErrorEvent} to
         # Error Reporting service.
         #
         # @example


### PR DESCRIPTION
Replace old brand names such as "Stackdriver error reporting" and "Cloud Error Reporting" with the up to date name "Error Reporting".
