### PR TITLE
feat: Update minimum Ruby version to 2.6

### DIFF
--- a/google-cloud-logging/README.md
+++ b/google-cloud-logging/README.md
@@ -182,14 +182,14 @@ end
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.5+.
+This library is supported on Ruby 2.6+.
 
 Google provides official support for Ruby versions that are actively supported
-by Ruby Core—that is, Ruby versions that are either in normal maintenance or in
-security maintenance, and not end of life. Currently, this means Ruby 2.5 and
-later. Older versions of Ruby _may_ still work, but are unsupported and not
-recommended. See https://www.ruby-lang.org/en/downloads/branches/ for details
-about the Ruby support schedule.
+by Ruby Core—that is, Ruby versions that are either in normal maintenance or
+in security maintenance, and not end of life. Older versions of Ruby _may_
+still work, but are unsupported and not recommended. See
+https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby
+support schedule.
 
 ## Versioning
 

--- a/google-cloud-logging/google-cloud-logging.gemspec
+++ b/google-cloud-logging/google-cloud-logging.gemspec
@@ -16,15 +16,15 @@ Gem::Specification.new do |gem|
                       ["OVERVIEW.md", "AUTHENTICATION.md", "INSTRUMENTATION.md", "LOGGING.md", "CONTRIBUTING.md", "TROUBLESHOOTING.md", "CHANGELOG.md", "CODE_OF_CONDUCT.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.5"
+  gem.required_ruby_version = ">= 2.6"
 
   gem.add_dependency "google-cloud-core", "~> 1.5"
   gem.add_dependency "google-cloud-logging-v2", "~> 0.0"
   gem.add_dependency "stackdriver-core", "~> 1.3"
   gem.add_dependency "concurrent-ruby", "~> 1.1"
 
-  gem.add_development_dependency "google-style", "~> 1.25.1"
-  gem.add_development_dependency "minitest", "~> 5.14"
+  gem.add_development_dependency "google-style", "~> 1.26.1"
+  gem.add_development_dependency "minitest", "~> 5.16"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"
   gem.add_development_dependency "minitest-focus", "~> 1.1"
   gem.add_development_dependency "minitest-rg", "~> 5.2"

--- a/google-cloud-logging/lib/google/cloud/logging/convert.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/convert.rb
@@ -24,7 +24,7 @@ module Google
         def self.hash_to_struct hash
           # TODO: ArgumentError if hash is not a Hash
           Google::Protobuf::Struct.new \
-            fields: Hash[hash.map { |k, v| [String(k), object_to_value(v)] }]
+            fields: hash.to_h { |k, v| [String(k), object_to_value(v)] }
         end
 
         ##
@@ -65,8 +65,7 @@ module Google
           if map.respond_to? :to_h
             map.to_h
           else
-            # Enumerable doesn't have to_h on ruby 2.0...
-            Hash[map.to_a]
+            map.to_a.to_h
           end
         end
       end

--- a/google-cloud-logging/lib/google/cloud/logging/entry.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/entry.rb
@@ -487,10 +487,10 @@ module Google
         def labels_grpc
           return {} if labels.nil?
           # Coerce symbols to strings
-          Hash[labels.map do |k, v|
+          labels.to_h do |k, v|
             v = String(v) if v.is_a? Symbol
             [String(k), v]
-          end]
+          end
         end
 
         ##

--- a/google-cloud-logging/lib/google/cloud/logging/rails.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/rails.rb
@@ -205,15 +205,15 @@ module Google
             end
           rescue Exception => e # rubocop:disable Lint/RescueException
             $stdout.puts "Note: Google::Cloud::Logging is disabled because " \
-              "it failed to authorize with the service. (#{e.message}) " \
-              "Falling back to the default Rails logger."
+                         "it failed to authorize with the service. (#{e.message}) " \
+                         "Falling back to the default Rails logger."
             return false
           end
 
           if project_id.to_s.empty?
             $stdout.puts "Note: Google::Cloud::Logging is disabled because " \
-              "the project ID could not be determined. " \
-              "Falling back to the default Rails logger."
+                         "the project ID could not be determined. " \
+                         "Falling back to the default Rails logger."
             return false
           end
 

--- a/google-cloud-logging/lib/google/cloud/logging/resource.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/resource.rb
@@ -66,7 +66,7 @@ module Google
           return nil if empty?
           Google::Api::MonitoredResource.new(
             type:   type,
-            labels: Hash[labels.map { |k, v| [String(k), String(v)] }]
+            labels: labels.to_h { |k, v| [String(k), String(v)] }
           )
         end
 

--- a/google-cloud-logging/lib/google/cloud/logging/service.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/service.rb
@@ -102,7 +102,7 @@ module Google
             entry.log_name = log_path entry.log_name
           end
           resource = resource.to_grpc if resource
-          labels = Hash[labels.map { |k, v| [String(k), String(v)] }] if labels
+          labels = labels.to_h { |k, v| [String(k), String(v)] } if labels
           logging.write_log_entries entries:         entries,
                                     log_name:        log_path(log_name),
                                     resource:        resource,

--- a/google-cloud-logging/samples/sample.rb
+++ b/google-cloud-logging/samples/sample.rb
@@ -15,10 +15,7 @@
 def create_logging_client
   require "google/cloud/logging"
 
-  logging = Google::Cloud::Logging.new
-
-  puts "Created #{logging}"
-  logging
+  Google::Cloud::Logging.new
 end
 
 def list_log_sinks

--- a/google-cloud-logging/test/google/cloud/logging/async_writer_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/async_writer_test.rb
@@ -54,7 +54,9 @@ describe Google::Cloud::Logging::AsyncWriter, :mock_logging do
         labels: labels
       )
     end
-    [entries: entries, log_name: nil, resource: nil, labels: nil, partial_success: true]
+    {
+      entries: entries, log_name: nil, resource: nil, labels: nil, partial_success: true
+    }
   end
 
   it "does not raise error on empty entries" do
@@ -82,7 +84,7 @@ describe Google::Cloud::Logging::AsyncWriter, :mock_logging do
     mock = Minitest::Mock.new
     logging.service.mocked_logging = mock
 
-    mock.expect :write_log_entries, write_res, write_req_args("payload1")
+    mock.expect :write_log_entries, write_res, **write_req_args("payload1")
 
     async_writer.write_entries(
       entries("payload1"),
@@ -100,7 +102,7 @@ describe Google::Cloud::Logging::AsyncWriter, :mock_logging do
     mock = Minitest::Mock.new
     logging.service.mocked_logging = mock
 
-    mock.expect :write_log_entries, write_res, write_req_args(["payload1", "payload2"], labels1)
+    mock.expect :write_log_entries, write_res, **write_req_args(["payload1", "payload2"], labels1)
 
     async_writer.write_entries(
       entries("payload1"),
@@ -127,10 +129,10 @@ describe Google::Cloud::Logging::AsyncWriter, :mock_logging do
     payload1_request = write_req_args(["payload1"], labels1)
     payload2_request = write_req_args("payload2", labels2)
     combined_request = payload1_request.dup.tap do |req|
-      req.first[:entries].concat payload2_request.first[:entries]
+      req[:entries].concat payload2_request[:entries]
     end
 
-    mock.expect :write_log_entries, write_res, combined_request
+    mock.expect :write_log_entries, write_res, **combined_request
 
     async_writer.write_entries(
       entries("payload1", labels1),

--- a/google-cloud-logging/test/google/cloud/logging/logger/add_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/add_test.rb
@@ -39,7 +39,13 @@ describe Google::Cloud::Logging::Logger, :add, :mock_logging do
                                                  text_payload: "Danger Will Robinson!",
                                                  severity: severity,
                                                  timestamp: timestamp_grpc)]
-    [entries: entries, log_name: "projects/test/logs/web_app_log", resource: resource.to_grpc, labels: labels, partial_success: nil]
+    {
+      entries: entries,
+      log_name: "projects/test/logs/web_app_log",
+      resource: resource.to_grpc,
+      labels: labels,
+      partial_success: nil
+    }
   end
 
   def apply_stubs
@@ -52,7 +58,7 @@ describe Google::Cloud::Logging::Logger, :add, :mock_logging do
 
   before do
     @mock = Minitest::Mock.new
-    @mock.expect :write_log_entries, write_res, write_req_args
+    @mock.expect :write_log_entries, write_res, **write_req_args
     logging.service.mocked_logging = @mock
   end
 

--- a/google-cloud-logging/test/google/cloud/logging/logger/debug_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/debug_test.rb
@@ -37,7 +37,13 @@ describe Google::Cloud::Logging::Logger, :debug, :mock_logging do
                                                  text_payload: "Danger Will Robinson!",
                                                  severity: severity,
                                                  timestamp: timestamp_grpc)]
-    [entries: entries, log_name: "projects/test/logs/web_app_log", resource: resource.to_grpc, labels: labels, partial_success: nil]
+    {
+      entries: entries,
+      log_name: "projects/test/logs/web_app_log",
+      resource: resource.to_grpc,
+      labels: labels,
+      partial_success: nil
+    }
   end
 
   def apply_stubs
@@ -62,7 +68,7 @@ describe Google::Cloud::Logging::Logger, :debug, :mock_logging do
 
   it "creates a log entry with #debug" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:DEBUG)
+    mock.expect :write_log_entries, write_res, **write_req_args(:DEBUG)
     logging.service.mocked_logging = mock
 
     apply_stubs do
@@ -74,7 +80,7 @@ describe Google::Cloud::Logging::Logger, :debug, :mock_logging do
 
   it "creates a log entry with #info" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:INFO)
+    mock.expect :write_log_entries, write_res, **write_req_args(:INFO)
     logging.service.mocked_logging = mock
 
     apply_stubs do
@@ -86,7 +92,7 @@ describe Google::Cloud::Logging::Logger, :debug, :mock_logging do
 
   it "creates a log entry with #warn" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:WARNING)
+    mock.expect :write_log_entries, write_res, **write_req_args(:WARNING)
     logging.service.mocked_logging = mock
 
     apply_stubs do
@@ -98,7 +104,7 @@ describe Google::Cloud::Logging::Logger, :debug, :mock_logging do
 
   it "creates a log entry with #error" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:ERROR)
+    mock.expect :write_log_entries, write_res, **write_req_args(:ERROR)
     logging.service.mocked_logging = mock
 
     apply_stubs do
@@ -110,7 +116,7 @@ describe Google::Cloud::Logging::Logger, :debug, :mock_logging do
 
   it "creates a log entry with #fatal" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:CRITICAL)
+    mock.expect :write_log_entries, write_res, **write_req_args(:CRITICAL)
     logging.service.mocked_logging = mock
 
     apply_stubs do
@@ -122,7 +128,7 @@ describe Google::Cloud::Logging::Logger, :debug, :mock_logging do
 
   it "creates a log entry with #unknown" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:DEFAULT)
+    mock.expect :write_log_entries, write_res, **write_req_args(:DEFAULT)
     logging.service.mocked_logging = mock
 
     apply_stubs do
@@ -134,7 +140,7 @@ describe Google::Cloud::Logging::Logger, :debug, :mock_logging do
 
   it "creates a log entry with #debug with a block" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:DEBUG)
+    mock.expect :write_log_entries, write_res, **write_req_args(:DEBUG)
     logging.service.mocked_logging = mock
 
     apply_stubs do
@@ -146,7 +152,7 @@ describe Google::Cloud::Logging::Logger, :debug, :mock_logging do
 
   it "creates a log entry with #info with a block" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:INFO)
