### PR TITLE
fix: Fixed a crash when making certain long-running-operations status calls

### DIFF
--- a/google-cloud-ai_platform-v1/lib/google/cloud/ai_platform/v1/dataset_service/operations.rb
+++ b/google-cloud-ai_platform-v1/lib/google/cloud/ai_platform/v1/dataset_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-ai_platform-v1/lib/google/cloud/ai_platform/v1/endpoint_service/operations.rb
+++ b/google-cloud-ai_platform-v1/lib/google/cloud/ai_platform/v1/endpoint_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-ai_platform-v1/lib/google/cloud/ai_platform/v1/featurestore_service/operations.rb
+++ b/google-cloud-ai_platform-v1/lib/google/cloud/ai_platform/v1/featurestore_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-ai_platform-v1/lib/google/cloud/ai_platform/v1/index_endpoint_service/operations.rb
+++ b/google-cloud-ai_platform-v1/lib/google/cloud/ai_platform/v1/index_endpoint_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-ai_platform-v1/lib/google/cloud/ai_platform/v1/index_service/operations.rb
+++ b/google-cloud-ai_platform-v1/lib/google/cloud/ai_platform/v1/index_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-ai_platform-v1/lib/google/cloud/ai_platform/v1/job_service/operations.rb
+++ b/google-cloud-ai_platform-v1/lib/google/cloud/ai_platform/v1/job_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-ai_platform-v1/lib/google/cloud/ai_platform/v1/metadata_service/operations.rb
+++ b/google-cloud-ai_platform-v1/lib/google/cloud/ai_platform/v1/metadata_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-ai_platform-v1/lib/google/cloud/ai_platform/v1/migration_service/operations.rb
+++ b/google-cloud-ai_platform-v1/lib/google/cloud/ai_platform/v1/migration_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-ai_platform-v1/lib/google/cloud/ai_platform/v1/model_service/operations.rb
+++ b/google-cloud-ai_platform-v1/lib/google/cloud/ai_platform/v1/model_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-ai_platform-v1/lib/google/cloud/ai_platform/v1/pipeline_service/operations.rb
+++ b/google-cloud-ai_platform-v1/lib/google/cloud/ai_platform/v1/pipeline_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-ai_platform-v1/lib/google/cloud/ai_platform/v1/specialist_pool_service/operations.rb
+++ b/google-cloud-ai_platform-v1/lib/google/cloud/ai_platform/v1/specialist_pool_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-ai_platform-v1/lib/google/cloud/ai_platform/v1/tensorboard_service/operations.rb
+++ b/google-cloud-ai_platform-v1/lib/google/cloud/ai_platform/v1/tensorboard_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-ai_platform-v1/lib/google/cloud/ai_platform/v1/vizier_service/operations.rb
+++ b/google-cloud-ai_platform-v1/lib/google/cloud/ai_platform/v1/vizier_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-api_gateway-v1/lib/google/cloud/api_gateway/v1/api_gateway_service/operations.rb
+++ b/google-cloud-api_gateway-v1/lib/google/cloud/api_gateway/v1/api_gateway_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-apigee_registry-v1/lib/google/cloud/apigee_registry/v1/provisioning/operations.rb
+++ b/google-cloud-apigee_registry-v1/lib/google/cloud/apigee_registry/v1/provisioning/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-app_engine-v1/lib/google/cloud/app_engine/v1/applications/operations.rb
+++ b/google-cloud-app_engine-v1/lib/google/cloud/app_engine/v1/applications/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-app_engine-v1/lib/google/cloud/app_engine/v1/domain_mappings/operations.rb
+++ b/google-cloud-app_engine-v1/lib/google/cloud/app_engine/v1/domain_mappings/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-app_engine-v1/lib/google/cloud/app_engine/v1/instances/operations.rb
+++ b/google-cloud-app_engine-v1/lib/google/cloud/app_engine/v1/instances/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-app_engine-v1/lib/google/cloud/app_engine/v1/services/operations.rb
+++ b/google-cloud-app_engine-v1/lib/google/cloud/app_engine/v1/services/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-app_engine-v1/lib/google/cloud/app_engine/v1/versions/operations.rb
+++ b/google-cloud-app_engine-v1/lib/google/cloud/app_engine/v1/versions/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-artifact_registry-v1/lib/google/cloud/artifact_registry/v1/artifact_registry/operations.rb
+++ b/google-cloud-artifact_registry-v1/lib/google/cloud/artifact_registry/v1/artifact_registry/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-artifact_registry-v1beta2/lib/google/cloud/artifact_registry/v1beta2/artifact_registry/operations.rb
+++ b/google-cloud-artifact_registry-v1beta2/lib/google/cloud/artifact_registry/v1beta2/artifact_registry/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-asset-v1/lib/google/cloud/asset/v1/asset_service/operations.rb
+++ b/google-cloud-asset-v1/lib/google/cloud/asset/v1/asset_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-assured_workloads-v1/lib/google/cloud/assured_workloads/v1/assured_workloads_service/operations.rb
+++ b/google-cloud-assured_workloads-v1/lib/google/cloud/assured_workloads/v1/assured_workloads_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-assured_workloads-v1beta1/lib/google/cloud/assured_workloads/v1beta1/assured_workloads_service/operations.rb
+++ b/google-cloud-assured_workloads-v1beta1/lib/google/cloud/assured_workloads/v1beta1/assured_workloads_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-automl-v1/lib/google/cloud/automl/v1/automl/operations.rb
+++ b/google-cloud-automl-v1/lib/google/cloud/automl/v1/automl/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-automl-v1/lib/google/cloud/automl/v1/prediction_service/operations.rb
+++ b/google-cloud-automl-v1/lib/google/cloud/automl/v1/prediction_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-automl-v1beta1/lib/google/cloud/automl/v1beta1/automl/operations.rb
+++ b/google-cloud-automl-v1beta1/lib/google/cloud/automl/v1beta1/automl/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-automl-v1beta1/lib/google/cloud/automl/v1beta1/prediction_service/operations.rb
+++ b/google-cloud-automl-v1beta1/lib/google/cloud/automl/v1beta1/prediction_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-bare_metal_solution-v2/lib/google/cloud/bare_metal_solution/v2/bare_metal_solution/operations.rb
+++ b/google-cloud-bare_metal_solution-v2/lib/google/cloud/bare_metal_solution/v2/bare_metal_solution/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-batch-v1/lib/google/cloud/batch/v1/batch_service/operations.rb
+++ b/google-cloud-batch-v1/lib/google/cloud/batch/v1/batch_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-bigtable-admin-v2/lib/google/cloud/bigtable/admin/v2/bigtable_instance_admin/operations.rb
+++ b/google-cloud-bigtable-admin-v2/lib/google/cloud/bigtable/admin/v2/bigtable_instance_admin/operations.rb
@@ -96,6 +96,9 @@ module Google
                   channel_args: @config.channel_args,
                   interceptors: @config.interceptors
                 )
