### PR TITLE
chore(bigtable): Fix tests for pre-Ruby 3 and minitest 5.16

### DIFF
--- a/google-cloud-bigtable/lib/google/cloud/bigtable/service.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/service.rb
@@ -282,7 +282,7 @@ module Google
           initial_splits = initial_splits.map { |key| { key: key } } if initial_splits
 
           tables.create_table(
-            {
+            **{
               parent:         instance_path(instance_id),
               table_id:       table_id,
               table:          table,
@@ -650,7 +650,7 @@ module Google
 
         def read_rows instance_id, table_id, app_profile_id: nil, rows: nil, filter: nil, rows_limit: nil
           client.read_rows(
-            {
+            **{
               table_name:     table_path(instance_id, table_id),
               rows:           rows,
               filter:         filter,
@@ -666,7 +666,7 @@ module Google
 
         def mutate_row table_name, row_key, mutations, app_profile_id: nil
           client.mutate_row(
-            {
+            **{
               table_name:     table_name,
               app_profile_id: app_profile_id,
               row_key:        row_key,
@@ -677,7 +677,7 @@ module Google
 
         def mutate_rows table_name, entries, app_profile_id: nil
           client.mutate_rows(
-            {
+            **{
               table_name:     table_name,
               app_profile_id: app_profile_id,
               entries:        entries
@@ -692,7 +692,7 @@ module Google
                                  true_mutations: nil,
                                  false_mutations: nil
           client.check_and_mutate_row(
-            {
+            **{
               table_name:       table_name,
               app_profile_id:   app_profile_id,
               row_key:          row_key,
@@ -705,7 +705,7 @@ module Google
 
         def read_modify_write_row table_name, row_key, rules, app_profile_id: nil
           client.read_modify_write_row(
-            {
+            **{
               table_name:     table_name,
               app_profile_id: app_profile_id,
               row_key:        row_key,

--- a/google-cloud-bigtable/test/google/cloud/bigtable/conformance_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/conformance_test.rb
@@ -42,13 +42,12 @@ class ReadRowsTest < MockBigtable
       table = bigtable.table(instance_id, table_id)
 
       resp = Google::Cloud::Bigtable::V2::ReadRowsResponse.new chunks: test.chunks.to_a
-      mock.expect :read_rows, [resp], [
+      mock.expect :read_rows, [resp],
         table_name: table_path(instance_id, table_id),
-          rows: Google::Cloud::Bigtable::V2::RowSet.new,
-          filter: nil,
-          rows_limit: nil,
-          app_profile_id: nil
-        ]
+        rows: Google::Cloud::Bigtable::V2::RowSet.new,
+        filter: nil,
+        rows_limit: nil,
+        app_profile_id: nil
       rows = table.read_rows
       if test.results.empty? # "no data after reset"
         expect do

--- a/google-cloud-bigtable/test/google/cloud/bigtable/instance/create_table_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/instance/create_table_test.rb
@@ -34,7 +34,7 @@ describe Google::Cloud::Bigtable::Instance, :create_table, :mock_bigtable do
       name: table_path(instance_id, table_id)
     )
 
-    mock.expect :create_table, create_res, [parent: instance_path(instance_id), table_id: table_id, table: req_table]
+    mock.expect :create_table, create_res, parent: instance_path(instance_id), table_id: table_id, table: req_table
     bigtable.service.mocked_tables = mock
 
     table = instance.create_table(table_id)
@@ -63,7 +63,7 @@ describe Google::Cloud::Bigtable::Instance, :create_table, :mock_bigtable do
       column_families: column_families,
       granularity: :MILLIS
     )
-    mock.expect :create_table, create_res.dup, [parent: instance_path(instance_id), table_id: table_id, table: req_table]
+    mock.expect :create_table, create_res.dup, parent: instance_path(instance_id), table_id: table_id, table: req_table
 
     get_res = Google::Cloud::Bigtable::Admin::V2::Table.new(
       table_hash(
@@ -114,7 +114,7 @@ describe Google::Cloud::Bigtable::Instance, :create_table, :mock_bigtable do
       column_families: column_families,
       granularity: :MILLIS
     )
-    mock.expect :create_table, create_res.dup, [parent: instance_path(instance_id), table_id: table_id, table: req_table]
+    mock.expect :create_table, create_res.dup, parent: instance_path(instance_id), table_id: table_id, table: req_table
 
     get_res = Google::Cloud::Bigtable::Admin::V2::Table.new(
       table_hash(
@@ -164,12 +164,11 @@ describe Google::Cloud::Bigtable::Instance, :create_table, :mock_bigtable do
       granularity: :MILLIS
     )
 
-    mock.expect :create_table, create_res.dup, [
+    mock.expect :create_table, create_res.dup,
       parent: instance_path(instance_id),
       table_id: table_id,
       table: req_table,
       initial_splits: initial_splits.map { |key| { key: key } }
-    ]
     bigtable.service.mocked_tables = mock
 
     table = instance.create_table(

--- a/google-cloud-bigtable/test/google/cloud/bigtable/project/create_table_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/project/create_table_test.rb
@@ -37,7 +37,7 @@ describe Google::Cloud::Bigtable::Project, :create_table, :mock_bigtable do
       column_families: column_families,
       granularity: :MILLIS
     )
-    mock.expect :create_table, create_res, [parent: instance_path(instance_id), table_id: table_id, table: req_table]
+    mock.expect :create_table, create_res, parent: instance_path(instance_id), table_id: table_id, table: req_table
 
     get_res = Google::Cloud::Bigtable::Admin::V2::Table.new(
       table_hash(
@@ -97,7 +97,7 @@ describe Google::Cloud::Bigtable::Project, :create_table, :mock_bigtable do
       column_families: column_families,
       granularity: :MILLIS
     )
-    mock.expect :create_table, create_res, [parent: instance_path(instance_id), table_id: table_id, table: req_table]
+    mock.expect :create_table, create_res, parent: instance_path(instance_id), table_id: table_id, table: req_table
 
     get_res = Google::Cloud::Bigtable::Admin::V2::Table.new(
       table_hash(
@@ -154,12 +154,11 @@ describe Google::Cloud::Bigtable::Project, :create_table, :mock_bigtable do
       column_families: column_families,
       granularity: :MILLIS
     )
-    mock.expect :create_table, create_res, [
+    mock.expect :create_table, create_res,
       parent: instance_path(instance_id),
       table_id: table_id,
       table: req_table,
       initial_splits: initial_splits.map { |key| { key: key } }
-    ]
 
     get_res = Google::Cloud::Bigtable::Admin::V2::Table.new(
       table_hash(

--- a/google-cloud-bigtable/test/google/cloud/bigtable/row_reader/read_rows_state_machine_acceptance_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/row_reader/read_rows_state_machine_acceptance_test.rb
@@ -86,7 +86,12 @@ describe Google::Cloud::Bigtable::RowsReader, :read_state_machine_acceptance, :m
       table = bigtable.table(instance_id, table_id)
 
       get_res = chunk_data_to_read_res(test_data["chunks_base64"])
-      mock.expect :read_rows, get_res, [Hash]
+      mock.expect :read_rows, get_res,
+        table_name: String,
+        rows: Google::Cloud::Bigtable::V2::RowSet,
+        filter: nil,
+        rows_limit: nil,
+        app_profile_id: nil
       assert_raises Google::Cloud::Bigtable::InvalidRowStateError do
         table.read_rows.each{|v| v}
       end
@@ -102,7 +107,12 @@ describe Google::Cloud::Bigtable::RowsReader, :read_state_machine_acceptance, :m
       table = bigtable.table(instance_id, table_id)
 
       get_res = chunk_data_to_read_res(test_data["chunks_base64"])
-      mock.expect :read_rows, get_res, [Hash]
+      mock.expect :read_rows, get_res,
+        table_name: String,
+        rows: Google::Cloud::Bigtable::V2::RowSet,
+        filter: nil,
+        rows_limit: nil,
+        app_profile_id: nil
 
       expected_result = TestResult.build(test_data["results"])
       expected_families = expected_result.map(&:fm).uniq.sort

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/check_and_mutate_row_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/check_and_mutate_row_test.rb
@@ -38,13 +38,12 @@ describe Google::Cloud::Bigtable::Table, :check_and_mutate_row, :mock_bigtable d
     ]
 
     res = Google::Cloud::Bigtable::V2::CheckAndMutateRowResponse.new(predicate_matched: true)
-    mock.expect :check_and_mutate_row, res, [
+    mock.expect :check_and_mutate_row, res,
       table_name: table_path(instance_id, table_id),
       row_key: row_key,
       predicate_filter: predicate_filter,
       true_mutations: true_mutations,
       false_mutations: false_mutations
-    ]
 
     result = table.check_and_mutate_row(
       row_key,

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/mutate_row_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/mutate_row_test.rb
@@ -37,12 +37,11 @@ describe Google::Cloud::Bigtable::Table, :mutate_row, :mock_bigtable do
     mutations = Google::Cloud::Bigtable::V2::Mutation.new(set_cell: {
       family_name: "cf1", column_qualifier: "field1", value: "XYZ"
     })
-    mock.expect :mutate_row, res, [
+    mock.expect :mutate_row, res,
       table_name: table_path(instance_id, table_id),
       row_key: row_key,
       mutations: [mutations],
       app_profile_id: app_profile_id
-    ]
 
     _(table.mutate_row(entry)).must_equal true
     mock.verify

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/mutate_rows_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/mutate_rows_test.rb
@@ -65,11 +65,10 @@ describe Google::Cloud::Bigtable::Table, :mutate_rows, :mock_bigtable do
       }]
     )
 
-    mock.expect :mutate_rows, [res], [
+    mock.expect :mutate_rows, [res],
       table_name: table_path(instance_id, table_id),
       entries: [mutation_entry_grpc],
       app_profile_id: app_profile_id
-    ]
 
     entry = Google::Cloud::Bigtable::MutationEntry.new(row_key)
     entry.set_cell(family, qualifier, cell_value, timestamp: timestamp)
@@ -101,7 +100,7 @@ describe Google::Cloud::Bigtable::Table, :mutate_rows, :mock_bigtable do
       }]
     )
     mock = Minitest::Mock.new
-    mock.expect :mutate_rows, [res], [table_name: table_path(instance_id, table_id), entries: [entry], app_profile_id: app_profile_id]
+    mock.expect :mutate_rows, [res], table_name: table_path(instance_id, table_id), entries: [entry], app_profile_id: app_profile_id
 
     bigtable.service.mocked_client = mock
 

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/read_modify_write_row_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/read_modify_write_row_test.rb
@@ -50,11 +50,10 @@ describe Google::Cloud::Bigtable::Table, :read_modify_write_row, :mock_bigtable 
       family_name: family_name, column_qualifier: qualifier, append_value: append_value
     )
 
-    mock.expect :read_modify_write_row, res, [
+    mock.expect :read_modify_write_row, res,
       table_name: table_path(instance_id, table_id),
       row_key: row_key,
       rules: [rule]
-    ]
 
     row = table.read_modify_write_row(
       row_key,
@@ -101,11 +100,10 @@ describe Google::Cloud::Bigtable::Table, :read_modify_write_row, :mock_bigtable 
       family_name: family_name, column_qualifier: qualifier, increment_amount: increment_amount
     )
 
-    mock.expect :read_modify_write_row, res, [
+    mock.expect :read_modify_write_row, res,
       table_name: table_path(instance_id, table_id),
       row_key: row_key,
       rules: [rule_1, rule_2]
-    ]
 
     row = table.read_modify_write_row(
       row_key,

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/read_rows_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/read_rows_test.rb
@@ -41,13 +41,11 @@ describe Google::Cloud::Bigtable::Table, :read_rows, :mock_bigtable do
     get_res = [Google::Cloud::Bigtable::V2::ReadRowsResponse.new(chunks: chunks)]
 
     mock.expect :read_rows, get_res,
-                [
-                  table_name: table_path(instance_id, table_id),
-                  rows: Google::Cloud::Bigtable::V2::RowSet.new,
-                  filter: nil,
-                  rows_limit: nil,
-                  app_profile_id: nil
-                ]
+                table_name: table_path(instance_id, table_id),
+                rows: Google::Cloud::Bigtable::V2::RowSet.new,
+                filter: nil,
+                rows_limit: nil,
+                app_profile_id: nil
 
     expected_row = Google::Cloud::Bigtable::Row.new("RK")
     expected_row.cells["A"] << Google::Cloud::Bigtable::Row::Cell.new(
@@ -194,16 +192,14 @@ describe Google::Cloud::Bigtable::Table, :read_rows, :mock_bigtable do
   it "read rows using row keys" do
     mock = Minitest::Mock.new
     mock.expect :read_rows, [],
-                [
-                  table_name: "projects/test/instances/test-instance/tables/test-table",
-                  rows: Google::Cloud::Bigtable::V2::RowSet.new(
-                    row_keys: ["A", "B"],
-                    row_ranges: []
-                  ),
-                  filter: nil,
-                  rows_limit: nil,
-                  app_profile_id: nil
-                ]
+                table_name: "projects/test/instances/test-instance/tables/test-table",
+                rows: Google::Cloud::Bigtable::V2::RowSet.new(
+                  row_keys: ["A", "B"],
+                  row_ranges: []
+                ),
+                filter: nil,
+                rows_limit: nil,
+                app_profile_id: nil
 
     bigtable.service.mocked_client = mock
     table = bigtable.table(instance_id, table_id)


### PR DESCRIPTION
Changes so that the tests will pass on both Ruby < 3.0 and >= 3.0. Minitest 5.16 forces us to mock methods in the same way (with respect to keyword arguments) that they are called. This requires us to call some of the underlying client methods as keyword arguments (on both Ruby 2 and Ruby 3) so that we can mock them in the same way.