+    mock.expect :write_log_entries, write_res, **write_req_args(:INFO)
     logging.service.mocked_logging = mock
 
     apply_stubs do
@@ -158,7 +164,7 @@ describe Google::Cloud::Logging::Logger, :debug, :mock_logging do
 
   it "creates a log entry with #warn with a block" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:WARNING)
+    mock.expect :write_log_entries, write_res, **write_req_args(:WARNING)
     logging.service.mocked_logging = mock
 
     apply_stubs do
@@ -170,7 +176,7 @@ describe Google::Cloud::Logging::Logger, :debug, :mock_logging do
 
   it "creates a log entry with #error with a block" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:ERROR)
+    mock.expect :write_log_entries, write_res, **write_req_args(:ERROR)
     logging.service.mocked_logging = mock
 
     apply_stubs do
@@ -182,7 +188,7 @@ describe Google::Cloud::Logging::Logger, :debug, :mock_logging do
 
   it "creates a log entry with #fatal with a block" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:CRITICAL)
+    mock.expect :write_log_entries, write_res, **write_req_args(:CRITICAL)
     logging.service.mocked_logging = mock
 
     apply_stubs do
@@ -194,7 +200,7 @@ describe Google::Cloud::Logging::Logger, :debug, :mock_logging do
 
   it "creates a log entry with #unknown with a block" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:DEFAULT)
+    mock.expect :write_log_entries, write_res, **write_req_args(:DEFAULT)
     logging.service.mocked_logging = mock
 
     apply_stubs do

--- a/google-cloud-logging/test/google/cloud/logging/logger/error_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/error_test.rb
@@ -37,7 +37,13 @@ describe Google::Cloud::Logging::Logger, :error, :mock_logging do
                                                  text_payload: "Danger Will Robinson!",
                                                  severity: severity,
                                                  timestamp: timestamp_grpc)]
-    [entries: entries, log_name: "projects/test/logs/web_app_log", resource: resource.to_grpc, labels: labels, partial_success: nil]
+    {
+      entries: entries,
+      log_name: "projects/test/logs/web_app_log",
+      resource: resource.to_grpc,
+      labels: labels,
+      partial_success: nil
+    }
   end
 
   def apply_stubs
@@ -74,7 +80,7 @@ describe Google::Cloud::Logging::Logger, :error, :mock_logging do
 
   it "creates a log entry with #error" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:ERROR)
+    mock.expect :write_log_entries, write_res, **write_req_args(:ERROR)
     logging.service.mocked_logging = mock
 
     apply_stubs do
@@ -86,7 +92,7 @@ describe Google::Cloud::Logging::Logger, :error, :mock_logging do
 
   it "creates a log entry with #fatal" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:CRITICAL)
+    mock.expect :write_log_entries, write_res, **write_req_args(:CRITICAL)
     logging.service.mocked_logging = mock
 
     apply_stubs do
@@ -98,7 +104,7 @@ describe Google::Cloud::Logging::Logger, :error, :mock_logging do
 
   it "creates a log entry with #unknown" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:DEFAULT)
+    mock.expect :write_log_entries, write_res, **write_req_args(:DEFAULT)
     logging.service.mocked_logging = mock
 
     apply_stubs do
@@ -122,7 +128,7 @@ describe Google::Cloud::Logging::Logger, :error, :mock_logging do
 
   it "creates a log entry with #error with a block" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:ERROR)
+    mock.expect :write_log_entries, write_res, **write_req_args(:ERROR)
     logging.service.mocked_logging = mock
 
     apply_stubs do
@@ -134,7 +140,7 @@ describe Google::Cloud::Logging::Logger, :error, :mock_logging do
 
   it "creates a log entry with #fatal with a block" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:CRITICAL)
+    mock.expect :write_log_entries, write_res, **write_req_args(:CRITICAL)
     logging.service.mocked_logging = mock
 
     apply_stubs do
@@ -146,7 +152,7 @@ describe Google::Cloud::Logging::Logger, :error, :mock_logging do
 
   it "creates a log entry with #unknown with a block" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:DEFAULT)
+    mock.expect :write_log_entries, write_res, **write_req_args(:DEFAULT)
     logging.service.mocked_logging = mock
 
     apply_stubs do

--- a/google-cloud-logging/test/google/cloud/logging/logger/fatal_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/fatal_test.rb
@@ -37,7 +37,13 @@ describe Google::Cloud::Logging::Logger, :fatal, :mock_logging do
                                                  text_payload: "Danger Will Robinson!",
                                                  severity: severity,
                                                  timestamp: timestamp_grpc)]
-    [entries: entries, log_name: "projects/test/logs/web_app_log", resource: resource.to_grpc, labels: labels, partial_success: nil]
+    {
+      entries: entries,
+      log_name: "projects/test/logs/web_app_log",
+      resource: resource.to_grpc,
+      labels: labels,
+      partial_success: nil
+    }
   end
 
   def apply_stubs
@@ -78,7 +84,7 @@ describe Google::Cloud::Logging::Logger, :fatal, :mock_logging do
 
   it "creates a log entry with #fatal" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:CRITICAL)
+    mock.expect :write_log_entries, write_res, **write_req_args(:CRITICAL)
     logging.service.mocked_logging = mock
 
     apply_stubs do
@@ -90,7 +96,7 @@ describe Google::Cloud::Logging::Logger, :fatal, :mock_logging do
 
   it "creates a log entry with #unknown" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:DEFAULT)
+    mock.expect :write_log_entries, write_res, **write_req_args(:DEFAULT)
     logging.service.mocked_logging = mock
 
     apply_stubs do
@@ -118,7 +124,7 @@ describe Google::Cloud::Logging::Logger, :fatal, :mock_logging do
 
   it "creates a log entry with #fatal with a block" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:CRITICAL)
+    mock.expect :write_log_entries, write_res, **write_req_args(:CRITICAL)
     logging.service.mocked_logging = mock
 
     apply_stubs do
@@ -130,7 +136,7 @@ describe Google::Cloud::Logging::Logger, :fatal, :mock_logging do
 
   it "creates a log entry with #unknown with a block" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:DEFAULT)
+    mock.expect :write_log_entries, write_res, **write_req_args(:DEFAULT)
     logging.service.mocked_logging = mock
 
     apply_stubs do

--- a/google-cloud-logging/test/google/cloud/logging/logger/info_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/info_test.rb
@@ -37,7 +37,13 @@ describe Google::Cloud::Logging::Logger, :info, :mock_logging do
                                                  text_payload: "Danger Will Robinson!",
                                                  severity: severity,
                                                  timestamp: timestamp_grpc)]
-    [entries: entries, log_name: "projects/test/logs/web_app_log", resource: resource.to_grpc, labels: labels, partial_success: nil]
+    {
+      entries: entries,
+      log_name: "projects/test/logs/web_app_log",
+      resource: resource.to_grpc,
+      labels: labels,
+      partial_success: nil
+    }
   end
 
   def apply_stubs
@@ -66,7 +72,7 @@ describe Google::Cloud::Logging::Logger, :info, :mock_logging do
 
   it "creates a log entry with #info" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:INFO)
+    mock.expect :write_log_entries, write_res, **write_req_args(:INFO)
     logging.service.mocked_logging = mock
 
     apply_stubs do
@@ -78,7 +84,7 @@ describe Google::Cloud::Logging::Logger, :info, :mock_logging do
 
   it "creates a log entry with #warn" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:WARNING)
+    mock.expect :write_log_entries, write_res, **write_req_args(:WARNING)
     logging.service.mocked_logging = mock
 
     apply_stubs do
@@ -90,7 +96,7 @@ describe Google::Cloud::Logging::Logger, :info, :mock_logging do
 
   it "creates a log entry with #error" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:ERROR)
+    mock.expect :write_log_entries, write_res, **write_req_args(:ERROR)
     logging.service.mocked_logging = mock
 
     apply_stubs do
@@ -102,7 +108,7 @@ describe Google::Cloud::Logging::Logger, :info, :mock_logging do
 
   it "creates a log entry with #fatal" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:CRITICAL)
+    mock.expect :write_log_entries, write_res, **write_req_args(:CRITICAL)
     logging.service.mocked_logging = mock
 
     apply_stubs do
@@ -114,7 +120,7 @@ describe Google::Cloud::Logging::Logger, :info, :mock_logging do
 
   it "creates a log entry with #unknown" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:DEFAULT)
+    mock.expect :write_log_entries, write_res, **write_req_args(:DEFAULT)
     logging.service.mocked_logging = mock
 
     apply_stubs do
@@ -130,7 +136,7 @@ describe Google::Cloud::Logging::Logger, :info, :mock_logging do
 
   it "creates a log entry with #info with a block" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:INFO)
+    mock.expect :write_log_entries, write_res, **write_req_args(:INFO)
     logging.service.mocked_logging = mock
 
     apply_stubs do
@@ -142,7 +148,7 @@ describe Google::Cloud::Logging::Logger, :info, :mock_logging do
 
   it "creates a log entry with #warn with a block" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:WARNING)
+    mock.expect :write_log_entries, write_res, **write_req_args(:WARNING)
     logging.service.mocked_logging = mock
 
     apply_stubs do
@@ -154,7 +160,7 @@ describe Google::Cloud::Logging::Logger, :info, :mock_logging do
 
   it "creates a log entry with #error with a block" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:ERROR)
+    mock.expect :write_log_entries, write_res, **write_req_args(:ERROR)
     logging.service.mocked_logging = mock
 
     apply_stubs do
@@ -166,7 +172,7 @@ describe Google::Cloud::Logging::Logger, :info, :mock_logging do
 
   it "creates a log entry with #fatal with a block" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:CRITICAL)
+    mock.expect :write_log_entries, write_res, **write_req_args(:CRITICAL)
     logging.service.mocked_logging = mock
 
     apply_stubs do
@@ -178,7 +184,7 @@ describe Google::Cloud::Logging::Logger, :info, :mock_logging do
 
   it "creates a log entry with #unknown with a block" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:DEFAULT)
+    mock.expect :write_log_entries, write_res, **write_req_args(:DEFAULT)
     logging.service.mocked_logging = mock
 
     apply_stubs do

--- a/google-cloud-logging/test/google/cloud/logging/logger/unknown_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/unknown_test.rb
@@ -37,7 +37,13 @@ describe Google::Cloud::Logging::Logger, :unknown, :mock_logging do
                                                  text_payload: "Danger Will Robinson!",
                                                  severity: severity,
                                                  timestamp: timestamp_grpc)]
-    [entries: entries, log_name: "projects/test/logs/web_app_log", resource: resource.to_grpc, labels: labels, partial_success: nil]
+    {
+      entries: entries,
+      log_name: "projects/test/logs/web_app_log", 
+      resource: resource.to_grpc,
+      labels: labels,
+      partial_success: nil
+    }
   end
 
   def apply_stubs
@@ -82,7 +88,7 @@ describe Google::Cloud::Logging::Logger, :unknown, :mock_logging do
 
   it "creates a log entry with #unknown" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:DEFAULT)
+    mock.expect :write_log_entries, write_res, **write_req_args(:DEFAULT)
     logging.service.mocked_logging = mock
 
     apply_stubs do
@@ -114,7 +120,7 @@ describe Google::Cloud::Logging::Logger, :unknown, :mock_logging do
 
   it "creates a log entry with #unknown with a block" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:DEFAULT)
+    mock.expect :write_log_entries, write_res, **write_req_args(:DEFAULT)
     logging.service.mocked_logging = mock
 
     apply_stubs do

