### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ on:
         description: "Commit reference from which to evaluate diffs"
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   CI:
     if: ${{ github.repository == 'googleapis/google-cloud-ruby' }}

--- a/.github/workflows/new-library.yml
+++ b/.github/workflows/new-library.yml
@@ -7,6 +7,9 @@ on:
         description: "The path to the protos and build file"
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   NewLibrary:
     if: ${{ github.repository == 'googleapis/google-cloud-ruby' }}

--- a/.github/workflows/owlbot.yml
+++ b/.github/workflows/owlbot.yml
@@ -10,6 +10,9 @@ on:
         description: "Extra flags to pass to toys owlbot"
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   OwlBot:
     if: ${{ github.repository == 'googleapis/google-cloud-ruby' }}

--- a/.github/workflows/release-please-bootstrap.yml
+++ b/.github/workflows/release-please-bootstrap.yml
@@ -6,6 +6,9 @@ on:
         description: "Space-delimited list of gems, or --all to bootstrap all gems."
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   release-please-bootstrap:
     if: ${{ github.repository == 'googleapis/google-cloud-ruby' }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,6 +11,9 @@ on:
         description: "Extra command line arguments."
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   release-please:
     if: ${{ github.repository == 'googleapis/google-cloud-ruby' }}

--- a/.github/workflows/spanner-integration-tests-against-emulator.yaml
+++ b/.github/workflows/spanner-integration-tests-against-emulator.yaml
@@ -8,6 +8,9 @@ on:
     paths:
       - 'google-cloud-spanner*/**'
 name: Run Spanner integration tests against service emulator
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-pr.yml
+++ b/.github/workflows/update-pr.yml
@@ -10,6 +10,9 @@ on:
         description: "Options"
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   OwlBot:
     if: ${{ github.repository == 'googleapis/google-cloud-ruby' }}

--- a/.github/workflows/update-release-levels.yml
+++ b/.github/workflows/update-release-levels.yml
@@ -6,6 +6,9 @@ on:
         description: "Extra command line arguments."
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   update-release-levels:
     if: ${{ github.repository == 'googleapis/google-cloud-ruby' }}


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
