### PR TITLE
[DO NOT MERGE] google-cloud-bigtable: read_rows return extra rows when DeadlineExceed during enumerate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         include:
           - os: ubuntu-latest
             ruby: "2.6"
-            task: "--test"
+            task: "--test --samples-latest"
           - os: ubuntu-latest
             ruby: "2.7"
             task: "--test"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ on:
 
 jobs:
   CI:
-    if: ${{ github.repository == 'googleapis/google-cloud-ruby' }}
     strategy:
       matrix:
         include:

--- a/google-cloud-bigtable/samples/acceptance/read_samples_test.rb
+++ b/google-cloud-bigtable/samples/acceptance/read_samples_test.rb
@@ -101,9 +101,10 @@ Column Family stats_summary
 \tconnected_cell: 1 @#{@timestamp}
 \tconnected_wifi: 1 @#{@timestamp}
 \tos_build: PQ2A.190405.004 @#{@timestamp}
+
 OUTPUT
 
-    assert_match expected, out
+    assert_equal expected, out
   end
 
   it "reads_rows_nil" do
@@ -140,9 +141,16 @@ Column Family stats_summary
 \tconnected_cell: 1 @#{@timestamp}
 \tconnected_wifi: 0 @#{@timestamp}
 \tos_build: PQ2A.190406.000 @#{@timestamp}
+
+Reading data for phone001#5c10102#20190502:
+Column Family stats_summary
+\tconnected_cell: 1 @#{@timestamp}
+\tconnected_wifi: 0 @#{@timestamp}
+\tos_build: PQ2A.190406.000 @#{@timestamp}
+
 OUTPUT
 
-    assert_match expected, out
+    assert_equal expected, out
   end
 
   it "reads_rows_empty" do
@@ -152,7 +160,7 @@ OUTPUT
     expected = <<~OUTPUT
 OUTPUT
 
-    assert_match expected, out
+    assert_equal expected, out
   end
 
   it "reads_rows_sleep" do
@@ -178,9 +186,10 @@ Column Family stats_summary
 \tconnected_cell: 1 @#{@timestamp}
 \tconnected_wifi: 1 @#{@timestamp}
 \tos_build: PQ2A.190405.004 @#{@timestamp}
+
 OUTPUT
 
-    assert_match expected, out
+    assert_equal expected, out
   end
 
   it "reads_row_range" do

--- a/google-cloud-bigtable/samples/acceptance/read_samples_test.rb
+++ b/google-cloud-bigtable/samples/acceptance/read_samples_test.rb
@@ -106,6 +106,55 @@ OUTPUT
     assert_match expected, out
   end
 
+  it "reads_rows_nil" do
+    out, _err = capture_io do
+      reads_rows_nil bigtable_instance_id, @table_id
+    end
+    expected = <<~OUTPUT
+Reading data for phone#4c410523#20190501:
+Column Family stats_summary
+\tconnected_cell: 1 @#{@timestamp}
+\tconnected_wifi: 1 @#{@timestamp}
+\tos_build: PQ2A.190405.003 @#{@timestamp}
+
+Reading data for phone#4c410523#20190502:
+Column Family stats_summary
+\tconnected_cell: 1 @#{@timestamp}
+\tconnected_wifi: 1 @#{@timestamp}
+\tos_build: PQ2A.190405.004 @#{@timestamp}
+
+Reading data for phone#4c410523#20190505:
+Column Family stats_summary
+\tconnected_cell: 0 @#{@timestamp}
+\tconnected_wifi: 1 @#{@timestamp}
+\tos_build: PQ2A.190406.000 @#{@timestamp}
+
+Reading data for phone#5c10102#20190501:
+Column Family stats_summary
+\tconnected_cell: 1 @#{@timestamp}
+\tconnected_wifi: 1 @#{@timestamp}
+\tos_build: PQ2A.190401.002 @#{@timestamp}
+
+Reading data for phone#5c10102#20190502:
+Column Family stats_summary
+\tconnected_cell: 1 @#{@timestamp}
+\tconnected_wifi: 0 @#{@timestamp}
+\tos_build: PQ2A.190406.000 @#{@timestamp}
+OUTPUT
+
+    assert_match expected, out
+  end
+
+  it "reads_rows_empty" do
+    out, _err = capture_io do
+      reads_rows_empty bigtable_instance_id, @table_id
+    end
+    expected = <<~OUTPUT
+OUTPUT
+
+    assert_match expected, out
+  end
+
   it "reads_rows_sleep" do
     Google::Cloud::Bigtable::V2::Bigtable::Client.configure do
       # reads_rows_sleep is expected to return two elements

--- a/google-cloud-bigtable/samples/acceptance/read_samples_test.rb
+++ b/google-cloud-bigtable/samples/acceptance/read_samples_test.rb
@@ -106,6 +106,27 @@ OUTPUT
     assert_match expected, out
   end
 
+  it "reads_rows_sleep" do
+    out, _err = capture_io do
+      reads_rows_sleep bigtable_instance_id, @table_id
+    end
+    expected = <<~OUTPUT
+Reading data for phone#4c410523#20190501:
+Column Family stats_summary
+\tconnected_cell: 1 @#{@timestamp}
+\tconnected_wifi: 1 @#{@timestamp}
+\tos_build: PQ2A.190405.003 @#{@timestamp}
+
+Reading data for phone#4c410523#20190502:
+Column Family stats_summary
+\tconnected_cell: 1 @#{@timestamp}
+\tconnected_wifi: 1 @#{@timestamp}
+\tos_build: PQ2A.190405.004 @#{@timestamp}
+OUTPUT
+
+    assert_match expected, out
+  end
+
   it "reads_row_range" do
     out, _err = capture_io do
       reads_row_range bigtable_instance_id, @table_id