+
+                # Used by an LRO wrapper for some methods of this service
+                @operations_client = self
               end
 
               # Service calls

--- a/google-cloud-bigtable-admin-v2/lib/google/cloud/bigtable/admin/v2/bigtable_table_admin/operations.rb
+++ b/google-cloud-bigtable-admin-v2/lib/google/cloud/bigtable/admin/v2/bigtable_table_admin/operations.rb
@@ -96,6 +96,9 @@ module Google
                   channel_args: @config.channel_args,
                   interceptors: @config.interceptors
                 )
+
+                # Used by an LRO wrapper for some methods of this service
+                @operations_client = self
               end
 
               # Service calls

--- a/google-cloud-build-v1/lib/google/cloud/build/v1/cloud_build/operations.rb
+++ b/google-cloud-build-v1/lib/google/cloud/build/v1/cloud_build/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-certificate_manager-v1/lib/google/cloud/certificate_manager/v1/certificate_manager/operations.rb
+++ b/google-cloud-certificate_manager-v1/lib/google/cloud/certificate_manager/v1/certificate_manager/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-channel-v1/lib/google/cloud/channel/v1/cloud_channel_service/operations.rb
+++ b/google-cloud-channel-v1/lib/google/cloud/channel/v1/cloud_channel_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-cloud_dms-v1/lib/google/cloud/cloud_dms/v1/data_migration_service/operations.rb
+++ b/google-cloud-cloud_dms-v1/lib/google/cloud/cloud_dms/v1/data_migration_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-contact_center_insights-v1/lib/google/cloud/contact_center_insights/v1/contact_center_insights/operations.rb
+++ b/google-cloud-contact_center_insights-v1/lib/google/cloud/contact_center_insights/v1/contact_center_insights/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-data_fusion-v1/lib/google/cloud/data_fusion/v1/data_fusion/operations.rb
+++ b/google-cloud-data_fusion-v1/lib/google/cloud/data_fusion/v1/data_fusion/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-data_labeling-v1beta1/lib/google/cloud/data_labeling/v1beta1/data_labeling_service/operations.rb
+++ b/google-cloud-data_labeling-v1beta1/lib/google/cloud/data_labeling/v1beta1/data_labeling_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-dataplex-v1/lib/google/cloud/dataplex/v1/dataplex_service/operations.rb
+++ b/google-cloud-dataplex-v1/lib/google/cloud/dataplex/v1/dataplex_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-dataproc-v1/lib/google/cloud/dataproc/v1/batch_controller/operations.rb
+++ b/google-cloud-dataproc-v1/lib/google/cloud/dataproc/v1/batch_controller/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-dataproc-v1/lib/google/cloud/dataproc/v1/cluster_controller/operations.rb
+++ b/google-cloud-dataproc-v1/lib/google/cloud/dataproc/v1/cluster_controller/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-dataproc-v1/lib/google/cloud/dataproc/v1/job_controller/operations.rb
+++ b/google-cloud-dataproc-v1/lib/google/cloud/dataproc/v1/job_controller/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-dataproc-v1/lib/google/cloud/dataproc/v1/workflow_template_service/operations.rb
+++ b/google-cloud-dataproc-v1/lib/google/cloud/dataproc/v1/workflow_template_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-datastore-admin-v1/lib/google/cloud/datastore/admin/v1/datastore_admin/operations.rb
+++ b/google-cloud-datastore-admin-v1/lib/google/cloud/datastore/admin/v1/datastore_admin/operations.rb
@@ -96,6 +96,9 @@ module Google
                   channel_args: @config.channel_args,
                   interceptors: @config.interceptors
                 )
