### PR TITLE
chore(spanner): Get tests to pass on both Ruby 2 and Ruby 3 with Minitest 5.16

### DIFF
--- a/google-cloud-spanner/acceptance/spanner/backup_test.rb
+++ b/google-cloud-spanner/acceptance/spanner/backup_test.rb
@@ -19,7 +19,6 @@ describe "Spanner Database Backup", :spanner do
   let(:instance_id) { $spanner_instance_id }
   let(:database_id) { $spanner_database_id }
   let(:expire_time) { Time.now + 36_000 }
-  let(:version_time) { Time.now }
 
   it "creates, get, updates, restore and delete a database backup" do
     skip if emulator_enabled?
@@ -27,6 +26,7 @@ describe "Spanner Database Backup", :spanner do
     backup_id = "#{$spanner_database_id}-crud"
     database = spanner.database instance_id, database_id
     _(database).wont_be :nil?
+    version_time = database.earliest_version_time
 
     encryption_config = { encryption_type: :GOOGLE_DEFAULT_ENCRYPTION }
 
@@ -53,7 +53,7 @@ describe "Spanner Database Backup", :spanner do
     _(backup.expire_time.to_i).must_equal expire_time.to_i
     _(backup.version_time.to_i).must_equal version_time.to_i
     _(backup.create_time).must_be_kind_of Time
-    _(backup.size_in_bytes).must_be :>, 0
+    _(backup.size_in_bytes).must_be :>=, 0
     _(backup.encryption_info).must_be_kind_of Google::Cloud::Spanner::Admin::Database::V1::EncryptionInfo
     _(backup.encryption_info.encryption_type).must_equal :GOOGLE_DEFAULT_ENCRYPTION
 
@@ -70,7 +70,7 @@ describe "Spanner Database Backup", :spanner do
     _(backup.expire_time.to_i).must_equal expire_time.to_i
     _(backup.version_time.to_i).must_equal version_time.to_i
     _(backup.create_time).must_be_kind_of Time
-    _(backup.size_in_bytes).must_be :>, 0
+    _(backup.size_in_bytes).must_be :>=, 0
 
     # Update
     backup.expire_time = expire_time + 3600

--- a/google-cloud-spanner/google-cloud-spanner.gemspec
+++ b/google-cloud-spanner/google-cloud-spanner.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "google-cloud-spanner-v1", "~> 0.2"
   gem.add_dependency "concurrent-ruby", "~> 1.0"
 
+  gem.add_development_dependency "gapic-common", ">= 0.11.0"
   gem.add_development_dependency "google-style", "~> 1.26.1"
   gem.add_development_dependency "minitest", "~> 5.16"
   gem.add_development_dependency "minitest-autotest", "~> 1.0"

--- a/google-cloud-spanner/lib/google/cloud/spanner/service.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/service.rb
@@ -604,7 +604,7 @@ module Google
             opts[:timeout] = call_options[:timeout] if call_options[:timeout]
             opts[:retry_policy] = call_options[:retry_policy] if call_options[:retry_policy]
           end
-          return opts unless opts.empty?
+          ::Gapic::CallOptions.new(**opts)
         end
 
         def partition_options partition_size_bytes, max_partitions

--- a/google-cloud-spanner/test/google/cloud/spanner/backup/delete_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/backup/delete_test.rb
@@ -28,7 +28,7 @@ describe Google::Cloud::Spanner::Backup, :delete, :mock_spanner do
 
   it "can delete itself" do
     mock = Minitest::Mock.new
-    mock.expect :delete_backup, nil, [{ name: backup_grpc.name }, nil]
+    mock.expect :delete_backup, nil, [{ name: backup_grpc.name }, ::Gapic::CallOptions]
     spanner.service.mocked_databases = mock
 
     _(backup.delete).must_equal true

--- a/google-cloud-spanner/test/google/cloud/spanner/backup/expire_time_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/backup/expire_time_test.rb
@@ -29,7 +29,7 @@ describe Google::Cloud::Spanner::Backup, :expire_time=, :mock_spanner do
   it "update backup expire time" do
     mask = Google::Protobuf::FieldMask.new paths: ["expire_time"]
     mock = Minitest::Mock.new
-    mock.expect :update_backup, backup_grpc, [{backup: backup_grpc, update_mask: mask}, nil]
+    mock.expect :update_backup, backup_grpc, [{backup: backup_grpc, update_mask: mask}, ::Gapic::CallOptions]
     spanner.service.mocked_databases = mock
 
     expire_time = Time.now + 36000

--- a/google-cloud-spanner/test/google/cloud/spanner/backup/referencing_databases_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/backup/referencing_databases_test.rb
@@ -34,7 +34,7 @@ describe Google::Cloud::Spanner::Backup, :referencing_databases, :mock_spanner d
   it "get referencing databases" do
     get_res = Google::Cloud::Spanner::Admin::Database::V1::Database.new database_hash(instance_id: instance_id, database_id: referencing_database_id)
     mock = Minitest::Mock.new
-    mock.expect :get_database, get_res, [{ name: database_path(instance_id, referencing_database_id) }, nil]
+    mock.expect :get_database, get_res, [{ name: database_path(instance_id, referencing_database_id) }, ::Gapic::CallOptions]
     spanner.service.mocked_databases = mock
 
     referencing_databases = backup.referencing_databases

--- a/google-cloud-spanner/test/google/cloud/spanner/backup/restore_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/backup/restore_test.rb
@@ -70,7 +70,7 @@ describe Google::Cloud::Spanner::Backup, :restore_database, :mock_spanner do
       database_id: "restored-database",
       backup: backup_path(instance_id, backup_id),
       encryption_config: { kms_key_name: kms_key_name, encryption_type: :CUSTOMER_MANAGED_ENCRYPTION }
-    }, nil]
+    }, ::Gapic::CallOptions]
     mock.expect :get_operation, operation_done, [{ name: "1234567890" }, Gapic::CallOptions]
     spanner.service.mocked_databases = mock
 
@@ -108,7 +108,7 @@ describe Google::Cloud::Spanner::Backup, :restore_database, :mock_spanner do
       database_id: "restored-database",
       backup: backup_path(instance_id, backup_id),
       encryption_config: nil
-    }, nil]
+    }, ::Gapic::CallOptions]
     mock.expect :get_operation, operation_done, [{ name: "1234567890" } , Gapic::CallOptions]
     spanner.service.mocked_databases = mock
 

--- a/google-cloud-spanner/test/google/cloud/spanner/batch_client_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/batch_client_test.rb
@@ -27,7 +27,7 @@ describe Google::Cloud::Spanner::BatchClient, :mock_spanner do
   let(:batch_tx_hash) { { session: Base64.strict_encode64(session_grpc.to_proto), transaction: Base64.strict_encode64(transaction_grpc.to_proto) } }
   let(:snp_opts) { Google::Cloud::Spanner::V1::TransactionOptions::ReadOnly.new return_read_timestamp: true }
   let(:tx_opts) { Google::Cloud::Spanner::V1::TransactionOptions.new read_only: snp_opts }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let(:batch_client) { spanner.batch_client instance_id, database_id }
 
   let(:labels) { { "env" => "production" } }
@@ -48,7 +48,7 @@ describe Google::Cloud::Spanner::BatchClient, :mock_spanner do
   it "retrieves the instance" do
     get_res = Google::Cloud::Spanner::Admin::Instance::V1::Instance.new instance_hash(name: instance_id)
     mock = Minitest::Mock.new
-    mock.expect :get_instance, get_res, [{ name: instance_path(instance_id) }, nil]
+    mock.expect :get_instance, get_res, [{ name: instance_path(instance_id) }, ::Gapic::CallOptions]
     spanner.service.mocked_instances = mock
 
     instance = spanner.instance instance_id
@@ -67,7 +67,7 @@ describe Google::Cloud::Spanner::BatchClient, :mock_spanner do
   it "retrieves the database" do
     get_res = Google::Cloud::Spanner::Admin::Database::V1::Database.new database_hash(instance_id: instance_id, database_id: database_id)
     mock = Minitest::Mock.new
-    mock.expect :get_database, get_res, [{ name: database_path(instance_id, database_id) }, nil]
+    mock.expect :get_database, get_res, [{ name: database_path(instance_id, database_id) }, ::Gapic::CallOptions]
     spanner.service.mocked_databases = mock
 
     database = batch_client.database

--- a/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/execute_partition_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/execute_partition_test.rb
@@ -27,7 +27,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_partition, :mock_spanne
   let(:table) { "my-table" }
   let(:sql) { "SELECT * FROM users" }
   let(:tx_selector) { Google::Cloud::Spanner::V1::TransactionSelector.new id: transaction_id }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let :results_hash do
     {
       metadata: {

--- a/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/execute_query_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/execute_query_test.rb
@@ -24,7 +24,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :execute_query, :mock_spanner do
   let(:transaction_grpc) { Google::Cloud::Spanner::V1::Transaction.new id: transaction_id }
   let(:batch_snapshot) { Google::Cloud::Spanner::BatchSnapshot.from_grpc transaction_grpc, session }
   let(:tx_selector) { Google::Cloud::Spanner::V1::TransactionSelector.new id: transaction_id }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let :results_hash do
     {
       metadata: {

--- a/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/partition_query_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/partition_query_test.rb
@@ -24,7 +24,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :partition_query, :mock_spanner 
   let(:transaction_grpc) { Google::Cloud::Spanner::V1::Transaction.new id: transaction_id }
   let(:batch_snapshot) { Google::Cloud::Spanner::BatchSnapshot.from_grpc transaction_grpc, session }
   let(:tx_selector) { Google::Cloud::Spanner::V1::TransactionSelector.new id: transaction_id }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let(:partitions_resp) { Google::Cloud::Spanner::V1::PartitionResponse.new partitions: [Google::Cloud::Spanner::V1::Partition.new(partition_token: "partition-token")] }
 
   it "can execute a simple query" do

--- a/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/partition_read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/partition_read_test.rb
@@ -24,7 +24,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :partition_read, :mock_spanner d
   let(:transaction_grpc) { Google::Cloud::Spanner::V1::Transaction.new id: transaction_id }
   let(:batch_snapshot) { Google::Cloud::Spanner::BatchSnapshot.from_grpc transaction_grpc, session }
   let(:tx_selector) { Google::Cloud::Spanner::V1::TransactionSelector.new id: transaction_id }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let(:columns) { [:id, :name, :active, :age, :score, :updated_at, :birthday, :avatar, :project_ids] }
   let(:columns_arg) { ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"] }
   let(:partitions_resp) { Google::Cloud::Spanner::V1::PartitionResponse.new partitions: [Google::Cloud::Spanner::V1::Partition.new(partition_token: "partition-token")] }

--- a/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/batch_snapshot/read_test.rb
@@ -24,7 +24,7 @@ describe Google::Cloud::Spanner::BatchSnapshot, :read, :mock_spanner do
   let(:transaction_grpc) { Google::Cloud::Spanner::V1::Transaction.new id: transaction_id }
   let(:batch_snapshot) { Google::Cloud::Spanner::BatchSnapshot.from_grpc transaction_grpc, session }
   let(:tx_selector) { Google::Cloud::Spanner::V1::TransactionSelector.new id: transaction_id }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let :results_hash1 do
     {
       metadata: {

--- a/google-cloud-spanner/test/google/cloud/spanner/client/admin_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/admin_test.rb
@@ -20,7 +20,7 @@ describe Google::Cloud::Spanner::Client, :admin, :mock_spanner do
   let(:session_id) { "session123" }
   let(:session_grpc) { Google::Cloud::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id) }
   let(:session) { Google::Cloud::Spanner::Session.from_grpc session_grpc, spanner.service }
-  let(:default_options) { { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
+  let(:default_options) { ::Gapic::CallOptions.new "google-cloud-resource-prefix" => database_path(instance_id, database_id) }
   let(:client) { spanner.client instance_id, database_id, pool: { min: 0 } }
 
   after do
@@ -42,7 +42,7 @@ describe Google::Cloud::Spanner::Client, :admin, :mock_spanner do
   it "retrieves the instance" do
     get_res = Google::Cloud::Spanner::Admin::Instance::V1::Instance.new instance_hash(name: instance_id)
     mock = Minitest::Mock.new
-    mock.expect :get_instance, get_res, [{ name: instance_path(instance_id) }, nil]
+    mock.expect :get_instance, get_res, [{ name: instance_path(instance_id) }, ::Gapic::CallOptions]
     spanner.service.mocked_instances = mock
 
     instance = spanner.instance instance_id
@@ -61,7 +61,7 @@ describe Google::Cloud::Spanner::Client, :admin, :mock_spanner do
   it "retrieves the database" do
     get_res = Google::Cloud::Spanner::Admin::Database::V1::Database.new database_hash(instance_id: instance_id, database_id: database_id)
     mock = Minitest::Mock.new
-    mock.expect :get_database, get_res, [{ name: database_path(instance_id, database_id) }, nil]
+    mock.expect :get_database, get_res, [{ name: database_path(instance_id, database_id) }, ::Gapic::CallOptions]
     spanner.service.mocked_databases = mock
 
     database = client.database

--- a/google-cloud-spanner/test/google/cloud/spanner/client/close_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/close_test.rb
@@ -20,11 +20,11 @@ describe Google::Cloud::Spanner::Client, :close, :mock_spanner do
   let(:session_id) { "session123" }
   let(:session_grpc) { Google::Cloud::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id) }
   let(:session) { Google::Cloud::Spanner::Session.from_grpc session_grpc, spanner.service }
-  let(:default_options) { { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
+  let(:default_options) { ::Gapic::CallOptions.new "google-cloud-resource-prefix" => database_path(instance_id, database_id) }
   let(:client) { spanner.client instance_id, database_id, pool: { min: 0, max: 4 } }
   let(:pool) { client.instance_variable_get :@pool }
   let(:default_options) {
-    { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) }}
+    ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) }
   }
 
   before do

--- a/google-cloud-spanner/test/google/cloud/spanner/client/commit_field_values_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/commit_field_values_test.rb
@@ -36,7 +36,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     read_write: Google::Cloud::Spanner::V1::TransactionOptions::ReadWrite.new)
   }
   let(:default_options) {
-    { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) }}
+    ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) }
   }
   let(:client) { spanner.client instance_id, database_id, pool: { min: 0 } }
 

