### PR TITLE
chore: fix toys script to fetch changed dirs

### DIFF
--- a/.toys/ci.rb
+++ b/.toys/ci.rb
@@ -285,7 +285,7 @@ def filter_gem_dirs dirs
         controller.in.puts "spec = Gem::Specification.load '#{dir}/#{dir}.gemspec'"
         controller.in.puts "puts spec.required_ruby_version.satisfied_by? Gem::Version.new(#{RUBY_VERSION.inspect})"
       end
-      result == "true"
+      result.chomp == "true"
     else
       false
     end

--- a/.toys/ci.rb
+++ b/.toys/ci.rb
@@ -285,7 +285,7 @@ def filter_gem_dirs dirs
         controller.in.puts "spec = Gem::Specification.load '#{dir}/#{dir}.gemspec'"
         controller.in.puts "puts spec.required_ruby_version.satisfied_by? Gem::Version.new(#{RUBY_VERSION.inspect})"
       end
-      result.chomp == "true"
+      result.strip == "true"
     else
       false
     end


### PR DESCRIPTION
Acceptance tests and samples test are not run due to script filtering all dirs. 
eg: https://source.cloud.google.com/results/invocations/f8eef62c-f459-4ed1-a30c-030b5dc8ead7/targets/cloud-devrel%2Fclient-libraries%2Fgoogle-cloud-ruby%2Fpresubmit%2Facceptance/log
This PR fixes the string comparison that had a new line at the end.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-ruby/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea.
- [ ] Follow the instructions in [CONTRIBUTING](CONTRIBUTING.md). Most importantly, ensure the tests and linter pass by running `bundle exec rake ci` in the gem subdirectory.
- [ ] Update code documentation if necessary.

closes: #<issue_number_goes_here>