+
+                # Used by an LRO wrapper for some methods of this service
+                @operations_client = self
               end
 
               # Service calls

--- a/google-cloud-datastream-v1/lib/google/cloud/datastream/v1/datastream/operations.rb
+++ b/google-cloud-datastream-v1/lib/google/cloud/datastream/v1/datastream/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-datastream-v1alpha1/lib/google/cloud/datastream/v1alpha1/datastream/operations.rb
+++ b/google-cloud-datastream-v1alpha1/lib/google/cloud/datastream/v1alpha1/datastream/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-deploy-v1/lib/google/cloud/deploy/v1/cloud_deploy/operations.rb
+++ b/google-cloud-deploy-v1/lib/google/cloud/deploy/v1/cloud_deploy/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-dialogflow-cx-v3/lib/google/cloud/dialogflow/cx/v3/agents/operations.rb
+++ b/google-cloud-dialogflow-cx-v3/lib/google/cloud/dialogflow/cx/v3/agents/operations.rb
@@ -96,6 +96,9 @@ module Google
                   channel_args: @config.channel_args,
                   interceptors: @config.interceptors
                 )
+
+                # Used by an LRO wrapper for some methods of this service
+                @operations_client = self
               end
 
               # Service calls

--- a/google-cloud-dialogflow-cx-v3/lib/google/cloud/dialogflow/cx/v3/environments/operations.rb
+++ b/google-cloud-dialogflow-cx-v3/lib/google/cloud/dialogflow/cx/v3/environments/operations.rb
@@ -96,6 +96,9 @@ module Google
                   channel_args: @config.channel_args,
                   interceptors: @config.interceptors
                 )
+
+                # Used by an LRO wrapper for some methods of this service
+                @operations_client = self
               end
 
               # Service calls

--- a/google-cloud-dialogflow-cx-v3/lib/google/cloud/dialogflow/cx/v3/flows/operations.rb
+++ b/google-cloud-dialogflow-cx-v3/lib/google/cloud/dialogflow/cx/v3/flows/operations.rb
@@ -96,6 +96,9 @@ module Google
                   channel_args: @config.channel_args,
                   interceptors: @config.interceptors
                 )
+
+                # Used by an LRO wrapper for some methods of this service
+                @operations_client = self
               end
 
               # Service calls

--- a/google-cloud-dialogflow-cx-v3/lib/google/cloud/dialogflow/cx/v3/test_cases/operations.rb
+++ b/google-cloud-dialogflow-cx-v3/lib/google/cloud/dialogflow/cx/v3/test_cases/operations.rb
@@ -96,6 +96,9 @@ module Google
                   channel_args: @config.channel_args,
                   interceptors: @config.interceptors
                 )
+
+                # Used by an LRO wrapper for some methods of this service
+                @operations_client = self
               end
 
               # Service calls

--- a/google-cloud-dialogflow-cx-v3/lib/google/cloud/dialogflow/cx/v3/versions/operations.rb
+++ b/google-cloud-dialogflow-cx-v3/lib/google/cloud/dialogflow/cx/v3/versions/operations.rb
@@ -96,6 +96,9 @@ module Google
                   channel_args: @config.channel_args,
                   interceptors: @config.interceptors
                 )