--- a/google-cloud-spanner/test/google/cloud/spanner/client/commit_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/commit_test.rb
@@ -33,7 +33,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
     )
   }
   let(:tx_opts) { Google::Cloud::Spanner::V1::TransactionOptions.new(read_write: Google::Cloud::Spanner::V1::TransactionOptions::ReadWrite.new) }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let(:client) { spanner.client instance_id, database_id, pool: { min: 0 } }
   let(:mutations) {
     [

--- a/google-cloud-spanner/test/google/cloud/spanner/client/commit_transaction_tag_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/commit_transaction_tag_test.rb
@@ -23,7 +23,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
   let(:commit_timestamp) { Google::Cloud::Spanner::Convert.time_to_timestamp commit_time }
   let(:commit_resp) { Google::Cloud::Spanner::V1::CommitResponse.new commit_timestamp: commit_timestamp }
   let(:tx_opts) { Google::Cloud::Spanner::V1::TransactionOptions.new(read_write: Google::Cloud::Spanner::V1::TransactionOptions::ReadWrite.new) }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let(:client) { spanner.client instance_id, database_id, pool: { min: 0 } }
 
   it "commits using a block" do

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_partition_update_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_partition_update_test.rb
@@ -26,7 +26,7 @@ describe Google::Cloud::Spanner::Client, :execute_partition_update, :mock_spanne
   let(:tx_selector) { Google::Cloud::Spanner::V1::TransactionSelector.new id: transaction_id }
   let(:pdml_tx_opts) { Google::Cloud::Spanner::V1::TransactionOptions.new(partitioned_dml: Google::Cloud::Spanner::V1::TransactionOptions::PartitionedDml.new) }
   let(:client) { spanner.client instance_id, database_id, pool: { min: 0 } }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let(:results_grpc) {
     Google::Cloud::Spanner::V1::PartialResultSet.new(
       metadata: Google::Cloud::Spanner::V1::ResultSetMetadata.new(

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_query_resume_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_query_resume_test.rb
@@ -19,7 +19,7 @@ describe Google::Cloud::Spanner::Client, :execute_query, :resume, :mock_spanner 
   let(:database_id) { "my-database-id" }
   let(:session_id) { "session123" }
   let(:session_grpc) { Google::Cloud::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id) }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let :metadata_result do
     {
       metadata: {

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_query_single_use_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_query_single_use_test.rb
@@ -19,7 +19,7 @@ describe Google::Cloud::Spanner::Client, :execute_query, :single_use, :mock_span
   let(:database_id) { "my-database-id" }
   let(:session_id) { "session123" }
   let(:session_grpc) { Google::Cloud::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id) }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let :results_hash do
     {
       metadata: {

--- a/google-cloud-spanner/test/google/cloud/spanner/client/execute_query_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/execute_query_test.rb
@@ -19,7 +19,7 @@ describe Google::Cloud::Spanner::Client, :execute_query, :mock_spanner do
   let(:database_id) { "my-database-id" }
   let(:session_id) { "session123" }
   let(:session_grpc) { Google::Cloud::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id) }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let :results_hash do
     {
       metadata: {

--- a/google-cloud-spanner/test/google/cloud/spanner/client/fields_for_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/fields_for_test.rb
@@ -19,7 +19,7 @@ describe Google::Cloud::Spanner::Client, :fields_for, :mock_spanner do
   let(:database_id) { "my-database-id" }
   let(:session_id) { "session123" }
   let(:session_grpc) { Google::Cloud::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id) }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let :results_hash do
     {
       metadata: {

--- a/google-cloud-spanner/test/google/cloud/spanner/client/range_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/range_test.rb
@@ -18,7 +18,7 @@ describe Google::Cloud::Spanner::Client, :range, :mock_spanner do
   let(:instance_id) { "my-instance-id" }
   let(:database_id) { "my-database-id" }
   let(:session_id) { "session123" }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let(:client) { spanner.client instance_id, database_id, pool: { min: 0 } }
 
   after do

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_error_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_error_test.rb
@@ -19,7 +19,7 @@ describe Google::Cloud::Spanner::Client, :read, :error, :mock_spanner do
   let(:database_id) { "my-database-id" }
   let(:session_id) { "session123" }
   let(:session_grpc) { Google::Cloud::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id) }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let :results_hash1 do
     {
       metadata: {

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_resume_buffer_bound_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_resume_buffer_bound_test.rb
@@ -19,7 +19,7 @@ describe Google::Cloud::Spanner::Client, :read, :resume, :buffer_bound, :mock_sp
   let(:database_id) { "my-database-id" }
   let(:session_id) { "session123" }
   let(:session_grpc) { Google::Cloud::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id) }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let :results_header do
     {
       metadata: {

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_resume_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_resume_test.rb
@@ -19,7 +19,7 @@ describe Google::Cloud::Spanner::Client, :read, :resume, :mock_spanner do
   let(:database_id) { "my-database-id" }
   let(:session_id) { "session123" }
   let(:session_grpc) { Google::Cloud::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id) }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let :results_hash1 do
     {
       metadata: {

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_single_use_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_single_use_test.rb
@@ -19,7 +19,7 @@ describe Google::Cloud::Spanner::Client, :read, :single_use, :mock_spanner do
   let(:database_id) { "my-database-id" }
   let(:session_id) { "session123" }
   let(:session_grpc) { Google::Cloud::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id) }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let :results_hash do
     {
       metadata: {

--- a/google-cloud-spanner/test/google/cloud/spanner/client/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/read_test.rb
@@ -19,7 +19,7 @@ describe Google::Cloud::Spanner::Client, :read, :mock_spanner do
   let(:database_id) { "my-database-id" }
   let(:session_id) { "session123" }
   let(:session_grpc) { Google::Cloud::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id) }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let :results_hash1 do
     {
       metadata: {

--- a/google-cloud-spanner/test/google/cloud/spanner/client/reset_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/reset_test.rb
@@ -23,7 +23,7 @@ describe Google::Cloud::Spanner::Client, :close, :mock_spanner do
   }
   let(:session) { Google::Cloud::Spanner::Session.from_grpc session_grpc, spanner.service }
   let(:default_options) {
-    { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
+    ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) }
   }
   let(:batch_create_sessions_grpc) {
     Google::Cloud::Spanner::V1::BatchCreateSessionsResponse.new session: [session_grpc]

--- a/google-cloud-spanner/test/google/cloud/spanner/client/snapshot_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/snapshot_test.rb
@@ -24,7 +24,7 @@ describe Google::Cloud::Spanner::Client, :snapshot, :mock_spanner do
   let(:transaction_grpc) { Google::Cloud::Spanner::V1::Transaction.new id: transaction_id }
   let(:snapshot) { Google::Cloud::Spanner::Snapshot.from_grpc transaction_grpc, session }
   let(:tx_selector) { Google::Cloud::Spanner::V1::TransactionSelector.new id: transaction_id }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let :results_hash do
     {
       metadata: {

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_retry_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_retry_test.rb
@@ -25,7 +25,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :retry, :mock_spanner do
   let(:transaction_grpc) { Google::Cloud::Spanner::V1::Transaction.new id: transaction_id }
   let(:transaction) { Google::Cloud::Spanner::Transaction.from_grpc transaction_grpc, session }
   let(:tx_selector) { Google::Cloud::Spanner::V1::TransactionSelector.new id: transaction_id }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let :results_hash do
     {
       metadata: {

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_rollback_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_rollback_test.rb
@@ -24,7 +24,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :rollback, :mock_spanner 
   let(:transaction_grpc) { Google::Cloud::Spanner::V1::Transaction.new id: transaction_id }
   let(:transaction) { Google::Cloud::Spanner::Transaction.from_grpc transaction_grpc, session }
   let(:tx_selector) { Google::Cloud::Spanner::V1::TransactionSelector.new id: transaction_id }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let :results_hash do
     {
       metadata: {

--- a/google-cloud-spanner/test/google/cloud/spanner/client/transaction_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/client/transaction_test.rb
@@ -24,7 +24,7 @@ describe Google::Cloud::Spanner::Client, :transaction, :mock_spanner do
   let(:transaction_grpc) { Google::Cloud::Spanner::V1::Transaction.new id: transaction_id }
   let(:transaction) { Google::Cloud::Spanner::Transaction.from_grpc transaction_grpc, session }
   let(:tx_selector) { Google::Cloud::Spanner::V1::TransactionSelector.new id: transaction_id }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let :results_hash do
     {
       metadata: {

--- a/google-cloud-spanner/test/google/cloud/spanner/database/backup_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/database/backup_test.rb
@@ -40,7 +40,7 @@ describe Google::Cloud::Spanner::Database, :backups, :mock_spanner do
   it "lists backups" do
     get_res =  MockPagedEnumerable.new([first_page])
     mock = Minitest::Mock.new
-    mock.expect :list_backups, get_res, [{ parent: instance_path(instance_id), filter: backup_filter, page_size: nil, page_token: nil }, nil]
+    mock.expect :list_backups, get_res, [{ parent: instance_path(instance_id), filter: backup_filter, page_size: nil, page_token: nil }, ::Gapic::CallOptions]
     database.service.mocked_databases = mock
 
     backups = database.backups
@@ -53,7 +53,7 @@ describe Google::Cloud::Spanner::Database, :backups, :mock_spanner do
   it "paginates backups with page size" do
     get_res =  MockPagedEnumerable.new([first_page])
     mock = Minitest::Mock.new
-    mock.expect :list_backups, get_res, [{ parent: instance_path(instance_id), filter: backup_filter, page_size: 3, page_token: nil }, nil]
+    mock.expect :list_backups, get_res, [{ parent: instance_path(instance_id), filter: backup_filter, page_size: 3, page_token: nil }, ::Gapic::CallOptions]
     database.service.mocked_databases = mock
 
     backups = database.backups page_size: 3
@@ -66,7 +66,7 @@ describe Google::Cloud::Spanner::Database, :backups, :mock_spanner do
   it "paginates backups with next? and next" do
     get_res =  MockPagedEnumerable.new([first_page, last_page])
     mock = Minitest::Mock.new
-    mock.expect :list_backups, get_res, [{ parent: instance_path(instance_id), filter: backup_filter, page_size: nil, page_token: nil }, nil]
+    mock.expect :list_backups, get_res, [{ parent: instance_path(instance_id), filter: backup_filter, page_size: nil, page_token: nil }, ::Gapic::CallOptions]
     database.service.mocked_databases = mock
 
     list = database.backups
@@ -82,7 +82,7 @@ describe Google::Cloud::Spanner::Database, :backups, :mock_spanner do
   it "paginates backups with next? and next and page size" do
     get_res =  MockPagedEnumerable.new([first_page, last_page])
     mock = Minitest::Mock.new
-    mock.expect :list_backups, get_res, [{ parent: instance_path(instance_id), filter: backup_filter, page_size: 3, page_token: nil }, nil]
+    mock.expect :list_backups, get_res, [{ parent: instance_path(instance_id), filter: backup_filter, page_size: 3, page_token: nil }, ::Gapic::CallOptions]
     database.service.mocked_databases = mock
 
     list = database.backups page_size: 3
@@ -98,7 +98,7 @@ describe Google::Cloud::Spanner::Database, :backups, :mock_spanner do
   it "paginates backups with all" do
     get_res =  MockPagedEnumerable.new([first_page, last_page])
     mock = Minitest::Mock.new
-    mock.expect :list_backups, get_res, [{ parent: instance_path(instance_id), filter: backup_filter, page_size: nil, page_token: nil }, nil]
+    mock.expect :list_backups, get_res, [{ parent: instance_path(instance_id), filter: backup_filter, page_size: nil, page_token: nil }, ::Gapic::CallOptions]
     database.service.mocked_databases = mock
 
     backups = database.backups.all.to_a
@@ -111,7 +111,7 @@ describe Google::Cloud::Spanner::Database, :backups, :mock_spanner do
   it "paginates backups with all and page size" do
     get_res =  MockPagedEnumerable.new([first_page, last_page])
     mock = Minitest::Mock.new
-    mock.expect :list_backups, get_res, [{ parent: instance_path(instance_id), filter: backup_filter, page_size: 3, page_token: nil }, nil]
+    mock.expect :list_backups, get_res, [{ parent: instance_path(instance_id), filter: backup_filter, page_size: 3, page_token: nil }, ::Gapic::CallOptions]
     database.service.mocked_databases = mock
 
     backups = database.backups(page_size: 3).all.to_a
@@ -124,7 +124,7 @@ describe Google::Cloud::Spanner::Database, :backups, :mock_spanner do
   it "iterates backups with all using Enumerator" do
     get_res =  MockPagedEnumerable.new([first_page, last_page])
     mock = Minitest::Mock.new
-    mock.expect :list_backups, get_res, [{ parent: instance_path(instance_id), filter: backup_filter, page_size: nil, page_token: nil }, nil]
+    mock.expect :list_backups, get_res, [{ parent: instance_path(instance_id), filter: backup_filter, page_size: nil, page_token: nil }, ::Gapic::CallOptions]
     database.service.mocked_databases = mock
 
     backups = database.backups.all.take(5)

--- a/google-cloud-spanner/test/google/cloud/spanner/database/create_backup_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/database/create_backup_test.rb
@@ -99,7 +99,7 @@ describe Google::Cloud::Spanner::Backup, :create_backup, :mock_spanner do
       backup_id: backup_id,
       backup: create_req,
       encryption_config: { kms_key_name: kms_key_name, encryption_type: :CUSTOMER_MANAGED_ENCRYPTION }
-    }, nil]
+    }, ::Gapic::CallOptions]
     mock.expect :get_operation, operation_done, [{ name: "1234567890" }, Gapic::CallOptions]
     spanner.service.mocked_databases = mock
 
@@ -150,7 +150,7 @@ describe Google::Cloud::Spanner::Backup, :create_backup, :mock_spanner do
       backup_id: backup_id,
       backup: create_req,
       encryption_config: nil
-    }, nil]
+    }, ::Gapic::CallOptions]
     mock.expect :cancel_operation, nil , [{ name: "1234567890" }, Gapic::CallOptions]
     mock.expect :get_operation, operation_cancel, [{ name: "1234567890" }, Gapic::CallOptions]
     spanner.service.mocked_databases = mock

--- a/google-cloud-spanner/test/google/cloud/spanner/database/database_operations_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/database/database_operations_test.rb
@@ -78,7 +78,7 @@ describe Google::Cloud::Spanner::Database, :database_operations, :mock_spanner d
     list_res =  MockPagedEnumerable.new([first_page])
 
     mock = Minitest::Mock.new
-    mock.expect :list_database_operations, list_res, [{ parent: instance_path(instance_id), filter: database_metadata_filter, page_size: nil, page_token: nil }, nil]
+    mock.expect :list_database_operations, list_res, [{ parent: instance_path(instance_id), filter: database_metadata_filter, page_size: nil, page_token: nil }, ::Gapic::CallOptions]
     3.times do
       gapic_operation = Gapic::Operation.new job_grpc_done, mock
       mock.expect :get_operation, gapic_operation, [{ name: job_name }, Gapic::CallOptions]
@@ -109,7 +109,7 @@ describe Google::Cloud::Spanner::Database, :database_operations, :mock_spanner d
     list_res =  MockPagedEnumerable.new([first_page])
 
     mock = Minitest::Mock.new
-    mock.expect :list_database_operations, list_res, [{ parent: instance_path(instance_id), filter: database_metadata_filter, page_size: 3, page_token: nil }, nil]
+    mock.expect :list_database_operations, list_res, [{ parent: instance_path(instance_id), filter: database_metadata_filter, page_size: 3, page_token: nil }, ::Gapic::CallOptions]
     3.times do
       gapic_operation = Gapic::Operation.new job_grpc_done, mock
       mock.expect :get_operation, gapic_operation, [{ name: job_name }, Gapic::CallOptions]
@@ -139,7 +139,7 @@ describe Google::Cloud::Spanner::Database, :database_operations, :mock_spanner d
   it "paginates database operations with next? and next" do
     list_res =  MockPagedEnumerable.new([first_page, last_page])
     mock = Minitest::Mock.new
-    mock.expect :list_database_operations, list_res, [{ parent: instance_path(instance_id), filter: database_metadata_filter, page_size: nil, page_token: nil}, nil]
+    mock.expect :list_database_operations, list_res, [{ parent: instance_path(instance_id), filter: database_metadata_filter, page_size: nil, page_token: nil}, ::Gapic::CallOptions]
 
     2.times do
       mock.expect :instance_variable_get, mock, ["@operations_client"]
@@ -159,7 +159,7 @@ describe Google::Cloud::Spanner::Database, :database_operations, :mock_spanner d
   it "paginates database operations with all" do
     list_res =  MockPagedEnumerable.new([first_page, last_page])
     mock = Minitest::Mock.new
-    mock.expect :list_database_operations, list_res, [{ parent: instance_path(instance_id), filter: database_metadata_filter, page_size: nil, page_token: nil }, nil]
+    mock.expect :list_database_operations, list_res, [{ parent: instance_path(instance_id), filter: database_metadata_filter, page_size: nil, page_token: nil }, ::Gapic::CallOptions]
     2.times do
       mock.expect :instance_variable_get, mock, ["@operations_client"]
     end
@@ -175,7 +175,7 @@ describe Google::Cloud::Spanner::Database, :database_operations, :mock_spanner d
   it "paginates database operations with all and page size" do
     list_res =  MockPagedEnumerable.new([first_page, last_page])
     mock = Minitest::Mock.new
-    mock.expect :list_database_operations, list_res, [{ parent: instance_path(instance_id), filter: database_metadata_filter, page_size: 3, page_token: nil }, nil]
+    mock.expect :list_database_operations, list_res, [{ parent: instance_path(instance_id), filter: database_metadata_filter, page_size: 3, page_token: nil }, ::Gapic::CallOptions]
     2.times do
       mock.expect :instance_variable_get, mock, ["@operations_client"]
     end
@@ -191,7 +191,7 @@ describe Google::Cloud::Spanner::Database, :database_operations, :mock_spanner d
   it "iterates database operations with all using Enumerator" do
     list_res =  MockPagedEnumerable.new([first_page, last_page])
     mock = Minitest::Mock.new
-    mock.expect :list_database_operations, list_res, [{ parent: instance_path(instance_id), filter: database_metadata_filter, page_size: nil, page_token: nil }, nil]
+    mock.expect :list_database_operations, list_res, [{ parent: instance_path(instance_id), filter: database_metadata_filter, page_size: nil, page_token: nil }, ::Gapic::CallOptions]
     2.times do
       mock.expect :instance_variable_get, mock, ["@operations_client"]
     end
@@ -211,7 +211,7 @@ describe Google::Cloud::Spanner::Database, :database_operations, :mock_spanner d
     )
     list_res =  MockPagedEnumerable.new([first_page])
     mock = Minitest::Mock.new
-    mock.expect :list_database_operations, list_res, [{ parent: instance_path(instance_id), filter: filter, page_size: nil, page_token: nil }, nil]
+    mock.expect :list_database_operations, list_res, [{ parent: instance_path(instance_id), filter: filter, page_size: nil, page_token: nil }, ::Gapic::CallOptions]
     mock.expect :instance_variable_get, mock, ["@operations_client"]
     database.service.mocked_databases = mock
 
@@ -229,7 +229,7 @@ describe Google::Cloud::Spanner::Database, :database_operations, :mock_spanner d
     )
     list_res =  MockPagedEnumerable.new([first_page])
     mock = Minitest::Mock.new
-    mock.expect :list_database_operations, list_res, [{ parent: instance_path(instance_id), filter: filter, page_size: 3, page_token: nil }, nil]
+    mock.expect :list_database_operations, list_res, [{ parent: instance_path(instance_id), filter: filter, page_size: 3, page_token: nil }, ::Gapic::CallOptions]
     mock.expect :instance_variable_get, mock, ["@operations_client"]
     database.service.mocked_databases = mock
 

--- a/google-cloud-spanner/test/google/cloud/spanner/database/ddl_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/database/ddl_test.rb
@@ -26,7 +26,7 @@ describe Google::Cloud::Spanner::Database, :ddl, :mock_spanner do
       statements: statements
     )
     mock = Minitest::Mock.new
-    mock.expect :get_database_ddl, update_res, [{ database: database_path(instance_id, database_id) }, nil]
+    mock.expect :get_database_ddl, update_res, [{ database: database_path(instance_id, database_id) }, ::Gapic::CallOptions]
     spanner.service.mocked_databases = mock
 
     ddl = database.ddl
@@ -51,7 +51,7 @@ describe Google::Cloud::Spanner::Database, :ddl, :mock_spanner do
       statements: statements.reverse
     )
     mock = Minitest::Mock.new
-    mock.expect :get_database_ddl, update_res, [{ database: database_path(instance_id, database_id) }, nil]
+    mock.expect :get_database_ddl, update_res, [{ database: database_path(instance_id, database_id) }, ::Gapic::CallOptions]
     spanner.service.mocked_databases = mock
 
     ddl = database.ddl force: true

--- a/google-cloud-spanner/test/google/cloud/spanner/database/drop_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/database/drop_test.rb
@@ -22,7 +22,7 @@ describe Google::Cloud::Spanner::Database, :drop, :mock_spanner do
 
   it "can delete itself" do
     mock = Minitest::Mock.new
-    mock.expect :drop_database, nil, [{ database: database_path(instance_id, database_id) }, nil]
+    mock.expect :drop_database, nil, [{ database: database_path(instance_id, database_id) }, ::Gapic::CallOptions]
     spanner.service.mocked_databases = mock
 
     database.drop

--- a/google-cloud-spanner/test/google/cloud/spanner/database/iam_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/database/iam_test.rb
@@ -47,7 +47,7 @@ describe Google::Cloud::Spanner::Database, :iam, :mock_spanner do
   it "gets the IAM Policy" do
     get_res = Google::Iam::V1::Policy.new viewer_policy_hash
     mock = Minitest::Mock.new
-    mock.expect :get_iam_policy, get_res, [{ resource: database.path }, nil]
+    mock.expect :get_iam_policy, get_res, [{ resource: database.path }, ::Gapic::CallOptions]
     database.service.mocked_databases = mock
 
     policy = database.policy
@@ -67,7 +67,7 @@ describe Google::Cloud::Spanner::Database, :iam, :mock_spanner do
   it "sets the IAM Policy" do
     get_res = Google::Iam::V1::Policy.new owner_policy_hash
     mock = Minitest::Mock.new
-    mock.expect :get_iam_policy, get_res, [{ resource: database.path }, nil]
+    mock.expect :get_iam_policy, get_res, [{ resource: database.path }, ::Gapic::CallOptions]
 
     updated_policy_hash = owner_policy_hash.dup
     updated_policy_hash[:bindings].first[:members].shift
@@ -75,7 +75,7 @@ describe Google::Cloud::Spanner::Database, :iam, :mock_spanner do
 
     set_req = Google::Iam::V1::Policy.new updated_policy_hash
     set_res = Google::Iam::V1::Policy.new updated_policy_hash.merge(etag: "\b\x10")
-    mock.expect :set_iam_policy, set_res, [{ resource: database.path, policy: set_req }, nil]
+    mock.expect :set_iam_policy, set_res, [{ resource: database.path, policy: set_req }, ::Gapic::CallOptions]
     database.service.mocked_databases = mock
 
     policy = database.policy
@@ -101,7 +101,7 @@ describe Google::Cloud::Spanner::Database, :iam, :mock_spanner do
   it "sets the IAM Policy in a block" do
     get_res = Google::Iam::V1::Policy.new owner_policy_hash
     mock = Minitest::Mock.new
-    mock.expect :get_iam_policy, get_res, [{ resource: database.path }, nil]
+    mock.expect :get_iam_policy, get_res, [{ resource: database.path }, ::Gapic::CallOptions]
 
     updated_policy_hash = owner_policy_hash.dup
     updated_policy_hash[:bindings].first[:members].shift
@@ -109,7 +109,7 @@ describe Google::Cloud::Spanner::Database, :iam, :mock_spanner do
 
     set_req = Google::Iam::V1::Policy.new updated_policy_hash
     set_res = Google::Iam::V1::Policy.new updated_policy_hash.merge(etag: "\b\x10")
-    mock.expect :set_iam_policy, set_res, [{ resource: database.path, policy: set_req }, nil]
+    mock.expect :set_iam_policy, set_res, [{ resource: database.path, policy: set_req }, ::Gapic::CallOptions]
     database.service.mocked_databases = mock
 
     policy = database.policy do |p|
@@ -136,7 +136,7 @@ describe Google::Cloud::Spanner::Database, :iam, :mock_spanner do
       permissions: ["spanner.databases.get"]
     )
     mock = Minitest::Mock.new
-    mock.expect :test_iam_permissions, test_res, [{ resource: database.path, permissions: permissions }, nil]
+    mock.expect :test_iam_permissions, test_res, [{ resource: database.path, permissions: permissions }, ::Gapic::CallOptions]
     database.service.mocked_databases = mock
 
     permissions = database.test_permissions "spanner.databases.get",

--- a/google-cloud-spanner/test/google/cloud/spanner/database/update_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/database/update_test.rb
@@ -37,7 +37,7 @@ describe Google::Cloud::Spanner::Database, :update, :mock_spanner do
         metadata_type: Google::Cloud::Spanner::Admin::Database::V1::UpdateDatabaseDdlRequest
       )
     mock = Minitest::Mock.new
-    mock.expect :update_database_ddl, update_res, [{ database: database_path(instance_id, database_id), statements: ["CREATE TABLE table4"], operation_id: nil }, nil]
+    mock.expect :update_database_ddl, update_res, [{ database: database_path(instance_id, database_id), statements: ["CREATE TABLE table4"], operation_id: nil }, ::Gapic::CallOptions]
     spanner.service.mocked_databases = mock
 
     job = database.update statements: "CREATE TABLE table4"
@@ -56,7 +56,7 @@ describe Google::Cloud::Spanner::Database, :update, :mock_spanner do
         metadata_type: Google::Cloud::Spanner::Admin::Database::V1::UpdateDatabaseDdlRequest
       )
     mock = Minitest::Mock.new
-    mock.expect :update_database_ddl, update_res, [{ database: database_path(instance_id, database_id), statements: ["CREATE TABLE table4", "CREATE TABLE table5"], operation_id: nil }, nil]
+    mock.expect :update_database_ddl, update_res, [{ database: database_path(instance_id, database_id), statements: ["CREATE TABLE table4", "CREATE TABLE table5"], operation_id: nil }, ::Gapic::CallOptions]
     spanner.service.mocked_databases = mock
 
     job = database.update statements: ["CREATE TABLE table4", "CREATE TABLE table5"]
@@ -75,7 +75,7 @@ describe Google::Cloud::Spanner::Database, :update, :mock_spanner do
         metadata_type: Google::Cloud::Spanner::Admin::Database::V1::UpdateDatabaseDdlRequest
       )
     mock = Minitest::Mock.new
-    mock.expect :update_database_ddl, update_res, [{ database: database_path(instance_id, database_id), statements: ["CREATE TABLE table4", "CREATE TABLE table5"], operation_id: "update123" }, nil]
+    mock.expect :update_database_ddl, update_res, [{ database: database_path(instance_id, database_id), statements: ["CREATE TABLE table4", "CREATE TABLE table5"], operation_id: "update123" }, ::Gapic::CallOptions]
     spanner.service.mocked_databases = mock
 
     job = database.update statements: ["CREATE TABLE table4", "CREATE TABLE table5"], operation_id: "update123"

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/backup_operations_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/backup_operations_test.rb
@@ -68,7 +68,7 @@ describe Google::Cloud::Spanner::Instance, :backup_operations, :mock_spanner do
     list_res =  MockPagedEnumerable.new([first_page])
 
     mock = Minitest::Mock.new
-    mock.expect :list_backup_operations, list_res, [{ parent: instance_path(instance_id), filter: nil, page_size: nil, page_token: nil }, nil]
+    mock.expect :list_backup_operations, list_res, [{ parent: instance_path(instance_id), filter: nil, page_size: nil, page_token: nil }, ::Gapic::CallOptions]
     3.times do
       gapic_operation = Gapic::Operation.new job_grpc_done, mock
       mock.expect :get_operation, gapic_operation, [{ name: job_name }, Gapic::CallOptions]
@@ -99,7 +99,7 @@ describe Google::Cloud::Spanner::Instance, :backup_operations, :mock_spanner do
     list_res =  MockPagedEnumerable.new([first_page])
 
     mock = Minitest::Mock.new
-    mock.expect :list_backup_operations, list_res, [{ parent: instance_path(instance_id), filter: nil, page_size: 3, page_token: nil }, nil]
+    mock.expect :list_backup_operations, list_res, [{ parent: instance_path(instance_id), filter: nil, page_size: 3, page_token: nil }, ::Gapic::CallOptions]
     3.times do
       gapic_operation = Gapic::Operation.new job_grpc_done, mock
       mock.expect :get_operation, gapic_operation, [{ name: job_name }, Gapic::CallOptions]
@@ -129,7 +129,7 @@ describe Google::Cloud::Spanner::Instance, :backup_operations, :mock_spanner do
   it "paginates backup operations with next? and next" do
     list_res =  MockPagedEnumerable.new([first_page, last_page])
     mock = Minitest::Mock.new
-    mock.expect :list_backup_operations, list_res, [{ parent: instance_path(instance_id), filter: nil, page_size: nil, page_token: nil }, nil]
+    mock.expect :list_backup_operations, list_res, [{ parent: instance_path(instance_id), filter: nil, page_size: nil, page_token: nil }, ::Gapic::CallOptions]
     2.times do
       mock.expect :instance_variable_get, mock, ["@operations_client"]
     end
@@ -148,7 +148,7 @@ describe Google::Cloud::Spanner::Instance, :backup_operations, :mock_spanner do
   it "paginates backup operations with all" do
     list_res =  MockPagedEnumerable.new([first_page, last_page])
     mock = Minitest::Mock.new
-    mock.expect :list_backup_operations, list_res, [{ parent: instance_path(instance_id), filter: nil, page_size: nil, page_token: nil }, nil]
+    mock.expect :list_backup_operations, list_res, [{ parent: instance_path(instance_id), filter: nil, page_size: nil, page_token: nil }, ::Gapic::CallOptions]
     2.times do
       mock.expect :instance_variable_get, mock, ["@operations_client"]
     end
@@ -164,7 +164,7 @@ describe Google::Cloud::Spanner::Instance, :backup_operations, :mock_spanner do
   it "paginates backup operations with all and page size" do
     list_res =  MockPagedEnumerable.new([first_page, last_page])
     mock = Minitest::Mock.new
-    mock.expect :list_backup_operations, list_res, [{ parent: instance_path(instance_id), filter: nil, page_size: 3, page_token: nil }, nil]
+    mock.expect :list_backup_operations, list_res, [{ parent: instance_path(instance_id), filter: nil, page_size: 3, page_token: nil }, ::Gapic::CallOptions]
     2.times do
       mock.expect :instance_variable_get, mock, ["@operations_client"]
     end
@@ -180,7 +180,7 @@ describe Google::Cloud::Spanner::Instance, :backup_operations, :mock_spanner do
   it "iterates backup operations with all using Enumerator" do
     list_res =  MockPagedEnumerable.new([first_page, last_page])
     mock = Minitest::Mock.new
-    mock.expect :list_backup_operations, list_res, [{ parent: instance_path(instance_id), filter: nil, page_size: nil, page_token: nil }, nil]
+    mock.expect :list_backup_operations, list_res, [{ parent: instance_path(instance_id), filter: nil, page_size: nil, page_token: nil }, ::Gapic::CallOptions]
     2.times do
       mock.expect :instance_variable_get, mock, ["@operations_client"]
     end
@@ -197,7 +197,7 @@ describe Google::Cloud::Spanner::Instance, :backup_operations, :mock_spanner do
     filter = 'metadata.@type:CreateBackupMetadata'
     list_res =  MockPagedEnumerable.new([first_page])
     mock = Minitest::Mock.new
-    mock.expect :list_backup_operations, list_res, [{ parent: instance_path(instance_id), filter: filter, page_size: nil, page_token: nil }, nil]
+    mock.expect :list_backup_operations, list_res, [{ parent: instance_path(instance_id), filter: filter, page_size: nil, page_token: nil }, ::Gapic::CallOptions]
     mock.expect :instance_variable_get, mock, ["@operations_client"]
     instance.service.mocked_databases = mock
 
@@ -212,7 +212,7 @@ describe Google::Cloud::Spanner::Instance, :backup_operations, :mock_spanner do
     filter = 'metadata.@type:CreateBackupMetadata'
     list_res =  MockPagedEnumerable.new([first_page])
     mock = Minitest::Mock.new
-    mock.expect :list_backup_operations, list_res, [{ parent: instance_path(instance_id), filter: filter, page_size: 3, page_token: nil }, nil]
+    mock.expect :list_backup_operations, list_res, [{ parent: instance_path(instance_id), filter: filter, page_size: 3, page_token: nil }, ::Gapic::CallOptions]
     mock.expect :instance_variable_get, mock, ["@operations_client"]
     instance.service.mocked_databases = mock
 

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/backup_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/backup_test.rb
@@ -32,7 +32,7 @@ describe Google::Cloud::Spanner::Instance, :backup, :mock_spanner do
     get_res = Google::Cloud::Spanner::Admin::Database::V1::Backup.new \
       backup_hash(instance_id: instance_id, database_id: database_id, backup_id: backup_id, encryption_info: encryption_info)
     mock = Minitest::Mock.new
-    mock.expect :get_backup, get_res, [{ name: backup_path(instance_id, backup_id) }, nil]
+    mock.expect :get_backup, get_res, [{ name: backup_path(instance_id, backup_id) }, ::Gapic::CallOptions]
     instance.service.mocked_databases = mock
 
     backup = instance.backup backup_id

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/backups_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/backups_test.rb
@@ -39,7 +39,7 @@ describe Google::Cloud::Spanner::Instance, :backups, :mock_spanner do
   it "lists backups" do
     get_res =  MockPagedEnumerable.new([first_page])
     mock = Minitest::Mock.new
-    mock.expect :list_backups, get_res, [{ parent: instance_path(instance_id), filter: nil, page_size: nil, page_token: nil }, nil]
+    mock.expect :list_backups, get_res, [{ parent: instance_path(instance_id), filter: nil, page_size: nil, page_token: nil }, ::Gapic::CallOptions]
     instance.service.mocked_databases = mock
 
     backups = instance.backups
@@ -52,7 +52,7 @@ describe Google::Cloud::Spanner::Instance, :backups, :mock_spanner do
   it "paginates backups with page size" do
     get_res =  MockPagedEnumerable.new([first_page])
     mock = Minitest::Mock.new
-    mock.expect :list_backups, get_res, [{ parent: instance_path(instance_id), filter: nil, page_size: 3, page_token: nil }, nil]
+    mock.expect :list_backups, get_res, [{ parent: instance_path(instance_id), filter: nil, page_size: 3, page_token: nil }, ::Gapic::CallOptions]
     instance.service.mocked_databases = mock
 
     backups = instance.backups page_size: 3
@@ -65,7 +65,7 @@ describe Google::Cloud::Spanner::Instance, :backups, :mock_spanner do
   it "paginates backups with next? and next" do
     get_res =  MockPagedEnumerable.new([first_page, last_page])
     mock = Minitest::Mock.new
-    mock.expect :list_backups, get_res, [{ parent: instance_path(instance_id), filter: nil, page_size: nil, page_token: nil }, nil]
+    mock.expect :list_backups, get_res, [{ parent: instance_path(instance_id), filter: nil, page_size: nil, page_token: nil }, ::Gapic::CallOptions]
 
     instance.service.mocked_databases = mock
 
@@ -82,7 +82,7 @@ describe Google::Cloud::Spanner::Instance, :backups, :mock_spanner do
   it "paginates backups with next? and next and page size" do
     get_res =  MockPagedEnumerable.new([first_page, last_page])
     mock = Minitest::Mock.new
-    mock.expect :list_backups, get_res, [{ parent: instance_path(instance_id), filter: nil, page_size: 3, page_token: nil }, nil]
+    mock.expect :list_backups, get_res, [{ parent: instance_path(instance_id), filter: nil, page_size: 3, page_token: nil }, ::Gapic::CallOptions]
     instance.service.mocked_databases = mock
 
     list = instance.backups page_size: 3
@@ -98,7 +98,7 @@ describe Google::Cloud::Spanner::Instance, :backups, :mock_spanner do
   it "paginates backups with all" do
     get_res =  MockPagedEnumerable.new([first_page, last_page])
     mock = Minitest::Mock.new
-    mock.expect :list_backups, get_res, [{ parent: instance_path(instance_id), filter: nil, page_size: nil, page_token: nil }, nil]
+    mock.expect :list_backups, get_res, [{ parent: instance_path(instance_id), filter: nil, page_size: nil, page_token: nil }, ::Gapic::CallOptions]
     instance.service.mocked_databases = mock
 
     backups = instance.backups.all.to_a
@@ -111,7 +111,7 @@ describe Google::Cloud::Spanner::Instance, :backups, :mock_spanner do
   it "paginates backups with all and page size" do
     get_res =  MockPagedEnumerable.new([first_page, last_page])
     mock = Minitest::Mock.new
-    mock.expect :list_backups, get_res, [{ parent: instance_path(instance_id), filter: nil, page_size: 3, page_token: nil }, nil]
+    mock.expect :list_backups, get_res, [{ parent: instance_path(instance_id), filter: nil, page_size: 3, page_token: nil }, ::Gapic::CallOptions]
     instance.service.mocked_databases = mock
 
     backups = instance.backups(page_size: 3).all.to_a
@@ -124,7 +124,7 @@ describe Google::Cloud::Spanner::Instance, :backups, :mock_spanner do
   it "iterates backups with all using Enumerator" do
     get_res =  MockPagedEnumerable.new([first_page, last_page])
     mock = Minitest::Mock.new
-    mock.expect :list_backups, get_res, [{ parent: instance_path(instance_id), filter: nil, page_size: nil, page_token: nil }, nil]
+    mock.expect :list_backups, get_res, [{ parent: instance_path(instance_id), filter: nil, page_size: nil, page_token: nil }, ::Gapic::CallOptions]
     instance.service.mocked_databases = mock
 
     backups = instance.backups.all.take(5)
@@ -137,7 +137,7 @@ describe Google::Cloud::Spanner::Instance, :backups, :mock_spanner do
   it "paginates backups with filter" do
     get_res =  MockPagedEnumerable.new([first_page])
     mock = Minitest::Mock.new
-    mock.expect :list_backups, get_res, [{ parent: instance_path(instance_id), filter: "name:db1", page_size: nil, page_token: nil }, nil]
+    mock.expect :list_backups, get_res, [{ parent: instance_path(instance_id), filter: "name:db1", page_size: nil, page_token: nil }, ::Gapic::CallOptions]
     instance.service.mocked_databases = mock
 
     backups = instance.backups filter: "name:db1"
@@ -150,7 +150,7 @@ describe Google::Cloud::Spanner::Instance, :backups, :mock_spanner do
   it "paginates backups with filter and page size" do
     get_res =  MockPagedEnumerable.new([first_page])
     mock = Minitest::Mock.new
-    mock.expect :list_backups, get_res, [{ parent: instance_path(instance_id), filter: "name:db1", page_size: 3, page_token: nil }, nil]
+    mock.expect :list_backups, get_res, [{ parent: instance_path(instance_id), filter: "name:db1", page_size: 3, page_token: nil }, ::Gapic::CallOptions]
     instance.service.mocked_databases = mock
 
     backups = instance.backups filter: "name:db1", page_size: 3

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/config_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/config_test.rb
@@ -22,7 +22,7 @@ describe Google::Cloud::Spanner::Instance, :config, :mock_spanner do
   it "gets an instance config object" do
     get_res = Google::Cloud::Spanner::Admin::Instance::V1::InstanceConfig.new instance_config_hash
     mock = Minitest::Mock.new
-    mock.expect :get_instance_config, get_res, [{ name: instance_grpc.config }, nil]
+    mock.expect :get_instance_config, get_res, [{ name: instance_grpc.config }, ::Gapic::CallOptions]
     spanner.service.mocked_instances = mock
 
     config = instance.config

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/create_database_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/create_database_test.rb
@@ -66,7 +66,7 @@ describe Google::Cloud::Spanner::Instance, :create_database, :mock_spanner do
         result_type: Google::Cloud::Spanner::Admin::Database::V1::Database,
         metadata_type: Google::Cloud::Spanner::Admin::Database::V1::CreateDatabaseMetadata
       )
-    mock.expect :create_database, create_res, [{ parent: instance_path(instance_id), create_statement: "CREATE DATABASE `#{database_id}`", extra_statements: [], encryption_config: nil }, nil]
+    mock.expect :create_database, create_res, [{ parent: instance_path(instance_id), create_statement: "CREATE DATABASE `#{database_id}`", extra_statements: [], encryption_config: nil }, ::Gapic::CallOptions]
     mock.expect :get_operation, operation_done, [{ name: "1234567890" }, Gapic::CallOptions]
     instance.service.mocked_databases = mock
 
@@ -98,7 +98,7 @@ describe Google::Cloud::Spanner::Instance, :create_database, :mock_spanner do
         metadata_type: Google::Cloud::Spanner::Admin::Database::V1::CreateDatabaseMetadata
       )
     mock = Minitest::Mock.new
-    mock.expect :create_database, create_res, [{ parent: instance_path(instance_id), create_statement: "CREATE DATABASE `#{database_id}`", extra_statements: ["CREATE TABLE table1;", "CREATE TABLE table2;"], encryption_config: nil }, nil]
+    mock.expect :create_database, create_res, [{ parent: instance_path(instance_id), create_statement: "CREATE DATABASE `#{database_id}`", extra_statements: ["CREATE TABLE table1;", "CREATE TABLE table2;"], encryption_config: nil }, ::Gapic::CallOptions]
     instance.service.mocked_databases = mock
 
     job = instance.create_database database_id, statements: [
@@ -125,7 +125,7 @@ describe Google::Cloud::Spanner::Instance, :create_database, :mock_spanner do
         metadata_type: Google::Cloud::Spanner::Admin::Database::V1::CreateDatabaseMetadata
       )
     mock = Minitest::Mock.new
-    mock.expect :create_database, create_res, [{ parent: instance_path(instance_id), create_statement: "CREATE DATABASE `#{database_id}`", extra_statements: [], encryption_config: { kms_key_name: kms_key_name } }, nil]
+    mock.expect :create_database, create_res, [{ parent: instance_path(instance_id), create_statement: "CREATE DATABASE `#{database_id}`", extra_statements: [], encryption_config: { kms_key_name: kms_key_name } }, ::Gapic::CallOptions]
     instance.service.mocked_databases = mock
 
     job = instance.create_database database_id, encryption_config: { kms_key_name: kms_key_name }

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/database_operations_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/database_operations_test.rb
@@ -68,7 +68,7 @@ describe Google::Cloud::Spanner::Instance, :database_operations, :mock_spanner d
     list_res =  MockPagedEnumerable.new([first_page])
 
     mock = Minitest::Mock.new
-    mock.expect :list_database_operations, list_res, [{ parent: instance_path(instance_id), filter: nil, page_size: nil, page_token: nil }, nil]
+    mock.expect :list_database_operations, list_res, [{ parent: instance_path(instance_id), filter: nil, page_size: nil, page_token: nil }, ::Gapic::CallOptions]
     3.times do
       gapic_operation = Gapic::Operation.new job_grpc_done, mock
       mock.expect :get_operation, gapic_operation, [{ name: job_name }, Gapic::CallOptions]
@@ -99,7 +99,7 @@ describe Google::Cloud::Spanner::Instance, :database_operations, :mock_spanner d
     list_res =  MockPagedEnumerable.new([first_page])
 
     mock = Minitest::Mock.new
-    mock.expect :list_database_operations, list_res, [{ parent: instance_path(instance_id), filter: nil, page_size: 3, page_token: nil }, nil]
+    mock.expect :list_database_operations, list_res, [{ parent: instance_path(instance_id), filter: nil, page_size: 3, page_token: nil }, ::Gapic::CallOptions]
     3.times do
       gapic_operation = Gapic::Operation.new job_grpc_done, mock
       mock.expect :get_operation, gapic_operation, [{ name: job_name }, Gapic::CallOptions]
@@ -129,7 +129,7 @@ describe Google::Cloud::Spanner::Instance, :database_operations, :mock_spanner d
   it "paginates database operations with next? and next" do
     list_res =  MockPagedEnumerable.new([first_page, last_page])
     mock = Minitest::Mock.new
-    mock.expect :list_database_operations, list_res, [{ parent: instance_path(instance_id), filter: nil, page_size: nil, page_token: nil }, nil]
+    mock.expect :list_database_operations, list_res, [{ parent: instance_path(instance_id), filter: nil, page_size: nil, page_token: nil }, ::Gapic::CallOptions]
     2.times do
       mock.expect :instance_variable_get, mock, ["@operations_client"]
     end
@@ -148,7 +148,7 @@ describe Google::Cloud::Spanner::Instance, :database_operations, :mock_spanner d
   it "paginates database operations with all" do
     list_res =  MockPagedEnumerable.new([first_page, last_page])
     mock = Minitest::Mock.new
-    mock.expect :list_database_operations, list_res, [{ parent: instance_path(instance_id), filter: nil, page_size: nil, page_token: nil }, nil]
+    mock.expect :list_database_operations, list_res, [{ parent: instance_path(instance_id), filter: nil, page_size: nil, page_token: nil }, ::Gapic::CallOptions]
     2.times do
       mock.expect :instance_variable_get, mock, ["@operations_client"]
     end
@@ -164,7 +164,7 @@ describe Google::Cloud::Spanner::Instance, :database_operations, :mock_spanner d
   it "paginates database operations with all and page size" do
     list_res =  MockPagedEnumerable.new([first_page, last_page])
     mock = Minitest::Mock.new
-    mock.expect :list_database_operations, list_res, [{ parent: instance_path(instance_id), filter: nil, page_size: 3, page_token: nil }, nil]
+    mock.expect :list_database_operations, list_res, [{ parent: instance_path(instance_id), filter: nil, page_size: 3, page_token: nil }, ::Gapic::CallOptions]
     2.times do
       mock.expect :instance_variable_get, mock, ["@operations_client"]
     end
@@ -180,7 +180,7 @@ describe Google::Cloud::Spanner::Instance, :database_operations, :mock_spanner d
   it "iterates database operations with all using Enumerator" do
     list_res =  MockPagedEnumerable.new([first_page, last_page])
     mock = Minitest::Mock.new
-    mock.expect :list_database_operations, list_res, [{ parent: instance_path(instance_id), filter: nil, page_size: nil, page_token: nil }, nil]
+    mock.expect :list_database_operations, list_res, [{ parent: instance_path(instance_id), filter: nil, page_size: nil, page_token: nil }, ::Gapic::CallOptions]
     2.times do
       mock.expect :instance_variable_get, mock, ["@operations_client"]
     end
@@ -197,7 +197,7 @@ describe Google::Cloud::Spanner::Instance, :database_operations, :mock_spanner d
     filter = 'metadata.@type:CreateDatabaseMetadata'
     list_res =  MockPagedEnumerable.new([first_page])
     mock = Minitest::Mock.new
-    mock.expect :list_database_operations, list_res, [{ parent: instance_path(instance_id), filter: filter, page_size: nil, page_token: nil }, nil]
+    mock.expect :list_database_operations, list_res, [{ parent: instance_path(instance_id), filter: filter, page_size: nil, page_token: nil }, ::Gapic::CallOptions]
     mock.expect :instance_variable_get, mock, ["@operations_client"]
     instance.service.mocked_databases = mock
 
@@ -212,7 +212,7 @@ describe Google::Cloud::Spanner::Instance, :database_operations, :mock_spanner d
     filter = 'metadata.@type:CreateDatabaseMetadata'
     list_res =  MockPagedEnumerable.new([first_page])
     mock = Minitest::Mock.new
-    mock.expect :list_database_operations, list_res, [{ parent: instance_path(instance_id), filter: filter, page_size: 3, page_token: nil }, nil]
+    mock.expect :list_database_operations, list_res, [{ parent: instance_path(instance_id), filter: filter, page_size: 3, page_token: nil }, ::Gapic::CallOptions]
     mock.expect :instance_variable_get, mock, ["@operations_client"]
     instance.service.mocked_databases = mock
 

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/database_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/database_test.rb
@@ -27,7 +27,7 @@ describe Google::Cloud::Spanner::Instance, :database, :mock_spanner do
 
     get_res = Google::Cloud::Spanner::Admin::Database::V1::Database.new database_hash(instance_id: instance_id, database_id: database_id, encryption_config: encryption_config)
     mock = Minitest::Mock.new
-    mock.expect :get_database, get_res, [{ name: database_path(instance_id, database_id) }, nil]
+    mock.expect :get_database, get_res, [{ name: database_path(instance_id, database_id) }, ::Gapic::CallOptions]
     instance.service.mocked_databases = mock
 
     database = instance.database database_id

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/databases_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/databases_test.rb
@@ -40,7 +40,7 @@ describe Google::Cloud::Spanner::Instance, :databases, :mock_spanner do
 
   it "lists databases" do
     mock = Minitest::Mock.new
-    mock.expect :list_databases, first_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: nil }, nil]
+    mock.expect :list_databases, first_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: nil }, ::Gapic::CallOptions]
     instance.service.mocked_databases = mock
 
     databases = instance.databases
