### PR TITLE
fix: Update grpc-google-iam-v1 dependency to 1.1

### DIFF
--- a/google-cloud-artifact_registry-v1/google-cloud-artifact_registry-v1.gemspec
+++ b/google-cloud-artifact_registry-v1/google-cloud-artifact_registry-v1.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "gapic-common", ">= 0.7", "< 2.a"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
-  gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.a"
+  gem.add_dependency "grpc-google-iam-v1", "~> 1.1"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"

--- a/google-cloud-artifact_registry-v1beta2/google-cloud-artifact_registry-v1beta2.gemspec
+++ b/google-cloud-artifact_registry-v1beta2/google-cloud-artifact_registry-v1beta2.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "gapic-common", ">= 0.7", "< 2.a"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
-  gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.a"
+  gem.add_dependency "grpc-google-iam-v1", "~> 1.1"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"

--- a/google-cloud-asset-v1/google-cloud-asset-v1.gemspec
+++ b/google-cloud-asset-v1/google-cloud-asset-v1.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "google-cloud-errors", "~> 1.0"
   gem.add_dependency "google-cloud-os_config-v1", "> 0.0", "< 2.a"
   gem.add_dependency "google-identity-access_context_manager-v1", "> 0.0", "< 2.a"
-  gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.a"
+  gem.add_dependency "grpc-google-iam-v1", "~> 1.1"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"

--- a/google-cloud-asset-v1beta1/google-cloud-asset-v1beta1.gemspec
+++ b/google-cloud-asset-v1beta1/google-cloud-asset-v1beta1.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "gapic-common", "~> 0.3"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
-  gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.0"
+  gem.add_dependency "grpc-google-iam-v1", "~> 1.1"
 
   gem.add_development_dependency "google-style", "~> 1.24.0"
   gem.add_development_dependency "minitest", "~> 5.14"

--- a/google-cloud-bigquery-connection-v1/google-cloud-bigquery-connection-v1.gemspec
+++ b/google-cloud-bigquery-connection-v1/google-cloud-bigquery-connection-v1.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "gapic-common", ">= 0.7", "< 2.a"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
-  gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.a"
+  gem.add_dependency "grpc-google-iam-v1", "~> 1.1"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"

--- a/google-cloud-bigtable-admin-v2/google-cloud-bigtable-admin-v2.gemspec
+++ b/google-cloud-bigtable-admin-v2/google-cloud-bigtable-admin-v2.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "gapic-common", ">= 0.7", "< 2.a"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
-  gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.a"
+  gem.add_dependency "grpc-google-iam-v1", "~> 1.1"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"

--- a/google-cloud-billing-v1/google-cloud-billing-v1.gemspec
+++ b/google-cloud-billing-v1/google-cloud-billing-v1.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "gapic-common", ">= 0.7", "< 2.a"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
-  gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.a"
+  gem.add_dependency "grpc-google-iam-v1", "~> 1.1"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"

--- a/google-cloud-container_analysis-v1/google-cloud-container_analysis-v1.gemspec
+++ b/google-cloud-container_analysis-v1/google-cloud-container_analysis-v1.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "gapic-common", ">= 0.7", "< 2.a"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
   gem.add_dependency "grafeas-v1", ">= 0.4", "< 2.a"
-  gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.a"
+  gem.add_dependency "grpc-google-iam-v1", "~> 1.1"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"

--- a/google-cloud-data_catalog-v1/google-cloud-data_catalog-v1.gemspec
+++ b/google-cloud-data_catalog-v1/google-cloud-data_catalog-v1.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "gapic-common", ">= 0.7", "< 2.a"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
-  gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.a"
+  gem.add_dependency "grpc-google-iam-v1", "~> 1.1"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"

--- a/google-cloud-functions-v1/google-cloud-functions-v1.gemspec
+++ b/google-cloud-functions-v1/google-cloud-functions-v1.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "gapic-common", ">= 0.7", "< 2.a"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
-  gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.a"
+  gem.add_dependency "grpc-google-iam-v1", "~> 1.1"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"

--- a/google-cloud-iap-v1/google-cloud-iap-v1.gemspec
+++ b/google-cloud-iap-v1/google-cloud-iap-v1.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "gapic-common", ">= 0.7", "< 2.a"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
-  gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.a"
+  gem.add_dependency "grpc-google-iam-v1", "~> 1.1"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"

--- a/google-cloud-iot-v1/google-cloud-iot-v1.gemspec
+++ b/google-cloud-iot-v1/google-cloud-iot-v1.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "gapic-common", ">= 0.7", "< 2.a"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
-  gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.a"
+  gem.add_dependency "grpc-google-iam-v1", "~> 1.1"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"

--- a/google-cloud-kms-v1/google-cloud-kms-v1.gemspec
+++ b/google-cloud-kms-v1/google-cloud-kms-v1.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "gapic-common", ">= 0.7", "< 2.a"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
-  gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.a"
+  gem.add_dependency "grpc-google-iam-v1", "~> 1.1"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"

--- a/google-cloud-policy_troubleshooter-v1/google-cloud-policy_troubleshooter-v1.gemspec
+++ b/google-cloud-policy_troubleshooter-v1/google-cloud-policy_troubleshooter-v1.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "gapic-common", ">= 0.7", "< 2.a"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
-  gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.a"
+  gem.add_dependency "grpc-google-iam-v1", "~> 1.1"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"

