### PR TITLE
chore(secret_manager): Conform samples to canonical style

### DIFF
--- a/.toys/.lib/sample_loader.rb
+++ b/.toys/.lib/sample_loader.rb
@@ -1,0 +1,318 @@
+# frozen_string_literal: true
+
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+##
+# A utility module that loads and introspects well-formed samples.
+# This is useful for testing samples and running them from a CLI.
+#
+# ## Usage
+#
+# This module expects to be run with the current directory within one of the
+# library directories (i.e. it will not work from the repository root).
+#
+# * Get a list of sample files present in the current library using
+#   `SampleLoader.list`
+# * Get info for a sample using `SampleLoader.load("filename.rb")`.
+# * The returned sample object provides a variety of information, including:
+#     * The full text of the sample.
+#     * Information on the parameters taken by the sample method.
+#     * Ability to run the sample.
+#
+# SampleLoader loads each sample method in a unique class to avoid conflicts
+# between samples as well as conflicts with other methods in the system.
+#
+module SampleLoader
+  @samples = {}
+
+  ##
+  # Namespace under which all sample classes will live
+  #
+  module Classes
+  end
+
+  ##
+  # Info about a single sample file. This may represent an actual well-formed
+  # sample (in which case `well_formed?` will return `true`) or not (in which
+  # case `well_formed?` will return `false`).
+  #
+  # Do not construct this object directly. Use {SampleLoader.load}.
+  #
+  class Sample
+    # @private
+    def initialize filename
+      @file_name = filename
+    end
+
+    ##
+    # The file path of a sample relative to the samples directory.
+    #
+    # @return [String]
+    #
+    attr_reader :file_name
+
+    ##
+    # The absolute path to the sample.
+    #
+    # @return [String]
+    #
+    def file_path
+      @file_path ||= File.join SampleLoader.samples_dir, file_name
+    end
+
+    ##
+    # An array of strings representing the parts of the path to a sample.
+    # For example, the sample `foo/bar_baz.rb` will have segments
+    # `["foo", "bar_baz"]`.
+    #
+    # @return [Array<String>]
+    #
+    def name_segments
+      @name_segments ||= begin
+        segs = file_name.gsub(%r{^/+|/+$}, "").split("/")
+        segs.push File.basename segs.pop, ".rb"
+        segs
+      end
+    end
+  
+    ##
+    # The method name of a sample. This is equal to the last name segment.
+    #
+    # @return [String]
+    #
+    def method_name
+      name_segments.last
+    end
+
+    ##
+    # The original sample code as loaded from the sample file. There is no
+    # guarantee that the sample is actually well-formed (see {well_formed?}).
+    # Returns the empty string if the sample file couldn't be read at all.
+    #
+    # @return [String]
+    #
+    def sample_text
+      @sample_text ||= File.read file_path rescue ""
+    end
+
+    ##
+    # A class containing the sample as loaded from the file. There is no
+    # guarantee that the sample is actually well-formed (see {well_formed?}).
+    #
+    # @return [Class]
+    #
+    def sample_class
+      @sample_class ||= begin
+        klass = SampleLoader::Classes
+        name_segments.map { |seg| camelize seg }.each_with_index do |name, index|
+          type = index == name_segments.size - 1 ? Class : Module
+          klass = traverse_name klass, name, type
+        end
+        bind = klass.class_eval { binding }
+        eval sample_text, bind, file_path rescue nil
+        klass
+      end
+    end
+
+    ##
+    # Get the names of the keyword arguments taken by the sample.
+    #
+    # @return [Array<Symbol>]
+    #
+    def param_names
+      @param_names ||=
+        if well_formed?
+          sample_class.instance_method(method_name)
+                      .parameters
+                      .select { |param| [:keyreq, :key].include? param.first }
+                      .map(&:last)
+        else
+          []
+        end
+    end
+
+    ##
+    # Return the type expected by the given parameter name, obtained from the
+    # yardoc comments associated with the sample method.
+    #
+    # @param name [Symbol] The parameter name
+    # @return [String] if the given name is actually a parameter
+    # @return [nil] if the given name is not a parameter
+    #
+    def param_type name
+      name = name.to_sym
+      return nil unless param_names.include? name
+      parse_yardoc
+      param = @parameters.find { |parameter| parameter[0] == name }
+      param ? param[1] : "String"
+    end
+
+    ##
+    # Return the description of the parameter, obtained from the yardoc comments
+    # associated with the sample method.
+    #
+    # @param name [Symbol] The parameter name
+    # @return [String] if the given name is actually a parameter
+    # @return [nil] if the given name is not a parameter
+    #
+    def param_desc name
+      name = name.to_sym
+      return nil unless param_names.include? name
+      parse_yardoc
+      param = @parameters.find { |parameter| parameter[0] == name }
+      param ? param[2] : "Value for the #{name} input"
+    end
+
+    ##
+    # Return a description of the sample from yardoc comments.
+    #
+    # @return [String]
+    #
+    def description
+      parse_yardoc
+      @description
+    end
+
+    ##
+    # Whether this sample exists and is well-formed. If this method returns
+    # false, the sample cannot be run.
+    #
+    # @return [boolean]
+    #
+    def well_formed?
+      sample_class.public_method_defined? method_name, false
+    end
+
+    ##
+    # Instantiate the sample class and run the sample, passing the given params.
+    #
+    # @param params [keywords] keyword arguments to pass to the sample. Must
+    #     match the keyword arguments accepted by the sample method.
+    # @raises RuntimeError if the sample is not well-formed
+    #
+    def run **params
+      raise "Sample #{file_name} is not well-formed" unless well_formed?
+      sample_class.new.send method_name, **params
+    end
+
+    private
+
+    def camelize name
+      ::File.basename(name, ".rb").split("_").map(&:capitalize).join
+    end
+
+    def traverse_name mod, name, type
+      if mod.const_defined? name
+        cur = mod.const_get name
+        return cur if type == Module && cur.is_a?(Module)
+        num = 1
+        orig_name = name
+        while true
+          name = "#{orig_name}__#{num}"
+          break unless mod.const_defined? name
+        end
+      end
+      obj = type.new
+      mod.const_set name, obj
+      obj
+    end
+
+    def parse_yardoc
+      unless defined? @parameters
+        @parameters = @description = ""
+        if sample_text =~ /(?:^|\n)((?:\s*#[^\n]*\n)+)\s*def #{method_name}/
+          cur_param = nil
+          desc = []
+          params = []
+          Regexp.last_match[1].split("\n").each do |line|
+            line = line.strip.gsub(/^#+\s?/, "")
+            if line.start_with? "@"
+              params << cur_param if cur_param
+              cur_param = false
+              if line =~ /^@param\s+(\w+)\s+\[(.+)\](?:\s+(.+))?/
+                match = Regexp.last_match
+                name = match[1].to_sym
+                cur_param = [name, match[2], [match[3] || ""]] if param_names.include? name
+              end
+            elsif !line.empty?
+              if cur_param
+                cur_param[2] << line
+              elsif cur_param.nil?
+                desc << line
+              end
+            end
+          end
+          params << cur_param if cur_param
+          @description = desc.join " "
+          @parameters = params.map { |param| [param[0], param[1], param[2].join(" ")] }
+        end
+      end
+    end
+  end
+
+  class << self
+    ##
+    # Returns all the potential samples found for this library. Generally, this
+    # includes all Ruby files under the samples directory, omitting any files
+    # under a directory called `acceptance`. It returns file paths relative to
+    # the samples directory. Returns the empty array if there is no samples
+    # directory or the current directory is not under a library directory.
+    #
+    # @return [Array<String>]
+    #
+    def list
+      if samples_dir
+        tentative = Dir.glob "**/*.rb", base: samples_dir
+        tentative.delete_if { |filename| filename =~ %r{(^|/)acceptance/} }
+      else
+        []
+      end
+    end
+
+    ##
+    # Attempt to load the sample given a relative file path.
+    # This always returns a Sample object. Check the object's `well_formed?`
+    # method to determine whether the file is actually a well-formed sample.
+    #
+    # @param filename [String] Relative file path
+    # @return [SampleLoader::Sample]
+    #
+    def load filename
+      filename = filename.to_s
+      filename = "#{filename}.rb" unless filename.end_with? ".rb"
+      @samples[filename] ||= Sample.new filename
+    end
+
+    ##
+    # Find the samples directory for the current library.
+    #
+    # @return [String] if the samples directory could be found.
+    # @return [nil] if the samples directory could not be found.
+    #
+    def samples_dir
+      unless defined? @samples_dir
+        @samples_dir = nil
+        base_dir = "#{File.dirname File.dirname __dir__}/"
+        cur_dir = Dir.getwd
+        if cur_dir.start_with? base_dir
+          gem_name = cur_dir[base_dir.length..].split("/").first
+          tentative_dir = File.join base_dir, gem_name, "samples"
+          @samples_dir = tentative_dir if ::File.directory? tentative_dir
+        end
+      end
+      @samples_dir
+    end
+  end
+end

--- a/.toys/sample.rb
+++ b/.toys/sample.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative ".lib/sample_loader"
+
+desc "Samples runnable from this directory"
+
+SampleLoader.list.each do |filename|
+  sample = SampleLoader.load filename
+
+  if sample.well_formed?
+    tool_name = sample.name_segments.map { |seg| seg.tr "_", "-" }
+    tool tool_name do
+      desc "Run the \"#{sample.file_name}\" sample"
+
+      sample.param_names.each do |param|
+        accepted_type =
+          case sample.param_type(param)
+          when "Integer"
+            Integer
+          when "Array<String>"
+            Array
+          else
+            String
+          end
+        flag param, accept: accepted_type, desc: sample.param_desc(param)
+      end
+
+      to_run do
+        params = sample.param_names.to_h { |param| [param, get(param)] }
+        sample.run(**params)
+      end
+    end
+  end
+end

--- a/google-cloud-secret_manager/samples/acceptance/access_secret_version_test.rb
+++ b/google-cloud-secret_manager/samples/acceptance/access_secret_version_test.rb
@@ -1,0 +1,27 @@
+# Copyright 2022 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "uri"
+
+require_relative "helper"
+
+describe "#access_secret_version", :secret_manager_snippet do
+  it "accesses the version" do
+    sample = SampleLoader.load "access_secret_version.rb"
+
+    assert_output(/Plaintext: hello world!/) do
+      sample.run project_id: project_id, secret_id: secret_id, version_id: version_id
+    end
+  end
+end

--- a/google-cloud-secret_manager/samples/acceptance/add_secret_version_test.rb
+++ b/google-cloud-secret_manager/samples/acceptance/add_secret_version_test.rb
@@ -1,0 +1,35 @@
+# Copyright 2022 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "uri"
+
+require_relative "helper"
+
+describe "#add_secret_version", :secret_manager_snippet do
+  it "adds a secret version" do
+    sample = SampleLoader.load "add_secret_version.rb"
+
+    o_list = client.list_secret_versions(parent: secret.name).to_a
+    assert_empty o_list
+
+    out, _err = capture_io do
+      sample.run project_id: project_id, secret_id: secret_id
+    end
+    assert_match(/Added secret version: \S+/, out)
+    version = /Added secret version: (\S+)/.match(out)[1]
+
+    n_list = client.list_secret_versions(parent: secret.name).to_a
+    assert_includes n_list.map(&:name), version
+  end
+end

--- a/google-cloud-secret_manager/samples/acceptance/create_secret_test.rb
+++ b/google-cloud-secret_manager/samples/acceptance/create_secret_test.rb
@@ -1,0 +1,29 @@
+# Copyright 2022 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "uri"
+
+require_relative "helper"
+
+describe "#create_secret", :secret_manager_snippet do
+  it "creates a secret" do
+    sample = SampleLoader.load "create_secret.rb"
+
+    out, _err = capture_io do
+      sample.run project_id: project_id, secret_id: secret_id
+    end
+    secret_id_regex = Regexp.escape secret_id
+    assert_match %r{Created secret: projects/\S+/secrets/#{secret_id_regex}}, out
+  end
+end

--- a/google-cloud-secret_manager/samples/acceptance/create_ummr_secret_test.rb
+++ b/google-cloud-secret_manager/samples/acceptance/create_ummr_secret_test.rb
@@ -1,0 +1,30 @@
+# Copyright 2022 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "uri"
+
+require_relative "helper"
+
+describe "#create_ummr_secret", :secret_manager_snippet do
+  it "creates a secret with user managed replication" do
+    sample = SampleLoader.load "create_ummr_secret.rb"
+
+    out, _err = capture_io do
+      sample.run project_id: project_id, secret_id: secret_id,
+                 locations: ["us-east1", "us-east4", "us-west1"]
+    end
+    secret_id_regex = Regexp.quote secret_id
+    assert_match %r{Created secret with user managed replication: \S+/#{secret_id_regex}}, out
+  end
+end

--- a/google-cloud-secret_manager/samples/acceptance/delete_secret_test.rb
+++ b/google-cloud-secret_manager/samples/acceptance/delete_secret_test.rb
@@ -1,0 +1,34 @@
+# Copyright 2022 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "uri"
+
+require_relative "helper"
+
+describe "#delete_secret", :secret_manager_snippet do
+  it "deletes the secret" do
+    sample = SampleLoader.load "delete_secret.rb"
+
+    refute_nil secret
+    client.get_secret name: secret_name
+
+    assert_output(/Deleted secret/) do
+      sample.run project_id: project_id, secret_id: secret_id
+    end
+
+    assert_raises Google::Cloud::NotFoundError do
+      client.get_secret name: secret_name
+    end
+  end
+end

--- a/google-cloud-secret_manager/samples/acceptance/destroy_secret_version_test.rb
+++ b/google-cloud-secret_manager/samples/acceptance/destroy_secret_version_test.rb
@@ -1,0 +1,33 @@
+# Copyright 2022 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "uri"
+
+require_relative "helper"
+
+describe "#destroy_secret_version", :secret_manager_snippet do
+  it "destroys the secret version" do
+    sample = SampleLoader.load "destroy_secret_version.rb"
+
+    refute_nil secret_version
+
+    assert_output(/Destroyed secret version/) do
+      sample.run project_id: project_id, secret_id: secret_id, version_id: version_id
+    end
+
+    n_version = client.get_secret_version name: version_name
+    refute_nil n_version
+    assert_equal "destroyed", n_version.state.to_s.downcase
+  end
+end

--- a/google-cloud-secret_manager/samples/acceptance/disable_secret_version_test.rb
+++ b/google-cloud-secret_manager/samples/acceptance/disable_secret_version_test.rb
@@ -1,0 +1,33 @@
+# Copyright 2022 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "uri"
+
+require_relative "helper"
+
+describe "#disable_secret_version", :secret_manager_snippet do
+  it "disables the secret version" do
+    sample = SampleLoader.load "disable_secret_version.rb"
+
+    refute_nil secret_version
+
+    assert_output(/Disabled secret version/) do
+      sample.run project_id: project_id, secret_id: secret_id, version_id: version_id
+    end
+
+    n_version = client.get_secret_version name: version_name
+    refute_nil n_version
+    assert_equal "disabled", n_version.state.to_s.downcase
+  end
+end

--- a/google-cloud-secret_manager/samples/acceptance/enable_secret_version_test.rb
+++ b/google-cloud-secret_manager/samples/acceptance/enable_secret_version_test.rb
@@ -1,0 +1,34 @@
+# Copyright 2022 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "uri"
+
+require_relative "helper"
+
+describe "#enable_secret_version", :secret_manager_snippet do
+  it "enables the secret version" do
+    sample = SampleLoader.load "enable_secret_version.rb"
+
+    refute_nil secret_version
+    client.disable_secret_version name: version_name
+
+    assert_output(/Enabled secret version/) do
+      sample.run project_id: project_id, secret_id: secret_id, version_id: version_id
+    end
+
+    n_version = client.get_secret_version name: version_name
+    refute_nil n_version
+    assert_equal "enabled", n_version.state.to_s.downcase
+  end
+end

--- a/google-cloud-secret_manager/samples/acceptance/get_secret_test.rb
+++ b/google-cloud-secret_manager/samples/acceptance/get_secret_test.rb
@@ -1,0 +1,30 @@
+# Copyright 2022 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "uri"
+
+require_relative "helper"
+
+describe "#get_secret", :secret_manager_snippet do
+  it "gets the secret" do
+    sample = SampleLoader.load "get_secret.rb"
+
+    refute_nil secret
+
+    escaped_name = Regexp.escape secret.name
+    assert_output(/Got secret #{escaped_name} with replication policy automatic/) do
+      sample.run project_id: project_id, secret_id: secret_id
+    end
+  end
+end

--- a/google-cloud-secret_manager/samples/acceptance/get_secret_version_test.rb
+++ b/google-cloud-secret_manager/samples/acceptance/get_secret_version_test.rb
@@ -1,0 +1,30 @@
+# Copyright 2022 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "uri"
+
+require_relative "helper"
+
+describe "#get_secret_version", :secret_manager_snippet do
+  it "gets the secret version" do
+    sample = SampleLoader.load "get_secret_version.rb"
+
+    refute_nil secret_version
+
+    escaped_name = Regexp.escape secret_version.name
+    assert_output(/Got secret version #{escaped_name} with state enabled/) do
+      sample.run project_id: project_id, secret_id: secret_id, version_id: version_id
+    end
+  end
+end

--- a/google-cloud-secret_manager/samples/acceptance/iam_grant_access_test.rb
+++ b/google-cloud-secret_manager/samples/acceptance/iam_grant_access_test.rb
@@ -1,0 +1,39 @@
+# Copyright 2022 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "uri"
+
+require_relative "helper"
+
+describe "#iam_grant_access", :secret_manager_snippet do
+  it "grants access to the secret" do
+    sample = SampleLoader.load "iam_grant_access.rb"
+
+    refute_nil secret
+
+    assert_output(/Updated IAM policy/) do
+      sample.run project_id: project_id, secret_id: secret_id, member: iam_user
+    end
+
+    name = client.secret_path project: project_id, secret: secret_id
+    n_policy = client.get_iam_policy resource: name
+    refute_nil n_policy
+
+    bind = n_policy.bindings.find do |b|
+      b.role == "roles/secretmanager.secretAccessor"
+    end
+    refute_nil bind
+    assert_includes bind.members, iam_user
+  end
+end

--- a/google-cloud-secret_manager/samples/acceptance/iam_revoke_access_test.rb
+++ b/google-cloud-secret_manager/samples/acceptance/iam_revoke_access_test.rb
@@ -1,0 +1,48 @@
+# Copyright 2022 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "uri"
+
+require_relative "helper"
+
+describe "#iam_revoke_access", :secret_manager_snippet do
+  it "revokes access to the secret" do
+    sample = SampleLoader.load "iam_revoke_access.rb"
+
+    refute_nil secret
+
+    # Add an IAM member
+    name = client.secret_path project: project_id, secret: secret_id
+    policy = client.get_iam_policy resource: name
+    policy.bindings << Google::Iam::V1::Binding.new(
+      members: [iam_user],
+      role:    "roles/secretmanager.secretAccessor"
+    )
+    client.set_iam_policy resource: name, policy: policy
+
+    assert_output(/Updated IAM policy/) do
+      sample.run project_id: project_id, secret_id: secret_id, member: iam_user
+    end
+
+    n_policy = client.get_iam_policy resource: name
+    refute_nil n_policy
+
+    bind = n_policy.bindings.find do |b|
+      b.role == "roles/secretmanager.secretAccessor"
+    end
+    # The only member was iam_user, so the server will remove the binding
+    # automatically.
+    assert_nil bind
+  end
+end

--- a/google-cloud-secret_manager/samples/acceptance/list_secret_versions_test.rb
+++ b/google-cloud-secret_manager/samples/acceptance/list_secret_versions_test.rb
@@ -1,0 +1,30 @@
+# Copyright 2022 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "uri"
+
+require_relative "helper"
+
+describe "#list_secret_versions", :secret_manager_snippet do
+  it "lists the secret versions" do
+    sample = SampleLoader.load "list_secret_versions.rb"
+
+    refute_nil secret
+    refute_nil secret_version
+
+    assert_output(/Got secret version \S+#{Regexp.escape version_id}/) do
+      sample.run project_id: project_id, secret_id: secret_id
+    end
+  end
+end

--- a/google-cloud-secret_manager/samples/acceptance/list_secrets_test.rb
+++ b/google-cloud-secret_manager/samples/acceptance/list_secrets_test.rb
@@ -1,0 +1,29 @@
+# Copyright 2022 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "uri"
+
+require_relative "helper"
+
+describe "#list_secrets", :secret_manager_snippet do
+  it "lists the secrets" do
+    sample = SampleLoader.load "list_secrets.rb"
+
+    refute_nil secret
+
+    assert_output(/Got secret \S+#{Regexp.escape secret_id}/) do
+      sample.run project_id: project_id
+    end
+  end
+end

--- a/google-cloud-secret_manager/samples/acceptance/quickstart_test.rb
+++ b/google-cloud-secret_manager/samples/acceptance/quickstart_test.rb
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 require_relative "helper"
-require_relative "../quickstart"
 
 describe "Secret Manager Quickstart" do
   let(:client) { Google::Cloud::SecretManager.secret_manager_service }
@@ -29,20 +28,20 @@ describe "Secret Manager Quickstart" do
   end
 
   it "creates and accesses a secret" do
+    sample = SampleLoader.load "quickstart.rb"
+
     assert_output "Plaintext: hello world!\n" do
-      quickstart project_id: project_id, secret_id: secret_id
+      sample.run project_id: project_id, secret_id: secret_id
     end
 
     secret = client.get_secret name: secret_name
-    _(secret).wont_be_nil
+    refute_nil secret
 
     versions = client.list_secret_versions parent: secret_name
-    _(versions.to_a.length).must_be :>, 0
+    refute_empty versions.to_a
 
-    version = client.access_secret_version(
-      name: "#{secret_name}/versions/latest"
-    )
-    _(version).wont_be_nil
-    _(version.payload.data).must_equal("hello world!")
+    version = client.access_secret_version name: "#{secret_name}/versions/latest"
+    refute_nil version
+    assert_equal "hello world!", version.payload.data
   end
 end

--- a/google-cloud-secret_manager/samples/acceptance/update_secret_test.rb
+++ b/google-cloud-secret_manager/samples/acceptance/update_secret_test.rb
@@ -1,0 +1,32 @@
+# Copyright 2022 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "uri"
+
+require_relative "helper"
+
+describe "#update_secret", :secret_manager_snippet do
+  it "updates the secret" do
+    sample = SampleLoader.load "update_secret.rb"
+
+    refute_nil secret
+
+    out, _err = capture_io do
+      sample.run project_id: project_id, secret_id: secret_id
+    end
+
+    assert_match(/Updated secret/, out)
+    assert_match(/New label: rocks/, out)
+  end
+end

--- a/google-cloud-secret_manager/samples/acceptance/update_secret_with_alias_test.rb
+++ b/google-cloud-secret_manager/samples/acceptance/update_secret_with_alias_test.rb
@@ -1,0 +1,33 @@
+# Copyright 2022 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "uri"
+
+require_relative "helper"
+
+describe "#update_secret_with_alias", :secret_manager_snippet do
+  it "updates the secret" do
+    sample = SampleLoader.load "update_secret_with_alias.rb"
+
+    refute_nil secret
+    refute_nil secret_version
+
+    out, _err = capture_io do
+      sample.run project_id: project_id, secret_id: secret_id
+    end
+
+    assert_match(/Updated secret/, out)
+    assert_match(/New version alias: 1/, out)
+  end
+end

--- a/google-cloud-secret_manager/samples/access_secret_version.rb
+++ b/google-cloud-secret_manager/samples/access_secret_version.rb
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,49 +12,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START secretmanager_quickstart]
+# [START secretmanager_access_secret_version]
 require "google/cloud/secret_manager"
 
 ##
-# Secret manager quickstart
+# Access a specific version of a secret
 #
 # @param project_id [String] Your Google Cloud project (e.g. "my-project")
 # @param secret_id [String] Your secret name (e.g. "my-secret")
+# @param version_id [String] The version (e.g. "5" or "latest")
 #
-def quickstart project_id:, secret_id:
-  # Create the Secret Manager client.
+def access_secret_version project_id:, secret_id:, version_id:
+  # Create a Secret Manager client.
   client = Google::Cloud::SecretManager.secret_manager_service
 
-  # Build the parent name from the project.
-  parent = "projects/#{project_id}"
-
-  # Create the parent secret.
-  secret = client.create_secret(
-    parent:    parent,
-    secret_id: secret_id,
-    secret:    {
-      replication: {
-        automatic: {}
-      }
-    }
-  )
-
-  # Add a secret version.
-  version = client.add_secret_version(
-    parent:  secret.name,
-    payload: {
-      data: "hello world!"
-    }
+  # Build the resource name of the secret version.
+  name = client.secret_version_path(
+    project:        project_id,
+    secret:         secret_id,
+    secret_version: version_id
   )
 
   # Access the secret version.
-  response = client.access_secret_version name: version.name
+  version = client.access_secret_version name: name
 
   # Print the secret payload.
   #
-  # WARNING: Do not print the secret in a production environment - this
-  # snippet is showing how to access the secret material.
-  payload = response.payload.data
+  # WARNING: Do not print the secret payload in a production environment - this
+  # snippet is merely showing how to access the secret material.
+  payload = version.payload.data
   puts "Plaintext: #{payload}"
 end
-# [END secretmanager_quickstart]
+# [END secretmanager_access_secret_version]

--- a/google-cloud-secret_manager/samples/add_secret_version.rb
+++ b/google-cloud-secret_manager/samples/add_secret_version.rb
@@ -1,0 +1,42 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START secretmanager_add_secret_version]
+require "google/cloud/secret_manager"
+
+##
+# Add a new secret version
+#
+# @param project_id [String] Your Google Cloud project (e.g. "my-project")
+# @param secret_id [String] Your secret name (e.g. "my-secret")
+#
+def add_secret_version project_id:, secret_id:
+  # Create a Secret Manager client.
+  client = Google::Cloud::SecretManager.secret_manager_service
+
+  # Build the resource name of the secret version.
+  name = client.secret_path project: project_id, secret: secret_id
+
+  # Add the secret version.
+  version = client.add_secret_version(
+    parent:  name,
+    payload: {
+      data: "my super secret data"
+    }
+  )
+
+  # Print the new secret version name.
+  puts "Added secret version: #{version.name}"
+end
+# [END secretmanager_add_secret_version]

--- a/google-cloud-secret_manager/samples/create_secret.rb
+++ b/google-cloud-secret_manager/samples/create_secret.rb
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,23 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START secretmanager_quickstart]
+# [START secretmanager_create_secret]
 require "google/cloud/secret_manager"
 
 ##
-# Secret manager quickstart
+# Create a secret
 #
 # @param project_id [String] Your Google Cloud project (e.g. "my-project")
 # @param secret_id [String] Your secret name (e.g. "my-secret")
 #
-def quickstart project_id:, secret_id:
-  # Create the Secret Manager client.
+def create_secret project_id:, secret_id:
+  # Create a Secret Manager client.
   client = Google::Cloud::SecretManager.secret_manager_service
 
-  # Build the parent name from the project.
-  parent = "projects/#{project_id}"
+  # Build the resource name of the parent project.
+  parent = client.project_path project: project_id
 
-  # Create the parent secret.
+  # Create the secret.
   secret = client.create_secret(
     parent:    parent,
     secret_id: secret_id,
@@ -39,22 +39,7 @@ def quickstart project_id:, secret_id:
     }
   )
 
-  # Add a secret version.
-  version = client.add_secret_version(
-    parent:  secret.name,
-    payload: {
-      data: "hello world!"
-    }
-  )
-
-  # Access the secret version.
-  response = client.access_secret_version name: version.name
-
-  # Print the secret payload.
-  #
-  # WARNING: Do not print the secret in a production environment - this
-  # snippet is showing how to access the secret material.
-  payload = response.payload.data
-  puts "Plaintext: #{payload}"
+  # Print the new secret name.
+  puts "Created secret: #{secret.name}"
 end
-# [END secretmanager_quickstart]
+# [END secretmanager_create_secret]

--- a/google-cloud-secret_manager/samples/create_ummr_secret.rb
+++ b/google-cloud-secret_manager/samples/create_ummr_secret.rb
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,49 +12,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START secretmanager_quickstart]
 require "google/cloud/secret_manager"
 
 ##
-# Secret manager quickstart
+# Create a secret with user-managed replication
 #
 # @param project_id [String] Your Google Cloud project (e.g. "my-project")
 # @param secret_id [String] Your secret name (e.g. "my-secret")
+# @param locations [Array<String>] Array of locations (e.g. ["us-east1"])
 #
-def quickstart project_id:, secret_id:
-  # Create the Secret Manager client.
+def create_ummr_secret project_id:, secret_id:, locations:
+  # Create a Secret Manager client.
   client = Google::Cloud::SecretManager.secret_manager_service
 
-  # Build the parent name from the project.
-  parent = "projects/#{project_id}"
+  # Build the resource name of the parent project.
+  parent = client.project_path project: project_id
 
-  # Create the parent secret.
+  # Create the secret.
   secret = client.create_secret(
     parent:    parent,
     secret_id: secret_id,
     secret:    {
       replication: {
-        automatic: {}
+        user_managed: {
+          replicas: locations.map { |x| { location: x } }
+        }
       }
     }
   )
 
-  # Add a secret version.
-  version = client.add_secret_version(
-    parent:  secret.name,
-    payload: {
-      data: "hello world!"
-    }
-  )
-
-  # Access the secret version.
-  response = client.access_secret_version name: version.name
-
-  # Print the secret payload.
-  #
-  # WARNING: Do not print the secret in a production environment - this
-  # snippet is showing how to access the secret material.
-  payload = response.payload.data
-  puts "Plaintext: #{payload}"
+  # Print the new secret name.
+  puts "Created secret with user managed replication: #{secret.name}"
 end
-# [END secretmanager_quickstart]

--- a/google-cloud-secret_manager/samples/delete_secret.rb
+++ b/google-cloud-secret_manager/samples/delete_secret.rb
@@ -1,0 +1,37 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START secretmanager_delete_secret]
+require "google/cloud/secret_manager"
+
+##
+# Delete a secret
+#
+# @param project_id [String] Your Google Cloud project (e.g. "my-project")
+# @param secret_id [String] Your secret name (e.g. "my-secret")
+#
+def delete_secret project_id:, secret_id:
+  # Create a Secret Manager client.
+  client = Google::Cloud::SecretManager.secret_manager_service
+
+  # Build the resource name of the secret.
+  name = client.secret_path project: project_id, secret: secret_id
+
+  # Delete the secret.
+  client.delete_secret name: name
+
+  # Print a success message.
+  puts "Deleted secret #{name}"
+end
+# [END secretmanager_delete_secret]

--- a/google-cloud-secret_manager/samples/destroy_secret_version.rb
+++ b/google-cloud-secret_manager/samples/destroy_secret_version.rb
@@ -1,0 +1,42 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START secretmanager_destroy_secret_version]
+require "google/cloud/secret_manager"
+
+##
+# Destroy a secret version
+#
+# @param project_id [String] Your Google Cloud project (e.g. "my-project")
+# @param secret_id [String] Your secret name (e.g. "my-secret")
+# @param version_id [String] The version (e.g. "5" or "latest")
+#
+def destroy_secret_version project_id:, secret_id:, version_id:
+  # Create a Secret Manager client.
+  client = Google::Cloud::SecretManager.secret_manager_service
+
+  # Build the resource name of the secret version.
+  name = client.secret_version_path(
+    project:        project_id,
+    secret:         secret_id,
+    secret_version: version_id
+  )
+
+  # Destroy the secret version.
+  response = client.destroy_secret_version name: name
+
+  # Print a success message.
+  puts "Destroyed secret version: #{response.name}"
+end
+# [END secretmanager_destroy_secret_version]

--- a/google-cloud-secret_manager/samples/disable_secret_version.rb
+++ b/google-cloud-secret_manager/samples/disable_secret_version.rb
@@ -1,0 +1,42 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START secretmanager_disable_secret_version]
+require "google/cloud/secret_manager"
+
+##
+# Disable a secret version
+#
+# @param project_id [String] Your Google Cloud project (e.g. "my-project")
+# @param secret_id [String] Your secret name (e.g. "my-secret")
+# @param version_id [String] The version (e.g. "5" or "latest")
+#
+def disable_secret_version project_id:, secret_id:, version_id:
+  # Create a Secret Manager client.
+  client = Google::Cloud::SecretManager.secret_manager_service
+
+  # Build the resource name of the secret version.
+  name = client.secret_version_path(
+    project:        project_id,
+    secret:         secret_id,
+    secret_version: version_id
+  )
+
+  # Disable the secret version.
+  response = client.disable_secret_version name: name
+
+  # Print a success message.
+  puts "Disabled secret version: #{response.name}"
+end
+# [END secretmanager_disable_secret_version]

--- a/google-cloud-secret_manager/samples/enable_secret_version.rb
+++ b/google-cloud-secret_manager/samples/enable_secret_version.rb
@@ -1,0 +1,42 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START secretmanager_enable_secret_version]
+require "google/cloud/secret_manager"
+
+##
+# Enable a secret version
+#
+# @param project_id [String] Your Google Cloud project (e.g. "my-project")
+# @param secret_id [String] Your secret name (e.g. "my-secret")
+# @param version_id [String] The version (e.g. "5" or "latest")
+#
+def enable_secret_version project_id:, secret_id:, version_id:
+  # Create a Secret Manager client.
+  client = Google::Cloud::SecretManager.secret_manager_service
+
+  # Build the resource name of the secret version.
+  name = client.secret_version_path(
+    project:        project_id,
+    secret:         secret_id,
+    secret_version: version_id
+  )
+
+  # Enable the secret version.
+  response = client.enable_secret_version name: name
+
+  # Print a success message.
+  puts "Enabled secret version: #{response.name}"
+end
+# [END secretmanager_enable_secret_version]

--- a/google-cloud-secret_manager/samples/get_secret.rb
+++ b/google-cloud-secret_manager/samples/get_secret.rb
@@ -1,0 +1,46 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START secretmanager_get_secret]
+require "google/cloud/secret_manager"
+
+##
+# Get a secret and its metadata
+#
+# @param project_id [String] Your Google Cloud project (e.g. "my-project")
+# @param secret_id [String] Your secret name (e.g. "my-secret")
+#
+def get_secret project_id:, secret_id:
+  # Create a Secret Manager client.
+  client = Google::Cloud::SecretManager.secret_manager_service
+
+  # Build the resource name of the secret.
+  name = client.secret_path project: project_id, secret: secret_id
+
+  # Get the secret.
+  secret = client.get_secret name: name
+
+  # Get the replication policy.
+  if !secret.replication.automatic.nil?
+    replication = "automatic"
+  elsif !secret.replication.user_managed.nil?
+    replication = "user managed"
+  else
+    raise "Unknown replication #{secret.replication}"
+  end
+
+  # Print a success message.
+  puts "Got secret #{secret.name} with replication policy #{replication}"
+end
+# [END secretmanager_get_secret]