+
+                # Used by an LRO wrapper for some methods of this service
+                @operations_client = self
               end
 
               # Service calls

--- a/google-cloud-dialogflow-v2/lib/google/cloud/dialogflow/v2/agents/operations.rb
+++ b/google-cloud-dialogflow-v2/lib/google/cloud/dialogflow/v2/agents/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-dialogflow-v2/lib/google/cloud/dialogflow/v2/conversation_datasets/operations.rb
+++ b/google-cloud-dialogflow-v2/lib/google/cloud/dialogflow/v2/conversation_datasets/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-dialogflow-v2/lib/google/cloud/dialogflow/v2/conversation_models/operations.rb
+++ b/google-cloud-dialogflow-v2/lib/google/cloud/dialogflow/v2/conversation_models/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-dialogflow-v2/lib/google/cloud/dialogflow/v2/conversation_profiles/operations.rb
+++ b/google-cloud-dialogflow-v2/lib/google/cloud/dialogflow/v2/conversation_profiles/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-dialogflow-v2/lib/google/cloud/dialogflow/v2/documents/operations.rb
+++ b/google-cloud-dialogflow-v2/lib/google/cloud/dialogflow/v2/documents/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-dialogflow-v2/lib/google/cloud/dialogflow/v2/entity_types/operations.rb
+++ b/google-cloud-dialogflow-v2/lib/google/cloud/dialogflow/v2/entity_types/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-dialogflow-v2/lib/google/cloud/dialogflow/v2/intents/operations.rb
+++ b/google-cloud-dialogflow-v2/lib/google/cloud/dialogflow/v2/intents/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-document_ai-v1/lib/google/cloud/document_ai/v1/document_processor_service/operations.rb
+++ b/google-cloud-document_ai-v1/lib/google/cloud/document_ai/v1/document_processor_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-document_ai-v1beta3/lib/google/cloud/document_ai/v1beta3/document_processor_service/operations.rb
+++ b/google-cloud-document_ai-v1beta3/lib/google/cloud/document_ai/v1beta3/document_processor_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-domains-v1/lib/google/cloud/domains/v1/domains/operations.rb
+++ b/google-cloud-domains-v1/lib/google/cloud/domains/v1/domains/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-domains-v1beta1/lib/google/cloud/domains/v1beta1/domains/operations.rb
+++ b/google-cloud-domains-v1beta1/lib/google/cloud/domains/v1beta1/domains/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-eventarc-v1/lib/google/cloud/eventarc/v1/eventarc/operations.rb
+++ b/google-cloud-eventarc-v1/lib/google/cloud/eventarc/v1/eventarc/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-filestore-v1/lib/google/cloud/filestore/v1/cloud_filestore_manager/operations.rb
+++ b/google-cloud-filestore-v1/lib/google/cloud/filestore/v1/cloud_filestore_manager/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-firestore-admin-v1/lib/google/cloud/firestore/admin/v1/firestore_admin/operations.rb
+++ b/google-cloud-firestore-admin-v1/lib/google/cloud/firestore/admin/v1/firestore_admin/operations.rb
@@ -96,6 +96,9 @@ module Google
                   channel_args: @config.channel_args,
                   interceptors: @config.interceptors
                 )
+
+                # Used by an LRO wrapper for some methods of this service
+                @operations_client = self
               end
 
               # Service calls

