### PR TITLE
chore: Make linkinator retry 500 responses during ci

### DIFF
--- a/.toys/ci.rb
+++ b/.toys/ci.rb
@@ -327,7 +327,7 @@ def run_linkinator dir
     "^https://cloud\\.google\\.com/ruby/docs/reference/#{dir}/latest$",
     "^https://rubygems.org/gems/#{dir_without_version}"
   ]
-  linkinator_cmd = ["npx", "linkinator", "./doc", "--skip", skip_regexes.join(" ")]
+  linkinator_cmd = ["npx", "linkinator", "./doc", "--retry-errors", "--skip", skip_regexes.join(" ")]
   result = exec linkinator_cmd, out: :capture, err: [:child, :out]
   puts result.captured_out
   checked_links = result.captured_out.split "\n"


### PR DESCRIPTION
Linkinator tests in CI are a bit flaky. Looks like it's usually grpc.io returning a 5xx. Configure linkinator to retry those responses.

Closes #19020 
Closes #19021 
Closes #19022 