--- a/google-cloud-secret_manager/samples/get_secret_version.rb
+++ b/google-cloud-secret_manager/samples/get_secret_version.rb
@@ -1,0 +1,45 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START secretmanager_get_secret_version]
+require "google/cloud/secret_manager"
+
+##
+# Get a secret version and its metadata
+#
+# @param project_id [String] Your Google Cloud project (e.g. "my-project")
+# @param secret_id [String] Your secret name (e.g. "my-secret")
+# @param version_id [String] The version (e.g. "5" or "latest")
+#
+def get_secret_version project_id:, secret_id:, version_id:
+  # Create a Secret Manager client.
+  client = Google::Cloud::SecretManager.secret_manager_service
+
+  # Build the resource name of the secret version.
+  name = client.secret_version_path(
+    project:        project_id,
+    secret:         secret_id,
+    secret_version: version_id
+  )
+
+  # Get the secret version.
+  version = client.get_secret_version name: name
+
+  # Get the state.
+  state = version.state.to_s.downcase
+
+  # Print a success message.
+  puts "Got secret version #{version.name} with state #{state}"
+end
+# [END secretmanager_get_secret_version]

--- a/google-cloud-secret_manager/samples/iam_grant_access.rb
+++ b/google-cloud-secret_manager/samples/iam_grant_access.rb
@@ -1,0 +1,47 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START secretmanager_iam_grant_access]
+require "google/cloud/secret_manager"
+
+##
+# Update the IAM policy to grant access to a user
+#
+# @param project_id [String] Your Google Cloud project (e.g. "my-project")
+# @param secret_id [String] Your secret name (e.g. "my-secret")
+# @param member [String] User or account (e.g. "user:foo@example.com")
+#
+def iam_grant_access project_id:, secret_id:, member:
+  # Create a Secret Manager client.
+  client = Google::Cloud::SecretManager.secret_manager_service
+
+  # Build the resource name of the secret.
+  name = client.secret_path project: project_id, secret: secret_id
+
+  # Get the current IAM policy.
+  policy = client.get_iam_policy resource: name
+
+  # Add new member to current bindings
+  policy.bindings << Google::Iam::V1::Binding.new(
+    members: [member],
+    role:    "roles/secretmanager.secretAccessor"
+  )
+
+  # Update IAM policy
+  client.set_iam_policy resource: name, policy: policy
+
+  # Print a success message.
+  puts "Updated IAM policy for #{secret_id}"
+end
+# [END secretmanager_iam_grant_access]