--- a/google-cloud-logging/test/google/cloud/logging/logger/warn_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger/warn_test.rb
@@ -37,7 +37,13 @@ describe Google::Cloud::Logging::Logger, :warn, :mock_logging do
                                                  text_payload: "Danger Will Robinson!",
                                                  severity: severity,
                                                  timestamp: timestamp_grpc)]
-    [entries: entries, log_name: "projects/test/logs/web_app_log", resource: resource.to_grpc, labels: labels, partial_success: nil]
+    {
+      entries: entries,
+      log_name: "projects/test/logs/web_app_log",
+      resource: resource.to_grpc,
+      labels: labels,
+      partial_success: nil
+    }
   end
 
   def apply_stubs
@@ -70,7 +76,7 @@ describe Google::Cloud::Logging::Logger, :warn, :mock_logging do
 
   it "creates a log entry with #warn" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:WARNING)
+    mock.expect :write_log_entries, write_res, **write_req_args(:WARNING)
     logging.service.mocked_logging = mock
 
     apply_stubs do
@@ -82,7 +88,7 @@ describe Google::Cloud::Logging::Logger, :warn, :mock_logging do
 
   it "creates a log entry with #error" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:ERROR)
+    mock.expect :write_log_entries, write_res, **write_req_args(:ERROR)
     logging.service.mocked_logging = mock
 
     apply_stubs do
@@ -94,7 +100,7 @@ describe Google::Cloud::Logging::Logger, :warn, :mock_logging do
 
   it "creates a log entry with #fatal" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:CRITICAL)
+    mock.expect :write_log_entries, write_res, **write_req_args(:CRITICAL)
     logging.service.mocked_logging = mock
 
     apply_stubs do
@@ -106,7 +112,7 @@ describe Google::Cloud::Logging::Logger, :warn, :mock_logging do
 
   it "creates a log entry with #unknown" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:DEFAULT)
+    mock.expect :write_log_entries, write_res, **write_req_args(:DEFAULT)
     logging.service.mocked_logging = mock
 
     apply_stubs do
@@ -126,7 +132,7 @@ describe Google::Cloud::Logging::Logger, :warn, :mock_logging do
 
   it "creates a log entry with #warn with a block" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:WARNING)
+    mock.expect :write_log_entries, write_res, **write_req_args(:WARNING)
     logging.service.mocked_logging = mock
 
     apply_stubs do
@@ -138,7 +144,7 @@ describe Google::Cloud::Logging::Logger, :warn, :mock_logging do
 
   it "creates a log entry with #error with a block" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:ERROR)
+    mock.expect :write_log_entries, write_res, **write_req_args(:ERROR)
     logging.service.mocked_logging = mock
 
     apply_stubs do
@@ -150,7 +156,7 @@ describe Google::Cloud::Logging::Logger, :warn, :mock_logging do
 
   it "creates a log entry with #fatal with a block" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:CRITICAL)
+    mock.expect :write_log_entries, write_res, **write_req_args(:CRITICAL)
     logging.service.mocked_logging = mock
 
     apply_stubs do
@@ -162,7 +168,7 @@ describe Google::Cloud::Logging::Logger, :warn, :mock_logging do
 
   it "creates a log entry with #unknown with a block" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:DEFAULT)
+    mock.expect :write_log_entries, write_res, **write_req_args(:DEFAULT)
     logging.service.mocked_logging = mock
 
     apply_stubs do

--- a/google-cloud-logging/test/google/cloud/logging/logger_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/logger_test.rb
@@ -40,13 +40,13 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
                                               timestamp: timestamp_grpc)
     entry.trace = trace if trace
     entry.trace_sampled = trace_sampled unless trace_sampled.nil?
-    [
+    {
       entries: [entry],
       log_name: "projects/test/logs/#{log_name_override || log_name}",
       resource: resource.to_grpc,
       labels: labels.merge(extra_labels),
       partial_success: nil
-    ]
+    }
   end
 
   def apply_stubs
@@ -65,7 +65,7 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
 
   it "creates a DEBUG log entry with #debug" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:DEBUG)
+    mock.expect :write_log_entries, write_res, **write_req_args(:DEBUG)
     logging.service.mocked_logging = mock
 
     apply_stubs do
@@ -77,7 +77,7 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
 
   it "creates an INFO log entry with #info" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:INFO)
+    mock.expect :write_log_entries, write_res, **write_req_args(:INFO)
     logging.service.mocked_logging = mock
 
     apply_stubs do
@@ -89,7 +89,7 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
 
   it "creates a WARNING log entry with #warn" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:WARNING)
+    mock.expect :write_log_entries, write_res, **write_req_args(:WARNING)
     logging.service.mocked_logging = mock
 
     apply_stubs do
@@ -101,7 +101,7 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
 
   it "creates a ERROR log entry with #error" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:ERROR)
+    mock.expect :write_log_entries, write_res, **write_req_args(:ERROR)
     logging.service.mocked_logging = mock
 
     apply_stubs do
@@ -113,7 +113,7 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
 
   it "creates a CRITICAL log entry with #fatal" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:CRITICAL)
+    mock.expect :write_log_entries, write_res, **write_req_args(:CRITICAL)
     logging.service.mocked_logging = mock
 
     apply_stubs do
@@ -125,7 +125,7 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
 
   it "creates a DEFAULT log entry with #unknown" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:DEFAULT)
+    mock.expect :write_log_entries, write_res, **write_req_args(:DEFAULT)
     logging.service.mocked_logging = mock
 
     apply_stubs do
@@ -137,7 +137,7 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
 
   it "creates a DEFAULT log entry with #<<" do
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, write_req_args(:DEFAULT)
+    mock.expect :write_log_entries, write_res, **write_req_args(:DEFAULT)
     logging.service.mocked_logging = mock
 
     apply_stubs do
@@ -158,7 +158,7 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
       mock.verify
     end
 
-    mock.expect :write_log_entries, write_res, write_req_args(:ERROR)
+    mock.expect :write_log_entries, write_res, **write_req_args(:ERROR)
     apply_stubs do
       logger.reopen
       logger.error "Danger Will Robinson!"
@@ -184,7 +184,7 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
                             extra_labels: { "traceId" => trace_id },
                             trace: "projects/#{project}/traces/#{trace_id}",
                             trace_sampled: true
-      mock.expect :write_log_entries, write_res, args
+      mock.expect :write_log_entries, write_res, **args
       logging.service.mocked_logging = mock
 
       info = Google::Cloud::Logging::Logger::RequestInfo.new trace_id, log_name, nil, true
@@ -213,7 +213,7 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
                                         "custom_label" => "just a string"
                                       }
 
-        mock.expect :write_log_entries, write_res, args
+        mock.expect :write_log_entries, write_res, **args
         logging.service.mocked_logging = mock
 
         logger.add_request_info env: env
@@ -241,7 +241,7 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
       it "executes the function and writes the result as a log label" do
         mock = Minitest::Mock.new
         args = write_req_args :ERROR, extra_labels: { "custom_header_value" => "42" }
-        mock.expect :write_log_entries, write_res, args
+        mock.expect :write_log_entries, write_res, **args
         logging.service.mocked_logging = mock
 
         logger.add_request_info env: env
@@ -263,7 +263,7 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
                             extra_labels: { "traceId" => trace_id,
                                             "appengine.googleapis.com/trace_id" => trace_id },
                             trace: "projects/#{project}/traces/#{trace_id}"
-      mock.expect :write_log_entries, write_res, args
+      mock.expect :write_log_entries, write_res, **args
       logging.service.mocked_logging = mock
 
       info = Google::Cloud::Logging::Logger::RequestInfo.new trace_id, log_name
@@ -305,7 +305,7 @@ describe Google::Cloud::Logging::Logger, :mock_logging do
     it "is reflected in log writes" do
       mock = Minitest::Mock.new
       mock.expect :write_log_entries, write_res,
-        write_req_args(:ERROR, log_name_override: "my_app_log")
+        **write_req_args(:ERROR, log_name_override: "my_app_log")
       logging.service.mocked_logging = mock
 
       logger.progname = "my_app_log"

--- a/google-cloud-logging/test/google/cloud/logging/metric_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/metric_test.rb
@@ -34,7 +34,7 @@ describe Google::Cloud::Logging::Metric, :mock_logging do
       filter: new_metric_filter
     )
     mock = Minitest::Mock.new
-    mock.expect :update_log_metric, metric_grpc, [metric_name: "projects/test/metrics/#{metric.name}", metric: new_metric]
+    mock.expect :update_log_metric, metric_grpc, metric_name: "projects/test/metrics/#{metric.name}", metric: new_metric
     metric.service.mocked_metrics = mock
 
     metric.description = new_metric_description
@@ -50,7 +50,7 @@ describe Google::Cloud::Logging::Metric, :mock_logging do
 
   it "can refresh itself" do
     mock = Minitest::Mock.new
-    mock.expect :get_log_metric, metric_grpc, [metric_name: "projects/test/metrics/#{metric.name}"]
+    mock.expect :get_log_metric, metric_grpc, metric_name: "projects/test/metrics/#{metric.name}"
     metric.service.mocked_metrics = mock
 
     metric.refresh!
@@ -60,7 +60,7 @@ describe Google::Cloud::Logging::Metric, :mock_logging do
 
   it "can delete itself" do
     mock = Minitest::Mock.new
-    mock.expect :delete_log_metric, metric_grpc, [metric_name: "projects/test/metrics/#{metric.name}"]
+    mock.expect :delete_log_metric, metric_grpc, metric_name: "projects/test/metrics/#{metric.name}"
     metric.service.mocked_metrics = mock
 
     metric.delete

