### PR TITLE
fix(storage): Update api for bucket update

### DIFF
--- a/google-cloud-storage/acceptance/storage/bucket_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_test.rb
@@ -61,7 +61,7 @@ describe Google::Cloud::Storage::Bucket, :storage do
     _(one_off_bucket.website_404).must_equal "not_found.html"
     _(one_off_bucket.requester_pays).must_equal true
     # labels with symbols are not strings
-    _(one_off_bucket.labels).must_equal({ :foo => :bar })
+    _(one_off_bucket.labels).must_equal({ "foo" => "bar" })
     _(one_off_bucket.location_type).must_equal "multi-region"
 
     one_off_bucket_copy = storage.bucket one_off_bucket_name, user_project: true

--- a/google-cloud-storage/acceptance/storage/bucket_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_test.rb
@@ -61,7 +61,7 @@ describe Google::Cloud::Storage::Bucket, :storage do
     _(one_off_bucket.website_404).must_equal "not_found.html"
     _(one_off_bucket.requester_pays).must_equal true
     # labels with symbols are not strings
-    _(one_off_bucket.labels).must_equal({ "foo" => "bar" })
+    _(one_off_bucket.labels).must_equal({ :foo => :bar })
     _(one_off_bucket.location_type).must_equal "multi-region"
 
     one_off_bucket_copy = storage.bucket one_off_bucket_name, user_project: true

--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -1178,11 +1178,11 @@ module Google
             [attr, @gapi.send(attr)]
           end]
           update_gapi = API::Bucket.new(**update_args)
-          service.update_bucket name,
-                                update_gapi,
-                                if_metageneration_match: if_metageneration_match,
-                                if_metageneration_not_match: if_metageneration_not_match,
-                                user_project: user_project
+          @gapi = service.update_bucket name,
+                                        update_gapi,
+                                        if_metageneration_match: if_metageneration_match,
+                                        if_metageneration_not_match: if_metageneration_not_match,
+                                        user_project: user_project
           @lazy = nil
           self
         end

--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -1169,22 +1169,10 @@ module Google
           updater.check_for_changed_labels!
           updater.check_for_mutable_cors!
           updater.check_for_mutable_lifecycle!
-
-          attributes = Array(updater.updates)
-          attributes.flatten!
-          return if attributes.empty?
-          ensure_service!
-          update_args = Hash[attributes.map do |attr|
-            [attr, @gapi.send(attr)]
-          end]
-          update_gapi = API::Bucket.new(**update_args)
-          @gapi = service.update_bucket name,
-                                        update_gapi,
-                                        if_metageneration_match: if_metageneration_match,
-                                        if_metageneration_not_match: if_metageneration_not_match,
-                                        user_project: user_project
-          @lazy = nil
-          self
+          return if updater.updates.empty?
+          update_gapi! updater.updates,
+                       if_metageneration_match: if_metageneration_match,
+                       if_metageneration_not_match: if_metageneration_not_match
         end
 
         ##
@@ -2913,6 +2901,26 @@ module Google
                                        if_metageneration_match: if_metageneration_match,
                                        if_metageneration_not_match: if_metageneration_not_match,
                                        user_project: user_project
+          @lazy = nil
+          self
+        end
+
+        def update_gapi! attributes,
+                         if_metageneration_match: nil,
+                         if_metageneration_not_match: nil
+          attributes = Array(attributes)
+          attributes.flatten!
+          return if attributes.empty?
+          ensure_service!
+          update_args = Hash[attributes.map do |attr|
+            [attr, @gapi.send(attr)]
+          end]
+          update_gapi = API::Bucket.new(**update_args)
+          @gapi = service.update_bucket name,
+                                        update_gapi,
+                                        if_metageneration_match: if_metageneration_match,
+                                        if_metageneration_not_match: if_metageneration_not_match,
+                                        user_project: user_project
           @lazy = nil
           self
         end

--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -1169,10 +1169,22 @@ module Google
           updater.check_for_changed_labels!
           updater.check_for_mutable_cors!
           updater.check_for_mutable_lifecycle!
