### PR TITLE
samples(pubsub): create exactly once delivery enabled subscription

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
@@ -209,22 +209,25 @@ module Google
         end
 
         def construct_create_subscription_options topic, subscription_name, options
-          options[:name] = subscription_path subscription_name, options
-          options[:topic] = topic_path topic
-          options[:message_retention_duration] = Convert.number_to_duration options.delete(:retention)
-          options[:dead_letter_policy] = dead_letter_policy options
-          options[:ack_deadline_seconds] = options[:deadline]
-          options[:retain_acked_messages] = options[:retain_acked]
-          options[:enable_message_ordering] = options[:message_ordering]
-          
           excess_options = [:deadline, 
+                            :retention,
                             :retain_acked, 
                             :message_ordering, 
                             :endpoint, 
                             :dead_letter_topic_name,
                             :dead_letter_max_delivery_attempts,
                             :dead_letter_topic]
-          options.filter { |k,v| !v.nil? && !excess_options.include?(k) }
+
+          new_options = options.filter { |k,v| !v.nil? && !excess_options.include?(k) }
+          new_options[:name] = subscription_path subscription_name, options
+          new_options[:topic] = topic_path topic
+          new_options[:message_retention_duration] = Convert.number_to_duration options[:retention]
+          new_options[:dead_letter_policy] = dead_letter_policy options
+          new_options[:ack_deadline_seconds] = options[:deadline]
+          new_options[:retain_acked_messages] = options[:retain_acked]
+          new_options[:enable_message_ordering] = options[:message_ordering]
+          
+          new_options.compact
         end
 
         def update_subscription subscription_obj, *fields

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
@@ -208,28 +208,6 @@ module Google
           subscriber.create_subscription **updated_option
         end
 
-        def construct_create_subscription_options topic, subscription_name, options
-          excess_options = [:deadline, 
-                            :retention,
-                            :retain_acked, 
-                            :message_ordering, 
-                            :endpoint, 
-                            :dead_letter_topic_name,
-                            :dead_letter_max_delivery_attempts,
-                            :dead_letter_topic]
-
-          new_options = options.filter { |k,v| !v.nil? && !excess_options.include?(k) }
-          new_options[:name] = subscription_path subscription_name, options
-          new_options[:topic] = topic_path topic
-          new_options[:message_retention_duration] = Convert.number_to_duration options[:retention]
-          new_options[:dead_letter_policy] = dead_letter_policy options
-          new_options[:ack_deadline_seconds] = options[:deadline]
-          new_options[:retain_acked_messages] = options[:retain_acked]
-          new_options[:enable_message_ordering] = options[:message_ordering]
-          
-          new_options.compact
-        end
-
         def update_subscription subscription_obj, *fields
           mask = Google::Protobuf::FieldMask.new paths: fields.map(&:to_s)
           subscriber.update_subscription subscription: subscription_obj, update_mask: mask
@@ -507,6 +485,30 @@ module Google
             policy.max_delivery_attempts = options[:dead_letter_max_delivery_attempts]
           end
           policy
+        end
+
+        private
+
+        def construct_create_subscription_options topic, subscription_name, options
+          excess_options = [:deadline, 
+                            :retention,
+                            :retain_acked, 
+                            :message_ordering, 
+                            :endpoint, 
+                            :dead_letter_topic_name,
+                            :dead_letter_max_delivery_attempts,
+                            :dead_letter_topic]
+
+          new_options = options.filter { |k,v| !v.nil? && !excess_options.include?(k) }
+          new_options[:name] = subscription_path subscription_name, options
+          new_options[:topic] = topic_path topic
+          new_options[:message_retention_duration] = Convert.number_to_duration options[:retention]
+          new_options[:dead_letter_policy] = dead_letter_policy options
+          new_options[:ack_deadline_seconds] = options[:deadline]
+          new_options[:retain_acked_messages] = options[:retain_acked]
+          new_options[:enable_message_ordering] = options[:message_ordering]
+          
+          new_options.compact
         end
       end
     end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
@@ -364,7 +364,7 @@ module Google
         ##
         # Creates a new {Subscription} object on the current Topic.
         #