--- a/google-cloud-logging/test/google/cloud/logging/project/list_entries_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/list_entries_test.rb
@@ -21,7 +21,7 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(num_entries)))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, list_res, [resource_names: ["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, page_token: nil]
+    mock.expect :list_log_entries, list_res, resource_names: ["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, page_token: nil
     logging.service.mocked_logging = mock
 
     entries = logging.entries
@@ -38,7 +38,7 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(num_entries)))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, list_res, [resource_names: ["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, page_token: nil]
+    mock.expect :list_log_entries, list_res, resource_names: ["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, page_token: nil
     logging.service.mocked_logging = mock
 
     entries = logging.find_entries
@@ -54,8 +54,8 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     second_list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(2)))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, first_list_res, [resource_names: ["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, page_token: nil]
-    mock.expect :list_log_entries, second_list_res, [resource_names: ["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, page_token: "next_page_token"]
+    mock.expect :list_log_entries, first_list_res, resource_names: ["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, page_token: nil
+    mock.expect :list_log_entries, second_list_res, resource_names: ["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, page_token: "next_page_token"
     logging.service.mocked_logging = mock
 
     first_entries = logging.entries
@@ -78,8 +78,8 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     second_list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(2)))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, first_list_res, [resource_names: ["projects/project1", "projects/project2", "projects/project3"], filter: 'resource.type:"gce_"', order_by: "timestamp", page_size: nil, page_token: nil]
-    mock.expect :list_log_entries, second_list_res, [resource_names: ["projects/project1", "projects/project2", "projects/project3"], filter: 'resource.type:"gce_"', order_by: "timestamp", page_size: nil, page_token: "next_page_token"]
+    mock.expect :list_log_entries, first_list_res, resource_names: ["projects/project1", "projects/project2", "projects/project3"], filter: 'resource.type:"gce_"', order_by: "timestamp", page_size: nil, page_token: nil
+    mock.expect :list_log_entries, second_list_res, resource_names: ["projects/project1", "projects/project2", "projects/project3"], filter: 'resource.type:"gce_"', order_by: "timestamp", page_size: nil, page_token: "next_page_token"
     logging.service.mocked_logging = mock
 
     first_entries = logging.entries projects: ["project1", "project2", "project3"],
@@ -121,8 +121,8 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     second_list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(2)))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, first_list_res, [resource_names: ["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, page_token: nil]
-    mock.expect :list_log_entries, second_list_res, [resource_names: ["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, page_token: "next_page_token"]
+    mock.expect :list_log_entries, first_list_res, resource_names: ["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, page_token: nil
+    mock.expect :list_log_entries, second_list_res, resource_names: ["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, page_token: "next_page_token"
     logging.service.mocked_logging = mock
 
     first_entries = logging.entries
@@ -144,8 +144,8 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     second_list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(2)))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, first_list_res, [resource_names: ["projects/project1", "projects/project2", "projects/project3"], filter: 'resource.type:"gce_"', order_by: "timestamp", page_size: nil, page_token: nil]
-    mock.expect :list_log_entries, second_list_res, [resource_names: ["projects/project1", "projects/project2", "projects/project3"], filter: 'resource.type:"gce_"', order_by: "timestamp", page_size: nil, page_token: "next_page_token"]
+    mock.expect :list_log_entries, first_list_res, resource_names: ["projects/project1", "projects/project2", "projects/project3"], filter: 'resource.type:"gce_"', order_by: "timestamp", page_size: nil, page_token: nil
+    mock.expect :list_log_entries, second_list_res, resource_names: ["projects/project1", "projects/project2", "projects/project3"], filter: 'resource.type:"gce_"', order_by: "timestamp", page_size: nil, page_token: "next_page_token"
     logging.service.mocked_logging = mock
 
     first_entries = logging.entries projects: ["project1", "project2", "project3"],
@@ -185,8 +185,8 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     second_list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(2)))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, first_list_res, [resource_names: ["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, page_token: nil]
-    mock.expect :list_log_entries, second_list_res, [resource_names: ["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, page_token: "next_page_token"]
+    mock.expect :list_log_entries, first_list_res, resource_names: ["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, page_token: nil
+    mock.expect :list_log_entries, second_list_res, resource_names: ["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, page_token: "next_page_token"
     logging.service.mocked_logging = mock
 
     all_entries = logging.entries.all.to_a
@@ -202,8 +202,8 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     second_list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(2)))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, first_list_res, [resource_names: ["projects/project1", "projects/project2", "projects/project3"], filter: 'resource.type:"gce_"', order_by: "timestamp", page_size: nil, page_token: nil]
-    mock.expect :list_log_entries, second_list_res, [resource_names: ["projects/project1", "projects/project2", "projects/project3"], filter: 'resource.type:"gce_"', order_by: "timestamp", page_size: nil, page_token: "next_page_token"]
+    mock.expect :list_log_entries, first_list_res, resource_names: ["projects/project1", "projects/project2", "projects/project3"], filter: 'resource.type:"gce_"', order_by: "timestamp", page_size: nil, page_token: nil
+    mock.expect :list_log_entries, second_list_res, resource_names: ["projects/project1", "projects/project2", "projects/project3"], filter: 'resource.type:"gce_"', order_by: "timestamp", page_size: nil, page_token: "next_page_token"
     logging.service.mocked_logging = mock
 
     all_entries = logging.entries(projects: ["project1", "project2", "project3"],
@@ -221,8 +221,8 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     second_list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(3, "second_page_token")))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, first_list_res, [resource_names: ["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, page_token: nil]
-    mock.expect :list_log_entries, second_list_res, [resource_names: ["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, page_token: "next_page_token"]
+    mock.expect :list_log_entries, first_list_res, resource_names: ["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, page_token: nil
+    mock.expect :list_log_entries, second_list_res, resource_names: ["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, page_token: "next_page_token"
     logging.service.mocked_logging = mock
 
     all_entries = logging.entries.all.take(5)
@@ -238,8 +238,8 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     second_list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(3, "second_page_token")))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, first_list_res, [resource_names: ["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, page_token: nil]
-    mock.expect :list_log_entries, second_list_res, [resource_names: ["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, page_token: "next_page_token"]
+    mock.expect :list_log_entries, first_list_res, resource_names: ["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, page_token: nil
+    mock.expect :list_log_entries, second_list_res, resource_names: ["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, page_token: "next_page_token"
     logging.service.mocked_logging = mock
 
     all_entries = logging.entries.all(request_limit: 1).to_a
@@ -254,7 +254,7 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(3, "next_page_token")))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, list_res, [resource_names: ["projects/project1"], filter: nil, order_by: nil, page_size: nil, page_token: nil]
+    mock.expect :list_log_entries, list_res, resource_names: ["projects/project1"], filter: nil, order_by: nil, page_size: nil, page_token: nil
     logging.service.mocked_logging = mock
 
     entries = logging.entries projects: "project1"
@@ -271,7 +271,7 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(3, "next_page_token")))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, list_res, [resource_names: ["projects/project1", "projects/project2", "projects/project3"], filter: nil, order_by: nil, page_size: nil, page_token: nil]
+    mock.expect :list_log_entries, list_res, resource_names: ["projects/project1", "projects/project2", "projects/project3"], filter: nil, order_by: nil, page_size: nil, page_token: nil
     logging.service.mocked_logging = mock
 
     entries = logging.entries projects: ["project1", "project2", "project3"]
@@ -288,7 +288,7 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(3, "next_page_token")))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, list_res, [resource_names: ["projects/project1", "projects/project2", "projects/project3"], filter: nil, order_by: nil, page_size: nil, page_token: nil]
+    mock.expect :list_log_entries, list_res, resource_names: ["projects/project1", "projects/project2", "projects/project3"], filter: nil, order_by: nil, page_size: nil, page_token: nil
     logging.service.mocked_logging = mock
 
     entries = logging.entries resources: ["projects/project1", "projects/project2", "projects/project3"]
@@ -307,7 +307,7 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(3, "next_page_token")))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, list_res, [resource_names: ["projects/#{project}"], filter: adv_logs_filter, order_by: nil, page_size: nil, page_token: nil]
+    mock.expect :list_log_entries, list_res, resource_names: ["projects/#{project}"], filter: adv_logs_filter, order_by: nil, page_size: nil, page_token: nil
 
     logging.service.mocked_logging = mock
 
@@ -325,7 +325,7 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(3, "next_page_token")))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, list_res, [resource_names: ["projects/#{project}"], filter: nil, order_by: "timestamp", page_size: nil, page_token: nil]
+    mock.expect :list_log_entries, list_res, resource_names: ["projects/#{project}"], filter: nil, order_by: "timestamp", page_size: nil, page_token: nil
 
     logging.service.mocked_logging = mock
 
@@ -343,7 +343,7 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(3, "next_page_token")))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, list_res, [resource_names: ["projects/#{project}"], filter: nil, order_by: "timestamp desc", page_size: nil, page_token: nil]
+    mock.expect :list_log_entries, list_res, resource_names: ["projects/#{project}"], filter: nil, order_by: "timestamp desc", page_size: nil, page_token: nil
 
     logging.service.mocked_logging = mock
 
@@ -361,7 +361,7 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(3, "next_page_token")))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, list_res, [resource_names: ["projects/#{project}"], filter: nil, order_by: nil, page_size: 3, page_token: nil]
+    mock.expect :list_log_entries, list_res, resource_names: ["projects/#{project}"], filter: nil, order_by: nil, page_size: 3, page_token: nil
 
     logging.service.mocked_logging = mock
 
@@ -379,7 +379,7 @@ describe Google::Cloud::Logging::Project, :list_entries, :mock_logging do
     list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListLogEntriesResponse.new(list_entries_hash(3, "next_page_token")))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_entries, list_res, [resource_names: ["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, page_token: nil]
+    mock.expect :list_log_entries, list_res, resource_names: ["projects/#{project}"], filter: nil, order_by: nil, page_size: nil, page_token: nil
 
     logging.service.mocked_logging = mock
 

--- a/google-cloud-logging/test/google/cloud/logging/project/list_logs_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/list_logs_test.rb
@@ -21,7 +21,7 @@ describe Google::Cloud::Logging::Project, :list_logs, :mock_logging do
     list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListLogsResponse.new(list_logs_hash(num_logs)))
 
     mock = Minitest::Mock.new
-    mock.expect :list_logs, list_res, [parent: "projects/#{project}", page_size: nil, page_token: nil]
+    mock.expect :list_logs, list_res, parent: "projects/#{project}", page_size: nil, page_token: nil
     logging.service.mocked_logging = mock
 
     logs = logging.logs
@@ -38,7 +38,7 @@ describe Google::Cloud::Logging::Project, :list_logs, :mock_logging do
     list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListLogsResponse.new(list_logs_hash(num_logs)))
 
     mock = Minitest::Mock.new
-    mock.expect :list_logs, list_res, [parent: "projects/#{project}", page_size: nil, page_token: nil]
+    mock.expect :list_logs, list_res, parent: "projects/#{project}", page_size: nil, page_token: nil
     logging.service.mocked_logging = mock
 
     logs = logging.find_logs
@@ -54,8 +54,8 @@ describe Google::Cloud::Logging::Project, :list_logs, :mock_logging do
     second_list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListLogsResponse.new(list_logs_hash(2)))
 
     mock = Minitest::Mock.new
-    mock.expect :list_logs, first_list_res, [parent: "projects/#{project}", page_size: nil, page_token: nil]
-    mock.expect :list_logs, second_list_res, [parent: "projects/#{project}", page_size: nil, page_token: "next_page_token"]
+    mock.expect :list_logs, first_list_res, parent: "projects/#{project}", page_size: nil, page_token: nil
+    mock.expect :list_logs, second_list_res, parent: "projects/#{project}", page_size: nil, page_token: "next_page_token"
     logging.service.mocked_logging = mock
 
     first_logs = logging.logs
@@ -78,8 +78,8 @@ describe Google::Cloud::Logging::Project, :list_logs, :mock_logging do
     second_list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListLogsResponse.new(list_logs_hash(2)))
 
     mock = Minitest::Mock.new
-    mock.expect :list_logs, first_list_res, [parent: "projects/#{project}", page_size: nil, page_token: nil]
-    mock.expect :list_logs, second_list_res, [parent: "projects/#{project}", page_size: nil, page_token: "next_page_token"]
+    mock.expect :list_logs, first_list_res, parent: "projects/#{project}", page_size: nil, page_token: nil
+    mock.expect :list_logs, second_list_res, parent: "projects/#{project}", page_size: nil, page_token: "next_page_token"
     logging.service.mocked_logging = mock
 
     first_logs = logging.logs
@@ -101,8 +101,8 @@ describe Google::Cloud::Logging::Project, :list_logs, :mock_logging do
     second_list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListLogsResponse.new(list_logs_hash(2)))
 
     mock = Minitest::Mock.new
-    mock.expect :list_logs, first_list_res, [parent: "projects/#{project}", page_size: nil, page_token: nil]
-    mock.expect :list_logs, second_list_res, [parent: "projects/#{project}", page_size: nil, page_token: "next_page_token"]
+    mock.expect :list_logs, first_list_res, parent: "projects/#{project}", page_size: nil, page_token: nil
+    mock.expect :list_logs, second_list_res, parent: "projects/#{project}", page_size: nil, page_token: "next_page_token"
     logging.service.mocked_logging = mock
 
     all_logs = logging.logs.all.to_a
@@ -118,8 +118,8 @@ describe Google::Cloud::Logging::Project, :list_logs, :mock_logging do
     second_list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListLogsResponse.new(list_logs_hash(3, "second_page_token")))
 
     mock = Minitest::Mock.new