-          return if updater.updates.empty?
-          patch_gapi! updater.updates,
-                      if_metageneration_match: if_metageneration_match,
-                      if_metageneration_not_match: if_metageneration_not_match
+
+          attributes = Array(updater.updates)
+          attributes.flatten!
+          return if attributes.empty?
+          ensure_service!
+          update_args = Hash[attributes.map do |attr|
+            [attr, @gapi.send(attr)]
+          end]
+          update_gapi = API::Bucket.new(**update_args)
+          service.update_bucket name,
+                                update_gapi,
+                                if_metageneration_match: if_metageneration_match,
+                                if_metageneration_not_match: if_metageneration_not_match,
+                                user_project: user_project
+          @lazy = nil
+          self
         end
 
         ##

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -727,7 +727,7 @@ module Google
                           if_metageneration_not_match: nil,
                           user_project: nil,
                           options: {}
-          
+
           bucket_gapi ||= Google::Apis::StorageV1::Bucket.new
 
           if options[:retries].nil?

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -721,15 +721,19 @@ module Google
           end
         end
 
-        ## Updates a bucket
+        ##
+        # Updates a bucket, including its ACL metadata.
         def update_bucket bucket_name,
                           bucket_gapi = nil,
+                          predefined_acl: nil,
+                          predefined_default_acl: nil, 
                           if_metageneration_match: nil,
                           if_metageneration_not_match: nil,
                           user_project: nil,
                           options: {}
-
           bucket_gapi ||= Google::Apis::StorageV1::Bucket.new
+          bucket_gapi.acl = [] if predefined_acl
+          bucket_gapi.default_object_acl = [] if predefined_default_acl
 
           if options[:retries].nil?
             is_idempotent = retry? if_metageneration_match: if_metageneration_match

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -721,6 +721,7 @@ module Google
           end
         end
 
+        ## Updates a bucket
         def update_bucket bucket_name,
                           bucket_gapi = nil,
                           if_metageneration_match: nil,

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -726,7 +726,7 @@ module Google
         def update_bucket bucket_name,
                           bucket_gapi = nil,
                           predefined_acl: nil,
-                          predefined_default_acl: nil, 
+                          predefined_default_acl: nil,
                           if_metageneration_match: nil,
                           if_metageneration_not_match: nil,
                           user_project: nil,

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -721,6 +721,32 @@ module Google
           end
         end
 
+        def update_bucket bucket_name,
+                          bucket_gapi = nil,
+                          if_metageneration_match: nil,
+                          if_metageneration_not_match: nil,
+                          user_project: nil,
+                          options: {}
+          
+          bucket_gapi ||= Google::Apis::StorageV1::Bucket.new
+          # bucket_gapi.acl = [] if predefined_acl
+          # bucket_gapi.default_object_acl = [] if predefined_default_acl
+
+          if options[:retry].nil?
+            is_idempotent = retry? if_metageneration_match: if_metageneration_match
+            options = is_idempotent ? {} : { retries: 0 }
+          end
+
+          execute do
+            service.update_bucket bucket_name,
+                                  bucket_gapi,
+                                  if_metageneration_match: if_metageneration_match,
+                                  if_metageneration_not_match: if_metageneration_not_match,
+                                  user_project: user_project(user_project),
+                                  options: options
+          end
+        end
+
         ##
         # Retrieves the mime-type for a file path.
         # An empty string is returned if no mime-type can be found.

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -729,10 +729,8 @@ module Google
                           options: {}
           
           bucket_gapi ||= Google::Apis::StorageV1::Bucket.new
-          # bucket_gapi.acl = [] if predefined_acl
-          # bucket_gapi.default_object_acl = [] if predefined_default_acl
 
-          if options[:retry].nil?
+          if options[:retries].nil?
             is_idempotent = retry? if_metageneration_match: if_metageneration_match
             options = is_idempotent ? {} : { retries: 0 }
           end

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -744,7 +744,7 @@ module Google
             service.update_bucket bucket_name,
                                   bucket_gapi,
                                   predefined_acl: predefined_acl,
-                                  predefined_default_object_acl: predefined_default_acl, 
+                                  predefined_default_object_acl: predefined_default_acl,
                                   if_metageneration_match: if_metageneration_match,
                                   if_metageneration_not_match: if_metageneration_not_match,
                                   user_project: user_project(user_project),

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -743,6 +743,8 @@ module Google
           execute do
             service.update_bucket bucket_name,
                                   bucket_gapi,