@@ -52,8 +52,8 @@ describe Google::Cloud::Spanner::Instance, :databases, :mock_spanner do
 
   it "paginates databases" do
     mock = Minitest::Mock.new
-    mock.expect :list_databases, first_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: nil }, nil]
-    mock.expect :list_databases, last_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: next_page_options }, nil]
+    mock.expect :list_databases, first_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: nil }, ::Gapic::CallOptions]
+    mock.expect :list_databases, last_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: next_page_options }, ::Gapic::CallOptions]
     instance.service.mocked_databases = mock
 
     first_databases = instance.databases
@@ -72,7 +72,7 @@ describe Google::Cloud::Spanner::Instance, :databases, :mock_spanner do
 
   it "paginates databases with max set" do
     mock = Minitest::Mock.new
-    mock.expect :list_databases, first_page, [{ parent: instance_path(instance_id), page_size: 3, page_token: nil }, nil]
+    mock.expect :list_databases, first_page, [{ parent: instance_path(instance_id), page_size: 3, page_token: nil }, ::Gapic::CallOptions]
     instance.service.mocked_databases = mock
 
     databases = instance.databases max: 3
@@ -87,8 +87,8 @@ describe Google::Cloud::Spanner::Instance, :databases, :mock_spanner do
 
   it "paginates databases with next? and next" do
     mock = Minitest::Mock.new