-    mock.expect :list_logs, first_list_res, [parent: "projects/#{project}", page_size: nil, page_token: nil]
-    mock.expect :list_logs, second_list_res, [parent: "projects/#{project}", page_size: nil, page_token: "next_page_token"]
+    mock.expect :list_logs, first_list_res, parent: "projects/#{project}", page_size: nil, page_token: nil
+    mock.expect :list_logs, second_list_res, parent: "projects/#{project}", page_size: nil, page_token: "next_page_token"
     logging.service.mocked_logging = mock
 
     all_logs = logging.logs.all.take(5)
@@ -135,8 +135,8 @@ describe Google::Cloud::Logging::Project, :list_logs, :mock_logging do
     second_list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListLogsResponse.new(list_logs_hash(3, "second_page_token")))
 
     mock = Minitest::Mock.new
-    mock.expect :list_logs, first_list_res, [parent: "projects/#{project}", page_size: nil, page_token: nil]
-    mock.expect :list_logs, second_list_res, [parent: "projects/#{project}", page_size: nil, page_token: "next_page_token"]
+    mock.expect :list_logs, first_list_res, parent: "projects/#{project}", page_size: nil, page_token: nil
+    mock.expect :list_logs, second_list_res, parent: "projects/#{project}", page_size: nil, page_token: "next_page_token"
     logging.service.mocked_logging = mock
 
     all_logs = logging.logs.all(request_limit: 1).to_a
@@ -151,7 +151,7 @@ describe Google::Cloud::Logging::Project, :list_logs, :mock_logging do
     list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListLogsResponse.new(list_logs_hash(3, "next_page_token")))
 
     mock = Minitest::Mock.new
-    mock.expect :list_logs, list_res, [parent: "projects/project1", page_size: nil, page_token: nil]
+    mock.expect :list_logs, list_res, parent: "projects/project1", page_size: nil, page_token: nil
     logging.service.mocked_logging = mock
 
     logs = logging.logs resource: "projects/project1"
@@ -169,8 +169,8 @@ describe Google::Cloud::Logging::Project, :list_logs, :mock_logging do
     second_list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListLogsResponse.new(list_logs_hash(2, "second_page_token")))
 
     mock = Minitest::Mock.new
-    mock.expect :list_logs, first_list_res, [parent: "projects/project1", page_size: nil, page_token: nil]
-    mock.expect :list_logs, second_list_res, [parent: "projects/project1", page_size: nil, page_token: "next_page_token"]
+    mock.expect :list_logs, first_list_res, parent: "projects/project1", page_size: nil, page_token: nil
+    mock.expect :list_logs, second_list_res, parent: "projects/project1", page_size: nil, page_token: "next_page_token"
     logging.service.mocked_logging = mock
 
     first_logs = logging.logs resource: "projects/project1"
@@ -202,8 +202,8 @@ describe Google::Cloud::Logging::Project, :list_logs, :mock_logging do
     second_list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListLogsResponse.new(list_logs_hash(2, "second_page_token")))
 
     mock = Minitest::Mock.new
-    mock.expect :list_logs, first_list_res, [parent: "projects/#{project}", page_size: 3, page_token: nil]
-    mock.expect :list_logs, second_list_res, [parent: "projects/#{project}", page_size: 3, page_token: "next_page_token"]
+    mock.expect :list_logs, first_list_res, parent: "projects/#{project}", page_size: 3, page_token: nil
+    mock.expect :list_logs, second_list_res, parent: "projects/#{project}", page_size: 3, page_token: "next_page_token"
     logging.service.mocked_logging = mock
 
     first_logs = logging.logs max: 3

--- a/google-cloud-logging/test/google/cloud/logging/project/metrics_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/metrics_test.rb
@@ -20,7 +20,7 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
     list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListLogMetricsResponse.new(list_metrics_hash(num_metrics)))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_metrics, list_res, [parent: project_path, page_size: nil, page_token: nil]
+    mock.expect :list_log_metrics, list_res, parent: project_path, page_size: nil, page_token: nil
     logging.service.mocked_metrics = mock
 
     metrics = logging.metrics
@@ -36,7 +36,7 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
     list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListLogMetricsResponse.new(list_metrics_hash(num_metrics)))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_metrics, list_res, [parent: project_path, page_size: nil, page_token: nil]
+    mock.expect :list_log_metrics, list_res, parent: project_path, page_size: nil, page_token: nil
     logging.service.mocked_metrics = mock
 
     metrics = logging.find_metrics
@@ -52,8 +52,8 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
     second_list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListLogMetricsResponse.new(list_metrics_hash(2)))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_metrics, first_list_res, [parent: project_path, page_size: nil, page_token: nil]
-    mock.expect :list_log_metrics, second_list_res, [parent: project_path, page_size: nil, page_token: "next_page_token"]
+    mock.expect :list_log_metrics, first_list_res, parent: project_path, page_size: nil, page_token: nil
+    mock.expect :list_log_metrics, second_list_res, parent: project_path, page_size: nil, page_token: "next_page_token"
     logging.service.mocked_metrics = mock
 
     first_metrics = logging.metrics
@@ -76,8 +76,8 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
     second_list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListLogMetricsResponse.new(list_metrics_hash(2)))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_metrics, first_list_res, [parent: project_path, page_size: nil, page_token: nil]
-    mock.expect :list_log_metrics, second_list_res, [parent: project_path, page_size: nil, page_token: "next_page_token"]
+    mock.expect :list_log_metrics, first_list_res, parent: project_path, page_size: nil, page_token: nil
+    mock.expect :list_log_metrics, second_list_res, parent: project_path, page_size: nil, page_token: "next_page_token"
     logging.service.mocked_metrics = mock
 
     first_metrics = logging.metrics
@@ -99,8 +99,8 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
     second_list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListLogMetricsResponse.new(list_metrics_hash(2, "second_page_token")))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_metrics, first_list_res, [parent: project_path, page_size: 3, page_token: nil]
-    mock.expect :list_log_metrics, second_list_res, [parent: project_path, page_size: 3, page_token: "next_page_token"]
+    mock.expect :list_log_metrics, first_list_res, parent: project_path, page_size: 3, page_token: nil
+    mock.expect :list_log_metrics, second_list_res, parent: project_path, page_size: 3, page_token: "next_page_token"
     logging.service.mocked_metrics = mock
 
     first_metrics = logging.metrics max: 3
@@ -130,8 +130,8 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
     second_list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListLogMetricsResponse.new(list_metrics_hash(2)))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_metrics, first_list_res, [parent: project_path, page_size: nil, page_token: nil]
-    mock.expect :list_log_metrics, second_list_res, [parent: project_path, page_size: nil, page_token: "next_page_token"]
+    mock.expect :list_log_metrics, first_list_res, parent: project_path, page_size: nil, page_token: nil
+    mock.expect :list_log_metrics, second_list_res, parent: project_path, page_size: nil, page_token: "next_page_token"
     logging.service.mocked_metrics = mock
 
     all_metrics = logging.metrics.all.to_a
@@ -147,8 +147,8 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
     second_list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListLogMetricsResponse.new(list_metrics_hash(2)))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_metrics, first_list_res, [parent: project_path, page_size: 3, page_token: nil]
-    mock.expect :list_log_metrics, second_list_res, [parent: project_path, page_size: 3, page_token: "next_page_token"]
+    mock.expect :list_log_metrics, first_list_res, parent: project_path, page_size: 3, page_token: nil
+    mock.expect :list_log_metrics, second_list_res, parent: project_path, page_size: 3, page_token: "next_page_token"
     logging.service.mocked_metrics = mock
 
     all_metrics = logging.metrics(max: 3).all.to_a
@@ -164,8 +164,8 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
     second_list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListLogMetricsResponse.new(list_metrics_hash(3, "second_page_token")))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_metrics, first_list_res, [parent: project_path, page_size: nil, page_token: nil]
-    mock.expect :list_log_metrics, second_list_res, [parent: project_path, page_size: nil, page_token: "next_page_token"]
+    mock.expect :list_log_metrics, first_list_res, parent: project_path, page_size: nil, page_token: nil
+    mock.expect :list_log_metrics, second_list_res, parent: project_path, page_size: nil, page_token: "next_page_token"
     logging.service.mocked_metrics = mock
 
     all_metrics = logging.metrics.all.take(5)
@@ -181,8 +181,8 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
     second_list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListLogMetricsResponse.new(list_metrics_hash(3, "second_page_token")))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_metrics, first_list_res, [parent: project_path, page_size: nil, page_token: nil]
-    mock.expect :list_log_metrics, second_list_res, [parent: project_path, page_size: nil, page_token: "next_page_token"]
+    mock.expect :list_log_metrics, first_list_res, parent: project_path, page_size: nil, page_token: nil
+    mock.expect :list_log_metrics, second_list_res, parent: project_path, page_size: nil, page_token: "next_page_token"
     logging.service.mocked_metrics = mock
 
     all_metrics = logging.metrics.all(request_limit: 1).to_a
@@ -197,7 +197,7 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
     list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListLogMetricsResponse.new(list_metrics_hash(3, "next_page_token")))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_metrics, list_res, [parent: project_path, page_size: 3, page_token: nil]
+    mock.expect :list_log_metrics, list_res, parent: project_path, page_size: 3, page_token: nil
     logging.service.mocked_metrics = mock
 
     metrics = logging.metrics max: 3
@@ -214,7 +214,7 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
     list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListLogMetricsResponse.new(list_metrics_hash(3, "next_page_token")))
 
     mock = Minitest::Mock.new
-    mock.expect :list_log_metrics, list_res, [parent: project_path, page_size: nil, page_token: nil]
+    mock.expect :list_log_metrics, list_res, parent: project_path, page_size: nil, page_token: nil
     logging.service.mocked_metrics = mock
 
     metrics = logging.metrics
@@ -238,7 +238,7 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
                                                                             filter: new_metric_filter))
 
     mock = Minitest::Mock.new
-    mock.expect :create_log_metric, create_res, [parent: "projects/test", metric: new_metric]
+    mock.expect :create_log_metric, create_res, parent: "projects/test", metric: new_metric
     logging.service.mocked_metrics = mock
 
     metric = logging.create_metric new_metric_name, new_metric_filter
@@ -266,7 +266,7 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
                                                                             filter: new_metric_filter))
 
     mock = Minitest::Mock.new
-    mock.expect :create_log_metric, create_res, [parent: "projects/test", metric: new_metric]
+    mock.expect :create_log_metric, create_res, parent: "projects/test", metric: new_metric
     logging.service.mocked_metrics = mock
 
     metric = logging.create_metric new_metric_name, new_metric_filter, description: new_metric_description
@@ -283,7 +283,7 @@ describe Google::Cloud::Logging::Project, :metrics, :mock_logging do
     get_res = Google::Cloud::Logging::V2::LogMetric.new(random_metric_hash.merge(name: metric_name))
 
     mock = Minitest::Mock.new
-    mock.expect :get_log_metric, get_res, [metric_name: "projects/test/metrics/#{metric_name}"]
+    mock.expect :get_log_metric, get_res, metric_name: "projects/test/metrics/#{metric_name}"
     logging.service.mocked_metrics = mock
 
     metric = logging.metric metric_name

--- a/google-cloud-logging/test/google/cloud/logging/project/resource_descriptors_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/resource_descriptors_test.rb
@@ -20,7 +20,7 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
     list_res = Google::Cloud::Logging::V2::ListMonitoredResourceDescriptorsResponse.new(list_resource_descriptors_hash(num_descriptors))
 
     mock = Minitest::Mock.new