+                                  predefined_acl: predefined_acl,
+                                  predefined_default_object_acl: predefined_default_acl, 
                                   if_metageneration_match: if_metageneration_match,
                                   if_metageneration_not_match: if_metageneration_not_match,
                                   user_project: user_project(user_project),

--- a/google-cloud-storage/test/google/cloud/storage/bucket_update_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_update_test.rb
@@ -75,13 +75,13 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
     mock.verify
   end
 
-  it "updates its versioning with if_metageneration_match" do
+  focus; it "updates its versioning with if_metageneration_match" do
     mock = Minitest::Mock.new
     patch_versioning_gapi = Google::Apis::StorageV1::Bucket::Versioning.new enabled: true
     patch_bucket_gapi = Google::Apis::StorageV1::Bucket.new versioning: patch_versioning_gapi
     returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
       random_bucket_hash(name: bucket_name, url_root: bucket_url, location: bucket_location, storage_class: bucket_storage_class, versioning: true).to_json
-    mock.expect :patch_bucket, returned_bucket_gapi, [bucket_name, patch_bucket_gapi], **patch_bucket_args(if_metageneration_match: metageneration)
+    mock.expect :update_bucket, returned_bucket_gapi, [bucket_name, patch_bucket_gapi], **patch_bucket_args(if_metageneration_match: metageneration)
 
     bucket.service.mocked_service = mock
 

--- a/google-cloud-storage/test/google/cloud/storage/bucket_update_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_update_test.rb
@@ -75,13 +75,13 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
     mock.verify
   end
 
-  focus; it "updates its versioning with if_metageneration_match" do
+  it "updates its versioning with if_metageneration_match" do
     mock = Minitest::Mock.new
     patch_versioning_gapi = Google::Apis::StorageV1::Bucket::Versioning.new enabled: true
     patch_bucket_gapi = Google::Apis::StorageV1::Bucket.new versioning: patch_versioning_gapi
     returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
       random_bucket_hash(name: bucket_name, url_root: bucket_url, location: bucket_location, storage_class: bucket_storage_class, versioning: true).to_json
-    mock.expect :update_bucket, returned_bucket_gapi, [bucket_name, patch_bucket_gapi], **patch_bucket_args(if_metageneration_match: metageneration)
+    mock.expect :update_bucket, returned_bucket_gapi, [bucket_name, patch_bucket_gapi], **update_bucket_args(if_metageneration_match: metageneration)
 
     bucket.service.mocked_service = mock
 
@@ -102,7 +102,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
     patch_bucket_gapi = Google::Apis::StorageV1::Bucket.new versioning: patch_versioning_gapi
     returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
       random_bucket_hash(name: bucket_name, url_root: bucket_url, location: bucket_location, storage_class: bucket_storage_class, versioning: true).to_json
-    mock.expect :patch_bucket, returned_bucket_gapi, [bucket_name, patch_bucket_gapi], **patch_bucket_args(if_metageneration_not_match: metageneration, options: {retries: 0})
+    mock.expect :update_bucket, returned_bucket_gapi, [bucket_name, patch_bucket_gapi], **update_bucket_args(if_metageneration_not_match: metageneration, options: {retries: 0})
 
     bucket.service.mocked_service = mock
 
@@ -175,7 +175,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
     patch_bucket_gapi = Google::Apis::StorageV1::Bucket.new logging: patch_logging_gapi
     returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
       random_bucket_hash(name: bucket_name, url_root: bucket_url, location: bucket_location, storage_class: bucket_storage_class, logging_bucket: bucket_logging_bucket, logging_prefix: bucket_logging_prefix).to_json
-    mock.expect :patch_bucket, returned_bucket_gapi, [bucket_name, patch_bucket_gapi.class], **patch_bucket_args(options: {retries: 0})
+    mock.expect :update_bucket, returned_bucket_gapi, [bucket_name, patch_bucket_gapi.class], **update_bucket_args(options: {retries: 0})
 
     bucket.service.mocked_service = mock
 
@@ -250,7 +250,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
     patch_bucket_gapi = Google::Apis::StorageV1::Bucket.new website: patch_website_gapi
     returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
       random_bucket_hash(name: bucket_name, url_root: bucket_url, location: bucket_location, storage_class: bucket_storage_class, website_main: bucket_website_main, website_404: bucket_website_404).to_json
