### PR TITLE
Fix Firestore::Convert.fields_to_hash

### DIFF
--- a/google-cloud-firestore/lib/google/cloud/firestore/convert.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/convert.rb
@@ -50,6 +50,7 @@ module Google
           end
 
           def fields_to_hash fields, client
+            # Google::Protobuf::Map#to_h ignores the given block, unlike Hash#to_h
             # rubocop:disable Style/MapToHash
             fields
               .map { |key, value| [key.to_sym, value_to_raw(value, client)] }

--- a/google-cloud-firestore/lib/google/cloud/firestore/convert.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/convert.rb
@@ -50,9 +50,11 @@ module Google
           end
 
           def fields_to_hash fields, client
-            fields.to_h do |key, value|
-              [key.to_sym, value_to_raw(value, client)]
-            end
+            # rubocop:disable Style/MapToHash
+            fields
+              .map { |key, value| [key.to_sym, value_to_raw(value, client)] }
+              .to_h
+            # rubocop:enable Style/MapToHash
           end
 
           def hash_to_fields hash


### PR DESCRIPTION
Because `fields` is an instance of `Google::Protobuf::Map` and not a `Hash`, the `#to_h` method ignores the given block, and the value returned instead of something like:

    {id: 123}

looks like:

    {"id"=>{:null_value=>:NULL_VALUE, :boolean_value=>false, :integer_value=>123, :double_value=>0.0, :timestamp_value=>nil, :string_value=>"", :bytes_value=>"", :reference_value=>"", :geo_point_value=>nil, :array_value=>nil, :map_value=>nil}

The existing tests already caught the issue, so adding new tests was not neccessary.

The issue was first introduced [here][1], and affects version `2.7.0` of the gem.

[1]: https://github.com/googleapis/google-cloud-ruby/pull/18446/files#diff-2b92cbc5743990a07fd45c459abcd96b9b4673566be07698bde11b62ba674f07L53

It is necessary to disable rubocop for this block of code. Otherwise, running auto-correct will re-introduce the issue.

closes: #18832