### PR TITLE
docs(firestore): Fix typo in data model reference

### DIFF
--- a/google-cloud-firestore/OVERVIEW.md
+++ b/google-cloud-firestore/OVERVIEW.md
@@ -108,7 +108,7 @@ and it can't contain other collections. You do not need to "create" or "delete"
 collections. After you create the first document in a collection, the collection
 exists. If you delete all of the documents in a collection, it no longer exists.
 (For more information, see [Cloud Firestore Data
-Model](https://cloud.google.com/firestore/docs/data-model).
+Model](https://cloud.google.com/firestore/docs/data-model).)
 
 Use {Google::Cloud::Firestore::Client#cols Client#cols} to list the root-level
 collections:


### PR DESCRIPTION
There was a missing )

- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-ruby/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea. **Trivial typo fix, so no bug necessary IMO**
- [x] Follow the instructions in [CONTRIBUTING](CONTRIBUTING.md). Most importantly, ensure the tests and linter pass by running `bundle exec rake ci` in the gem subdirectory.
- [x] Update code documentation if necessary. **Purely a documentation fix**