-    mock.expect :patch_bucket, returned_bucket_gapi, [bucket_name, patch_bucket_gapi], **patch_bucket_args(options: {retries: 0})
+    mock.expect :update_bucket, returned_bucket_gapi, [bucket_name, patch_bucket_gapi], **update_bucket_args(options: {retries: 0})
 
     bucket.service.mocked_service = mock
 
@@ -320,7 +320,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
     returned_bucket_hash = random_bucket_hash name: bucket_name, url_root: bucket_url, location: bucket_location, storage_class: "NEARLINE", versioning: true, logging_bucket: bucket_logging_bucket, logging_prefix: bucket_logging_prefix, website_main: bucket_website_main, website_404: bucket_website_404, cors: [], requester_pays: bucket_requester_pays
     returned_bucket_hash[:labels] = { "env" => "production" }
     returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json returned_bucket_hash.to_json
-    mock.expect :patch_bucket, returned_bucket_gapi, [bucket_name, patch_bucket_gapi], **patch_bucket_args(options: {retries: 0})
+    mock.expect :update_bucket, returned_bucket_gapi, [bucket_name, patch_bucket_gapi], **update_bucket_args(options: {retries: 0})
 
     bucket.service.mocked_service = mock
 
@@ -395,7 +395,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
       ]
       returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
         random_bucket_hash(name: bucket_name, url_root: bucket_url, location: bucket_location, storage_class: bucket_storage_class, cors: [bucket_cors_hash]).to_json
-      mock.expect :patch_bucket, returned_bucket_gapi, [bucket_name, patch_bucket_gapi], **patch_bucket_args(options: {retries: 0})
+      mock.expect :update_bucket, returned_bucket_gapi, [bucket_name, patch_bucket_gapi], **update_bucket_args(options: {retries: 0})
       bucket_with_cors.service.mocked_service = mock
 
       _(bucket_with_cors.cors).must_be :frozen?
@@ -430,7 +430,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
       ]
       returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
         random_bucket_hash(name: bucket_name, url_root: bucket_url, location: bucket_location, storage_class: bucket_storage_class, cors: [bucket_cors_hash]).to_json
-      mock.expect :patch_bucket, returned_bucket_gapi, [bucket_name, patch_bucket_gapi], **patch_bucket_args(options: {retries: 0})
+      mock.expect :update_bucket, returned_bucket_gapi, [bucket_name, patch_bucket_gapi], **update_bucket_args(options: {retries: 0})
       bucket_with_cors.service.mocked_service = mock
 
       bucket_with_cors.update do |b|
@@ -580,7 +580,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
 
       returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
         random_bucket_hash(name: bucket_name, url_root: bucket_url, location: bucket_location, storage_class: bucket_storage_class, lifecycle: bucket_lifecycle_hash).to_json
-      mock.expect :patch_bucket, returned_bucket_gapi, [bucket_name, patch_bucket_gapi], **patch_bucket_args(options: {retries: 0})
+      mock.expect :update_bucket, returned_bucket_gapi, [bucket_name, patch_bucket_gapi], **update_bucket_args(options: {retries: 0})
       bucket_with_cors.service.mocked_service = mock
 
       _(bucket_with_cors.lifecycle).must_be :frozen?
@@ -606,7 +606,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
       )
       returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
         random_bucket_hash(name: bucket_name, url_root: bucket_url, location: bucket_location, storage_class: bucket_storage_class, lifecycle: bucket_lifecycle_hash).to_json
-      mock.expect :patch_bucket, returned_bucket_gapi, [bucket_name, patch_bucket_gapi], **patch_bucket_args(options: {retries: 0})
+      mock.expect :update_bucket, returned_bucket_gapi, [bucket_name, patch_bucket_gapi], **update_bucket_args(options: {retries: 0})
       bucket_with_cors.service.mocked_service = mock
 
       bucket_with_cors.update do |b|
@@ -641,7 +641,7 @@ describe Google::Cloud::Storage::Bucket, :update, :mock_storage do
       )
       returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
         random_bucket_hash(name: bucket_name, url_root: bucket_url, location: bucket_location, storage_class: bucket_storage_class, lifecycle: bucket_lifecycle_hash).to_json