-    mock.expect :list_databases, first_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: nil }, nil]
-    mock.expect :list_databases, last_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: next_page_options }, nil]
+    mock.expect :list_databases, first_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: nil }, ::Gapic::CallOptions]
+    mock.expect :list_databases, last_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: next_page_options }, ::Gapic::CallOptions]
     instance.service.mocked_databases = mock
 
     first_databases = instance.databases
@@ -105,8 +105,8 @@ describe Google::Cloud::Spanner::Instance, :databases, :mock_spanner do
 
   it "paginates databases with next? and next and max set" do
     mock = Minitest::Mock.new
-    mock.expect :list_databases, first_page, [{ parent: instance_path(instance_id), page_size: 3, page_token: nil }, nil]
-    mock.expect :list_databases, last_page, [{ parent: instance_path(instance_id), page_size: 3, page_token: next_page_options }, nil]
+    mock.expect :list_databases, first_page, [{ parent: instance_path(instance_id), page_size: 3, page_token: nil }, ::Gapic::CallOptions]
+    mock.expect :list_databases, last_page, [{ parent: instance_path(instance_id), page_size: 3, page_token: next_page_options }, ::Gapic::CallOptions]
     instance.service.mocked_databases = mock
 
     first_databases = instance.databases max: 3
@@ -123,8 +123,8 @@ describe Google::Cloud::Spanner::Instance, :databases, :mock_spanner do
 
   it "paginates databases with all" do
     mock = Minitest::Mock.new