-        # @param [String] subscription_name Name of the new subscription. Required.
+        # @option options [String] subscription_name Name of the new subscription. Required.
         #   The value can be a simple subscription ID (relative name), in which
         #   case the current project ID will be supplied, or a fully-qualified
         #   subscription name in the form
@@ -375,26 +375,26 @@ module Google
         #   underscores (`_`), periods (`.`), tildes (`~`), plus (`+`) or percent
         #   signs (`%`). It must be between 3 and 255 characters in length, and
         #   it must not start with `goog`.
-        # @param [Integer] deadline The maximum number of seconds after a
+        # @option options [Integer] deadline The maximum number of seconds after a
         #   subscriber receives a message before the subscriber should
         #   acknowledge the message.
-        # @param [Boolean] retain_acked Indicates whether to retain acknowledged
+        # @option options [Boolean] retain_acked Indicates whether to retain acknowledged
         #   messages. If `true`, then messages are not expunged from the
         #   subscription's backlog, even if they are acknowledged, until they
         #   fall out of the `retention` window. Default is `false`.
-        # @param [Numeric] retention How long to retain unacknowledged messages
+        # @option options [Numeric] retention How long to retain unacknowledged messages
         #   in the subscription's backlog, from the moment a message is
         #   published. If `retain_acked` is `true`, then this also configures
         #   the retention of acknowledged messages, and thus configures how far
         #   back in time a {Subscription#seek} can be done. Cannot be more than
         #   604,800 seconds (7 days) or less than 600 seconds (10 minutes).
         #   Default is 604,800 seconds (7 days).
-        # @param [String] endpoint A URL locating the endpoint to which messages
+        # @option options [String] endpoint A URL locating the endpoint to which messages
         #   should be pushed. The parameters `push_config` and `endpoint` should not both be provided.
-        # @param [Google::Cloud::PubSub::Subscription::PushConfig] push_config The configuration for a push delivery
+        # @option options [Google::Cloud::PubSub::Subscription::PushConfig] push_config The configuration for a push delivery
         #   endpoint that should contain the endpoint, and can contain authentication data (OIDC token authentication).
         #   The parameters `push_config` and `endpoint` should not both be provided.
-        # @param [Hash] labels A hash of user-provided labels associated with
+        # @option options [Hash] labels A hash of user-provided labels associated with
         #   the subscription. You can use these to organize and group your
         #   subscriptions. Label keys and values can be no longer than 63
         #   characters, can only contain lowercase letters, numeric characters,
@@ -402,12 +402,12 @@ module Google
         #   values are optional. Label keys must start with a letter and each
         #   label in the list must have a different key. See [Creating and
         #   Managing Labels](https://cloud.google.com/pubsub/docs/labels).
-        # @param [Boolean] message_ordering Whether to enable message ordering
+        # @option options [Boolean] message_ordering Whether to enable message ordering
         #   on the subscription.
-        # @param [String] filter An expression written in the Cloud Pub/Sub filter language. If non-empty, then only
+        # @option options [String] filter An expression written in the Cloud Pub/Sub filter language. If non-empty, then only
         #   {Message} instances whose `attributes` field matches the filter are delivered on this subscription. If
         #   empty, then no messages are filtered out. Optional.
-        # @param [Topic] dead_letter_topic The {Topic} to which dead letter messages for the subscription should be
+        # @option options [Topic] dead_letter_topic The {Topic} to which dead letter messages for the subscription should be
         #   published. Dead lettering is done on a best effort basis. The same message might be dead lettered multiple
         #   times. The Cloud Pub/Sub service account associated with the enclosing subscription's parent project (i.e.,
         #   `service-{project_number}@gcp-sa-pubsub.iam.gserviceaccount.com`) must have permission to Publish() to
@@ -415,11 +415,11 @@ module Google
         #
         #   The operation will fail if the topic does not exist. Users should ensure that there is a subscription
         #   attached to this topic since messages published to a topic with no subscriptions are lost.