-      mock.expect :patch_bucket, returned_bucket_gapi, [bucket_name, patch_bucket_gapi], **patch_bucket_args(options: {retries: 0})
+      mock.expect :update_bucket, returned_bucket_gapi, [bucket_name, patch_bucket_gapi], **update_bucket_args(options: {retries: 0})
       bucket_with_cors.service.mocked_service = mock
 
       _(bucket_with_cors.lifecycle).must_be :frozen?

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_update_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_update_test.rb
@@ -111,7 +111,7 @@ describe Google::Cloud::Storage::Bucket, :update, :lazy, :mock_storage do
     patch_bucket_gapi = Google::Apis::StorageV1::Bucket.new logging: patch_logging_gapi
     returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
       random_bucket_hash(name: bucket_name, url_root: bucket_url, location: bucket_location, storage_class: bucket_storage_class, logging_bucket: bucket_logging_bucket, logging_prefix: bucket_logging_prefix).to_json
-    mock.expect :patch_bucket, returned_bucket_gapi, [bucket_name, patch_bucket_gapi.class], **patch_bucket_args(options: {retries: 0})
+    mock.expect :update_bucket, returned_bucket_gapi, [bucket_name, patch_bucket_gapi.class], **update_bucket_args(options: {retries: 0})
 
     bucket.service.mocked_service = mock
 
@@ -185,7 +185,7 @@ describe Google::Cloud::Storage::Bucket, :update, :lazy, :mock_storage do
     patch_bucket_gapi = Google::Apis::StorageV1::Bucket.new website: patch_website_gapi
     returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
       random_bucket_hash(name: bucket_name, url_root: bucket_url, location: bucket_location, storage_class: bucket_storage_class, website_main: bucket_website_main, website_404: bucket_website_404).to_json
-    mock.expect :patch_bucket, returned_bucket_gapi, [bucket_name, patch_bucket_gapi], **patch_bucket_args(options: {retries: 0})
+    mock.expect :update_bucket, returned_bucket_gapi, [bucket_name, patch_bucket_gapi], **update_bucket_args(options: {retries: 0})
 
     bucket.service.mocked_service = mock
 
@@ -255,7 +255,7 @@ describe Google::Cloud::Storage::Bucket, :update, :lazy, :mock_storage do
     returned_bucket_hash = random_bucket_hash name: bucket_name, url_root: bucket_url, location: bucket_location, storage_class: "NEARLINE", versioning: true, logging_bucket: bucket_logging_bucket, logging_prefix: bucket_logging_prefix, website_main: bucket_website_main, website_404: bucket_website_404, cors: [], requester_pays: bucket_requester_pays
     returned_bucket_hash[:labels] = { "env" => "production" }
     returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json returned_bucket_hash.to_json
-    mock.expect :patch_bucket, returned_bucket_gapi, [bucket_name, patch_bucket_gapi], **patch_bucket_args(options: {retries: 0})
+    mock.expect :update_bucket, returned_bucket_gapi, [bucket_name, patch_bucket_gapi], **update_bucket_args(options: {retries: 0})
 
     bucket.service.mocked_service = mock
 
@@ -333,7 +333,7 @@ describe Google::Cloud::Storage::Bucket, :update, :lazy, :mock_storage do
       ]
       returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
         random_bucket_hash(name: bucket_name, url_root: bucket_url, location: bucket_location, storage_class: bucket_storage_class, cors: [bucket_cors_hash]).to_json
-      mock.expect :patch_bucket, returned_bucket_gapi, [bucket_name, patch_bucket_gapi], **patch_bucket_args(options: {retries: 0})
+      mock.expect :update_bucket, returned_bucket_gapi, [bucket_name, patch_bucket_gapi], **update_bucket_args(options: {retries: 0})
       bucket.service.mocked_service = mock
 
       _(bucket.cors).must_be :frozen?
@@ -367,7 +367,7 @@ describe Google::Cloud::Storage::Bucket, :update, :lazy, :mock_storage do
       ]
       returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
         random_bucket_hash(name: bucket_name, url_root: bucket_url, location: bucket_location, storage_class: bucket_storage_class, cors: [bucket_cors_hash]).to_json