--- a/google-cloud-functions-v1/lib/google/cloud/functions/v1/cloud_functions_service/operations.rb
+++ b/google-cloud-functions-v1/lib/google/cloud/functions/v1/cloud_functions_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-gaming-v1/lib/google/cloud/gaming/v1/game_server_clusters_service/operations.rb
+++ b/google-cloud-gaming-v1/lib/google/cloud/gaming/v1/game_server_clusters_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-gaming-v1/lib/google/cloud/gaming/v1/game_server_configs_service/operations.rb
+++ b/google-cloud-gaming-v1/lib/google/cloud/gaming/v1/game_server_configs_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-gaming-v1/lib/google/cloud/gaming/v1/game_server_deployments_service/operations.rb
+++ b/google-cloud-gaming-v1/lib/google/cloud/gaming/v1/game_server_deployments_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-gaming-v1/lib/google/cloud/gaming/v1/realms_service/operations.rb
+++ b/google-cloud-gaming-v1/lib/google/cloud/gaming/v1/realms_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-gke_backup-v1/lib/google/cloud/gke_backup/v1/backup_for_gke/operations.rb
+++ b/google-cloud-gke_backup-v1/lib/google/cloud/gke_backup/v1/backup_for_gke/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-gke_hub-v1/lib/google/cloud/gke_hub/v1/gke_hub/operations.rb
+++ b/google-cloud-gke_hub-v1/lib/google/cloud/gke_hub/v1/gke_hub/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-gke_hub-v1beta1/lib/google/cloud/gke_hub/v1beta1/gke_hub_membership_service/operations.rb
+++ b/google-cloud-gke_hub-v1beta1/lib/google/cloud/gke_hub/v1beta1/gke_hub_membership_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-gke_multi_cloud-v1/lib/google/cloud/gke_multi_cloud/v1/aws_clusters/operations.rb
+++ b/google-cloud-gke_multi_cloud-v1/lib/google/cloud/gke_multi_cloud/v1/aws_clusters/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-gke_multi_cloud-v1/lib/google/cloud/gke_multi_cloud/v1/azure_clusters/operations.rb
+++ b/google-cloud-gke_multi_cloud-v1/lib/google/cloud/gke_multi_cloud/v1/azure_clusters/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-ids-v1/lib/google/cloud/ids/v1/ids/operations.rb
+++ b/google-cloud-ids-v1/lib/google/cloud/ids/v1/ids/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-life_sciences-v2beta/lib/google/cloud/life_sciences/v2beta/workflows_service/operations.rb
+++ b/google-cloud-life_sciences-v2beta/lib/google/cloud/life_sciences/v2beta/workflows_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-logging-v2/lib/google/cloud/logging/v2/config_service/operations.rb
+++ b/google-cloud-logging-v2/lib/google/cloud/logging/v2/config_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-managed_identities-v1/lib/google/cloud/managed_identities/v1/managed_identities_service/operations.rb
+++ b/google-cloud-managed_identities-v1/lib/google/cloud/managed_identities/v1/managed_identities_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-memcache-v1/lib/google/cloud/memcache/v1/cloud_memcache/operations.rb
+++ b/google-cloud-memcache-v1/lib/google/cloud/memcache/v1/cloud_memcache/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-memcache-v1beta2/lib/google/cloud/memcache/v1beta2/cloud_memcache/operations.rb
+++ b/google-cloud-memcache-v1beta2/lib/google/cloud/memcache/v1beta2/cloud_memcache/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-metastore-v1/lib/google/cloud/metastore/v1/dataproc_metastore/operations.rb
+++ b/google-cloud-metastore-v1/lib/google/cloud/metastore/v1/dataproc_metastore/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-metastore-v1beta/lib/google/cloud/metastore/v1beta/dataproc_metastore/operations.rb
+++ b/google-cloud-metastore-v1beta/lib/google/cloud/metastore/v1beta/dataproc_metastore/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-monitoring-metrics_scope-v1/lib/google/cloud/monitoring/metrics_scope/v1/metrics_scopes/operations.rb
+++ b/google-cloud-monitoring-metrics_scope-v1/lib/google/cloud/monitoring/metrics_scope/v1/metrics_scopes/operations.rb
@@ -96,6 +96,9 @@ module Google
                   channel_args: @config.channel_args,
                   interceptors: @config.interceptors
                 )
+
+                # Used by an LRO wrapper for some methods of this service
+                @operations_client = self
               end
 
               # Service calls

--- a/google-cloud-network_connectivity-v1/lib/google/cloud/network_connectivity/v1/hub_service/operations.rb
+++ b/google-cloud-network_connectivity-v1/lib/google/cloud/network_connectivity/v1/hub_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-network_connectivity-v1alpha1/lib/google/cloud/network_connectivity/v1alpha1/hub_service/operations.rb
+++ b/google-cloud-network_connectivity-v1alpha1/lib/google/cloud/network_connectivity/v1alpha1/hub_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-network_management-v1/lib/google/cloud/network_management/v1/reachability_service/operations.rb
+++ b/google-cloud-network_management-v1/lib/google/cloud/network_management/v1/reachability_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-network_security-v1beta1/lib/google/cloud/network_security/v1beta1/network_security/operations.rb
+++ b/google-cloud-network_security-v1beta1/lib/google/cloud/network_security/v1beta1/network_security/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-notebooks-v1/lib/google/cloud/notebooks/v1/managed_notebook_service/operations.rb
+++ b/google-cloud-notebooks-v1/lib/google/cloud/notebooks/v1/managed_notebook_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-notebooks-v1/lib/google/cloud/notebooks/v1/notebook_service/operations.rb
+++ b/google-cloud-notebooks-v1/lib/google/cloud/notebooks/v1/notebook_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-notebooks-v1beta1/lib/google/cloud/notebooks/v1beta1/notebook_service/operations.rb
+++ b/google-cloud-notebooks-v1beta1/lib/google/cloud/notebooks/v1beta1/notebook_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-optimization-v1/lib/google/cloud/optimization/v1/fleet_routing/operations.rb
+++ b/google-cloud-optimization-v1/lib/google/cloud/optimization/v1/fleet_routing/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-orchestration-airflow-service-v1/lib/google/cloud/orchestration/airflow/service/v1/environments/operations.rb
+++ b/google-cloud-orchestration-airflow-service-v1/lib/google/cloud/orchestration/airflow/service/v1/environments/operations.rb
@@ -97,6 +97,9 @@ module Google
                     channel_args: @config.channel_args,
                     interceptors: @config.interceptors
                   )