-    mock.expect :list_databases, first_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: nil }, nil]
-    mock.expect :list_databases, last_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: next_page_options }, nil]
+    mock.expect :list_databases, first_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: nil }, ::Gapic::CallOptions]
+    mock.expect :list_databases, last_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: next_page_options }, ::Gapic::CallOptions]
     instance.service.mocked_databases = mock
 
     databases = instance.databases.all.to_a
@@ -136,8 +136,8 @@ describe Google::Cloud::Spanner::Instance, :databases, :mock_spanner do
 
   it "paginates databases with all and max set" do
     mock = Minitest::Mock.new
-    mock.expect :list_databases, first_page, [{ parent: instance_path(instance_id), page_size: 3, page_token: nil }, nil]
-    mock.expect :list_databases, last_page, [{ parent: instance_path(instance_id), page_size: 3, page_token: next_page_options }, nil]
+    mock.expect :list_databases, first_page, [{ parent: instance_path(instance_id), page_size: 3, page_token: nil }, ::Gapic::CallOptions]
+    mock.expect :list_databases, last_page, [{ parent: instance_path(instance_id), page_size: 3, page_token: next_page_options }, ::Gapic::CallOptions]
     instance.service.mocked_databases = mock
 
     databases = instance.databases(max: 3).all.to_a
@@ -149,8 +149,8 @@ describe Google::Cloud::Spanner::Instance, :databases, :mock_spanner do
 
   it "iterates databases with all using Enumerator" do
     mock = Minitest::Mock.new
-    mock.expect :list_databases, first_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: nil }, nil]
-    mock.expect :list_databases, second_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: next_page_options }, nil]
+    mock.expect :list_databases, first_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: nil }, ::Gapic::CallOptions]
+    mock.expect :list_databases, second_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: next_page_options }, ::Gapic::CallOptions]
     instance.service.mocked_databases = mock
 
     databases = instance.databases.all.take(5)
@@ -162,8 +162,8 @@ describe Google::Cloud::Spanner::Instance, :databases, :mock_spanner do
 
   it "iterates databases with all and request_limit set" do
     mock = Minitest::Mock.new
-    mock.expect :list_databases, first_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: nil }, nil]
-    mock.expect :list_databases, second_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: next_page_options }, nil]
+    mock.expect :list_databases, first_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: nil }, ::Gapic::CallOptions]
+    mock.expect :list_databases, second_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: next_page_options }, ::Gapic::CallOptions]
     instance.service.mocked_databases = mock
 
     databases = instance.databases.all(request_limit: 1).to_a

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/delete_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/delete_test.rb
@@ -21,7 +21,7 @@ describe Google::Cloud::Spanner::Instance, :delete, :mock_spanner do
 
   it "can delete itself" do
     mock = Minitest::Mock.new
-    mock.expect :delete_instance, nil, [{ name: instance_grpc.name }, nil]
+    mock.expect :delete_instance, nil, [{ name: instance_grpc.name }, ::Gapic::CallOptions]
     spanner.service.mocked_instances = mock
 
     instance.delete

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/iam_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/iam_test.rb
@@ -46,7 +46,7 @@ describe Google::Cloud::Spanner::Instance, :iam, :mock_spanner do
  it "gets the IAM Policy" do
     get_res = Google::Iam::V1::Policy.new viewer_policy_hash
     mock = Minitest::Mock.new
-    mock.expect :get_iam_policy, get_res, [{ resource: instance.path }, nil]
+    mock.expect :get_iam_policy, get_res, [{ resource: instance.path }, ::Gapic::CallOptions]
     instance.service.mocked_instances = mock
 
     policy = instance.policy
@@ -66,7 +66,7 @@ describe Google::Cloud::Spanner::Instance, :iam, :mock_spanner do
   it "sets the IAM Policy" do
     get_res = Google::Iam::V1::Policy.new owner_policy_hash
     mock = Minitest::Mock.new
-    mock.expect :get_iam_policy, get_res, [{ resource: instance.path }, nil]
+    mock.expect :get_iam_policy, get_res, [{ resource: instance.path }, ::Gapic::CallOptions]
 
     updated_policy_hash = owner_policy_hash.dup
     updated_policy_hash[:bindings].first[:members].shift
@@ -74,7 +74,7 @@ describe Google::Cloud::Spanner::Instance, :iam, :mock_spanner do
 
     set_req = Google::Iam::V1::Policy.new updated_policy_hash
     set_res = Google::Iam::V1::Policy.new updated_policy_hash.merge(etag: "\b\x10")
-    mock.expect :set_iam_policy, set_res, [{ resource: instance.path, policy: set_req }, nil]
+    mock.expect :set_iam_policy, set_res, [{ resource: instance.path, policy: set_req }, ::Gapic::CallOptions]
     instance.service.mocked_instances = mock
 
     policy = instance.policy
@@ -101,7 +101,7 @@ describe Google::Cloud::Spanner::Instance, :iam, :mock_spanner do
 
     get_res = Google::Iam::V1::Policy.new owner_policy_hash
     mock = Minitest::Mock.new
