### PR TITLE
sample(storage): Fix a failing sample by removing skip_lookup while fetching metadata

### DIFF
--- a/google-cloud-storage/samples/storage_get_metadata.rb
+++ b/google-cloud-storage/samples/storage_get_metadata.rb
@@ -23,7 +23,7 @@ def get_metadata bucket_name:, file_name:
   require "google/cloud/storage"
 
   storage = Google::Cloud::Storage.new
-  bucket  = storage.bucket bucket_name, skip_lookup: true
+  bucket  = storage.bucket bucket_name
   file    = bucket.file file_name
 
   puts "Name: #{file.name}"


### PR DESCRIPTION
This PR fixes a failing spec introduced in #17865, which the CI didn't catch somehow.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-ruby/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea.
- [ ] Follow the instructions in [CONTRIBUTING](CONTRIBUTING.md). Most importantly, ensure the tests and linter pass by running `bundle exec rake ci` in the gem subdirectory.
- [ ] Update code documentation if necessary.

closes: #<issue_number_goes_here>