--- a/google-cloud-bigtable/samples/acceptance/read_samples_test.rb
+++ b/google-cloud-bigtable/samples/acceptance/read_samples_test.rb
@@ -107,6 +107,13 @@ OUTPUT
   end
 
   it "reads_rows_sleep" do
+    Google::Cloud::Bigtable::V2::Bigtable::Client.configure do
+      # reads_rows_sleep is expected to return two elements
+      # let it timeout when processing 2nd element
+      # reproduce make sure its retry doesn't read extra (i.e. 3rd) element
+      config.rpcs.read_rows.timeout = 1.5
+    end
+
     out, _err = capture_io do
       reads_rows_sleep bigtable_instance_id, @table_id
     end

--- a/google-cloud-bigtable/samples/read_samples.rb
+++ b/google-cloud-bigtable/samples/read_samples.rb
@@ -58,6 +58,22 @@ def reads_rows instance_id, table_id
   # [END bigtable_reads_rows]
 end
 
+def reads_rows_sleep instance_id, table_id
+  # [START bigtable_reads_rows_sleep]
+  # instance_id = "my-instance"
+  # table_id    = "my-table"
+  bigtable = Google::Cloud::Bigtable.new
+  table = bigtable.table instance_id, table_id
+
+  count = 0
+  table.read_rows(keys: ["phone#4c410523#20190501", "phone#4c410523#20190502"]).each do |row|
+    count += 1
+    sleep(count)
+    print_row row
+  end
+  # [END bigtable_reads_rows_sleep]
+end
+
 def reads_row_range instance_id, table_id
   # [START bigtable_reads_row_range]
   # instance_id = "my-instance"

--- a/google-cloud-bigtable/samples/read_samples.rb
+++ b/google-cloud-bigtable/samples/read_samples.rb
@@ -91,13 +91,10 @@ def reads_rows_sleep instance_id, table_id
   bigtable = Google::Cloud::Bigtable.new
   table = bigtable.table instance_id, table_id
 
-  enumerator = table.read_rows(keys: ["phone#4c410523#20190501", "phone#4c410523#20190502"])
-  2.times do
+  table.read_rows(keys: ["phone#4c410523#20190501", "phone#4c410523#20190502"]).each do |row|
     print_row(enumerator.next)
+    sleep(1)
   end
-  
-  sleep(2)
-  print_row(enumerator.next)
   # [END bigtable_reads_rows_sleep]
 end
 

--- a/google-cloud-bigtable/samples/read_samples.rb
+++ b/google-cloud-bigtable/samples/read_samples.rb
@@ -65,10 +65,13 @@ def reads_rows_sleep instance_id, table_id
   bigtable = Google::Cloud::Bigtable.new
   table = bigtable.table instance_id, table_id
 
-  table.read_rows(keys: ["phone#4c410523#20190501", "phone#4c410523#20190502"]).each do |row|
-    print_row row
-    sleep(1)
+  enumerator = table.read_rows(keys: ["phone#4c410523#20190501", "phone#4c410523#20190502"])
+  2.times do
+    print_row(enumerator.next)
   end
+  
+  sleep(2)
+  print_row(enumerator.next)
   # [END bigtable_reads_rows_sleep]
 end
 

--- a/google-cloud-bigtable/samples/read_samples.rb
+++ b/google-cloud-bigtable/samples/read_samples.rb
@@ -58,6 +58,32 @@ def reads_rows instance_id, table_id
   # [END bigtable_reads_rows]
 end
 
+def reads_rows_nil instance_id, table_id
+  # [START bigtable_reads_rows]
+  # instance_id = "my-instance"
+  # table_id    = "my-table"
+  bigtable = Google::Cloud::Bigtable.new
+  table = bigtable.table instance_id, table_id
+
+  table.read_rows(keys: nil).each do |row|
+    print_row row
+  end
+  # [END bigtable_reads_rows]
+end
+
+def reads_rows_empty instance_id, table_id
+  # [START bigtable_reads_rows]
+  # instance_id = "my-instance"
+  # table_id    = "my-table"
+  bigtable = Google::Cloud::Bigtable.new
+  table = bigtable.table instance_id, table_id
+
+  table.read_rows(keys: []).each do |row|
+    print_row row
+  end
+  # [END bigtable_reads_rows]
+end
+
 def reads_rows_sleep instance_id, table_id
   # [START bigtable_reads_rows_sleep]
   # instance_id = "my-instance"

--- a/google-cloud-bigtable/samples/read_samples.rb
+++ b/google-cloud-bigtable/samples/read_samples.rb
@@ -65,11 +65,9 @@ def reads_rows_sleep instance_id, table_id
   bigtable = Google::Cloud::Bigtable.new
   table = bigtable.table instance_id, table_id
 
-  count = 0
   table.read_rows(keys: ["phone#4c410523#20190501", "phone#4c410523#20190502"]).each do |row|
-    count += 1
-    sleep(count)
     print_row row
+    sleep(1)
   end
   # [END bigtable_reads_rows_sleep]
 end


### PR DESCRIPTION
this PR is just a reproducible step of https://github.com/googleapis/google-cloud-ruby/issues/19112

not reproducible in unit test, because we mock the response chunk there.
It is reproducible in integration test with a real Bigtable instance. I didn't test with Bigtable Emulator yet