+
+                  # Used by an LRO wrapper for some methods of this service
+                  @operations_client = self
                 end
 
                 # Service calls

--- a/google-cloud-os_config-v1/lib/google/cloud/os_config/v1/os_config_zonal_service/operations.rb
+++ b/google-cloud-os_config-v1/lib/google/cloud/os_config/v1/os_config_zonal_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-os_config-v1alpha/lib/google/cloud/os_config/v1alpha/os_config_zonal_service/operations.rb
+++ b/google-cloud-os_config-v1alpha/lib/google/cloud/os_config/v1alpha/os_config_zonal_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-recommendation_engine-v1beta1/lib/google/cloud/recommendation_engine/v1beta1/catalog_service/operations.rb
+++ b/google-cloud-recommendation_engine-v1beta1/lib/google/cloud/recommendation_engine/v1beta1/catalog_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-recommendation_engine-v1beta1/lib/google/cloud/recommendation_engine/v1beta1/user_event_service/operations.rb
+++ b/google-cloud-recommendation_engine-v1beta1/lib/google/cloud/recommendation_engine/v1beta1/user_event_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-redis-v1/lib/google/cloud/redis/v1/cloud_redis/operations.rb
+++ b/google-cloud-redis-v1/lib/google/cloud/redis/v1/cloud_redis/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-redis-v1beta1/lib/google/cloud/redis/v1beta1/cloud_redis/operations.rb
+++ b/google-cloud-redis-v1beta1/lib/google/cloud/redis/v1beta1/cloud_redis/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-resource_manager-v3/lib/google/cloud/resource_manager/v3/folders/operations.rb
+++ b/google-cloud-resource_manager-v3/lib/google/cloud/resource_manager/v3/folders/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-resource_manager-v3/lib/google/cloud/resource_manager/v3/projects/operations.rb
+++ b/google-cloud-resource_manager-v3/lib/google/cloud/resource_manager/v3/projects/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-resource_manager-v3/lib/google/cloud/resource_manager/v3/tag_bindings/operations.rb
+++ b/google-cloud-resource_manager-v3/lib/google/cloud/resource_manager/v3/tag_bindings/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-resource_manager-v3/lib/google/cloud/resource_manager/v3/tag_keys/operations.rb
+++ b/google-cloud-resource_manager-v3/lib/google/cloud/resource_manager/v3/tag_keys/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-resource_manager-v3/lib/google/cloud/resource_manager/v3/tag_values/operations.rb
+++ b/google-cloud-resource_manager-v3/lib/google/cloud/resource_manager/v3/tag_values/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-retail-v2/lib/google/cloud/retail/v2/completion_service/operations.rb
+++ b/google-cloud-retail-v2/lib/google/cloud/retail/v2/completion_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-retail-v2/lib/google/cloud/retail/v2/product_service/operations.rb
+++ b/google-cloud-retail-v2/lib/google/cloud/retail/v2/product_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-retail-v2/lib/google/cloud/retail/v2/user_event_service/operations.rb
+++ b/google-cloud-retail-v2/lib/google/cloud/retail/v2/user_event_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-run-v2/lib/google/cloud/run/v2/revisions/operations.rb
+++ b/google-cloud-run-v2/lib/google/cloud/run/v2/revisions/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-run-v2/lib/google/cloud/run/v2/services/operations.rb
+++ b/google-cloud-run-v2/lib/google/cloud/run/v2/services/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-security-private_ca-v1/lib/google/cloud/security/private_ca/v1/certificate_authority_service/operations.rb
+++ b/google-cloud-security-private_ca-v1/lib/google/cloud/security/private_ca/v1/certificate_authority_service/operations.rb
@@ -96,6 +96,9 @@ module Google
                   channel_args: @config.channel_args,
                   interceptors: @config.interceptors
                 )