-        # @param [Integer] dead_letter_max_delivery_attempts The maximum number of delivery attempts for any message in
+        # @option options [Integer] dead_letter_max_delivery_attempts The maximum number of delivery attempts for any message in
         #   the subscription's dead letter policy. Dead lettering is done on a best effort basis. The same message might
         #   be dead lettered multiple times. The value must be between 5 and 100. If this parameter is 0, a default
         #   value of 5 is used. The `dead_letter_topic` must also be set.
-        # @param [RetryPolicy] retry_policy A policy that specifies how Cloud Pub/Sub retries message delivery for
+        # @option options [RetryPolicy] retry_policy A policy that specifies how Cloud Pub/Sub retries message delivery for
         #   this subscription. If not set, the default retry policy is applied. This generally implies that messages
         #   will be retried as soon as possible for healthy subscribers. Retry Policy will be triggered on NACKs or
         #   acknowledgement deadline exceeded events for a given message.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
@@ -486,14 +486,14 @@ module Google
         #   retry_policy = Google::Cloud::PubSub::RetryPolicy.new minimum_backoff: 5, maximum_backoff: 300
         #   sub = topic.subscribe "my-topic-sub", retry_policy: retry_policy
         #
-        def subscribe subscription_name, options = {}
+        def subscribe subscription_name, **options
           ensure_service!
           if options[:push_config] && options[:endpoint]
             raise ArgumentError, "endpoint and push_config were both provided. Please provide only one."
           end
           if options[:endpoint]
             options[:push_config] =
-              Google::Cloud::PubSub::Subscription::PushConfig.new endpoint: options.delete(:endpoint)
+              Google::Cloud::PubSub::Subscription::PushConfig.new endpoint: options[:endpoint]
           end
 
           options[:dead_letter_topic_name] = options[:dead_letter_topic].name if options[:dead_letter_topic]

--- a/google-cloud-pubsub/samples/acceptance/subscriptions_test.rb
+++ b/google-cloud-pubsub/samples/acceptance/subscriptions_test.rb
@@ -15,6 +15,7 @@
 require_relative "helper"
 require_relative "../subscriptions.rb"
 require_relative "../pubsub_create_subscription_with_filter.rb"
+require_relative "../pubsub_create_subscription_with_exactly_once_delivery.rb"
 
 describe "subscriptions" do
   let(:pubsub) { Google::Cloud::Pubsub.new }
@@ -184,13 +185,13 @@ describe "subscriptions" do
     project_id = pubsub.project
     topic_id = @topic.name
     subscription_id = random_subscription_id
-    filter = "attributes.author=\"unknown\""
 
     assert_output "Created subscription with exactly once delivery enabled: #{subscription_id}\n" do     
-      PubsubCreateSubscriptionWithFilter.new.create_subscription_with_filter project_id: project_id,
-                                                                             topic_id: topic_id,
-                                                                             subscription_id: subscription_id,
-                                                                             enable_exactly_once_delivery: true
+      PubsubCreateSubscriptionWithExactlyOnceDelivery.new.create_subscription_with_exactly_once_delivery(
+        project_id: project_id,
+        topic_id: topic_id,
+        subscription_id: subscription_id
+      )
     end
   end 
 end

--- a/google-cloud-pubsub/samples/acceptance/subscriptions_test.rb
+++ b/google-cloud-pubsub/samples/acceptance/subscriptions_test.rb
@@ -179,4 +179,18 @@ describe "subscriptions" do
                                                                              filter: filter
     end
   end 
+
+  it "supports creating subscription with exactly once delivery enabled" do
+    project_id = pubsub.project
+    topic_id = @topic.name
+    subscription_id = random_subscription_id
+    filter = "attributes.author=\"unknown\""
+
+    assert_output "Created subscription with exactly once delivery enabled: #{subscription_id}\n" do     
+      PubsubCreateSubscriptionWithFilter.new.create_subscription_with_filter project_id: project_id,
+                                                                             topic_id: topic_id,
+                                                                             subscription_id: subscription_id,
+                                                                             enable_exactly_once_delivery: true
+    end
+  end 
 end

