### PR TITLE
feat(pubsub): introduce min_duration_per_lease_extension

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb
@@ -332,6 +332,16 @@ module Google
         end
 
         ##
+        # The minimum amount of time in seconds for a single lease extension attempt. Bounds the delay before a message
+        # redelivery if the subscriber fails to extend the deadline. Default is 0 (disabled).
+        #
+        # @return [Integer] The minimum number of seconds.
+        #
+        def min_duration_per_lease_extension
+          @inventory[:min_duration_per_lease_extension]
+        end
+
+        ##
         # @private
         def stream_inventory
           {
@@ -339,6 +349,7 @@ module Google
             bytesize:                         @inventory[:max_outstanding_bytes].fdiv(@streams).ceil,
             extension:                        @inventory[:max_total_lease_duration],
             max_duration_per_lease_extension: @inventory[:max_duration_per_lease_extension],
+            min_duration_per_lease_extension: @inventory[:min_duration_per_lease_extension],
             use_legacy_flow_control:          @inventory[:use_legacy_flow_control]
           }
         end
@@ -394,6 +405,7 @@ module Google
           @inventory[:max_outstanding_bytes] = Integer(@inventory[:max_outstanding_bytes] || 100_000_000)
           @inventory[:max_total_lease_duration] = Integer(@inventory[:max_total_lease_duration] || 3600)
           @inventory[:max_duration_per_lease_extension] = Integer(@inventory[:max_duration_per_lease_extension] || 0)
+          @inventory[:min_duration_per_lease_extension] = Integer(@inventory[:min_duration_per_lease_extension] || 0)
           @inventory[:use_legacy_flow_control] = @inventory[:use_legacy_flow_control] || false
         end
 

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/inventory.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/inventory.rb
@@ -35,16 +35,18 @@ module Google
           attr_reader :bytesize
           attr_reader :extension
           attr_reader :max_duration_per_lease_extension
+          attr_accessor :min_duration_per_lease_extension
           attr_reader :use_legacy_flow_control
 
           def initialize stream, limit:, bytesize:, extension:, max_duration_per_lease_extension:,
-                         use_legacy_flow_control:
+                         min_duration_per_lease_extension:, use_legacy_flow_control:
             super()
             @stream = stream
             @limit = limit
             @bytesize = bytesize
             @extension = extension
             @max_duration_per_lease_extension = max_duration_per_lease_extension
+            @min_duration_per_lease_extension = min_duration_per_lease_extension
             @use_legacy_flow_control = use_legacy_flow_control
             @inventory = {}
             @wait_cond = new_cond
@@ -162,6 +164,8 @@ module Google
           def calc_delay
             delay = (stream.subscriber.deadline - 3) * rand(0.8..0.9)
             delay = [delay, max_duration_per_lease_extension].min if max_duration_per_lease_extension.positive?
+            delay = [delay, min_duration_per_lease_extension].max if min_duration_per_lease_extension.positive? &&
+                                                                     stream.exactly_once_delivery_enabled
             delay
           end
         end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/inventory_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/inventory_test.rb
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 require "helper"
-require 'ostruct'
+require "ostruct"
 
 describe Google::Cloud::PubSub::Subscriber, :inventory, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
@@ -179,7 +179,7 @@ describe Google::Cloud::PubSub::Subscriber, :inventory, :mock_pubsub do
                                                                  use_legacy_flow_control: false
 
     inventory.add rec_msg1_grpc
-    delay = inventory.send(:calc_delay)
+    delay = inventory.send :calc_delay
     assert_equal 61, delay
   end
 

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/inventory_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/inventory_test.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 require "helper"
+require 'ostruct'
 
 describe Google::Cloud::PubSub::Subscriber, :inventory, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
@@ -165,9 +166,32 @@ describe Google::Cloud::PubSub::Subscriber, :inventory, :mock_pubsub do
     _(mod_ack_hash[60].sort).must_equal ["ack-id-1111", "ack-id-1112", "ack-id-1113"]
   end
 
+  it "calculates delay considering min_duration_per_lease_extension" do
+    subscriber_mock = Minitest::Mock.new
+    subscriber_mock.expect :subscriber, OpenStruct.new({:deadline => 60})
+    subscriber_mock.expect :exactly_once_delivery_enabled, true
+    inventory = Google::Cloud::PubSub::Subscriber::Inventory.new subscriber_mock, 
+                                                                 limit: 2, 
+                                                                 bytesize: 100_000, 
+                                                                 extension: 3600, 
+                                                                 max_duration_per_lease_extension: 0, 
+                                                                 min_duration_per_lease_extension: 61,
+                                                                 use_legacy_flow_control: false
+
+    inventory.add rec_msg1_grpc
+    delay = inventory.send(:calc_delay)
+    assert_equal 61, delay
+  end
+
   it "knows its count limit" do
     subscriber_mock = Minitest::Mock.new
