### PR TITLE
feat: Initial generation of google-cloud-run-client

### DIFF
--- a/google-cloud-run-client/lib/google/cloud/run/client/version.rb
+++ b/google-cloud-run-client/lib/google/cloud/run/client/version.rb
@@ -14,6 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# The generator thinks this gem name is "google-cloud-run" and defines the
+# version constant under that namespace. This handwritten file ensures the
+# constant is also defined under the "correct" namespace.
+
 require "google/cloud/run/version"
 
 module Google


### PR DESCRIPTION
The main goal is actually to get an appropriate conventional commit into the repo to trigger release-please.