### PR TITLE
Add default_labels config option

### DIFF
--- a/google-cloud-trace/lib/google-cloud-trace.rb
+++ b/google-cloud-trace/lib/google-cloud-trace.rb
@@ -152,4 +152,5 @@ Google::Cloud.configure.add_config! :trace do |config|
   config.add_field! :notifications, nil, match: Array
   config.add_field! :max_data_length, nil, match: Integer
   config.add_field! :on_error, nil, match: Proc
+  config.add_field! :default_labels, {}, match: Hash
 end

--- a/google-cloud-trace/lib/google/cloud/trace.rb
+++ b/google-cloud-trace/lib/google/cloud/trace.rb
@@ -144,6 +144,8 @@ module Google
       # * `on_error` - (Proc) A Proc to be run when an error is encountered
       #   during the reporting of traces by the middleware. The Proc must take
       #   the error object as the single argument.
+      # * `default_labels` - (Hash) A Hash that contains the default labels
+      #   which will be added to every root span.
       #
       # See the {file:INSTRUMENTATION.md Configuration Guide} for full
       # configuration parameters.

--- a/google-cloud-trace/lib/google/cloud/trace/middleware.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/middleware.rb
@@ -301,11 +301,24 @@ module Google
         #
         def configure_span span, env
           span.name = get_path env
+          set_default_labels span.labels
           set_basic_labels span.labels, env
           set_extended_labels span.labels,
                               span.trace.trace_context.capture_stack?
           span
         end
+
+        ##
+        # Configures default labels.
+        # @private
+        #
+        # rubocop:disable Naming/AccessorMethodName
+        def set_default_labels labels
+          configuration.default_labels.each do |key, value|
+            set_label labels, key, value
+          end
+        end
+        # rubocop:enable Naming/AccessorMethodName
 
         ##
         # Configures standard labels.

--- a/google-cloud-trace/lib/google/cloud/trace/rails.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/rails.rb
@@ -85,6 +85,7 @@ module Google
         config.google_cloud.trace.notifications = DEFAULT_NOTIFICATIONS.dup
         config.google_cloud.trace.max_data_length =
           Google::Cloud::Trace::Notifications::DEFAULT_MAX_DATA_LENGTH
+        config.google_cloud.trace.default_labels = {}
 
         initializer "Google.Cloud.Trace" do |app|
           self.class.consolidate_rails_config app.config
@@ -168,6 +169,9 @@ module Google
             end
             config.sampler ||= trace_config.sampler
             config.span_id_generator ||= trace_config.span_id_generator
+            if trace_config.default_labels.present?
+              config.default_labels = trace_config.default_labels
+            end
           end
         end
 

--- a/google-cloud-trace/test/google/cloud/trace/rails_test.rb
+++ b/google-cloud-trace/test/google/cloud/trace/rails_test.rb
@@ -58,6 +58,7 @@ describe Google::Cloud::Trace::Railtie do
           _(config.max_data_length).must_equal 123
           _(config.sampler).must_equal "test-sampler"
           _(config.span_id_generator).must_equal a_test_generator
+          _(config.default_labels).must_equal({})
         end
       end
     end
@@ -71,6 +72,7 @@ describe Google::Cloud::Trace::Railtie do
         config.max_data_length = 345
         config.sampler = "another-test-sampler"
         config.span_id_generator = another_generator
+        config.default_labels = { '/component' => 'test-service' }
       end
 
       STDOUT.stub :puts, nil do
@@ -84,6 +86,7 @@ describe Google::Cloud::Trace::Railtie do
           _(config.max_data_length).must_equal 345
           _(config.sampler).must_equal "another-test-sampler"
           _(config.span_id_generator).must_equal another_generator
+          _(config.default_labels).must_equal({ '/component' => 'test-service' })
         end
       end
     end


### PR DESCRIPTION
Adds a `default_labels` config option to Cloud Trace. The labels defined there will be added to every root span.

For example, this config:

```ruby
Rails.application.configure do |config|
  config.google_cloud.trace.default_labels = {
      '/component' => 'test-component'
    }
end
```

will result in the `/component` label being added:

<img width="472" alt="CleanShot 2022-08-25 at 14 37 49@2x" src="https://user-images.githubusercontent.com/773/186666776-fff5886b-859e-4764-9512-400b4da1b9b0.png">