-    inventory = Google::Cloud::PubSub::Subscriber::Inventory.new subscriber_mock, limit: 2, bytesize: 100_000, extension: 3600, max_duration_per_lease_extension: 0, use_legacy_flow_control: false
+    inventory = Google::Cloud::PubSub::Subscriber::Inventory.new subscriber_mock, 
+                                                                 limit: 2, 
+                                                                 bytesize: 100_000, 
+                                                                 extension: 3600, 
+                                                                 max_duration_per_lease_extension: 0, 
+                                                                 min_duration_per_lease_extension: 0,
+                                                                 use_legacy_flow_control: false
 
     inventory.add rec_msg1_grpc
     _(inventory).wont_be :full?
@@ -179,7 +203,13 @@ describe Google::Cloud::PubSub::Subscriber, :inventory, :mock_pubsub do
 
   it "knows its bytesize limit" do
     subscriber_mock = Minitest::Mock.new
-    inventory = Google::Cloud::PubSub::Subscriber::Inventory.new subscriber_mock, limit: 1000, bytesize: 100, extension: 3600, max_duration_per_lease_extension: 0, use_legacy_flow_control: false
+    inventory = Google::Cloud::PubSub::Subscriber::Inventory.new subscriber_mock, 
+                                                                 limit: 1000, 
+                                                                 bytesize: 100, 
+                                                                 extension: 3600, 
+                                                                 max_duration_per_lease_extension: 0, 
+                                                                 min_duration_per_lease_extension: 0,
+                                                                 use_legacy_flow_control: false
 
     inventory.add rec_msg1_grpc
     _(inventory).wont_be :full?
@@ -191,7 +221,13 @@ describe Google::Cloud::PubSub::Subscriber, :inventory, :mock_pubsub do
 
   it "removes expired items" do
     subscriber_mock = Minitest::Mock.new
-    inventory = Google::Cloud::PubSub::Subscriber::Inventory.new subscriber_mock, limit: 1000, bytesize: 100_000, extension: 3600, max_duration_per_lease_extension: 0, use_legacy_flow_control: false
+    inventory = Google::Cloud::PubSub::Subscriber::Inventory.new subscriber_mock, 
+                                                                 limit: 1000, 
+                                                                 bytesize: 100_000, 
+                                                                 extension: 3600, 
+                                                                 max_duration_per_lease_extension: 0,
+                                                                 min_duration_per_lease_extension: 0,
+                                                                 use_legacy_flow_control: false
 
     expired_time = Time.now - 7200
 
@@ -209,8 +245,27 @@ describe Google::Cloud::PubSub::Subscriber, :inventory, :mock_pubsub do
 
   it "knows its max_duration_per_lease_extension limit" do
     subscriber_mock = Minitest::Mock.new
-    inventory = Google::Cloud::PubSub::Subscriber::Inventory.new subscriber_mock, limit: 1000, bytesize: 100, extension: 3600, max_duration_per_lease_extension: 10, use_legacy_flow_control: false
+    inventory = Google::Cloud::PubSub::Subscriber::Inventory.new subscriber_mock, 
+                                                                 limit: 1000,
+                                                                 bytesize: 100, 
+                                                                 extension: 3600, 
+                                                                 max_duration_per_lease_extension: 10, 
+                                                                 min_duration_per_lease_extension: 0,
+                                                                 use_legacy_flow_control: false
 
     _(inventory.max_duration_per_lease_extension).must_equal 10
+  end
+
+  it "knows its min_duration_per_lease_extension limit" do
+    subscriber_mock = Minitest::Mock.new
+    inventory = Google::Cloud::PubSub::Subscriber::Inventory.new subscriber_mock, 
+                                                                 limit: 1000, 
+                                                                 bytesize: 100, 
+                                                                 extension: 3600, 
+                                                                 max_duration_per_lease_extension: 0, 
+                                                                 min_duration_per_lease_extension: 10, 
+                                                                 use_legacy_flow_control: false
+
+    _(inventory.min_duration_per_lease_extension).must_equal 10
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber_test.rb
@@ -54,7 +54,8 @@ describe Google::Cloud::PubSub::Subscriber, :mock_pubsub do
     _(subscriber.inventory_extension).must_equal 3600 # deprecated Use #max_total_lease_duration.
     _(subscriber.max_total_lease_duration).must_equal 3600
     _(subscriber.max_duration_per_lease_extension).must_equal 0