--- a/google-cloud-pubsub/samples/pubsub_create_subscription_with_exactly_once_delivery.rb
+++ b/google-cloud-pubsub/samples/pubsub_create_subscription_with_exactly_once_delivery.rb
@@ -1,0 +1,45 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START pubsub_create_subscription_with_exactly_once_delivery]
+require "google/cloud/pubsub"
+
+# Shows how to create a new subscription with filter for a given topic
+class PubsubCreateSubscriptionWithExactlyOnceDelivery
+  def create_subscription_with_exactly_once_delivery project_id:, topic_id:, subscription_id:
+    pubsub = Google::Cloud::Pubsub.new project_id: project_id
+    topic = pubsub.topic topic_id
+    subscription = topic.subscribe subscription_id, enable_exactly_once_delivery: true
+    puts "Created subscription with exactly once delivery enabled: #{subscription_id}"
+  end
+
+  def self.run
+    # TODO(developer): Replace these variables before running the sample.
+    project_id = "your-project-id"
+    topic_id = "your-topic-id"
+    subscription_id = "id-for-new-subcription"
+    filter = "attributes.author=\"unknown\""
+    pubsub_create_subscription_with_exactly_once_delivery = PubsubCreateSubscriptionWithExactlyOnceDelivery.new
+    pubsub_create_subscription_with_exactly_once_delivery.create_subscription_with_exactly_once_delivery(
+      project_id: project_id,
+      topic_id: topic_id,
+      subscription_id: subscription_id
+    )
+  end
+end
+
+if $PROGRAM_NAME == __FILE__
+  PubsubCreateSubscriptionWithExactlyOnceDelivery.run
+end
+# [END pubsub_create_subscription_with_exactly_once_delivery]

--- a/google-cloud-pubsub/samples/pubsub_create_subscription_with_exactly_once_delivery.rb
+++ b/google-cloud-pubsub/samples/pubsub_create_subscription_with_exactly_once_delivery.rb
@@ -15,7 +15,7 @@
 # [START pubsub_create_subscription_with_exactly_once_delivery]
 require "google/cloud/pubsub"
 
-# Shows how to create a new subscription with filter for a given topic
+# Shows how to create a new subscription with exactly once delivery enabled
 class PubsubCreateSubscriptionWithExactlyOnceDelivery
   def create_subscription_with_exactly_once_delivery project_id:, topic_id:, subscription_id:
     pubsub = Google::Cloud::Pubsub.new project_id: project_id
@@ -29,7 +29,6 @@ class PubsubCreateSubscriptionWithExactlyOnceDelivery
     project_id = "your-project-id"
     topic_id = "your-topic-id"
     subscription_id = "id-for-new-subcription"
-    filter = "attributes.author=\"unknown\""
     pubsub_create_subscription_with_exactly_once_delivery = PubsubCreateSubscriptionWithExactlyOnceDelivery.new
     pubsub_create_subscription_with_exactly_once_delivery.create_subscription_with_exactly_once_delivery(
       project_id: project_id,

--- a/google-cloud-pubsub/test/helper.rb
+++ b/google-cloud-pubsub/test/helper.rb
@@ -207,7 +207,7 @@ class MockPubsub < Minitest::Spec
                                topic_name,
                                push_config: nil,
                                ack_deadline_seconds: nil,
-                               retain_acked_messages: false,
+                               retain_acked_messages: nil,
                                message_retention_duration: nil,
                                labels: nil,
                                enable_message_ordering: nil,
@@ -226,7 +226,7 @@ class MockPubsub < Minitest::Spec
       filter: filter,
       dead_letter_policy: dead_letter_policy,
       retry_policy: retry_policy
-    }
+    }.compact
   end
 
   def snapshots_hash topic_name, num_snapshots, token = nil


### PR DESCRIPTION
- Add sample and test for creating exactly once delivery enabled subscription
- Refactor topic and service to accept any options instead of manually adding them each time a new option is added in api
- Had to leave some unpleasant delete for backward compatibility


Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-ruby/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea.
- [x] Follow the instructions in [CONTRIBUTING](CONTRIBUTING.md). Most importantly, ensure the tests and linter pass by running `bundle exec rake ci` in the gem subdirectory.
- [x] Update code documentation if necessary.

b/227478067