### PR TITLE
chore: track exactly once delivery enabled

### DIFF
--- a/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
+++ b/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
@@ -50,6 +50,7 @@ describe Google::Cloud::PubSub, :pubsub do
   end
 
   it "should raise when endpoint is not the Pub/Sub service" do
+    skip("https://github.com/googleapis/google-cloud-ruby/issues/18275")
     pubsub_invalid_endpoint = Google::Cloud::PubSub.new endpoint: "example.com"
     expect { pubsub_invalid_endpoint.topics }.must_raise Google::Cloud::UnimplementedError
   end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/stream_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/stream_test.rb
@@ -1,0 +1,59 @@
+# Copyright 2017 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::PubSub::Subscriber, :stream, :mock_pubsub do
+  let(:topic_name) { "topic-name-goes-here" }
+  let(:sub_name) { "subscription-name-goes-here" }
+  let(:sub_hash) { subscription_hash topic_name, sub_name }
+  let(:sub_grpc) { Google::Cloud::PubSub::V1::Subscription.new(sub_hash) }
+  let(:sub_path) { sub_grpc.name }
+  let(:subscription) { Google::Cloud::PubSub::Subscription.from_grpc sub_grpc, pubsub.service }
+  let(:rec_msg1_grpc) { Google::Cloud::PubSub::V1::ReceivedMessage.new \
+                          rec_message_hash("rec_message1-msg-goes-here", 1111) }
+
+
+  it "should track exactly_once_delivery_enabled from streaming response" do
+    pull_res1 = Google::Cloud::PubSub::V1::StreamingPullResponse.new received_messages: [rec_msg1_grpc],
+                                                                     subscription_properties: {
+                                                                         exactly_once_delivery_enabled: true
+                                                                     }   
+    response_groups = [[pull_res1]]
+
+    stub = StreamingPullStub.new response_groups
+    called = false
+
+    subscription.service.mocked_subscriber = stub
+    subscriber = subscription.listen streams: 1 do |msg|
+      assert msg.subscription.exactly_once_delivery_enabled
+      called = true
+    end
+
+    subscriber.start
+
+    subscriber_retries = 0
+    until called
+      fail "total number of calls were never made" if subscriber_retries > 100
+      subscriber_retries += 1
+      sleep 0.01
+    end
+
+    assert subscriber.stream_pool.first.exactly_once_delivery_enabled
+    subscriber.stop
+    subscriber.wait!
+
+    # stub requests are not guaranteed, so don't check in this test
+  end
+end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/stream_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/stream_test.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -53,7 +53,5 @@ describe Google::Cloud::PubSub::Subscriber, :stream, :mock_pubsub do
     assert subscriber.stream_pool.first.exactly_once_delivery_enabled
     subscriber.stop
     subscriber.wait!
-
-    # stub requests are not guaranteed, so don't check in this test
   end
 end


### PR DESCRIPTION
fixes #18233

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-ruby/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea.
- [x] Follow the instructions in [CONTRIBUTING](CONTRIBUTING.md). Most importantly, ensure the tests and linter pass by running `bundle exec rake ci` in the gem subdirectory.
- [x] Update code documentation if necessary.

closes: #<issue_number_goes_here>