### PR TITLE
fix: samples and tests of Compute V1

### DIFF
--- a/google-cloud-compute-v1/acceptance/google/cloud/compute/v1/instances_smoke_test.rb
+++ b/google-cloud-compute-v1/acceptance/google/cloud/compute/v1/instances_smoke_test.rb
@@ -77,13 +77,6 @@ class InstancesSmokeTest < Minitest::Test
     assert_match(/The resource '[^']+' was not found/, exception.message)
   end
 
-  def test_client_error_no_prj
-    exception = assert_raises Google::Cloud::InvalidArgumentError do
-      @client.get instance: "nonexists1123512345", zone: @default_zone
-    end
-    assert exception.message.include?("An error has occurred when making a REST request: Invalid resource field value in the request.")
-  end
-
   def test_update_desc_to_empty
     # We test here: 1)set body field to empty string
     #               2)optional body field not set

--- a/google-cloud-compute-v1/samples/acceptance/firewall_test.rb
+++ b/google-cloud-compute-v1/samples/acceptance/firewall_test.rb
@@ -50,7 +50,7 @@ class ComputeFirewallTest < Minitest::Test
     client = ::Google::Cloud::Compute::V1::Firewalls::Rest::Client.new
     firewall = client.get project: project, firewall: firewall_name
     assert_equal 1000, firewall.priority
-    patch_firewall_priority project: project, name: firewall_name, priority: 500
+    patch_firewall_priority project: project, name: firewall_name, allowed: firewall.allowed, priority: 500
     firewall = client.get project: project, firewall: firewall_name
     assert_equal 500, firewall.priority
     delete_firewall_rule project: project, name: firewall_name

--- a/google-cloud-compute-v1/samples/acceptance/helper.rb
+++ b/google-cloud-compute-v1/samples/acceptance/helper.rb
@@ -20,19 +20,19 @@ require "securerandom"
 $temp_instances = []
 
 def random_instance_name
-  "i-#{SecureRandom.hex 6}"
+  "rubysamplestest-i-#{SecureRandom.hex 6}"
 end
 
 def random_bucket_name
-  "test-#{SecureRandom.hex 10}"
+  "rubysamplestest-b-#{SecureRandom.hex 10}"
 end
 
 def random_firewall_name
-  "firewall-#{SecureRandom.hex 10}"
+  "rubysamplestest-f-#{SecureRandom.hex 10}"
 end
 
 def project
-  ENV["GOOGLE_CLOUD_PROJECT"]
+  ENV["GOOGLE_CLOUD_PROJECT"] || raise("No project defined. Set `GOOGLE_CLOUD_PROJECT` env var to your_project_name")
 end
 
 def zone

--- a/google-cloud-compute-v1/samples/default_values.rb
+++ b/google-cloud-compute-v1/samples/default_values.rb
@@ -48,7 +48,7 @@ def set_usage_export_bucket project:, bucket_name:, report_name_prefix: ""
   projects_client = ::Google::Cloud::Compute::V1::Projects::Rest::Client.new
   operation = projects_client.set_usage_export_bucket project: project,
                                                       usage_export_location_resource: export_location
-  wait_until_done project: project, operation: operation.operation
+  wait_until_done operation: operation
 end
 # [END compute_usage_report_set]
 
@@ -82,6 +82,6 @@ def disable_usage_export project:
 
   # Passing nil (default) to usage_export_location_resource disables the usage report generation.
   operation = projects_client.set_usage_export_bucket project: project
-  wait_until_done project: project, operation: operation.operation
+  wait_until_done operation: operation
 end
 # [END compute_usage_report_disable]

--- a/google-cloud-compute-v1/samples/default_values.rb
+++ b/google-cloud-compute-v1/samples/default_values.rb
@@ -80,8 +80,8 @@ end
 def disable_usage_export project:
   projects_client = ::Google::Cloud::Compute::V1::Projects::Rest::Client.new
 
-  # Passing nil (default) to usage_export_location_resource disables the usage report generation.
-  operation = projects_client.set_usage_export_bucket project: project
+  # Passing an empty message to usage_export_location_resource disables the usage report generation.
+  operation = projects_client.set_usage_export_bucket project: project, usage_export_location_resource: {}
   wait_until_done operation: operation
 end
 # [END compute_usage_report_disable]

--- a/google-cloud-compute-v1/samples/firewall.rb
+++ b/google-cloud-compute-v1/samples/firewall.rb
@@ -96,10 +96,20 @@ end
 #
 # @param [String] project project ID or project number of the Cloud project you want to use.
 # @param [String] name name of the rule you want to modify.
+# @param [Google::Protobuf::RepeatedField] allowed the repeated instances of the Allowed field in the rule.
+#         Compute errors out if allowed is empty.
 # @param [Integer] priority the new priority to be set for the rule.
-def patch_firewall_priority project:, name:, priority:
+def patch_firewall_priority project:, name:, allowed:, priority:
+  allowed_arr = allowed.map do |instance|
+    {
+      I_p_protocol: instance.I_p_protocol,
+      ports: instance.ports.to_a
+    }
+  end.to_a
+
   rule = {
-    priority: priority
+    priority: priority,
+    allowed: allowed_arr
   }
 
   request = {

--- a/google-cloud-compute-v1/samples/firewall.rb
+++ b/google-cloud-compute-v1/samples/firewall.rb
@@ -87,7 +87,7 @@ def create_firewall_rule project:, name:, network: "global/networks/default"
   client = ::Google::Cloud::Compute::V1::Firewalls::Rest::Client.new
   operation = client.insert request
 
-  wait_until_done project: project, operation: operation.operation
+  wait_until_done operation: operation
 end
 # [END compute_firewall_create]
 
@@ -113,7 +113,7 @@ def patch_firewall_priority project:, name:, priority:
   client = ::Google::Cloud::Compute::V1::Firewalls::Rest::Client.new
   operation = client.patch request
 
-  wait_until_done project: project, operation: operation.operation
+  wait_until_done operation: operation
 end
 # [END compute_firewall_patch]
 
@@ -127,6 +127,6 @@ def delete_firewall_rule project:, name:
   client = ::Google::Cloud::Compute::V1::Firewalls::Rest::Client.new
   operation = client.delete project: project, firewall: name
 
-  wait_until_done project: project, operation: operation.operation
+  wait_until_done operation: operation
 end
 # [END compute_firewall_delete]


### PR DESCRIPTION
Split into semantically meaningful commits for reading convenience.

- Fixes related to transcoding being strict.
- Fix of the Firewall's Patch method that requires a repeatable field to be non-empty server-side
- Use Generic LRO's waiting on operations.