+
+                # Used by an LRO wrapper for some methods of this service
+                @operations_client = self
               end
 
               # Service calls

--- a/google-cloud-security-private_ca-v1beta1/lib/google/cloud/security/private_ca/v1beta1/certificate_authority_service/operations.rb
+++ b/google-cloud-security-private_ca-v1beta1/lib/google/cloud/security/private_ca/v1beta1/certificate_authority_service/operations.rb
@@ -96,6 +96,9 @@ module Google
                   channel_args: @config.channel_args,
                   interceptors: @config.interceptors
                 )
+
+                # Used by an LRO wrapper for some methods of this service
+                @operations_client = self
               end
 
               # Service calls

--- a/google-cloud-security_center-v1/lib/google/cloud/security_center/v1/security_center/operations.rb
+++ b/google-cloud-security_center-v1/lib/google/cloud/security_center/v1/security_center/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-security_center-v1p1beta1/lib/google/cloud/security_center/v1p1beta1/security_center/operations.rb
+++ b/google-cloud-security_center-v1p1beta1/lib/google/cloud/security_center/v1p1beta1/security_center/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-service_management-v1/lib/google/cloud/service_management/v1/service_manager/operations.rb
+++ b/google-cloud-service_management-v1/lib/google/cloud/service_management/v1/service_manager/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-service_usage-v1/lib/google/cloud/service_usage/v1/service_usage/operations.rb
+++ b/google-cloud-service_usage-v1/lib/google/cloud/service_usage/v1/service_usage/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-shell-v1/lib/google/cloud/shell/v1/cloud_shell_service/operations.rb
+++ b/google-cloud-shell-v1/lib/google/cloud/shell/v1/cloud_shell_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-spanner-admin-database-v1/lib/google/cloud/spanner/admin/database/v1/database_admin/operations.rb
+++ b/google-cloud-spanner-admin-database-v1/lib/google/cloud/spanner/admin/database/v1/database_admin/operations.rb
@@ -97,6 +97,9 @@ module Google
                     channel_args: @config.channel_args,
                     interceptors: @config.interceptors
                   )
+
+                  # Used by an LRO wrapper for some methods of this service
+                  @operations_client = self
                 end
 
                 # Service calls

--- a/google-cloud-spanner-admin-instance-v1/lib/google/cloud/spanner/admin/instance/v1/instance_admin/operations.rb
+++ b/google-cloud-spanner-admin-instance-v1/lib/google/cloud/spanner/admin/instance/v1/instance_admin/operations.rb
@@ -97,6 +97,9 @@ module Google
                     channel_args: @config.channel_args,
                     interceptors: @config.interceptors
                   )
+
+                  # Used by an LRO wrapper for some methods of this service
+                  @operations_client = self
                 end
 
                 # Service calls

--- a/google-cloud-speech-v1/lib/google/cloud/speech/v1/speech/operations.rb
+++ b/google-cloud-speech-v1/lib/google/cloud/speech/v1/speech/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-speech-v1p1beta1/lib/google/cloud/speech/v1p1beta1/speech/operations.rb
+++ b/google-cloud-speech-v1p1beta1/lib/google/cloud/speech/v1p1beta1/speech/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-storage_transfer-v1/lib/google/cloud/storage_transfer/v1/storage_transfer_service/operations.rb
+++ b/google-cloud-storage_transfer-v1/lib/google/cloud/storage_transfer/v1/storage_transfer_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-talent-v4/lib/google/cloud/talent/v4/job_service/operations.rb
+++ b/google-cloud-talent-v4/lib/google/cloud/talent/v4/job_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-talent-v4beta1/lib/google/cloud/talent/v4beta1/job_service/operations.rb
+++ b/google-cloud-talent-v4beta1/lib/google/cloud/talent/v4beta1/job_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-tpu-v1/lib/google/cloud/tpu/v1/tpu/operations.rb
+++ b/google-cloud-tpu-v1/lib/google/cloud/tpu/v1/tpu/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-translate-v3/lib/google/cloud/translate/v3/translation_service/operations.rb
+++ b/google-cloud-translate-v3/lib/google/cloud/translate/v3/translation_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-video-live_stream-v1/lib/google/cloud/video/live_stream/v1/livestream_service/operations.rb
+++ b/google-cloud-video-live_stream-v1/lib/google/cloud/video/live_stream/v1/livestream_service/operations.rb
@@ -96,6 +96,9 @@ module Google
                   channel_args: @config.channel_args,
                   interceptors: @config.interceptors
                 )