--- a/google-cloud-secret_manager/samples/iam_revoke_access.rb
+++ b/google-cloud-secret_manager/samples/iam_revoke_access.rb
@@ -1,0 +1,48 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START secretmanager_iam_revoke_access]
+require "google/cloud/secret_manager"
+
+##
+# Update the IAM policy to revoke access for a user
+#
+# @param project_id [String] Your Google Cloud project (e.g. "my-project")
+# @param secret_id [String] Your secret name (e.g. "my-secret")
+# @param member [String] User or account (e.g. "user:foo@example.com")
+#
+def iam_revoke_access project_id:, secret_id:, member:
+  # Create a Secret Manager client.
+  client = Google::Cloud::SecretManager.secret_manager_service
+
+  # Build the resource name of the secret.
+  name = client.secret_path project: project_id, secret: secret_id
+
+  # Get the current IAM policy.
+  policy = client.get_iam_policy resource: name
+
+  # Remove the member from the current bindings
+  policy.bindings.each do |bind|
+    if bind.role == "roles/secretmanager.secretAccessor"
+      bind.members.delete member
+    end
+  end
+
+  # Update IAM policy
+  client.set_iam_policy resource: name, policy: policy
+
+  # Print a success message.
+  puts "Updated IAM policy for #{secret_id}"
+end
+# [END secretmanager_iam_revoke_access]

