### PR TITLE
Patch 1

### DIFF
--- a/google-cloud-storage/lib/google/cloud/storage/file/signer_v2.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/signer_v2.rb
@@ -48,7 +48,7 @@ module Google
           #
           def ext_path
             path = "/#{@bucket}/#{@path}"
-            escaped = Addressable::URI.encode_component(path, Addressable::URI::CharacterClasses::PATH)
+            escaped = Addressable::URI.encode_component path, Addressable::URI::CharacterClasses::PATH
             special_var = "${filename}"
             # Restore the unencoded `${filename}` variable, if present.
             if path.include? special_var

--- a/google-cloud-storage/lib/google/cloud/storage/file/signer_v2.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/signer_v2.rb
@@ -48,7 +48,7 @@ module Google
           #
           def ext_path
             path = "/#{@bucket}/#{@path}"
-            escaped = Addressable::URI.escape path
+            escaped = Addressable::URI.encode_component(path, Addressable::URI::CharacterClasses::PATH)
             special_var = "${filename}"
             # Restore the unencoded `${filename}` variable, if present.
             if path.include? special_var

--- a/google-cloud-storage/lib/google/cloud/storage/file/signer_v4.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/signer_v4.rb
@@ -326,7 +326,7 @@ module Google
           #
           def post_object_ext_path
             path = "/#{@bucket_name}/#{@file_name}"
-            escaped = Addressable::URI.escape path
+            escaped = Addressable::URI.encode_component(path, Addressable::URI::CharacterClasses::PATH)
             special_var = "${filename}"
             # Restore the unencoded `${filename}` variable, if present.
             if path.include? special_var

--- a/google-cloud-storage/lib/google/cloud/storage/file/signer_v4.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/signer_v4.rb
@@ -326,7 +326,7 @@ module Google
           #
           def post_object_ext_path
             path = "/#{@bucket_name}/#{@file_name}"
-            escaped = Addressable::URI.encode_component(path, Addressable::URI::CharacterClasses::PATH)
+            escaped = Addressable::URI.encode_component path, Addressable::URI::CharacterClasses::PATH
             special_var = "${filename}"
             # Restore the unencoded `${filename}` variable, if present.
             if path.include? special_var

--- a/google-cloud-storage/test/google/cloud/storage/file_signed_url_v2_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_signed_url_v2_test.rb
@@ -172,21 +172,21 @@ describe Google::Cloud::Storage::File, :signed_url, :mock_storage do
     }.must_raise ArgumentError
   end
 
-  describe "Files with spaces in them" do
-    let(:file_name) { "hello world.txt" }
+  describe "Files with spaces and hashes in them" do
+    let(:file_name) { "hello world #1.txt" }
 
     it "properly escapes the path when generating signed_url" do
       Time.stub :now, Time.new(2012,1,1,0,0,0, "+00:00") do
         signing_key_mock = Minitest::Mock.new
         signing_key_mock.expect :is_a?, false, [Proc]
-        signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GET\n\n\n1325376300\n/bucket/hello%20world.txt"]
+        signing_key_mock.expect :sign, "native-signature", [OpenSSL::Digest::SHA256, "GET\n\n\n1325376300\n/bucket/hello%20world%20%231.txt"]
         credentials.issuer = "native_client_email"
         credentials.signing_key = signing_key_mock
 
         signed_url = file.signed_url
 
         signed_uri = URI signed_url
-        _(signed_uri.path).must_equal "/bucket/hello%20world.txt"
+        _(signed_uri.path).must_equal "/bucket/hello%20world%20%231.txt"
 
         signed_url_params = CGI::parse signed_uri.query
         _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]


### PR DESCRIPTION
The `Addressable::URI.escape` method tries to parse it's input as a full URI, the best it can. However, when a `#` character is included, it incorrectly treats everything before it as the path, and everything after it as a fragment.

As a consequence, the `#` character is not escaped properly, and the `signed_url` method will return a bad url with a `NoSuchKey` error.

Here, instead of using the generic `parse`, we specifically call `encode_component`, treating the path explicitly as a path. In this situation, `#` will be properly encoded as `%23`

closes: #18286 