### PR TITLE
fix(pubsub): honour async options of topic

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/project.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/project.rb
@@ -160,7 +160,7 @@ module Google
         #
         def topic topic_name, project: nil, skip_lookup: nil, async: nil
           ensure_service!
-          options = { project: project }
+          options = { project: project, async: async }
           return Topic.from_name topic_name, service, options if skip_lookup
           grpc = service.get_topic topic_name, options
           Topic.from_grpc grpc, service, async: async

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
@@ -1065,7 +1065,7 @@ module Google
         # @private New reference {Topic} object without making an HTTP request.
         def self.from_name name, service, options = {}
           name = service.topic_path name, options
-          from_grpc(nil, service).tap do |t|
+          from_grpc(nil, service, async: options[:async]).tap do |t|
             t.instance_variable_set :@resource_name, name
           end
         end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/project_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/project_test.rb
@@ -18,4 +18,10 @@ describe Google::Cloud::PubSub::Project, :mock_pubsub do
   it "knows the project identifier" do
     _(pubsub.project).must_equal project
   end
+
+  it "creates topic with async options when skip_lookup enabled" do
+    topic = pubsub.topic("test", skip_lookup: true, async: { interval: 1 })
+    topic.publish_async("{}")
+    _(topic.async_publisher.instance_variable_get("@interval")).must_equal 1
+  end
 end


### PR DESCRIPTION
- update the async options when skip lookup is enabled

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-ruby/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea.
- [x] Follow the instructions in [CONTRIBUTING](CONTRIBUTING.md). Most importantly, ensure the tests and linter pass by running `bundle exec rake ci` in the gem subdirectory.
- [x] Update code documentation if necessary.

closes: #18428 