--- a/google-cloud-secret_manager/samples/list_secret_versions.rb
+++ b/google-cloud-secret_manager/samples/list_secret_versions.rb
@@ -1,0 +1,39 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START secretmanager_list_secret_versions]
+require "google/cloud/secret_manager"
+
+##
+# List versions for a secret
+#
+# @param project_id [String] Your Google Cloud project (e.g. "my-project")
+# @param secret_id [String] Your secret name (e.g. "my-secret")
+#
+def list_secret_versions project_id:, secret_id:
+  # Create a Secret Manager client.
+  client = Google::Cloud::SecretManager.secret_manager_service
+
+  # Build the resource name of the parent.
+  parent = client.secret_path project: project_id, secret: secret_id
+
+  # Get the list of secret versions.
+  list = client.list_secret_versions parent: parent
+
+  # List all secret versions.
+  list.each do |version|
+    puts "Got secret version #{version.name}"
+  end
+end
+# [END secretmanager_list_secret_versions]

--- a/google-cloud-secret_manager/samples/list_secrets.rb
+++ b/google-cloud-secret_manager/samples/list_secrets.rb
@@ -1,0 +1,38 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START secretmanager_list_secrets]
+require "google/cloud/secret_manager"
+
+##
+# List secrets in a project
+#
+# @param project_id [String] Your Google Cloud project (e.g. "my-project")
+#
+def list_secrets project_id:
+  # Create a Secret Manager client.
+  client = Google::Cloud::SecretManager.secret_manager_service
+
+  # Build the resource name of the parent.
+  parent = client.project_path project: project_id
+
+  # Get the list of secrets.
+  list = client.list_secrets parent: parent
+
+  # Print out all secrets.
+  list.each do |secret|
+    puts "Got secret #{secret.name}"
+  end
+end
+# [END secretmanager_list_secrets]