-    mock.expect :list_monitored_resource_descriptors, list_res, [page_size: nil, page_token: nil]
+    mock.expect :list_monitored_resource_descriptors, list_res, page_size: nil, page_token: nil
     logging.service.mocked_logging = mock
 
     resource_descriptors = logging.resource_descriptors
@@ -36,7 +36,7 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
     list_res = Google::Cloud::Logging::V2::ListMonitoredResourceDescriptorsResponse.new(list_resource_descriptors_hash(num_descriptors))
 
     mock = Minitest::Mock.new
-    mock.expect :list_monitored_resource_descriptors, list_res, [page_size: nil, page_token: nil]
+    mock.expect :list_monitored_resource_descriptors, list_res, page_size: nil, page_token: nil
     logging.service.mocked_logging = mock
 
     resource_descriptors = logging.find_resource_descriptors
@@ -52,8 +52,8 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
     second_list_res = Google::Cloud::Logging::V2::ListMonitoredResourceDescriptorsResponse.new(list_resource_descriptors_hash(2))
 
     mock = Minitest::Mock.new
-    mock.expect :list_monitored_resource_descriptors, first_list_res, [page_size: nil, page_token: nil]
-    mock.expect :list_monitored_resource_descriptors, second_list_res, [page_size: nil, page_token: "next_page_token"]
+    mock.expect :list_monitored_resource_descriptors, first_list_res, page_size: nil, page_token: nil
+    mock.expect :list_monitored_resource_descriptors, second_list_res, page_size: nil, page_token: "next_page_token"
     logging.service.mocked_logging = mock
 
     first_descriptors = logging.resource_descriptors
@@ -76,8 +76,8 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
     second_list_res = Google::Cloud::Logging::V2::ListMonitoredResourceDescriptorsResponse.new(list_resource_descriptors_hash(2))
 
     mock = Minitest::Mock.new
-    mock.expect :list_monitored_resource_descriptors, first_list_res, [page_size: nil, page_token: nil]
-    mock.expect :list_monitored_resource_descriptors, second_list_res, [page_size: nil, page_token: "next_page_token"]
+    mock.expect :list_monitored_resource_descriptors, first_list_res, page_size: nil, page_token: nil
+    mock.expect :list_monitored_resource_descriptors, second_list_res, page_size: nil, page_token: "next_page_token"
 
     logging.service.mocked_logging = mock
 
@@ -100,8 +100,8 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
     second_list_res = Google::Cloud::Logging::V2::ListMonitoredResourceDescriptorsResponse.new(list_resource_descriptors_hash(2, "second_page_token"))
 
     mock = Minitest::Mock.new
-    mock.expect :list_monitored_resource_descriptors, first_list_res, [page_size: 3, page_token: nil]
-    mock.expect :list_monitored_resource_descriptors, second_list_res, [page_size: 3, page_token: "next_page_token"]
+    mock.expect :list_monitored_resource_descriptors, first_list_res, page_size: 3, page_token: nil
+    mock.expect :list_monitored_resource_descriptors, second_list_res, page_size: 3, page_token: "next_page_token"
 
     logging.service.mocked_logging = mock
 
@@ -132,8 +132,8 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
     second_list_res = Google::Cloud::Logging::V2::ListMonitoredResourceDescriptorsResponse.new(list_resource_descriptors_hash(2))
 
     mock = Minitest::Mock.new
-    mock.expect :list_monitored_resource_descriptors, first_list_res, [page_size: nil, page_token: nil]
-    mock.expect :list_monitored_resource_descriptors, second_list_res, [page_size: nil, page_token: "next_page_token"]
+    mock.expect :list_monitored_resource_descriptors, first_list_res, page_size: nil, page_token: nil
+    mock.expect :list_monitored_resource_descriptors, second_list_res, page_size: nil, page_token: "next_page_token"
 
     logging.service.mocked_logging = mock
 
@@ -150,8 +150,8 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
     second_list_res = Google::Cloud::Logging::V2::ListMonitoredResourceDescriptorsResponse.new(list_resource_descriptors_hash(2))
 
     mock = Minitest::Mock.new
-    mock.expect :list_monitored_resource_descriptors, first_list_res, [page_size: 3, page_token: nil]
-    mock.expect :list_monitored_resource_descriptors, second_list_res, [page_size: 3, page_token: "next_page_token"]
+    mock.expect :list_monitored_resource_descriptors, first_list_res, page_size: 3, page_token: nil
+    mock.expect :list_monitored_resource_descriptors, second_list_res, page_size: 3, page_token: "next_page_token"
 
     logging.service.mocked_logging = mock
 
@@ -168,8 +168,8 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
     second_list_res = Google::Cloud::Logging::V2::ListMonitoredResourceDescriptorsResponse.new(list_resource_descriptors_hash(3, "second_page_token"))
 
     mock = Minitest::Mock.new
-    mock.expect :list_monitored_resource_descriptors, first_list_res, [page_size: nil, page_token: nil]
-    mock.expect :list_monitored_resource_descriptors, second_list_res, [page_size: nil, page_token: "next_page_token"]
+    mock.expect :list_monitored_resource_descriptors, first_list_res, page_size: nil, page_token: nil
+    mock.expect :list_monitored_resource_descriptors, second_list_res, page_size: nil, page_token: "next_page_token"
 
     logging.service.mocked_logging = mock
 
@@ -186,8 +186,8 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
     second_list_res = Google::Cloud::Logging::V2::ListMonitoredResourceDescriptorsResponse.new(list_resource_descriptors_hash(3, "second_page_token"))
 
     mock = Minitest::Mock.new
-    mock.expect :list_monitored_resource_descriptors, first_list_res, [page_size: nil, page_token: nil]
-    mock.expect :list_monitored_resource_descriptors, second_list_res, [page_size: nil, page_token: "next_page_token"]
+    mock.expect :list_monitored_resource_descriptors, first_list_res, page_size: nil, page_token: nil
+    mock.expect :list_monitored_resource_descriptors, second_list_res, page_size: nil, page_token: "next_page_token"
 
     logging.service.mocked_logging = mock
 
@@ -203,7 +203,7 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
     list_res = Google::Cloud::Logging::V2::ListMonitoredResourceDescriptorsResponse.new(list_resource_descriptors_hash(3, "next_page_token"))
 
     mock = Minitest::Mock.new
-    mock.expect :list_monitored_resource_descriptors, list_res, [page_size: 3, page_token: nil]
+    mock.expect :list_monitored_resource_descriptors, list_res, page_size: 3, page_token: nil
     logging.service.mocked_logging = mock
 
     resource_descriptors = logging.resource_descriptors max: 3
@@ -220,7 +220,7 @@ describe Google::Cloud::Logging::Project, :resource_descriptors, :mock_logging d
     list_res = Google::Cloud::Logging::V2::ListMonitoredResourceDescriptorsResponse.new(list_resource_descriptors_hash(3, "next_page_token"))
 
     mock = Minitest::Mock.new
-    mock.expect :list_monitored_resource_descriptors, list_res, [page_size: nil, page_token: nil]
+    mock.expect :list_monitored_resource_descriptors, list_res, page_size: nil, page_token: nil
     logging.service.mocked_logging = mock
 
     resource_descriptors = logging.resource_descriptors

--- a/google-cloud-logging/test/google/cloud/logging/project/sinks_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/sinks_test.rb
@@ -20,7 +20,7 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
     list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListSinksResponse.new(list_sinks_hash(num_sinks)))
 
     mock = Minitest::Mock.new
-    mock.expect :list_sinks, list_res, [parent: project_path, page_size: nil, page_token: nil]
+    mock.expect :list_sinks, list_res, parent: project_path, page_size: nil, page_token: nil
     logging.service.mocked_sinks = mock
 
     sinks = logging.sinks
@@ -36,7 +36,7 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
     list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListSinksResponse.new(list_sinks_hash(num_sinks)))
 
     mock = Minitest::Mock.new
-    mock.expect :list_sinks, list_res, [parent: project_path, page_size: nil, page_token: nil]
+    mock.expect :list_sinks, list_res, parent: project_path, page_size: nil, page_token: nil
     logging.service.mocked_sinks = mock
 
     sinks = logging.find_sinks
@@ -52,8 +52,8 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
     second_list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListSinksResponse.new(list_sinks_hash(2)))
 
     mock = Minitest::Mock.new
-    mock.expect :list_sinks, first_list_res, [parent: project_path, page_size: nil, page_token: nil]
-    mock.expect :list_sinks, second_list_res, [parent: project_path, page_size: nil, page_token: "next_page_token"]
+    mock.expect :list_sinks, first_list_res, parent: project_path, page_size: nil, page_token: nil
+    mock.expect :list_sinks, second_list_res, parent: project_path, page_size: nil, page_token: "next_page_token"
     logging.service.mocked_sinks = mock
 
     first_sinks = logging.sinks
@@ -76,8 +76,8 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
     second_list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListSinksResponse.new(list_sinks_hash(2)))
 
     mock = Minitest::Mock.new
-    mock.expect :list_sinks, first_list_res, [parent: project_path, page_size: nil, page_token: nil]
-    mock.expect :list_sinks, second_list_res, [parent: project_path, page_size: nil, page_token: "next_page_token"]
+    mock.expect :list_sinks, first_list_res, parent: project_path, page_size: nil, page_token: nil
+    mock.expect :list_sinks, second_list_res, parent: project_path, page_size: nil, page_token: "next_page_token"
     logging.service.mocked_sinks = mock
 
     first_sinks = logging.sinks
@@ -99,8 +99,8 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
     second_list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListSinksResponse.new(list_sinks_hash(2, "second_page_token")))
 
     mock = Minitest::Mock.new
-    mock.expect :list_sinks, first_list_res, [parent: project_path, page_size: 3, page_token: nil]
-    mock.expect :list_sinks, second_list_res, [parent: project_path, page_size: 3, page_token: "next_page_token"]
+    mock.expect :list_sinks, first_list_res, parent: project_path, page_size: 3, page_token: nil
+    mock.expect :list_sinks, second_list_res, parent: project_path, page_size: 3, page_token: "next_page_token"
     logging.service.mocked_sinks = mock
 
     first_sinks = logging.sinks max: 3
@@ -130,8 +130,8 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
     second_list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListSinksResponse.new(list_sinks_hash(2)))
 
     mock = Minitest::Mock.new
-    mock.expect :list_sinks, first_list_res, [parent: project_path, page_size: nil, page_token: nil]
-    mock.expect :list_sinks, second_list_res, [parent: project_path, page_size: nil, page_token: "next_page_token"]
+    mock.expect :list_sinks, first_list_res, parent: project_path, page_size: nil, page_token: nil
+    mock.expect :list_sinks, second_list_res, parent: project_path, page_size: nil, page_token: "next_page_token"
     logging.service.mocked_sinks = mock
 
     all_sinks = logging.sinks.all.to_a
@@ -147,8 +147,8 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
     second_list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListSinksResponse.new(list_sinks_hash(2)))
 
     mock = Minitest::Mock.new
-    mock.expect :list_sinks, first_list_res, [parent: project_path, page_size: 3, page_token: nil]
-    mock.expect :list_sinks, second_list_res, [parent: project_path, page_size: 3, page_token: "next_page_token"]
+    mock.expect :list_sinks, first_list_res, parent: project_path, page_size: 3, page_token: nil
+    mock.expect :list_sinks, second_list_res, parent: project_path, page_size: 3, page_token: "next_page_token"
     logging.service.mocked_sinks = mock
 
     all_sinks = logging.sinks(max: 3).all.to_a