-      mock.expect :patch_bucket, returned_bucket_gapi, [bucket_name, patch_bucket_gapi], **patch_bucket_args(options: {retries: 0})
+      mock.expect :update_bucket, returned_bucket_gapi, [bucket_name, patch_bucket_gapi], **update_bucket_args(options: {retries: 0})
       bucket.service.mocked_service = mock
 
       bucket.update do |b|
@@ -460,7 +460,7 @@ describe Google::Cloud::Storage::Bucket, :update, :lazy, :mock_storage do
       )
       returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
         random_bucket_hash(name: bucket_name, url_root: bucket_url, location: bucket_location, storage_class: bucket_storage_class, lifecycle: bucket_lifecycle_hash).to_json
-      mock.expect :patch_bucket, returned_bucket_gapi, [bucket_name, patch_bucket_gapi], **patch_bucket_args(options: {retries: 0})
+      mock.expect :update_bucket, returned_bucket_gapi, [bucket_name, patch_bucket_gapi], **update_bucket_args(options: {retries: 0})
       bucket.service.mocked_service = mock
 
       _(bucket.lifecycle).must_be :frozen?
@@ -483,7 +483,7 @@ describe Google::Cloud::Storage::Bucket, :update, :lazy, :mock_storage do
       )
       returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
         random_bucket_hash(name: bucket_name, url_root: bucket_url, location: bucket_location, storage_class: bucket_storage_class, lifecycle: bucket_lifecycle_hash).to_json
-      mock.expect :patch_bucket, returned_bucket_gapi, [bucket_name, patch_bucket_gapi], **patch_bucket_args(options: {retries: 0})
+      mock.expect :update_bucket, returned_bucket_gapi, [bucket_name, patch_bucket_gapi], **update_bucket_args(options: {retries: 0})
       bucket.service.mocked_service = mock
 
       bucket.update do |b|
@@ -507,7 +507,7 @@ describe Google::Cloud::Storage::Bucket, :update, :lazy, :mock_storage do
       )
       returned_bucket_gapi = Google::Apis::StorageV1::Bucket.from_json \
         random_bucket_hash(name: bucket_name, url_root: bucket_url, location: bucket_location, storage_class: bucket_storage_class, cors: nil, lifecycle: bucket_lifecycle_hash).to_json
-      mock.expect :patch_bucket, returned_bucket_gapi, [bucket_name, patch_bucket_gapi], **patch_bucket_args(options: {retries: 0})
+      mock.expect :update_bucket, returned_bucket_gapi, [bucket_name, patch_bucket_gapi], **update_bucket_args(options: {retries: 0})
       bucket.service.mocked_service = mock
 
       _(bucket.lifecycle).must_be :frozen?

--- a/google-cloud-storage/test/helper.rb
+++ b/google-cloud-storage/test/helper.rb
@@ -239,6 +239,18 @@ class MockStorage < Minitest::Spec
     }
   end
 
+  def update_bucket_args if_metageneration_match: nil,
+                         if_metageneration_not_match: nil,
+                         user_project: nil,
+                         options: {}
+    {
+      if_metageneration_match: if_metageneration_match,
+      if_metageneration_not_match: if_metageneration_not_match,
+      user_project: user_project,
+      options: options
+    }
+  end
+
   def patch_bucket_args if_metageneration_match: nil,
                         if_metageneration_not_match: nil,
                         predefined_acl: nil,

--- a/google-cloud-storage/test/helper.rb
+++ b/google-cloud-storage/test/helper.rb
@@ -241,11 +241,15 @@ class MockStorage < Minitest::Spec
 
   def update_bucket_args if_metageneration_match: nil,
                          if_metageneration_not_match: nil,
+                         predefined_acl: nil,
+                         predefined_default_object_acl: nil, 
                          user_project: nil,
                          options: {}
     {
       if_metageneration_match: if_metageneration_match,
       if_metageneration_not_match: if_metageneration_not_match,
+      predefined_acl: predefined_acl,
+      predefined_default_object_acl: predefined_default_object_acl,
       user_project: user_project,
       options: options
     }


### PR DESCRIPTION
closes: http://b/232352080 (internal)

This PR changes the following implementation:
```
service method "update_bucket" --calls--> apiary method "patch_bucket"
```
to:
```
service method "update_bucket" --calls--> apiary method "update_bucket"
```

It also provides a retry option for the `update_bucket` method and sets it to `0` as default value.