--- a/google-cloud-secret_manager/samples/snippets.rb
+++ b/google-cloud-secret_manager/samples/snippets.rb
@@ -1,4 +1,4 @@
-# Copyright 2020 Google, Inc
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google-cloud-secret_manager/samples/update_secret.rb
+++ b/google-cloud-secret_manager/samples/update_secret.rb
@@ -1,0 +1,48 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START secretmanager_update_secret]
+require "google/cloud/secret_manager"
+
+##
+# Update a secret's labels
+#
+# @param project_id [String] Your Google Cloud project (e.g. "my-project")
+# @param secret_id [String] Your secret name (e.g. "my-secret")
+#
+def update_secret project_id:, secret_id:
+  # Create a Secret Manager client.
+  client = Google::Cloud::SecretManager.secret_manager_service
+
+  # Build the resource name of the secret.
+  name = client.secret_path project: project_id, secret: secret_id
+
+  # Create the secret.
+  secret = client.update_secret(
+    secret: {
+      name: name,
+      labels: {
+        secretmanager: "rocks"
+      }
+    },
+    update_mask: {
+      paths: ["labels"]
+    }
+  )
+
+  # Print the updated secret name and the new label value.
+  puts "Updated secret: #{secret.name}"
+  puts "New label: #{secret.labels['secretmanager']}"
+end
+# [END secretmanager_update_secret]

