### PR TITLE
fix: update non EOS ack to return Success always

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/received_message.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/received_message.rb
@@ -204,7 +204,12 @@ module Google
         #
         def acknowledge! &block
           ensure_subscription!
-          subscription.acknowledge ack_id, &block
+          if subscription.respond_to?(:exactly_once_delivery_enabled) && subscription.exactly_once_delivery_enabled
+            subscription.acknowledge ack_id, &block
+          else
+            subscription.acknowledge ack_id
+            yield AcknowledgeResult.new(AcknowledgeResult::SUCCESS) if block_given?
+          end
         end
         alias ack! acknowledge!
 
@@ -265,7 +270,12 @@ module Google
         #
         def modify_ack_deadline! new_deadline, &block
           ensure_subscription!
-          subscription.modify_ack_deadline new_deadline, ack_id, &block
+          if subscription.respond_to?(:exactly_once_delivery_enabled) && subscription.exactly_once_delivery_enabled
+            subscription.modify_ack_deadline new_deadline, ack_id, &block
+          else
+            subscription.modify_ack_deadline new_deadline, ack_id
+            yield AcknowledgeResult.new(AcknowledgeResult::SUCCESS) if block_given?
+          end
         end
 
         ##

--- a/google-cloud-pubsub/samples/acceptance/subscriptions_test.rb
+++ b/google-cloud-pubsub/samples/acceptance/subscriptions_test.rb
@@ -15,7 +15,7 @@
 require_relative "helper"
 require_relative "../subscriptions.rb"
 require_relative "../pubsub_create_subscription_with_filter.rb"
-require_relative "../pubsub_subscriber_exactly_once.rb"
+require_relative "../pubsub_subscriber_exactly_once_delivery.rb"
 require_relative "../pubsub_create_subscription_with_exactly_once_delivery.rb"
 
 describe "subscriptions" do
@@ -112,9 +112,9 @@ describe "subscriptions" do
 
     expect_with_retry "pubsub_subscriber_async_pull_with_ack_response" do
       out, _err = capture_io do
-        PubsubSubscriberExactlyOnce.new.subscriber_exactly_once project_id: project_id,
-                                                                topic_id: topic_id,
-                                                                subscription_id: subscription_id
+        PubsubSubscriberExactlyOnceDelivery.new.subscriber_exactly_once_delivery project_id: project_id,
+                                                                                 topic_id: topic_id,
+                                                                                 subscription_id: subscription_id
       end
 
       assert_includes out, "Received message: This is a test message."

--- a/google-cloud-pubsub/samples/pubsub_subscriber_exactly_once_delivery.rb
+++ b/google-cloud-pubsub/samples/pubsub_subscriber_exactly_once_delivery.rb
@@ -16,8 +16,8 @@
 require "google/cloud/pubsub"
 
 # Shows how to register callback to acknowledge method and access the result passed in
-class PubsubSubscriberExactlyOnce
-  def subscriber_exactly_once project_id:, topic_id:, subscription_id:
+class PubsubSubscriberExactlyOnceDelivery
+  def subscriber_exactly_once_delivery project_id:, topic_id:, subscription_id:
     pubsub = Google::Cloud::Pubsub.new project_id: project_id
     topic = pubsub.topic topic_id
     subscription = pubsub.subscription subscription_id
@@ -42,13 +42,13 @@ class PubsubSubscriberExactlyOnce
     project_id = "your-project-id"
     topic_id = "your-topic-id"
     subscription_id = "id-for-new-subcription" # subscription with exactly once delivery enabled
-    PubsubSubscriberExactlyOnce.new.subscriber_exactly_once project_id: project_id,
-                                                            topic_id: topic_id,
-                                                            subscription_id: subscription_id
+    PubsubSubscriberExactlyOnceDelivery.new.subscriber_exactly_once_delivery project_id: project_id,
+                                                                             topic_id: topic_id,
+                                                                             subscription_id: subscription_id
   end
 end
 
 if $PROGRAM_NAME == __FILE__
-  PubsubSubscriberExactlyOnce.run
+  PubsubSubscriberExactlyOnceDelivery.run
 end
 # [END pubsub_subscriber_exactly_once]

--- a/google-cloud-pubsub/samples/pubsub_subscriber_exactly_once_delivery.rb
+++ b/google-cloud-pubsub/samples/pubsub_subscriber_exactly_once_delivery.rb
@@ -24,7 +24,8 @@ class PubsubSubscriberExactlyOnceDelivery
     subscriber   = subscription.listen do |received_message|
       puts "Received message: #{received_message.data}"
 
-      # Pass in callback to access the acknowledge result
+      # Pass in callback to access the acknowledge result.
+      # For subscription with Exactly once delivery disabled the result will be success always.
       received_message.acknowledge! do |result|
         puts "Acknowledge result's status: #{result.status}"
       end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/received_message_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/received_message_test.rb
@@ -101,6 +101,19 @@ describe Google::Cloud::PubSub::ReceivedMessage, :mock_pubsub do
     mock.verify
   end
 
+  it "can ack with block and returns success" do
+    ack_res = nil
+    mock = Minitest::Mock.new
+    mock.expect :acknowledge, ack_res, subscription: subscription_path(subscription_name), ack_ids: [rec_message.ack_id]
+    subscription.service.mocked_subscriber = mock
+
+    rec_message.ack! do |result|
+      assert_equal result.status, Google::Cloud::PubSub::AcknowledgeResult::SUCCESS, Proc.new { raise "Staus did not match!" }
+    end
+
+    mock.verify
+  end
+
   it "can modify_ack_deadline" do
     new_deadline = 42
     mad_res = nil
@@ -109,6 +122,20 @@ describe Google::Cloud::PubSub::ReceivedMessage, :mock_pubsub do
     subscription.service.mocked_subscriber = mock
 
     rec_message.modify_ack_deadline! new_deadline
+
+    mock.verify
+  end
+
+  it "can modify_ack_deadline with block and returns success" do
+    new_deadline = 42
+    mad_res = nil
+    mock = Minitest::Mock.new
+    mock.expect :modify_ack_deadline, mad_res, subscription: subscription_path(subscription_name), ack_ids: [rec_message.ack_id], ack_deadline_seconds: new_deadline
+    subscription.service.mocked_subscriber = mock
+
+    rec_message.modify_ack_deadline! new_deadline do |result|
+      assert_equal result.status, Google::Cloud::PubSub::AcknowledgeResult::SUCCESS, Proc.new { raise "Staus did not match!" }
+    end
 
     mock.verify
   end


### PR DESCRIPTION
- update the ack/modack of non EOS subscription to return success always
- update sample file, class and method to contain `delivery`
- update RETAIABLE_ERRORS constant name

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-ruby/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea.
- [ ] Follow the instructions in [CONTRIBUTING](CONTRIBUTING.md). Most importantly, ensure the tests and linter pass by running `bundle exec rake ci` in the gem subdirectory.
- [ ] Update code documentation if necessary.

closes: #<issue_number_goes_here>