@@ -164,8 +164,8 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
     second_list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListSinksResponse.new(list_sinks_hash(3, "second_page_token")))
 
     mock = Minitest::Mock.new
-    mock.expect :list_sinks, first_list_res, [parent: project_path, page_size: nil, page_token: nil]
-    mock.expect :list_sinks, second_list_res, [parent: project_path, page_size: nil, page_token: "next_page_token"]
+    mock.expect :list_sinks, first_list_res, parent: project_path, page_size: nil, page_token: nil
+    mock.expect :list_sinks, second_list_res, parent: project_path, page_size: nil, page_token: "next_page_token"
     logging.service.mocked_sinks = mock
 
     all_sinks = logging.sinks.all.take(5)
@@ -181,8 +181,8 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
     second_list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListSinksResponse.new(list_sinks_hash(3, "second_page_token")))
 
     mock = Minitest::Mock.new
-    mock.expect :list_sinks, first_list_res, [parent: project_path, page_size: nil, page_token: nil]
-    mock.expect :list_sinks, second_list_res, [parent: project_path, page_size: nil, page_token: "next_page_token"]
+    mock.expect :list_sinks, first_list_res, parent: project_path, page_size: nil, page_token: nil
+    mock.expect :list_sinks, second_list_res, parent: project_path, page_size: nil, page_token: "next_page_token"
     logging.service.mocked_sinks = mock
 
     all_sinks = logging.sinks.all(request_limit: 1).to_a
@@ -198,7 +198,7 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
     list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListSinksResponse.new(list_sinks_hash(3, "next_page_token")))
 
     mock = Minitest::Mock.new
-    mock.expect :list_sinks, list_res, [parent: project_path, page_size: 3, page_token: nil]
+    mock.expect :list_sinks, list_res, parent: project_path, page_size: 3, page_token: nil
     logging.service.mocked_sinks = mock
 
     sinks = logging.sinks max: 3
@@ -216,7 +216,7 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
     list_res = OpenStruct.new(response: Google::Cloud::Logging::V2::ListSinksResponse.new(list_sinks_hash(3, "next_page_token")))
 
     mock = Minitest::Mock.new
-    mock.expect :list_sinks, list_res, [parent: project_path, page_size: nil, page_token: nil]
+    mock.expect :list_sinks, list_res, parent: project_path, page_size: nil, page_token: nil
     logging.service.mocked_sinks = mock
 
     sinks = logging.sinks
@@ -239,7 +239,7 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
                                                                         writer_identity: "roles/owner"))
 
     mock = Minitest::Mock.new
-    mock.expect :create_sink, create_res, [parent: "projects/test", sink: new_sink, unique_writer_identity: nil]
+    mock.expect :create_sink, create_res, parent: "projects/test", sink: new_sink, unique_writer_identity: nil
     logging.service.mocked_sinks = mock
 
     sink = logging.create_sink new_sink_name, new_sink_destination
@@ -269,7 +269,7 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
                                                           writer_identity: "roles/owner"))
 
     mock = Minitest::Mock.new
-    mock.expect :create_sink, create_res, [parent: "projects/test", sink: new_sink, unique_writer_identity: nil]
+    mock.expect :create_sink, create_res, parent: "projects/test", sink: new_sink, unique_writer_identity: nil
     logging.service.mocked_sinks = mock
 
     sink = logging.create_sink new_sink_name,
@@ -295,7 +295,7 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
                                                                         writer_identity: "serviceAccount:cloud-logs@system.gserviceaccount.com"))
 
     mock = Minitest::Mock.new
-    mock.expect :create_sink, create_res, [parent: "projects/test", sink: new_sink, unique_writer_identity: true]
+    mock.expect :create_sink, create_res, parent: "projects/test", sink: new_sink, unique_writer_identity: true
     logging.service.mocked_sinks = mock
 
     sink = logging.create_sink new_sink_name, new_sink_destination, unique_writer_identity: true
@@ -314,7 +314,7 @@ describe Google::Cloud::Logging::Project, :sinks, :mock_logging do
     get_res = Google::Cloud::Logging::V2::LogSink.new(random_sink_hash.merge(name: sink_name))
 
     mock = Minitest::Mock.new
-    mock.expect :get_sink, get_res, [sink_name: "projects/test/sinks/#{sink_name}"]
+    mock.expect :get_sink, get_res, sink_name: "projects/test/sinks/#{sink_name}"
     logging.service.mocked_sinks = mock
 
     sink = logging.sink sink_name

--- a/google-cloud-logging/test/google/cloud/logging/project/write_entries_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project/write_entries_test.rb
@@ -23,7 +23,7 @@ describe Google::Cloud::Logging::Project, :write_entries, :mock_logging do
     write_res = Google::Cloud::Logging::V2::WriteLogEntriesResponse.new
 
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, [entries: [entry.to_grpc], log_name: nil, resource: nil, labels: nil, partial_success: nil]
+    mock.expect :write_log_entries, write_res, entries: [entry.to_grpc], log_name: nil, resource: nil, labels: nil, partial_success: nil
     logging.service.mocked_logging = mock
 
     logging.write_entries entry
@@ -42,7 +42,7 @@ describe Google::Cloud::Logging::Project, :write_entries, :mock_logging do
     write_res = Google::Cloud::Logging::V2::WriteLogEntriesResponse.new
 
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, [entries: [entry1.to_grpc, entry2.to_grpc], log_name: nil, resource: nil, labels: nil, partial_success: nil]
+    mock.expect :write_log_entries, write_res, entries: [entry1.to_grpc, entry2.to_grpc], log_name: nil, resource: nil, labels: nil, partial_success: nil
     logging.service.mocked_logging = mock
 
     logging.write_entries [entry1, entry2]
@@ -58,7 +58,7 @@ describe Google::Cloud::Logging::Project, :write_entries, :mock_logging do
     write_res = Google::Cloud::Logging::V2::WriteLogEntriesResponse.new
 
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, [entries: [entry.to_grpc], log_name: "projects/test/logs/testlog", resource: nil, labels: nil, partial_success: nil]
+    mock.expect :write_log_entries, write_res, entries: [entry.to_grpc], log_name: "projects/test/logs/testlog", resource: nil, labels: nil, partial_success: nil
     logging.service.mocked_logging = mock
 
     logging.write_entries entry, log_name: "testlog"
@@ -77,7 +77,7 @@ describe Google::Cloud::Logging::Project, :write_entries, :mock_logging do
     write_res = Google::Cloud::Logging::V2::WriteLogEntriesResponse.new
 
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, [entries: [entry.to_grpc], log_name: nil, resource: resource.to_grpc, labels: nil, partial_success: nil]
+    mock.expect :write_log_entries, write_res, entries: [entry.to_grpc], log_name: nil, resource: resource.to_grpc, labels: nil, partial_success: nil
     logging.service.mocked_logging = mock
 
     logging.write_entries entry, resource: resource
@@ -93,7 +93,7 @@ describe Google::Cloud::Logging::Project, :write_entries, :mock_logging do
     write_res = Google::Cloud::Logging::V2::WriteLogEntriesResponse.new
 
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, [entries: [entry.to_grpc], log_name: nil, resource: nil, labels: { "env" => "production" }, partial_success: nil]
+    mock.expect :write_log_entries, write_res, entries: [entry.to_grpc], log_name: nil, resource: nil, labels: { "env" => "production" }, partial_success: nil
     logging.service.mocked_logging = mock
 
     logging.write_entries entry, labels: {env: :production}
@@ -109,7 +109,7 @@ describe Google::Cloud::Logging::Project, :write_entries, :mock_logging do
     write_res = Google::Cloud::Logging::V2::WriteLogEntriesResponse.new
 
     mock = Minitest::Mock.new
-    mock.expect :write_log_entries, write_res, [entries: [entry.to_grpc], log_name: nil, resource: nil, labels: nil, partial_success: true]
+    mock.expect :write_log_entries, write_res, entries: [entry.to_grpc], log_name: nil, resource: nil, labels: nil, partial_success: true
     logging.service.mocked_logging = mock
 
     logging.write_entries entry, partial_success: true

--- a/google-cloud-logging/test/google/cloud/logging/project_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/project_test.rb
@@ -81,7 +81,7 @@ describe Google::Cloud::Logging::Project, :mock_logging do
     log_name = "syslog"
 
     mock = Minitest::Mock.new
-    mock.expect :delete_log, Google::Protobuf::Empty.new, [log_name: "projects/#{project}/logs/#{log_name}"]
+    mock.expect :delete_log, Google::Protobuf::Empty.new, log_name: "projects/#{project}/logs/#{log_name}"
     logging.service.mocked_logging = mock
 
     success = logging.delete_log log_name
@@ -95,7 +95,7 @@ describe Google::Cloud::Logging::Project, :mock_logging do
     log_name = "projects/#{project}/logs/syslog"
 
     mock = Minitest::Mock.new
-    mock.expect :delete_log, Google::Protobuf::Empty.new, [log_name: log_name]
+    mock.expect :delete_log, Google::Protobuf::Empty.new, log_name: log_name
     logging.service.mocked_logging = mock
 
     success = logging.delete_log log_name

--- a/google-cloud-logging/test/google/cloud/logging/sink_test.rb
+++ b/google-cloud-logging/test/google/cloud/logging/sink_test.rb
@@ -82,7 +82,7 @@ describe Google::Cloud::Logging::Sink, :mock_logging do
       filter: new_sink_filter
     )
     mock = Minitest::Mock.new
-    mock.expect :update_sink, sink_grpc, [sink_name: "projects/test/sinks/#{sink.name}", sink: new_sink, unique_writer_identity: nil]
+    mock.expect :update_sink, sink_grpc, sink_name: "projects/test/sinks/#{sink.name}", sink: new_sink, unique_writer_identity: nil
     sink.service.mocked_sinks = mock
 
     sink.destination = new_sink_destination
@@ -111,7 +111,7 @@ describe Google::Cloud::Logging::Sink, :mock_logging do
       filter: new_sink_filter
     )
     mock = Minitest::Mock.new
-    mock.expect :update_sink, sink_grpc, [sink_name: "projects/test/sinks/#{sink.name}", sink: new_sink, unique_writer_identity: true]
+    mock.expect :update_sink, sink_grpc, sink_name: "projects/test/sinks/#{sink.name}", sink: new_sink, unique_writer_identity: true
     sink.service.mocked_sinks = mock
 
     sink.destination = new_sink_destination
@@ -129,7 +129,7 @@ describe Google::Cloud::Logging::Sink, :mock_logging do
 
   it "can refresh itself" do
     mock = Minitest::Mock.new
-    mock.expect :get_sink, sink_grpc, [sink_name: "projects/test/sinks/#{sink.name}"]
+    mock.expect :get_sink, sink_grpc, sink_name: "projects/test/sinks/#{sink.name}"
     sink.service.mocked_sinks = mock
 
     sink.refresh!
@@ -139,7 +139,7 @@ describe Google::Cloud::Logging::Sink, :mock_logging do
 
   it "can delete itself" do
     mock = Minitest::Mock.new
-    mock.expect :delete_sink, sink_grpc, [sink_name: "projects/test/sinks/#{sink.name}"]
+    mock.expect :delete_sink, sink_grpc, sink_name: "projects/test/sinks/#{sink.name}"
     sink.service.mocked_sinks = mock
 
     sink.delete