--- a/google-cloud-secret_manager/samples/update_secret_with_alias.rb
+++ b/google-cloud-secret_manager/samples/update_secret_with_alias.rb
@@ -1,0 +1,48 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START secretmanager_update_secret_with_alias]
+require "google/cloud/secret_manager"
+
+##
+# Update a secret's version aliases
+#
+# @param project_id [String] Your Google Cloud project (e.g. "my-project")
+# @param secret_id [String] Your secret name (e.g. "my-secret")
+#
+def update_secret_with_alias project_id:, secret_id:
+  # Create a Secret Manager client.
+  client = Google::Cloud::SecretManager.secret_manager_service
+
+  # Build the resource name of the secret.
+  name = client.secret_path project: project_id, secret: secret_id
+
+  # Create the secret.
+  secret = client.update_secret(
+    secret: {
+      name: name,
+      version_aliases: {
+        test: 1
+      }
+    },
+    update_mask: {
+      paths: ["version_aliases"]
+    }
+  )
+
+  # Print the updated secret name and the new version alias.
+  puts "Updated secret: #{secret.name}"
+  puts "New version alias: #{secret.version_aliases['test']}"
+end
+# [END secretmanager_update_secret_with_alias]


### PR DESCRIPTION
This pull request updates the Secret Manager samples to conform to https://googlecloudplatform.github.io/samples-style-guide. We are currently claiming these samples to be our canonical samples for the purpose of style and format, so they need to be in better shape.

Included:

* Splits the "snippets.rb" file into a separate file per sample.
* Includes the "sample method" within the region tag to give each sample some context.
* Uses yardoc formatted comments to document inputs.
* Eliminates return values for sample methods
* Omits the "embedded" CLI
* Provides a separate test file for each sample file by splitting up "acceptance/snippets_test.rb"

Note: the previous snippets.rb remains untouched because it is still the file that is referenced from cloudsite. We'll need to merge this pull request, then update the links on cloudsite, and then remove the old snippets.rb in a follow-up pull request.

Also includes a tool for wrapping sample methods in automatically generated classes for safe testing, and a related tool for automatically generating a toys-based CLI for running samples.