--- a/google-cloud-pubsub-v1/google-cloud-pubsub-v1.gemspec
+++ b/google-cloud-pubsub-v1/google-cloud-pubsub-v1.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "gapic-common", ">= 0.7", "< 2.a"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
-  gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.a"
+  gem.add_dependency "grpc-google-iam-v1", "~> 1.1"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"

--- a/google-cloud-resource_manager-v3/google-cloud-resource_manager-v3.gemspec
+++ b/google-cloud-resource_manager-v3/google-cloud-resource_manager-v3.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "gapic-common", ">= 0.7", "< 2.a"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
-  gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.a"
+  gem.add_dependency "grpc-google-iam-v1", "~> 1.1"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"

--- a/google-cloud-secret_manager-v1/google-cloud-secret_manager-v1.gemspec
+++ b/google-cloud-secret_manager-v1/google-cloud-secret_manager-v1.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "gapic-common", ">= 0.7", "< 2.a"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
-  gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.a"
+  gem.add_dependency "grpc-google-iam-v1", "~> 1.1"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"

--- a/google-cloud-secret_manager-v1beta1/google-cloud-secret_manager-v1beta1.gemspec
+++ b/google-cloud-secret_manager-v1beta1/google-cloud-secret_manager-v1beta1.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "gapic-common", ">= 0.7", "< 2.a"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
-  gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.a"
+  gem.add_dependency "grpc-google-iam-v1", "~> 1.1"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"

--- a/google-cloud-security-private_ca-v1/google-cloud-security-private_ca-v1.gemspec
+++ b/google-cloud-security-private_ca-v1/google-cloud-security-private_ca-v1.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "gapic-common", ">= 0.7", "< 2.a"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
   gem.add_dependency "google-cloud-location", "> 0.0", "< 2.a"
-  gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.a"
+  gem.add_dependency "grpc-google-iam-v1", "~> 1.1"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"

--- a/google-cloud-security_center-v1/google-cloud-security_center-v1.gemspec
+++ b/google-cloud-security_center-v1/google-cloud-security_center-v1.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "gapic-common", ">= 0.7", "< 2.a"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
-  gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.a"
+  gem.add_dependency "grpc-google-iam-v1", "~> 1.1"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"

--- a/google-cloud-security_center-v1p1beta1/google-cloud-security_center-v1p1beta1.gemspec
+++ b/google-cloud-security_center-v1p1beta1/google-cloud-security_center-v1p1beta1.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "gapic-common", ">= 0.7", "< 2.a"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
-  gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.a"
+  gem.add_dependency "grpc-google-iam-v1", "~> 1.1"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"

--- a/google-cloud-service_directory-v1/google-cloud-service_directory-v1.gemspec
+++ b/google-cloud-service_directory-v1/google-cloud-service_directory-v1.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "gapic-common", ">= 0.7", "< 2.a"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
-  gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.a"
+  gem.add_dependency "grpc-google-iam-v1", "~> 1.1"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"

--- a/google-cloud-service_directory-v1beta1/google-cloud-service_directory-v1beta1.gemspec
+++ b/google-cloud-service_directory-v1beta1/google-cloud-service_directory-v1beta1.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "gapic-common", ">= 0.7", "< 2.a"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
-  gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.a"
+  gem.add_dependency "grpc-google-iam-v1", "~> 1.1"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"

--- a/google-cloud-spanner-admin-database-v1/google-cloud-spanner-admin-database-v1.gemspec
+++ b/google-cloud-spanner-admin-database-v1/google-cloud-spanner-admin-database-v1.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "gapic-common", ">= 0.7", "< 2.a"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
-  gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.a"
+  gem.add_dependency "grpc-google-iam-v1", "~> 1.1"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"

--- a/google-cloud-spanner-admin-instance-v1/google-cloud-spanner-admin-instance-v1.gemspec
+++ b/google-cloud-spanner-admin-instance-v1/google-cloud-spanner-admin-instance-v1.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "gapic-common", ">= 0.7", "< 2.a"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
-  gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.a"
+  gem.add_dependency "grpc-google-iam-v1", "~> 1.1"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"

--- a/google-cloud-tasks-v2/google-cloud-tasks-v2.gemspec
+++ b/google-cloud-tasks-v2/google-cloud-tasks-v2.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "gapic-common", ">= 0.7", "< 2.a"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
-  gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.a"
+  gem.add_dependency "grpc-google-iam-v1", "~> 1.1"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"

--- a/google-cloud-tasks-v2beta2/google-cloud-tasks-v2beta2.gemspec
+++ b/google-cloud-tasks-v2beta2/google-cloud-tasks-v2beta2.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "gapic-common", ">= 0.7", "< 2.a"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
-  gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.a"
+  gem.add_dependency "grpc-google-iam-v1", "~> 1.1"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"

--- a/google-cloud-tasks-v2beta3/google-cloud-tasks-v2beta3.gemspec
+++ b/google-cloud-tasks-v2beta3/google-cloud-tasks-v2beta3.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "gapic-common", ">= 0.7", "< 2.a"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
-  gem.add_dependency "grpc-google-iam-v1", ">= 0.6.10", "< 2.a"
+  gem.add_dependency "grpc-google-iam-v1", "~> 1.1"
 
   gem.add_development_dependency "google-style", "~> 1.25.1"
   gem.add_development_dependency "minitest", "~> 5.14"


### PR DESCRIPTION
This pre-empts owlbot regeneration in response to cl/439955362, so that we can get a clean update that isn't polluted by other open owlbot PRs.