-    mock.expect :get_iam_policy, get_res, [{ resource: instance.path }, nil]
+    mock.expect :get_iam_policy, get_res, [{ resource: instance.path }, ::Gapic::CallOptions]
 
     updated_policy_hash = owner_policy_hash.dup
     updated_policy_hash[:bindings].first[:members].shift
@@ -109,7 +109,7 @@ describe Google::Cloud::Spanner::Instance, :iam, :mock_spanner do
 
     set_req = Google::Iam::V1::Policy.new updated_policy_hash
     set_res = Google::Iam::V1::Policy.new updated_policy_hash.merge(etag: "\b\x10")
-    mock.expect :set_iam_policy, set_res, [{ resource: instance.path, policy: set_req }, nil]
+    mock.expect :set_iam_policy, set_res, [{ resource: instance.path, policy: set_req }, ::Gapic::CallOptions]
     instance.service.mocked_instances = mock
 
     policy = instance.policy do |p|
@@ -136,7 +136,7 @@ describe Google::Cloud::Spanner::Instance, :iam, :mock_spanner do
       permissions: ["spanner.instances.get"]
     )
     mock = Minitest::Mock.new
-    mock.expect :test_iam_permissions, test_res, [{ resource: instance.path, permissions: permissions }, nil]
+    mock.expect :test_iam_permissions, test_res, [{ resource: instance.path, permissions: permissions }, ::Gapic::CallOptions]
     instance.service.mocked_instances = mock
 
     permissions = instance.test_permissions "spanner.instances.get",

--- a/google-cloud-spanner/test/google/cloud/spanner/instance/save_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/instance/save_test.rb
@@ -42,7 +42,7 @@ describe Google::Cloud::Spanner::Instance, :save, :mock_spanner do
 
     mask = Google::Protobuf::FieldMask.new paths: ["display_name", "node_count", "labels"]
     mock = Minitest::Mock.new
-    mock.expect :update_instance, update_res, [{ instance: instance_grpc, field_mask: mask }, nil]
+    mock.expect :update_instance, update_res, [{ instance: instance_grpc, field_mask: mask }, ::Gapic::CallOptions]
     spanner.service.mocked_instances = mock
 
     job = instance.save
@@ -60,7 +60,7 @@ describe Google::Cloud::Spanner::Instance, :save, :mock_spanner do
 
     mask = Google::Protobuf::FieldMask.new paths: ["display_name", "node_count", "labels"]
     mock = Minitest::Mock.new
-    mock.expect :update_instance, update_res, [{ instance: instance_grpc, field_mask: mask }, nil]
+    mock.expect :update_instance, update_res, [{ instance: instance_grpc, field_mask: mask }, ::Gapic::CallOptions]
     spanner.service.mocked_instances = mock
 
     job = instance.save
@@ -76,7 +76,7 @@ describe Google::Cloud::Spanner::Instance, :save, :mock_spanner do
 
     mask = Google::Protobuf::FieldMask.new paths: ["processing_units"]
     mock = Minitest::Mock.new
-    mock.expect :update_instance, update_res, [{ instance: instance_grpc, field_mask: mask }, nil]
+    mock.expect :update_instance, update_res, [{ instance: instance_grpc, field_mask: mask }, ::Gapic::CallOptions]
     spanner.service.mocked_instances = mock
 
     job = instance.save
@@ -94,7 +94,7 @@ describe Google::Cloud::Spanner::Instance, :save, :mock_spanner do
 
     mask = Google::Protobuf::FieldMask.new paths: ["processing_units"]
     mock = Minitest::Mock.new
-    mock.expect :update_instance, update_res, [{ instance: instance_grpc, field_mask: mask }, nil]
+    mock.expect :update_instance, update_res, [{ instance: instance_grpc, field_mask: mask }, ::Gapic::CallOptions]
     spanner.service.mocked_instances = mock
 
     job = instance.save

--- a/google-cloud-spanner/test/google/cloud/spanner/pool/close_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool/close_test.rb
@@ -20,9 +20,8 @@ describe Google::Cloud::Spanner::Pool, :close, :mock_spanner do
   let(:session_id) { "session123" }
   let(:session_grpc) { Google::Cloud::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id) }
   let(:session) { Google::Cloud::Spanner::Session.from_grpc session_grpc, spanner.service }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:default_options) { ::Gapic::CallOptions.new  metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let(:client) { spanner.client instance_id, database_id, pool: { min: 0, max: 4 } }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
   let(:pool) do
     session.instance_variable_set :@last_updated_at, Time.now
     p = client.instance_variable_get :@pool

--- a/google-cloud-spanner/test/google/cloud/spanner/pool/keepalive_or_release_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool/keepalive_or_release_test.rb
@@ -23,7 +23,7 @@ describe Google::Cloud::Spanner::Pool, :keepalive_or_release, :mock_spanner do
   let(:transaction_id) { "tx789" }
   let(:transaction_grpc) { Google::Cloud::Spanner::V1::Transaction.new id: transaction_id }
   let(:transaction) { Google::Cloud::Spanner::Transaction.from_grpc transaction_grpc, session }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let(:tx_opts) { Google::Cloud::Spanner::V1::TransactionOptions.new(read_write: Google::Cloud::Spanner::V1::TransactionOptions::ReadWrite.new) }
   let(:client) { spanner.client instance_id, database_id, pool: { min: 0, max: 4 } }
   let(:pool) { client.instance_variable_get :@pool }

--- a/google-cloud-spanner/test/google/cloud/spanner/pool/new_sessions_in_process_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool/new_sessions_in_process_test.rb
@@ -20,9 +20,8 @@ describe Google::Cloud::Spanner::Pool, :new_sessions_in_process, :mock_spanner d
   let(:session_id) { "session123" }
   let(:session_grpc) { Google::Cloud::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id) }
   let(:session) { Google::Cloud::Spanner::Session.from_grpc session_grpc, spanner.service }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let(:client) { spanner.client instance_id, database_id, pool: { min: 0, max: 4 } }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
   let(:tx_opts) { Google::Cloud::Spanner::V1::TransactionOptions.new(read_write: Google::Cloud::Spanner::V1::TransactionOptions::ReadWrite.new) }
   let(:pool) do
     session.instance_variable_set :@last_updated_at, Time.now

--- a/google-cloud-spanner/test/google/cloud/spanner/pool/write_ratio_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool/write_ratio_test.rb
@@ -19,7 +19,7 @@ describe Google::Cloud::Spanner::Pool, :write_ratio, :mock_spanner do
   let(:database_id) { "my-database-id" }
   let(:client) { spanner.client instance_id, database_id, pool: { min: 0, max: 4 } }
   let(:tx_opts) { Google::Cloud::Spanner::V1::TransactionOptions.new(read_write: Google::Cloud::Spanner::V1::TransactionOptions::ReadWrite.new) }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let(:client_pool) do
     session.instance_variable_set :@last_updated_at, Time.now
     p = client.instance_variable_get :@pool

--- a/google-cloud-spanner/test/google/cloud/spanner/pool_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/pool_test.rb
@@ -20,7 +20,7 @@ describe Google::Cloud::Spanner::Pool, :mock_spanner do
   let(:session_id) { "session123" }
   let(:session_grpc) { Google::Cloud::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id) }
   let(:session) { Google::Cloud::Spanner::Session.from_grpc session_grpc, spanner.service }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let(:client) { spanner.client instance_id, database_id, pool: { min: 0, max: 4 } }
   let(:tx_opts) { Google::Cloud::Spanner::V1::TransactionOptions.new(read_write: Google::Cloud::Spanner::V1::TransactionOptions::ReadWrite.new) }
   let(:pool) do

--- a/google-cloud-spanner/test/google/cloud/spanner/project/create_database_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project/create_database_test.rb
@@ -38,7 +38,7 @@ describe Google::Cloud::Spanner::Project, :create_database, :mock_spanner do
         metadata_type: Google::Cloud::Spanner::Admin::Database::V1::CreateDatabaseMetadata
       )
     mock = Minitest::Mock.new
-    mock.expect :create_database, create_res, [{ parent: instance_path(instance_id), create_statement: "CREATE DATABASE `#{database_id}`", extra_statements: [], encryption_config: nil }, nil]
+    mock.expect :create_database, create_res, [{ parent: instance_path(instance_id), create_statement: "CREATE DATABASE `#{database_id}`", extra_statements: [], encryption_config: nil }, ::Gapic::CallOptions]
     spanner.service.mocked_databases = mock
 
     job = spanner.create_database instance_id, database_id
@@ -60,7 +60,7 @@ describe Google::Cloud::Spanner::Project, :create_database, :mock_spanner do
         metadata_type: Google::Cloud::Spanner::Admin::Database::V1::CreateDatabaseMetadata
     )
     mock = Minitest::Mock.new
-    mock.expect :create_database, create_res, [{ parent: instance_path(instance_id), create_statement: "CREATE DATABASE `#{database_id}`", extra_statements: ["CREATE TABLE table1;", "CREATE TABLE table2;"], encryption_config: nil }, nil]
+    mock.expect :create_database, create_res, [{ parent: instance_path(instance_id), create_statement: "CREATE DATABASE `#{database_id}`", extra_statements: ["CREATE TABLE table1;", "CREATE TABLE table2;"], encryption_config: nil }, ::Gapic::CallOptions]
     spanner.service.mocked_databases = mock
 
     job = spanner.create_database instance_id, database_id, statements: [
@@ -87,7 +87,7 @@ describe Google::Cloud::Spanner::Project, :create_database, :mock_spanner do
         metadata_type: Google::Cloud::Spanner::Admin::Database::V1::CreateDatabaseMetadata
     )
     mock = Minitest::Mock.new
-    mock.expect :create_database, create_res, [{ parent: instance_path(instance_id), create_statement: "CREATE DATABASE `#{database_id}`", extra_statements: [], encryption_config: { kms_key_name: kms_key_name } }, nil]
+    mock.expect :create_database, create_res, [{ parent: instance_path(instance_id), create_statement: "CREATE DATABASE `#{database_id}`", extra_statements: [], encryption_config: { kms_key_name: kms_key_name } }, ::Gapic::CallOptions]
     spanner.service.mocked_databases = mock
 
     job = spanner.create_database instance_id, database_id, encryption_config: { kms_key_name: kms_key_name }

--- a/google-cloud-spanner/test/google/cloud/spanner/project/create_instance_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project/create_instance_test.rb
@@ -65,7 +65,7 @@ describe Google::Cloud::Spanner::Project, :create_instance, :mock_spanner do
         result_type: Google::Cloud::Spanner::Admin::Instance::V1::Instance,
         metadata_type: Google::Cloud::Spanner::Admin::Instance::V1::CreateInstanceMetadata
     )
-    mock.expect :create_instance, create_res, [{ parent: project_path, instance_id: instance_id, instance: create_req }, nil]
+    mock.expect :create_instance, create_res, [{ parent: project_path, instance_id: instance_id, instance: create_req }, ::Gapic::CallOptions]
     mock.expect :get_operation, operation_done, [{name: "1234567890"}, Gapic::CallOptions]
     spanner.service.mocked_instances = mock
 
@@ -98,7 +98,7 @@ describe Google::Cloud::Spanner::Project, :create_instance, :mock_spanner do
         metadata_type: Google::Cloud::Spanner::Admin::Instance::V1::CreateInstanceMetadata
       )
     mock = Minitest::Mock.new
-    mock.expect :create_instance, create_res, [{ parent: project_path, instance_id: instance_id, instance: create_req }, nil]
+    mock.expect :create_instance, create_res, [{ parent: project_path, instance_id: instance_id, instance: create_req }, ::Gapic::CallOptions]
     spanner.service.mocked_instances = mock
 
     job = spanner.create_instance instance_id, config: config, name: "My New Instance", nodes: 99, labels: { env: :production }
@@ -122,7 +122,7 @@ describe Google::Cloud::Spanner::Project, :create_instance, :mock_spanner do
       )
     mock = Minitest::Mock.new
 
-    mock.expect :create_instance, create_res, [{ parent: project_path, instance_id: instance_id, instance: create_req }, nil]
+    mock.expect :create_instance, create_res, [{ parent: project_path, instance_id: instance_id, instance: create_req }, ::Gapic::CallOptions]
     spanner.service.mocked_instances = mock
 
     job = spanner.create_instance instance_id, config: config, name: "My New Instance", processing_units: 1000, labels: { env: :production }

--- a/google-cloud-spanner/test/google/cloud/spanner/project/database_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project/database_test.rb
@@ -25,7 +25,7 @@ describe Google::Cloud::Spanner::Project, :database, :mock_spanner do
 
     get_res = Google::Cloud::Spanner::Admin::Database::V1::Database.new database_hash(instance_id: instance_id, database_id: database_id, encryption_config: encryption_config)
     mock = Minitest::Mock.new
-    mock.expect :get_database, get_res, [{ name: database_path(instance_id, database_id) }, nil]
+    mock.expect :get_database, get_res, [{ name: database_path(instance_id, database_id) }, ::Gapic::CallOptions]
     spanner.service.mocked_databases = mock
 
     database = spanner.database instance_id, database_id

--- a/google-cloud-spanner/test/google/cloud/spanner/project/databases_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project/databases_test.rb
@@ -38,7 +38,7 @@ describe Google::Cloud::Spanner::Project, :databases, :mock_spanner do
 
   it "lists databases" do
     mock = Minitest::Mock.new
-    mock.expect :list_databases, first_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: nil }, nil]
+    mock.expect :list_databases, first_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: nil }, ::Gapic::CallOptions]
     spanner.service.mocked_databases = mock
 
     databases = spanner.databases instance_id
@@ -50,8 +50,8 @@ describe Google::Cloud::Spanner::Project, :databases, :mock_spanner do
 
   it "paginates databases" do
     mock = Minitest::Mock.new
-    mock.expect :list_databases, first_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: nil }, nil]
-    mock.expect :list_databases, last_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: next_page_options }, nil]
+    mock.expect :list_databases, first_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: nil }, ::Gapic::CallOptions]
+    mock.expect :list_databases, last_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: next_page_options }, ::Gapic::CallOptions]
     spanner.service.mocked_databases = mock
 
     first_databases = spanner.databases instance_id
@@ -70,7 +70,7 @@ describe Google::Cloud::Spanner::Project, :databases, :mock_spanner do
 
   it "paginates databases with max set" do
     mock = Minitest::Mock.new