-    _(subscriber.stream_inventory).must_equal({limit: 500, bytesize: 50000000, max_duration_per_lease_extension: 0, extension: 3600, use_legacy_flow_control: false})
+    _(subscriber.min_duration_per_lease_extension).must_equal 0
+    _(subscriber.stream_inventory).must_equal({limit: 500, bytesize: 50000000, max_duration_per_lease_extension: 0, min_duration_per_lease_extension: 0, extension: 3600, use_legacy_flow_control: false})
     _(subscriber.callback_threads).must_equal 8
     _(subscriber.push_threads).must_equal 4
   end
@@ -73,7 +74,8 @@ describe Google::Cloud::PubSub::Subscriber, :mock_pubsub do
     _(subscriber.inventory_extension).must_equal 3600 # deprecated Use #max_total_lease_duration.
     _(subscriber.max_total_lease_duration).must_equal 3600
     _(subscriber.max_duration_per_lease_extension).must_equal 0
-    _(subscriber.stream_inventory).must_equal({limit: 250, bytesize: 12500000, max_duration_per_lease_extension: 0, extension: 3600, use_legacy_flow_control: false})
+    _(subscriber.min_duration_per_lease_extension).must_equal 0
+    _(subscriber.stream_inventory).must_equal({limit: 250, bytesize: 12500000, max_duration_per_lease_extension: 0, min_duration_per_lease_extension: 0, extension: 3600, use_legacy_flow_control: false})
     _(subscriber.callback_threads).must_equal callback_threads
     _(subscriber.push_threads).must_equal push_threads
 
@@ -92,6 +94,6 @@ describe Google::Cloud::PubSub::Subscriber, :mock_pubsub do
     )
     _(subscriber.max_outstanding_messages).must_equal 999
     _(subscriber.use_legacy_flow_control?).must_equal true
-    _(subscriber.stream_inventory).must_equal({limit: 500, bytesize: 50000000, max_duration_per_lease_extension: 0, extension: 3600, use_legacy_flow_control: true})
+    _(subscriber.stream_inventory).must_equal({limit: 500, bytesize: 50000000, max_duration_per_lease_extension: 0, min_duration_per_lease_extension: 0, extension: 3600, use_legacy_flow_control: true})
   end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscription/listen_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscription/listen_test.rb
@@ -230,6 +230,26 @@ describe Google::Cloud::PubSub::Subscription, :listen, :mock_pubsub do
     _(subscriber.use_legacy_flow_control?).must_equal false
   end
 
+  it "will set inventory min_duration_per_lease_extension while creating a Subscriber" do
+    subscriber = subscription.listen inventory: { min_duration_per_lease_extension: 10 } do |msg|
+      puts msg.msg_id
+    end
+    _(subscriber).must_be_kind_of Google::Cloud::PubSub::Subscriber
+    _(subscriber.subscription_name).must_equal subscription.name
+    _(subscriber.deadline).must_equal 60
+    _(subscriber.streams).must_equal 2
+    _(subscriber.inventory).must_equal 1000
+    _(subscriber.inventory_limit).must_equal 1000
+    _(subscriber.max_outstanding_messages).must_equal 1000
+    _(subscriber.inventory_bytesize).must_equal 100000000
+    _(subscriber.max_outstanding_bytes).must_equal 100000000
+    _(subscriber.inventory_extension).must_equal 3600
+    _(subscriber.max_total_lease_duration).must_equal 3600
+    _(subscriber.max_duration_per_lease_extension).must_equal 0
+    _(subscriber.min_duration_per_lease_extension).must_equal 10
+    _(subscriber.use_legacy_flow_control?).must_equal false
+  end
+
   it "will use inventory use_legacy_flow_control while creating a Subscriber" do
     subscriber = subscription.listen inventory: { use_legacy_flow_control: true } do |msg|
       puts msg.msg_id


### PR DESCRIPTION
- the new attribute is used to calculate the delay for automated lease extension.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-ruby/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea.
- [x] Follow the instructions in [CONTRIBUTING](CONTRIBUTING.md). Most importantly, ensure the tests and linter pass by running `bundle exec rake ci` in the gem subdirectory.
- [x] Update code documentation if necessary.

closes: #18234