+
+                # Used by an LRO wrapper for some methods of this service
+                @operations_client = self
               end
 
               # Service calls

--- a/google-cloud-video_intelligence-v1/lib/google/cloud/video_intelligence/v1/video_intelligence_service/operations.rb
+++ b/google-cloud-video_intelligence-v1/lib/google/cloud/video_intelligence/v1/video_intelligence_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-video_intelligence-v1beta2/lib/google/cloud/video_intelligence/v1beta2/video_intelligence_service/operations.rb
+++ b/google-cloud-video_intelligence-v1beta2/lib/google/cloud/video_intelligence/v1beta2/video_intelligence_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-video_intelligence-v1p1beta1/lib/google/cloud/video_intelligence/v1p1beta1/video_intelligence_service/operations.rb
+++ b/google-cloud-video_intelligence-v1p1beta1/lib/google/cloud/video_intelligence/v1p1beta1/video_intelligence_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-video_intelligence-v1p2beta1/lib/google/cloud/video_intelligence/v1p2beta1/video_intelligence_service/operations.rb
+++ b/google-cloud-video_intelligence-v1p2beta1/lib/google/cloud/video_intelligence/v1p2beta1/video_intelligence_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-video_intelligence-v1p3beta1/lib/google/cloud/video_intelligence/v1p3beta1/video_intelligence_service/operations.rb
+++ b/google-cloud-video_intelligence-v1p3beta1/lib/google/cloud/video_intelligence/v1p3beta1/video_intelligence_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-vision-v1/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/google-cloud-vision-v1/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-vision-v1/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/google-cloud-vision-v1/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-vision-v1p3beta1/lib/google/cloud/vision/v1p3beta1/image_annotator/operations.rb
+++ b/google-cloud-vision-v1p3beta1/lib/google/cloud/vision/v1p3beta1/image_annotator/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-vision-v1p3beta1/lib/google/cloud/vision/v1p3beta1/product_search/operations.rb
+++ b/google-cloud-vision-v1p3beta1/lib/google/cloud/vision/v1p3beta1/product_search/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-vision-v1p4beta1/lib/google/cloud/vision/v1p4beta1/image_annotator/operations.rb
+++ b/google-cloud-vision-v1p4beta1/lib/google/cloud/vision/v1p4beta1/image_annotator/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-vision-v1p4beta1/lib/google/cloud/vision/v1p4beta1/product_search/operations.rb
+++ b/google-cloud-vision-v1p4beta1/lib/google/cloud/vision/v1p4beta1/product_search/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-vm_migration-v1/lib/google/cloud/vm_migration/v1/vm_migration/operations.rb
+++ b/google-cloud-vm_migration-v1/lib/google/cloud/vm_migration/v1/vm_migration/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-vpc_access-v1/lib/google/cloud/vpc_access/v1/vpc_access_service/operations.rb
+++ b/google-cloud-vpc_access-v1/lib/google/cloud/vpc_access/v1/vpc_access_service/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-workflows-v1/lib/google/cloud/workflows/v1/workflows/operations.rb
+++ b/google-cloud-workflows-v1/lib/google/cloud/workflows/v1/workflows/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-cloud-workflows-v1beta/lib/google/cloud/workflows/v1beta/workflows/operations.rb
+++ b/google-cloud-workflows-v1beta/lib/google/cloud/workflows/v1beta/workflows/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls

--- a/google-iam-v1beta/lib/google/iam/v1beta/workload_identity_pools/operations.rb
+++ b/google-iam-v1beta/lib/google/iam/v1beta/workload_identity_pools/operations.rb
@@ -94,6 +94,9 @@ module Google
               channel_args: @config.channel_args,
               interceptors: @config.interceptors
             )
+
+            # Used by an LRO wrapper for some methods of this service
+            @operations_client = self
           end
 
           # Service calls

--- a/google-identity-access_context_manager-v1/lib/google/identity/access_context_manager/v1/access_context_manager/operations.rb
+++ b/google-identity-access_context_manager-v1/lib/google/identity/access_context_manager/v1/access_context_manager/operations.rb
@@ -95,6 +95,9 @@ module Google
                 channel_args: @config.channel_args,
                 interceptors: @config.interceptors
               )
+
+              # Used by an LRO wrapper for some methods of this service
+              @operations_client = self
             end
 
             # Service calls


### PR DESCRIPTION
These come from a fix done in the generator, and were extracted from an owlbot PR, into a separate PR for conventional commit purposes.