-    mock.expect :list_databases, first_page, [{ parent: instance_path(instance_id), page_size: 3, page_token: nil }, nil]
+    mock.expect :list_databases, first_page, [{ parent: instance_path(instance_id), page_size: 3, page_token: nil }, ::Gapic::CallOptions]
     spanner.service.mocked_databases = mock
 
     databases = spanner.databases instance_id, max: 3
@@ -85,8 +85,8 @@ describe Google::Cloud::Spanner::Project, :databases, :mock_spanner do
 
   it "paginates databases with next? and next" do
     mock = Minitest::Mock.new
-    mock.expect :list_databases, first_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: nil }, nil]
-    mock.expect :list_databases, last_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: next_page_options }, nil]
+    mock.expect :list_databases, first_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: nil }, ::Gapic::CallOptions]
+    mock.expect :list_databases, last_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: next_page_options }, ::Gapic::CallOptions]
     spanner.service.mocked_databases = mock
 
     first_databases = spanner.databases instance_id
@@ -103,8 +103,8 @@ describe Google::Cloud::Spanner::Project, :databases, :mock_spanner do
 
   it "paginates databases with next? and next and max set" do
     mock = Minitest::Mock.new
-    mock.expect :list_databases, first_page, [{ parent: instance_path(instance_id), page_size: 3, page_token: nil }, nil]
-    mock.expect :list_databases, last_page, [{ parent: instance_path(instance_id), page_size: 3, page_token: next_page_options }, nil]
+    mock.expect :list_databases, first_page, [{ parent: instance_path(instance_id), page_size: 3, page_token: nil }, ::Gapic::CallOptions]
+    mock.expect :list_databases, last_page, [{ parent: instance_path(instance_id), page_size: 3, page_token: next_page_options }, ::Gapic::CallOptions]
     spanner.service.mocked_databases = mock
 
     first_databases = spanner.databases instance_id, max: 3
@@ -121,8 +121,8 @@ describe Google::Cloud::Spanner::Project, :databases, :mock_spanner do
 
   it "paginates databases with all" do
     mock = Minitest::Mock.new
-    mock.expect :list_databases, first_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: nil }, nil]
-    mock.expect :list_databases, last_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: next_page_options }, nil]
+    mock.expect :list_databases, first_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: nil }, ::Gapic::CallOptions]
+    mock.expect :list_databases, last_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: next_page_options }, ::Gapic::CallOptions]
     spanner.service.mocked_databases = mock
 
     databases = spanner.databases(instance_id).all.to_a
@@ -134,8 +134,8 @@ describe Google::Cloud::Spanner::Project, :databases, :mock_spanner do
 
   it "paginates databases with all and max set" do
     mock = Minitest::Mock.new
-    mock.expect :list_databases, first_page, [{ parent: instance_path(instance_id), page_size: 3, page_token: nil }, nil]
-    mock.expect :list_databases, last_page, [{ parent: instance_path(instance_id), page_size: 3, page_token: next_page_options }, nil]
+    mock.expect :list_databases, first_page, [{ parent: instance_path(instance_id), page_size: 3, page_token: nil }, ::Gapic::CallOptions]
+    mock.expect :list_databases, last_page, [{ parent: instance_path(instance_id), page_size: 3, page_token: next_page_options }, ::Gapic::CallOptions]
     spanner.service.mocked_databases = mock
 
     databases = spanner.databases(instance_id, max: 3).all.to_a
@@ -147,8 +147,8 @@ describe Google::Cloud::Spanner::Project, :databases, :mock_spanner do
 
   it "iterates databases with all using Enumerator" do
     mock = Minitest::Mock.new
-    mock.expect :list_databases, first_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: nil }, nil]
-    mock.expect :list_databases, second_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: next_page_options }, nil]
+    mock.expect :list_databases, first_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: nil }, ::Gapic::CallOptions]
+    mock.expect :list_databases, second_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: next_page_options }, ::Gapic::CallOptions]
     spanner.service.mocked_databases = mock
 
     databases = spanner.databases(instance_id).all.take(5)
@@ -160,8 +160,8 @@ describe Google::Cloud::Spanner::Project, :databases, :mock_spanner do
 
   it "iterates databases with all and request_limit set" do
     mock = Minitest::Mock.new
-    mock.expect :list_databases, first_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: nil }, nil]
-    mock.expect :list_databases, second_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: next_page_options }, nil]
+    mock.expect :list_databases, first_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: nil }, ::Gapic::CallOptions]
+    mock.expect :list_databases, second_page, [{ parent: instance_path(instance_id), page_size: nil, page_token: next_page_options }, ::Gapic::CallOptions]
     spanner.service.mocked_databases = mock
 
     databases = spanner.databases(instance_id).all(request_limit: 1).to_a

--- a/google-cloud-spanner/test/google/cloud/spanner/project/instance_config_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project/instance_config_test.rb
@@ -20,7 +20,7 @@ describe Google::Cloud::Spanner::Project, :instance_config, :mock_spanner do
 
     get_res = Google::Cloud::Spanner::Admin::Instance::V1::InstanceConfig.new instance_config_hash
     mock = Minitest::Mock.new
-    mock.expect :get_instance_config, get_res, [{ name: instance_config_path(config_name) }, nil]
+    mock.expect :get_instance_config, get_res, [{ name: instance_config_path(config_name) }, ::Gapic::CallOptions]
     spanner.service.mocked_instances = mock
 
     config = spanner.instance_config config_name

--- a/google-cloud-spanner/test/google/cloud/spanner/project/instance_configs_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project/instance_configs_test.rb
@@ -37,7 +37,7 @@ describe Google::Cloud::Spanner::Project, :instance_configs, :mock_spanner do
 
   it "lists configs" do
     mock = Minitest::Mock.new
-    mock.expect :list_instance_configs, first_page, [{ parent: project_path, page_size: nil, page_token: nil }, nil]
+    mock.expect :list_instance_configs, first_page, [{ parent: project_path, page_size: nil, page_token: nil }, ::Gapic::CallOptions]
     spanner.service.mocked_instances = mock
 
     configs = spanner.instance_configs
@@ -49,8 +49,8 @@ describe Google::Cloud::Spanner::Project, :instance_configs, :mock_spanner do
 
   it "paginates configs" do
     mock = Minitest::Mock.new
-    mock.expect :list_instance_configs, first_page, [{ parent: project_path, page_size: nil, page_token: nil }, nil]
-    mock.expect :list_instance_configs, last_page, [{ parent: project_path, page_size: nil, page_token: next_page_options }, nil]
+    mock.expect :list_instance_configs, first_page, [{ parent: project_path, page_size: nil, page_token: nil }, ::Gapic::CallOptions]
+    mock.expect :list_instance_configs, last_page, [{ parent: project_path, page_size: nil, page_token: next_page_options }, ::Gapic::CallOptions]
     spanner.service.mocked_instances = mock
 
     first_configs = spanner.instance_configs
@@ -69,7 +69,7 @@ describe Google::Cloud::Spanner::Project, :instance_configs, :mock_spanner do
 
   it "paginates configs with max set" do
     mock = Minitest::Mock.new
-    mock.expect :list_instance_configs, first_page, [{ parent: project_path, page_size: 3, page_token: nil }, nil]
+    mock.expect :list_instance_configs, first_page, [{ parent: project_path, page_size: 3, page_token: nil }, ::Gapic::CallOptions]
     spanner.service.mocked_instances = mock
 
     configs = spanner.instance_configs max: 3
@@ -84,8 +84,8 @@ describe Google::Cloud::Spanner::Project, :instance_configs, :mock_spanner do
 
   it "paginates configs with next? and next" do
     mock = Minitest::Mock.new
-    mock.expect :list_instance_configs, first_page, [{ parent: project_path, page_size: nil, page_token: nil }, nil]
-    mock.expect :list_instance_configs, last_page, [{ parent: project_path, page_size: nil, page_token: next_page_options }, nil]
+    mock.expect :list_instance_configs, first_page, [{ parent: project_path, page_size: nil, page_token: nil }, ::Gapic::CallOptions]
+    mock.expect :list_instance_configs, last_page, [{ parent: project_path, page_size: nil, page_token: next_page_options }, ::Gapic::CallOptions]
     spanner.service.mocked_instances = mock
 
     first_configs = spanner.instance_configs
@@ -102,8 +102,8 @@ describe Google::Cloud::Spanner::Project, :instance_configs, :mock_spanner do
 
   it "paginates configs with next? and next and max set" do
     mock = Minitest::Mock.new
-    mock.expect :list_instance_configs, first_page, [{ parent: project_path, page_size: 3, page_token: nil }, nil]
-    mock.expect :list_instance_configs, last_page, [{ parent: project_path, page_size: 3, page_token: next_page_options }, nil]
+    mock.expect :list_instance_configs, first_page, [{ parent: project_path, page_size: 3, page_token: nil }, ::Gapic::CallOptions]
+    mock.expect :list_instance_configs, last_page, [{ parent: project_path, page_size: 3, page_token: next_page_options }, ::Gapic::CallOptions]
     spanner.service.mocked_instances = mock
 
     first_configs = spanner.instance_configs max: 3
@@ -120,8 +120,8 @@ describe Google::Cloud::Spanner::Project, :instance_configs, :mock_spanner do
 
   it "paginates configs with all" do
     mock = Minitest::Mock.new
-    mock.expect :list_instance_configs, first_page, [{ parent: project_path, page_size: nil, page_token: nil }, nil]
-    mock.expect :list_instance_configs, last_page, [{ parent: project_path, page_size: nil, page_token: next_page_options }, nil]
+    mock.expect :list_instance_configs, first_page, [{ parent: project_path, page_size: nil, page_token: nil }, ::Gapic::CallOptions]
+    mock.expect :list_instance_configs, last_page, [{ parent: project_path, page_size: nil, page_token: next_page_options }, ::Gapic::CallOptions]
     spanner.service.mocked_instances = mock
 
     configs = spanner.instance_configs.all.to_a
@@ -133,8 +133,8 @@ describe Google::Cloud::Spanner::Project, :instance_configs, :mock_spanner do
 
   it "paginates configs with all and max set" do
     mock = Minitest::Mock.new
-    mock.expect :list_instance_configs, first_page, [{ parent: project_path, page_size: 3, page_token: nil }, nil]
-    mock.expect :list_instance_configs, last_page, [{ parent: project_path, page_size: 3, page_token: next_page_options }, nil]
+    mock.expect :list_instance_configs, first_page, [{ parent: project_path, page_size: 3, page_token: nil }, ::Gapic::CallOptions]
+    mock.expect :list_instance_configs, last_page, [{ parent: project_path, page_size: 3, page_token: next_page_options }, ::Gapic::CallOptions]
     spanner.service.mocked_instances = mock
 
     configs = spanner.instance_configs(max: 3).all.to_a
@@ -146,8 +146,8 @@ describe Google::Cloud::Spanner::Project, :instance_configs, :mock_spanner do
 
   it "iterates configs with all using Enumerator" do
     mock = Minitest::Mock.new
-    mock.expect :list_instance_configs, first_page, [{ parent: project_path, page_size: nil, page_token: nil }, nil]
-    mock.expect :list_instance_configs, second_page, [{ parent: project_path, page_size: nil, page_token: next_page_options }, nil]
+    mock.expect :list_instance_configs, first_page, [{ parent: project_path, page_size: nil, page_token: nil }, ::Gapic::CallOptions]
+    mock.expect :list_instance_configs, second_page, [{ parent: project_path, page_size: nil, page_token: next_page_options }, ::Gapic::CallOptions]
     spanner.service.mocked_instances = mock
 
     configs = spanner.instance_configs.all.take(5)
@@ -159,8 +159,8 @@ describe Google::Cloud::Spanner::Project, :instance_configs, :mock_spanner do
 
   it "iterates configs with all and request_limit set" do
     mock = Minitest::Mock.new
-    mock.expect :list_instance_configs, first_page, [{ parent: project_path, page_size: nil, page_token: nil }, nil]
-    mock.expect :list_instance_configs, second_page, [{ parent: project_path, page_size: nil, page_token: next_page_options }, nil]
+    mock.expect :list_instance_configs, first_page, [{ parent: project_path, page_size: nil, page_token: nil }, ::Gapic::CallOptions]
+    mock.expect :list_instance_configs, second_page, [{ parent: project_path, page_size: nil, page_token: next_page_options }, ::Gapic::CallOptions]
     spanner.service.mocked_instances = mock
 
     configs = spanner.instance_configs.all(request_limit: 1).to_a

--- a/google-cloud-spanner/test/google/cloud/spanner/project/instance_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project/instance_test.rb
@@ -20,7 +20,7 @@ describe Google::Cloud::Spanner::Project, :instance, :mock_spanner do
 
     get_res = Google::Cloud::Spanner::Admin::Instance::V1::Instance.new instance_hash(name: instance_id)
     mock = Minitest::Mock.new
-    mock.expect :get_instance, get_res, [{ name: instance_path(instance_id) }, nil]
+    mock.expect :get_instance, get_res, [{ name: instance_path(instance_id) }, ::Gapic::CallOptions]
     spanner.service.mocked_instances = mock
 
     instance = spanner.instance instance_id

--- a/google-cloud-spanner/test/google/cloud/spanner/project/instances_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/project/instances_test.rb
@@ -37,7 +37,7 @@ describe Google::Cloud::Spanner::Project, :instances, :mock_spanner do
 
   it "lists instances" do
     mock = Minitest::Mock.new
-    mock.expect :list_instances, first_page, [{ parent: project_path, page_size: nil, page_token: nil }, nil]
+    mock.expect :list_instances, first_page, [{ parent: project_path, page_size: nil, page_token: nil }, ::Gapic::CallOptions]
     spanner.service.mocked_instances = mock
 
     instances = spanner.instances
@@ -49,8 +49,8 @@ describe Google::Cloud::Spanner::Project, :instances, :mock_spanner do
 
   it "paginates instances" do
     mock = Minitest::Mock.new
-    mock.expect :list_instances, first_page, [{ parent: project_path, page_size: nil, page_token: nil }, nil]
-    mock.expect :list_instances, last_page, [{ parent: project_path, page_size: nil, page_token: next_page_options }, nil]
+    mock.expect :list_instances, first_page, [{ parent: project_path, page_size: nil, page_token: nil }, ::Gapic::CallOptions]
+    mock.expect :list_instances, last_page, [{ parent: project_path, page_size: nil, page_token: next_page_options }, ::Gapic::CallOptions]
     spanner.service.mocked_instances = mock
 
     first_instances = spanner.instances
