### PR TITLE
fix(google-cloud-bigtable): fix reads_prefix sample

### DIFF
--- a/google-cloud-bigtable/samples/acceptance/read_samples_test.rb
+++ b/google-cloud-bigtable/samples/acceptance/read_samples_test.rb
@@ -44,6 +44,10 @@ describe Google::Cloud::Bigtable, "Read Samples", :bigtable do
             .set_cell("stats_summary", "os_build", "PQ2A.190401.002", timestamp: @timestamp) <<
         @table.new_mutation_entry("phone#5c10102#20190502").set_cell("stats_summary", "connected_cell", "1", timestamp: @timestamp)
             .set_cell("stats_summary", "connected_wifi", "0", timestamp: @timestamp)
+            .set_cell("stats_summary", "os_build", "PQ2A.190406.000", timestamp: @timestamp) <<
+        # extra mutation to validate reads_prefix of "phone#" correctness
+        @table.new_mutation_entry("phone001#5c10102#20190502").set_cell("stats_summary", "connected_cell", "1", timestamp: @timestamp)
+            .set_cell("stats_summary", "connected_wifi", "0", timestamp: @timestamp)
             .set_cell("stats_summary", "os_build", "PQ2A.190406.000", timestamp: @timestamp)
 
     @table.mutate_rows entries

--- a/google-cloud-bigtable/samples/read_samples.rb
+++ b/google-cloud-bigtable/samples/read_samples.rb
@@ -97,7 +97,8 @@ def reads_prefix instance_id, table_id
   table = bigtable.table instance_id, table_id
 
   prefix = "phone#"
-  range = table.new_row_range.between prefix, prefix.next
+  end_key = prefix[0...-1] + prefix[-1].next
+  range = table.new_row_range.between prefix, end_key
   table.read_rows(ranges: range).each do |row|
     print_row row
   end


### PR DESCRIPTION
closes: https://github.com/googleapis/google-cloud-ruby/issues/18270

### How this PR fix it
#### before this PR

```ruby
prefix = "phone#"
=> "phone#"
prefix.next
=> "phonf#"
```

"phon001" is ordered between "phone#" and "phonf#", so it will wrongly include a lot rows not prefix by "phone#", e.g. "phone001#"

but actually it should expect end key `phone$`, align with [python example](https://cloud.google.com/bigtable/docs/reading-data#prefix).

#### after this PR
```
prefix[0...-1] + prefix[-1].next
=> "phone$"
```