--- a/google-cloud-resource_manager/README.md
+++ b/google-cloud-resource_manager/README.md
@@ -80,14 +80,14 @@ Google::Apis.logger = my_logger
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.5+.
+This library is supported on Ruby 2.6+.
 
 Google provides official support for Ruby versions that are actively supported
-by Ruby Core—that is, Ruby versions that are either in normal maintenance or in
-security maintenance, and not end of life. Currently, this means Ruby 2.5 and
-later. Older versions of Ruby _may_ still work, but are unsupported and not
-recommended. See [https://www.ruby-lang.org/en/downloads/branches/](https://www.ruby-lang.org/en/downloads/branches) for details
-about the Ruby support schedule.
+by Ruby Core—that is, Ruby versions that are either in normal maintenance or
+in security maintenance, and not end of life. Older versions of Ruby _may_
+still work, but are unsupported and not recommended. See
+https://www.ruby-lang.org/en/downloads/branches/ for details about the Ruby
+support schedule.
 
 ## Versioning
 

--- a/google-cloud-resource_manager/google-cloud-resource_manager.gemspec
+++ b/google-cloud-resource_manager/google-cloud-resource_manager.gemspec
@@ -16,14 +16,14 @@ Gem::Specification.new do |gem|
                       ["OVERVIEW.md", "AUTHENTICATION.md", "LOGGING.md", "CONTRIBUTING.md", "TROUBLESHOOTING.md", "CHANGELOG.md", "CODE_OF_CONDUCT.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.5"
+  gem.required_ruby_version = ">= 2.6"
 
   gem.add_dependency "google-cloud-core", "~> 1.6"
   gem.add_dependency "google-apis-cloudresourcemanager_v1", "~> 0.1"
   gem.add_dependency "googleauth", ">= 0.16.2", "< 2.a"
 
-  gem.add_development_dependency "google-style", "~> 1.25.1"
-  gem.add_development_dependency "minitest", "~> 5.14"
+  gem.add_development_dependency "google-style", "~> 1.26.1"
+  gem.add_development_dependency "minitest", "~> 5.16"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"
   gem.add_development_dependency "minitest-focus", "~> 1.1"
   gem.add_development_dependency "minitest-rg", "~> 5.2"

--- a/google-cloud-resource_manager/test/google/cloud/resource_manager/manager_test.rb
+++ b/google-cloud-resource_manager/test/google/cloud/resource_manager/manager_test.rb
@@ -70,7 +70,7 @@ describe Google::Cloud::ResourceManager::Manager, :mock_res_man do
 
   it "lists projects" do
     mock = Minitest::Mock.new
-    mock.expect :list_projects, list_projects_response(3), [{ page_token: nil, page_size: nil, filter: nil }]
+    mock.expect :list_projects, list_projects_response(3), page_token: nil, page_size: nil, filter: nil
 
     resource_manager.service.mocked_service = mock
     projects = resource_manager.projects
@@ -82,7 +82,7 @@ describe Google::Cloud::ResourceManager::Manager, :mock_res_man do
 
   it "lists projects with max set" do
     mock = Minitest::Mock.new
-    mock.expect :list_projects, list_projects_response(3, "next_page_token"), [{ page_token: nil, page_size: 3, filter: nil }]
+    mock.expect :list_projects, list_projects_response(3, "next_page_token"), page_token: nil, page_size: 3, filter: nil
 
     resource_manager.service.mocked_service = mock
     projects = resource_manager.projects max: 3
@@ -96,7 +96,7 @@ describe Google::Cloud::ResourceManager::Manager, :mock_res_man do
 
   it "lists projects with filter set" do
     mock = Minitest::Mock.new
-    mock.expect :list_projects, list_projects_response(3, "next_page_token"), [{ page_token: nil, page_size: nil, filter: "labels.env:production" }]
+    mock.expect :list_projects, list_projects_response(3, "next_page_token"), page_token: nil, page_size: nil, filter: "labels.env:production"
 
     resource_manager.service.mocked_service = mock
     projects = resource_manager.projects filter: "labels.env:production"
@@ -110,8 +110,8 @@ describe Google::Cloud::ResourceManager::Manager, :mock_res_man do
 
   it "paginates projects" do
     mock = Minitest::Mock.new
-    mock.expect :list_projects, list_projects_response(3, "next_page_token"), [{ page_token: nil, page_size: nil, filter: nil }]
-    mock.expect :list_projects, list_projects_response(2),                    [{ page_token: "next_page_token", page_size: nil, filter: nil }]
+    mock.expect :list_projects, list_projects_response(3, "next_page_token"), page_token: nil, page_size: nil, filter: nil
+    mock.expect :list_projects, list_projects_response(2),                    page_token: "next_page_token", page_size: nil, filter: nil
 
     resource_manager.service.mocked_service = mock
     first_projects = resource_manager.projects
@@ -130,8 +130,8 @@ describe Google::Cloud::ResourceManager::Manager, :mock_res_man do
 
   it "paginates projects with next? and next" do
     mock = Minitest::Mock.new
-    mock.expect :list_projects, list_projects_response(3, "next_page_token"), [{ page_token: nil, page_size: nil, filter: nil }]
-    mock.expect :list_projects, list_projects_response(2),                    [{ page_token: "next_page_token", page_size: nil, filter: nil }]
+    mock.expect :list_projects, list_projects_response(3, "next_page_token"), page_token: nil, page_size: nil, filter: nil
+    mock.expect :list_projects, list_projects_response(2),                    page_token: "next_page_token", page_size: nil, filter: nil
 
     resource_manager.service.mocked_service = mock
     first_projects = resource_manager.projects
@@ -149,8 +149,8 @@ describe Google::Cloud::ResourceManager::Manager, :mock_res_man do
 
   it "paginates projects with next? and next and max set" do
     mock = Minitest::Mock.new
-    mock.expect :list_projects, list_projects_response(3, "next_page_token"), [{ page_token: nil, page_size: 3, filter: nil }]
-    mock.expect :list_projects, list_projects_response(2),                    [{ page_token: "next_page_token", page_size: 3, filter: nil }]
+    mock.expect :list_projects, list_projects_response(3, "next_page_token"), page_token: nil, page_size: 3, filter: nil
+    mock.expect :list_projects, list_projects_response(2),                    page_token: "next_page_token", page_size: 3, filter: nil
 
     resource_manager.service.mocked_service = mock
     first_projects = resource_manager.projects max: 3
@@ -168,8 +168,8 @@ describe Google::Cloud::ResourceManager::Manager, :mock_res_man do
 
   it "paginates projects with next? and next and filter set" do
     mock = Minitest::Mock.new
-    mock.expect :list_projects, list_projects_response(3, "next_page_token"), [{ page_token: nil, page_size: nil, filter: "labels.env:production" }]
-    mock.expect :list_projects, list_projects_response(2),                    [{ page_token: "next_page_token", page_size: nil, filter: "labels.env:production" }]
+    mock.expect :list_projects, list_projects_response(3, "next_page_token"), page_token: nil, page_size: nil, filter: "labels.env:production"
+    mock.expect :list_projects, list_projects_response(2),                    page_token: "next_page_token", page_size: nil, filter: "labels.env:production"
 
     resource_manager.service.mocked_service = mock
     first_projects = resource_manager.projects filter: "labels.env:production"
@@ -187,8 +187,8 @@ describe Google::Cloud::ResourceManager::Manager, :mock_res_man do
 
   it "paginates projects with all" do
     mock = Minitest::Mock.new
-    mock.expect :list_projects, list_projects_response(3, "next_page_token"), [{ page_token: nil, page_size: nil, filter: nil }]
-    mock.expect :list_projects, list_projects_response(2),                    [{ page_token: "next_page_token", page_size: nil, filter: nil }]
+    mock.expect :list_projects, list_projects_response(3, "next_page_token"), page_token: nil, page_size: nil, filter: nil
+    mock.expect :list_projects, list_projects_response(2),                    page_token: "next_page_token", page_size: nil, filter: nil
 
     resource_manager.service.mocked_service = mock
     projects = resource_manager.projects.all.to_a
@@ -200,8 +200,8 @@ describe Google::Cloud::ResourceManager::Manager, :mock_res_man do
 
   it "paginates projects with all and max set" do
     mock = Minitest::Mock.new
-    mock.expect :list_projects, list_projects_response(3, "next_page_token"), [{ page_token: nil, page_size: 3, filter: nil }]
-    mock.expect :list_projects, list_projects_response(2),                    [{ page_token: "next_page_token", page_size: 3, filter: nil }]
+    mock.expect :list_projects, list_projects_response(3, "next_page_token"), page_token: nil, page_size: 3, filter: nil
+    mock.expect :list_projects, list_projects_response(2),                    page_token: "next_page_token", page_size: 3, filter: nil
 
     resource_manager.service.mocked_service = mock
     projects = resource_manager.projects(max: 3).all.to_a
@@ -213,8 +213,8 @@ describe Google::Cloud::ResourceManager::Manager, :mock_res_man do
 
   it "paginates projects with all and filter set" do
     mock = Minitest::Mock.new
-    mock.expect :list_projects, list_projects_response(3, "next_page_token"), [{ page_token: nil, page_size: nil, filter: "labels.env:production" }]
-    mock.expect :list_projects, list_projects_response(2),                    [{ page_token: "next_page_token", page_size: nil, filter: "labels.env:production" }]
+    mock.expect :list_projects, list_projects_response(3, "next_page_token"), page_token: nil, page_size: nil, filter: "labels.env:production"
+    mock.expect :list_projects, list_projects_response(2),                    page_token: "next_page_token", page_size: nil, filter: "labels.env:production"
 
     resource_manager.service.mocked_service = mock
     projects = resource_manager.projects(filter: "labels.env:production").all.to_a
@@ -226,8 +226,8 @@ describe Google::Cloud::ResourceManager::Manager, :mock_res_man do
 
   it "paginates projects with all using Enumerator" do
     mock = Minitest::Mock.new
-    mock.expect :list_projects, list_projects_response(3, "next_page_token"),   [{ page_token: nil, page_size: nil, filter: nil }]
-    mock.expect :list_projects, list_projects_response(3, "second_page_token"), [{ page_token: "next_page_token", page_size: nil, filter: nil }]
+    mock.expect :list_projects, list_projects_response(3, "next_page_token"),   page_token: nil, page_size: nil, filter: nil
+    mock.expect :list_projects, list_projects_response(3, "second_page_token"), page_token: "next_page_token", page_size: nil, filter: nil
 
     resource_manager.service.mocked_service = mock
     projects = resource_manager.projects.all.take(5)
@@ -239,8 +239,8 @@ describe Google::Cloud::ResourceManager::Manager, :mock_res_man do
 
   it "paginates projects with all and request_limit set" do
     mock = Minitest::Mock.new
-    mock.expect :list_projects, list_projects_response(3, "next_page_token"),   [{ page_token: nil, page_size: nil, filter: nil }]
-    mock.expect :list_projects, list_projects_response(3, "second_page_token"), [{ page_token: "next_page_token", page_size: nil, filter: nil }]
+    mock.expect :list_projects, list_projects_response(3, "next_page_token"),   page_token: nil, page_size: nil, filter: nil
+    mock.expect :list_projects, list_projects_response(3, "second_page_token"), page_token: "next_page_token", page_size: nil, filter: nil
 
     resource_manager.service.mocked_service = mock
     projects = resource_manager.projects.all(request_limit: 1).to_a


### PR DESCRIPTION
For google-cloud-logging and google-cloud-resource_manager. Also updates tests for minitest 5.16 compatibility.