@@ -69,7 +69,7 @@ describe Google::Cloud::Spanner::Project, :instances, :mock_spanner do
 
   it "paginates instances with max set" do
     mock = Minitest::Mock.new
-    mock.expect :list_instances, first_page, [{ parent: project_path, page_size: 3, page_token: nil }, nil]
+    mock.expect :list_instances, first_page, [{ parent: project_path, page_size: 3, page_token: nil }, ::Gapic::CallOptions]
     spanner.service.mocked_instances = mock
 
     instances = spanner.instances max: 3
@@ -84,8 +84,8 @@ describe Google::Cloud::Spanner::Project, :instances, :mock_spanner do
 
   it "paginates instances with next? and next" do
     mock = Minitest::Mock.new
-    mock.expect :list_instances, first_page, [{ parent: project_path, page_size: nil, page_token: nil }, nil]
-    mock.expect :list_instances, last_page, [{ parent: project_path, page_size: nil, page_token: next_page_options }, nil]
+    mock.expect :list_instances, first_page, [{ parent: project_path, page_size: nil, page_token: nil }, ::Gapic::CallOptions]
+    mock.expect :list_instances, last_page, [{ parent: project_path, page_size: nil, page_token: next_page_options }, ::Gapic::CallOptions]
     spanner.service.mocked_instances = mock
 
     first_instances = spanner.instances
@@ -102,8 +102,8 @@ describe Google::Cloud::Spanner::Project, :instances, :mock_spanner do
 
   it "paginates instances with next? and next and max set" do
     mock = Minitest::Mock.new
-    mock.expect :list_instances, first_page, [{ parent: project_path, page_size: 3, page_token: nil }, nil]
-    mock.expect :list_instances, last_page, [{ parent: project_path, page_size: 3, page_token: next_page_options }, nil]
+    mock.expect :list_instances, first_page, [{ parent: project_path, page_size: 3, page_token: nil }, ::Gapic::CallOptions]
+    mock.expect :list_instances, last_page, [{ parent: project_path, page_size: 3, page_token: next_page_options }, ::Gapic::CallOptions]
     spanner.service.mocked_instances = mock
 
     first_instances = spanner.instances max: 3
@@ -120,8 +120,8 @@ describe Google::Cloud::Spanner::Project, :instances, :mock_spanner do
 
   it "paginates instances with all" do
     mock = Minitest::Mock.new
-    mock.expect :list_instances, first_page, [{ parent: project_path, page_size: nil, page_token: nil }, nil]
-    mock.expect :list_instances, last_page, [{ parent: project_path, page_size: nil, page_token: next_page_options }, nil]
+    mock.expect :list_instances, first_page, [{ parent: project_path, page_size: nil, page_token: nil }, ::Gapic::CallOptions]
+    mock.expect :list_instances, last_page, [{ parent: project_path, page_size: nil, page_token: next_page_options }, ::Gapic::CallOptions]
     spanner.service.mocked_instances = mock
 
     instances = spanner.instances.all.to_a
@@ -133,8 +133,8 @@ describe Google::Cloud::Spanner::Project, :instances, :mock_spanner do
 
   it "paginates instances with all and max set" do
     mock = Minitest::Mock.new
-    mock.expect :list_instances, first_page, [{ parent: project_path, page_size: 3, page_token: nil }, nil]
-    mock.expect :list_instances, last_page, [{ parent: project_path, page_size: 3, page_token: next_page_options }, nil]
+    mock.expect :list_instances, first_page, [{ parent: project_path, page_size: 3, page_token: nil }, ::Gapic::CallOptions]
+    mock.expect :list_instances, last_page, [{ parent: project_path, page_size: 3, page_token: next_page_options }, ::Gapic::CallOptions]
     spanner.service.mocked_instances = mock
 
     instances = spanner.instances(max: 3).all.to_a
@@ -146,8 +146,8 @@ describe Google::Cloud::Spanner::Project, :instances, :mock_spanner do
 
   it "iterates instances with all using Enumerator" do
     mock = Minitest::Mock.new
-    mock.expect :list_instances, first_page, [{ parent: project_path, page_size: nil, page_token: nil }, nil]
-    mock.expect :list_instances, second_page, [{ parent: project_path, page_size: nil, page_token: next_page_options }, nil]
+    mock.expect :list_instances, first_page, [{ parent: project_path, page_size: nil, page_token: nil }, ::Gapic::CallOptions]
+    mock.expect :list_instances, second_page, [{ parent: project_path, page_size: nil, page_token: next_page_options }, ::Gapic::CallOptions]
     spanner.service.mocked_instances = mock
 
     instances = spanner.instances.all.take(5)
@@ -159,8 +159,8 @@ describe Google::Cloud::Spanner::Project, :instances, :mock_spanner do
 
   it "iterates instances with all and request_limit set" do
     mock = Minitest::Mock.new
-    mock.expect :list_instances, first_page, [{ parent: project_path, page_size: nil, page_token: nil }, nil]
-    mock.expect :list_instances, second_page, [{ parent: project_path, page_size: nil, page_token: next_page_options }, nil]
+    mock.expect :list_instances, first_page, [{ parent: project_path, page_size: nil, page_token: nil }, ::Gapic::CallOptions]
+    mock.expect :list_instances, second_page, [{ parent: project_path, page_size: nil, page_token: next_page_options }, ::Gapic::CallOptions]
     spanner.service.mocked_instances = mock
 
     instances = spanner.instances.all(request_limit: 1).to_a

--- a/google-cloud-spanner/test/google/cloud/spanner/session/commit_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/commit_test.rb
@@ -24,7 +24,7 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
   let(:commit_timestamp) { Google::Cloud::Spanner::Convert.time_to_timestamp commit_time }
   let(:commit_resp) { Google::Cloud::Spanner::V1::CommitResponse.new commit_timestamp: commit_timestamp }
   let(:tx_opts) { Google::Cloud::Spanner::V1::TransactionOptions.new(read_write: Google::Cloud::Spanner::V1::TransactionOptions::ReadWrite.new) }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
 
   it "commits using a block" do
     mutations = [

--- a/google-cloud-spanner/test/google/cloud/spanner/session/execute_query_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/execute_query_test.rb
@@ -20,7 +20,7 @@ describe Google::Cloud::Spanner::Session, :execute_query, :mock_spanner do
   let(:session_id) { "session123" }
   let(:session_grpc) { Google::Cloud::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id) }
   let(:session) { Google::Cloud::Spanner::Session.from_grpc session_grpc, spanner.service }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let :results_hash do
     {
       metadata: {

--- a/google-cloud-spanner/test/google/cloud/spanner/session/keepalive_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/keepalive_test.rb
@@ -20,7 +20,7 @@ describe Google::Cloud::Spanner::Session, :keepalive, :mock_spanner do
   let(:session_id) { "session123" }
   let(:session_grpc) { Google::Cloud::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id) }
   let(:session) { Google::Cloud::Spanner::Session.from_grpc session_grpc, spanner.service }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let :results_hash do
     {
       metadata: {

--- a/google-cloud-spanner/test/google/cloud/spanner/session/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/read_test.rb
@@ -21,7 +21,7 @@ describe Google::Cloud::Spanner::Session, :read, :mock_spanner do
   let(:session_grpc) { Google::Cloud::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id) }
   let(:session) { Google::Cloud::Spanner::Session.from_grpc session_grpc, spanner.service }
   let(:columns) { ["id", "name", "active", "age", "score", "updated_at", "birthday", "avatar", "project_ids"] }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let :results_hash1 do
     {
       metadata: {

--- a/google-cloud-spanner/test/google/cloud/spanner/session/release_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/release_test.rb
@@ -20,7 +20,7 @@ describe Google::Cloud::Spanner::Session, :release, :mock_spanner do
   let(:session_id) { "session123" }
   let(:session_grpc) { Google::Cloud::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id) }
   let(:session) { Google::Cloud::Spanner::Session.from_grpc session_grpc, spanner.service }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
 
   it "can release itself" do
     mock = Minitest::Mock.new

--- a/google-cloud-spanner/test/google/cloud/spanner/session/reload_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/session/reload_test.rb
@@ -20,7 +20,7 @@ describe Google::Cloud::Spanner::Session, :reload, :mock_spanner do
   let(:session_id) { "session123" }
   let(:session_grpc) { Google::Cloud::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id) }
   let(:session) { Google::Cloud::Spanner::Session.from_grpc session_grpc, spanner.service }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
 
   let(:labels) { { "env" => "production" } }
   let(:session_grpc_labels) { Google::Cloud::Spanner::V1::Session.new name: session_path(instance_id, database_id, session_id), labels: labels }

--- a/google-cloud-spanner/test/google/cloud/spanner/snapshot/execute_query_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/snapshot/execute_query_test.rb
@@ -24,7 +24,7 @@ describe Google::Cloud::Spanner::Snapshot, :execute_query, :mock_spanner do
   let(:transaction_grpc) { Google::Cloud::Spanner::V1::Transaction.new id: transaction_id }
   let(:snapshot) { Google::Cloud::Spanner::Snapshot.from_grpc transaction_grpc, session }
   let(:tx_selector) { Google::Cloud::Spanner::V1::TransactionSelector.new id: transaction_id }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let :results_hash do
     {
       metadata: {

--- a/google-cloud-spanner/test/google/cloud/spanner/snapshot/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/snapshot/read_test.rb
@@ -24,7 +24,7 @@ describe Google::Cloud::Spanner::Snapshot, :read, :mock_spanner do
   let(:transaction_grpc) { Google::Cloud::Spanner::V1::Transaction.new id: transaction_id }
   let(:snapshot) { Google::Cloud::Spanner::Snapshot.from_grpc transaction_grpc, session }
   let(:tx_selector) { Google::Cloud::Spanner::V1::TransactionSelector.new id: transaction_id }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let :results_hash1 do
     {
       metadata: {

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/batch_update_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/batch_update_test.rb
@@ -24,7 +24,7 @@ describe Google::Cloud::Spanner::Transaction, :batch_update, :mock_spanner do
   let(:transaction_grpc) { Google::Cloud::Spanner::V1::Transaction.new id: transaction_id }
   let(:transaction) { Google::Cloud::Spanner::Transaction.from_grpc transaction_grpc, session }
   let(:tx_selector) { Google::Cloud::Spanner::V1::TransactionSelector.new id: transaction_id }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let(:timestamp) { Time.parse "2017-01-01 20:04:05.06 -0700" }
   let(:date) { Date.parse "2017-01-02" }
   let(:file) { StringIO.new "contents" }

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/execute_query_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/execute_query_test.rb
@@ -24,7 +24,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_query, :mock_spanner do
   let(:transaction_grpc) { Google::Cloud::Spanner::V1::Transaction.new id: transaction_id }
   let(:transaction) { Google::Cloud::Spanner::Transaction.from_grpc transaction_grpc, session }
   let(:tx_selector) { Google::Cloud::Spanner::V1::TransactionSelector.new id: transaction_id }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let :results_hash do
     {
       metadata: {

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/execute_update_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/execute_update_test.rb
@@ -24,7 +24,7 @@ describe Google::Cloud::Spanner::Transaction, :execute_update, :mock_spanner do
   let(:transaction_grpc) { Google::Cloud::Spanner::V1::Transaction.new id: transaction_id }
   let(:transaction) { Google::Cloud::Spanner::Transaction.from_grpc transaction_grpc, session }
   let(:tx_selector) { Google::Cloud::Spanner::V1::TransactionSelector.new id: transaction_id }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let(:results_grpc) {
     Google::Cloud::Spanner::V1::PartialResultSet.new(
       metadata: Google::Cloud::Spanner::V1::ResultSetMetadata.new(

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/fields_for_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/fields_for_test.rb
@@ -24,7 +24,7 @@ describe Google::Cloud::Spanner::Transaction, :fields_for, :mock_spanner do
   let(:transaction_grpc) { Google::Cloud::Spanner::V1::Transaction.new id: transaction_id }
   let(:transaction) { Google::Cloud::Spanner::Transaction.from_grpc transaction_grpc, session }
   let(:tx_selector) { Google::Cloud::Spanner::V1::TransactionSelector.new id: transaction_id }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let :results_hash do
     {
       metadata: {

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/keepalive_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/keepalive_test.rb
@@ -23,7 +23,7 @@ describe Google::Cloud::Spanner::Session, :keepalive, :mock_spanner do
   let(:transaction_id) { "tx789" }
   let(:transaction_grpc) { Google::Cloud::Spanner::V1::Transaction.new id: transaction_id }
   let(:transaction) { Google::Cloud::Spanner::Transaction.from_grpc transaction_grpc, session }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let(:tx_opts) { Google::Cloud::Spanner::V1::TransactionOptions.new(read_write: Google::Cloud::Spanner::V1::TransactionOptions::ReadWrite.new) }
 
   it "creates new transaction when calling keepalive" do

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/read_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/read_test.rb
@@ -24,7 +24,7 @@ describe Google::Cloud::Spanner::Transaction, :read, :mock_spanner do
   let(:transaction_grpc) { Google::Cloud::Spanner::V1::Transaction.new id: transaction_id }
   let(:transaction) { Google::Cloud::Spanner::Transaction.from_grpc transaction_grpc, session }
   let(:tx_selector) { Google::Cloud::Spanner::V1::TransactionSelector.new id: transaction_id }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
   let :results_hash1 do
     {
       metadata: {

--- a/google-cloud-spanner/test/google/cloud/spanner/transaction/release_test.rb
+++ b/google-cloud-spanner/test/google/cloud/spanner/transaction/release_test.rb
@@ -23,7 +23,7 @@ describe Google::Cloud::Spanner::Session, :release, :mock_spanner do
   let(:transaction_id) { "tx789" }
   let(:transaction_grpc) { Google::Cloud::Spanner::V1::Transaction.new id: transaction_id }
   let(:transaction) { Google::Cloud::Spanner::Transaction.from_grpc transaction_grpc, session }
-  let(:default_options) { { metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } } }
+  let(:default_options) { ::Gapic::CallOptions.new metadata: { "google-cloud-resource-prefix" => database_path(instance_id, database_id) } }
 
   it "can release itself" do
     mock = Minitest::Mock.new


### PR DESCRIPTION
Also fixed a clock skew related flake in the acceptance tests, and
Fixes #18362