### PR TITLE
feat(storage): add retry support for non-idempotent operations

### DIFF
--- a/google-cloud-storage/OVERVIEW.md
+++ b/google-cloud-storage/OVERVIEW.md
@@ -593,6 +593,8 @@ service = storage.service
 service.get_bucket bucket_name, options: {retries: 0}
 ```
 
+For those API requests which are never idempotent, the library passes retries=0 by default, suppressing any retries.
+
 See the [Storage status and error
 codes](https://cloud.google.com/storage/docs/json_api/v1/status-codes)
 for a list of error conditions.

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -299,6 +299,10 @@ module Google
               topic: topic_path(topic_name) }.delete_if { |_k, v| v.nil? }
           new_notification = Google::Apis::StorageV1::Notification.new(**params)
 
+          if options[:retries].nil?
+            options = options.merge({ retries: 0 })
+          end
+
           execute do
             service.insert_notification \
               bucket_name, new_notification,
@@ -656,6 +660,11 @@ module Google
         # Returns Google::Apis::StorageV1::HmacKey.
         def create_hmac_key service_account_email, project_id: nil,
                             user_project: nil, options: {}
+
+          if options[:retries].nil?
+            options = options.merge({ retries: 0 })
+          end
+
           execute do
             service.create_project_hmac_key \
               (project_id || @project), service_account_email,

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -196,6 +196,9 @@ module Google
         def insert_bucket_acl bucket_name, entity, role, user_project: nil, options: {}
           params = { entity: entity, role: role }.delete_if { |_k, v| v.nil? }
           new_acl = Google::Apis::StorageV1::BucketAccessControl.new(**params)
+          if options[:retries].nil?
+            options = options.merge({ retries: 0 })
+          end
           execute do
             service.insert_bucket_access_control \
               bucket_name, new_acl, user_project: user_project(user_project),
@@ -206,6 +209,9 @@ module Google
         ##
         # Permanently deletes a bucket ACL.
         def delete_bucket_acl bucket_name, entity, user_project: nil, options: {}
+          if options[:retries].nil?
+            options = options.merge({ retries: 0 })
+          end
           execute do
             service.delete_bucket_access_control \
               bucket_name, entity, user_project: user_project(user_project),

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -232,6 +232,9 @@ module Google
         ##
         # Creates a new default ACL.
         def insert_default_acl bucket_name, entity, role, user_project: nil, options: {}
+          if options[:retries].nil?
+            options = options.merge({ retries: 0 })
+          end
           param = { entity: entity, role: role }.delete_if { |_k, v| v.nil? }
           new_acl = Google::Apis::StorageV1::ObjectAccessControl.new(**param)
           execute do
@@ -244,6 +247,9 @@ module Google
         ##
         # Permanently deletes a default ACL.
         def delete_default_acl bucket_name, entity, user_project: nil, options: {}
+          if options[:retries].nil?
+            options = options.merge({ retries: 0 })
+          end
           execute do
             service.delete_default_object_access_control \
               bucket_name, entity, user_project: user_project(user_project),
@@ -639,6 +645,9 @@ module Google
         def insert_file_acl bucket_name, file_name, entity, role,
                             generation: nil, user_project: nil,
                             options: {}
+          if options[:retries].nil?
+            options = options.merge({ retries: 0 })
+          end
           params = { entity: entity, role: role }.delete_if { |_k, v| v.nil? }
           new_acl = Google::Apis::StorageV1::ObjectAccessControl.new(**params)
           execute do
@@ -653,6 +662,9 @@ module Google
         # Permanently deletes a file ACL.
         def delete_file_acl bucket_name, file_name, entity, generation: nil,
                             user_project: nil, options: {}
+          if options[:retries].nil?
+            options = options.merge({ retries: 0 })
+          end
           execute do
             service.delete_object_access_control \
               bucket_name, file_name, entity,

--- a/google-cloud-storage/samples/acceptance/hmac_test.rb
+++ b/google-cloud-storage/samples/acceptance/hmac_test.rb
@@ -74,7 +74,8 @@ describe "HMAC Snippets" do
 
   it "create_hmac_key" do
     mock = Minitest::Mock.new
-    mock.expect :create_project_hmac_key, hmac_key_gapi, ["test", service_account_email], user_project: nil, options: {retries: 0}
+    mock.expect :create_project_hmac_key, hmac_key_gapi, ["test", service_account_email], user_project: nil,
+options: { retries: 0 }
     storage.service.mocked_service = mock
 
     Google::Cloud::Storage.stub :new, storage do

--- a/google-cloud-storage/samples/acceptance/hmac_test.rb
+++ b/google-cloud-storage/samples/acceptance/hmac_test.rb
@@ -74,7 +74,7 @@ describe "HMAC Snippets" do
 
   it "create_hmac_key" do
     mock = Minitest::Mock.new
-    mock.expect :create_project_hmac_key, hmac_key_gapi, ["test", service_account_email], user_project: nil, options: {}
+    mock.expect :create_project_hmac_key, hmac_key_gapi, ["test", service_account_email], user_project: nil, options: {retries: 0}
     storage.service.mocked_service = mock
 
     Google::Cloud::Storage.stub :new, storage do

--- a/google-cloud-storage/test/google/cloud/storage/bucket_acl_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_acl_test.rb
@@ -77,7 +77,7 @@ describe Google::Cloud::Storage::Bucket, :acl, :mock_storage do
       [bucket_name], user_project: nil, options: {}
     mock.expect :insert_bucket_access_control,
       Google::Apis::StorageV1::BucketAccessControl.from_json(writer_acl.to_json),
-      [bucket_name, Google::Apis::StorageV1::BucketAccessControl.new(entity: entity, role: "WRITER")], user_project: nil, options: {}
+      [bucket_name, Google::Apis::StorageV1::BucketAccessControl.new(entity: entity, role: "WRITER")], user_project: nil, options: {retries: 0}
 
     storage.service.mocked_service = mock
 
@@ -113,7 +113,7 @@ describe Google::Cloud::Storage::Bucket, :acl, :mock_storage do
     mock.expect :get_bucket, bucket_gapi, [bucket_name], **get_bucket_args(user_project: "test")
     mock.expect :insert_bucket_access_control,
       Google::Apis::StorageV1::BucketAccessControl.from_json(acl_hash.to_json),
-      [bucket_name, Google::Apis::StorageV1::BucketAccessControl.new(entity: entity, role: "READER")], user_project: "test", options: {}
+      [bucket_name, Google::Apis::StorageV1::BucketAccessControl.new(entity: entity, role: "READER")], user_project: "test", options: {retries: 0}
 
     storage.service.mocked_service = mock
 
@@ -144,7 +144,7 @@ describe Google::Cloud::Storage::Bucket, :acl, :mock_storage do
       [bucket_name], user_project: "test", options: {}
     mock.expect :insert_bucket_access_control,
       Google::Apis::StorageV1::BucketAccessControl.from_json(acl_hash.to_json),
-      [bucket_name, Google::Apis::StorageV1::BucketAccessControl.new(entity: entity, role: "WRITER")], user_project: "test", options: {}
+      [bucket_name, Google::Apis::StorageV1::BucketAccessControl.new(entity: entity, role: "WRITER")], user_project: "test", options: {retries: 0}
 
     storage.service.mocked_service = mock
 
@@ -180,7 +180,7 @@ describe Google::Cloud::Storage::Bucket, :acl, :mock_storage do
     mock.expect :get_bucket, bucket_gapi, [bucket_name], **get_bucket_args(user_project: "test")
     mock.expect :insert_bucket_access_control,
       Google::Apis::StorageV1::BucketAccessControl.from_json(acl_hash.to_json),
-      [bucket_name, Google::Apis::StorageV1::BucketAccessControl.new(entity: entity, role: "OWNER")], user_project: "test", options: {}
+      [bucket_name, Google::Apis::StorageV1::BucketAccessControl.new(entity: entity, role: "OWNER")], user_project: "test", options: {retries: 0}
 
     storage.service.mocked_service = mock
 
@@ -200,7 +200,7 @@ describe Google::Cloud::Storage::Bucket, :acl, :mock_storage do
       Google::Apis::StorageV1::BucketAccessControls.from_json(random_bucket_acl_hash(bucket_name).to_json),
       [bucket_name], user_project: nil, options: {}
     mock.expect :delete_bucket_access_control, nil,
-      [bucket_name, existing_reader_entity], user_project: nil, options: {}
+      [bucket_name, existing_reader_entity], user_project: nil, options: {retries: 0}
 
     storage.service.mocked_service = mock
 
@@ -228,7 +228,7 @@ describe Google::Cloud::Storage::Bucket, :acl, :mock_storage do
       Google::Apis::StorageV1::BucketAccessControls.from_json(random_bucket_acl_hash(bucket_name).to_json),
       [bucket_name], user_project: "test", options: {}
     mock.expect :delete_bucket_access_control, nil,
-      [bucket_name, existing_reader_entity], user_project: "test", options: {}
+      [bucket_name, existing_reader_entity], user_project: "test", options: {retries: 0}
 
     storage.service.mocked_service = mock
 

--- a/google-cloud-storage/test/google/cloud/storage/bucket_default_acl_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_default_acl_test.rb
@@ -75,7 +75,7 @@ describe Google::Cloud::Storage::Bucket, :default_acl, :mock_storage do
       [bucket_name], user_project: nil, options: {}
     mock.expect :insert_default_object_access_control,
       Google::Apis::StorageV1::BucketAccessControl.from_json(reader_acl.to_json),
-      [bucket_name, Google::Apis::StorageV1::BucketAccessControl.new(entity: reader_entity, role: "READER")], user_project: nil, options: {}
+      [bucket_name, Google::Apis::StorageV1::BucketAccessControl.new(entity: reader_entity, role: "READER")], user_project: nil, options: {retries: 0}
 
     storage.service.mocked_service = mock
 
@@ -112,7 +112,7 @@ describe Google::Cloud::Storage::Bucket, :default_acl, :mock_storage do
       [bucket_name], user_project: "test", options: {}
     mock.expect :insert_default_object_access_control,
       Google::Apis::StorageV1::BucketAccessControl.from_json(reader_acl.to_json),
-      [bucket_name, Google::Apis::StorageV1::BucketAccessControl.new(entity: reader_entity, role: "READER")], user_project: "test", options: {}
+      [bucket_name, Google::Apis::StorageV1::BucketAccessControl.new(entity: reader_entity, role: "READER")], user_project: "test", options: {retries: 0}
 
     storage.service.mocked_service = mock
 
@@ -138,7 +138,7 @@ describe Google::Cloud::Storage::Bucket, :default_acl, :mock_storage do
       Google::Apis::StorageV1::ObjectAccessControls.from_json(random_default_acl_hash(bucket_name).to_json),
       [bucket_name], user_project: nil, options: {}
     mock.expect :delete_default_object_access_control, nil,
-      [bucket_name, existing_reader_entity], user_project: nil, options: {}
+      [bucket_name, existing_reader_entity], user_project: nil, options: {retries: 0}
 
     storage.service.mocked_service = mock
 
@@ -164,7 +164,7 @@ describe Google::Cloud::Storage::Bucket, :default_acl, :mock_storage do
       Google::Apis::StorageV1::ObjectAccessControls.from_json(random_default_acl_hash(bucket_name).to_json),
       [bucket_name], user_project: "test", options: {}
     mock.expect :delete_default_object_access_control, nil,
-      [bucket_name, existing_reader_entity], user_project: "test", options: {}
+      [bucket_name, existing_reader_entity], user_project: "test", options: {retries: 0}
 
     storage.service.mocked_service = mock
 

--- a/google-cloud-storage/test/google/cloud/storage/bucket_notification_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_notification_test.rb
@@ -33,7 +33,7 @@ describe Google::Cloud::Storage::Bucket, :notification, :mock_storage do
   it "creates a notification" do
     mock = Minitest::Mock.new
     mock.expect :insert_notification, random_notification_gapi(id: notification_id, topic: topic_name_full_path),
-                [bucket.name, random_notification_gapi(id: nil, topic: topic_name_full_path)], user_project: nil, options: {}
+                [bucket.name, random_notification_gapi(id: nil, topic: topic_name_full_path)], user_project: nil, options: {retries: 0}
 
     bucket.service.mocked_service = mock
 
@@ -57,7 +57,7 @@ describe Google::Cloud::Storage::Bucket, :notification, :mock_storage do
   it "creates a notification with a boolean payload" do
     mock = Minitest::Mock.new
     mock.expect :insert_notification, random_notification_gapi(id: notification_id, payload: "JSON_API_V1"),
-                [bucket.name, random_notification_gapi(id: nil, payload: "JSON_API_V1")], user_project: nil, options: {}
+                [bucket.name, random_notification_gapi(id: nil, payload: "JSON_API_V1")], user_project: nil, options: {retries: 0}
 
     bucket.service.mocked_service = mock
 
@@ -74,7 +74,7 @@ describe Google::Cloud::Storage::Bucket, :notification, :mock_storage do
   it "creates a notification with a array of symbols event type" do
     mock = Minitest::Mock.new
     mock.expect :insert_notification, random_notification_gapi(id: notification_id),
-                [bucket.name, random_notification_gapi(id: nil)], user_project: nil, options: {}
+                [bucket.name, random_notification_gapi(id: nil)], user_project: nil, options: {retries: 0}
 
     bucket.service.mocked_service = mock
 
@@ -91,7 +91,7 @@ describe Google::Cloud::Storage::Bucket, :notification, :mock_storage do
   it "creates a notification with a single symbol event type" do
     mock = Minitest::Mock.new
     mock.expect :insert_notification, random_notification_gapi(id: notification_id),
-                [bucket.name, random_notification_gapi(id: nil)], user_project: nil, options: {}
+                [bucket.name, random_notification_gapi(id: nil)], user_project: nil, options: {retries: 0}
 
     bucket.service.mocked_service = mock
 
@@ -108,7 +108,7 @@ describe Google::Cloud::Storage::Bucket, :notification, :mock_storage do
   it "creates a notification with new_notification alias" do
     mock = Minitest::Mock.new
     mock.expect :insert_notification, minimal_notification_gapi,
-                [bucket.name, minimal_notification_gapi], user_project: nil, options: {}
+                [bucket.name, minimal_notification_gapi], user_project: nil, options: {retries: 0}
 
     bucket.service.mocked_service = mock
 
@@ -120,7 +120,7 @@ describe Google::Cloud::Storage::Bucket, :notification, :mock_storage do
   it "creates a notification with user_project set to true" do
     mock = Minitest::Mock.new
     mock.expect :insert_notification, minimal_notification_gapi,
-                [bucket_user_project.name, minimal_notification_gapi], user_project: "test", options: {}
+                [bucket_user_project.name, minimal_notification_gapi], user_project: "test", options: {retries: 0}
 
     bucket_user_project.service.mocked_service = mock
 

--- a/google-cloud-storage/test/google/cloud/storage/file_acl_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_acl_test.rb
@@ -81,7 +81,7 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
       [bucket_name, file_name], user_project: nil, options: {}
     mock.expect :insert_object_access_control,
       Google::Apis::StorageV1::BucketAccessControl.from_json(reader_acl.to_json),
-      [bucket_name, file_name, Google::Apis::StorageV1::BucketAccessControl.new(entity: reader_entity, role: "READER")], generation: nil, user_project: nil, options: {}
+      [bucket_name, file_name, Google::Apis::StorageV1::BucketAccessControl.new(entity: reader_entity, role: "READER")], generation: nil, user_project: nil, options: {retries: 0}
 
     storage.service.mocked_service = mock
 
@@ -119,7 +119,7 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
       [bucket_name, file_name], user_project: nil, options: {}
     mock.expect :insert_object_access_control,
       Google::Apis::StorageV1::BucketAccessControl.from_json(reader_acl.to_json),
-      [bucket_name, file_name, Google::Apis::StorageV1::BucketAccessControl.new(entity: reader_entity, role: "READER")], generation: generation, user_project: nil, options: {}
+      [bucket_name, file_name, Google::Apis::StorageV1::BucketAccessControl.new(entity: reader_entity, role: "READER")], generation: generation, user_project: nil, options: {retries: 0}
 
     storage.service.mocked_service = mock
 
@@ -156,7 +156,7 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
       [bucket_name, file_name], user_project: "test", options: {}
     mock.expect :insert_object_access_control,
       Google::Apis::StorageV1::BucketAccessControl.from_json(reader_acl.to_json),
-      [bucket_name, file_name, Google::Apis::StorageV1::BucketAccessControl.new(entity: reader_entity, role: "READER")], generation: nil, user_project: "test", options: {}
+      [bucket_name, file_name, Google::Apis::StorageV1::BucketAccessControl.new(entity: reader_entity, role: "READER")], generation: nil, user_project: "test", options: {retries: 0}
 
     storage.service.mocked_service = mock
 
@@ -182,7 +182,7 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
       Google::Apis::StorageV1::ObjectAccessControls.from_json(random_file_acl_hash(bucket_name, file_name).to_json),
       [bucket_name, file_name], user_project: nil, options: {}
     mock.expect :delete_object_access_control, nil,
-      [bucket_name, file_name, existing_reader_entity], generation: nil, user_project: nil, options: {}
+      [bucket_name, file_name, existing_reader_entity], generation: nil, user_project: nil, options: {retries: 0}
 
     storage.service.mocked_service = mock
 
@@ -209,7 +209,7 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
       Google::Apis::StorageV1::ObjectAccessControls.from_json(random_file_acl_hash(bucket_name, file_name).to_json),
       [bucket_name, file_name], user_project: nil, options: {}
     mock.expect :delete_object_access_control, nil,
-      [bucket_name, file_name, existing_reader_entity], generation: generation, user_project: nil, options: {}
+      [bucket_name, file_name, existing_reader_entity], generation: generation, user_project: nil, options: {retries: 0}
 
     storage.service.mocked_service = mock
 
@@ -235,7 +235,7 @@ describe Google::Cloud::Storage::File, :acl, :mock_storage do
       Google::Apis::StorageV1::ObjectAccessControls.from_json(random_file_acl_hash(bucket_name, file_name).to_json),
       [bucket_name, file_name], user_project: "test", options: {}
     mock.expect :delete_object_access_control, nil,
-      [bucket_name, file_name, existing_reader_entity], generation: nil, user_project: "test", options: {}
+      [bucket_name, file_name, existing_reader_entity], generation: nil, user_project: "test", options: {retries: 0}
 
     storage.service.mocked_service = mock
 

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_acl_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_acl_test.rb
@@ -71,7 +71,7 @@ describe Google::Cloud::Storage::Bucket, :acl, :lazy, :mock_storage do
       [bucket_name], user_project: nil, options: {}
     mock.expect :insert_bucket_access_control,
       Google::Apis::StorageV1::BucketAccessControl.from_json(writer_acl.to_json),
-      [bucket_name, Google::Apis::StorageV1::BucketAccessControl.new(entity: writer_entity, role: "WRITER")], user_project: nil, options: {}
+      [bucket_name, Google::Apis::StorageV1::BucketAccessControl.new(entity: writer_entity, role: "WRITER")], user_project: nil, options: {retries: 0}
 
     storage.service.mocked_service = mock
 
@@ -109,7 +109,7 @@ describe Google::Cloud::Storage::Bucket, :acl, :lazy, :mock_storage do
       [bucket_name], user_project: "test", options: {}
     mock.expect :insert_bucket_access_control,
       Google::Apis::StorageV1::BucketAccessControl.from_json(writer_acl.to_json),
-      [bucket_name, Google::Apis::StorageV1::BucketAccessControl.new(entity: writer_entity, role: "WRITER")], user_project: "test", options: {}
+      [bucket_name, Google::Apis::StorageV1::BucketAccessControl.new(entity: writer_entity, role: "WRITER")], user_project: "test", options: {retries: 0}
 
     storage.service.mocked_service = mock
 
@@ -136,7 +136,7 @@ describe Google::Cloud::Storage::Bucket, :acl, :lazy, :mock_storage do
       Google::Apis::StorageV1::BucketAccessControls.from_json(random_bucket_acl_hash(bucket_name).to_json),
       [bucket_name], user_project: nil, options: {}
     mock.expect :delete_bucket_access_control, nil,
-      [bucket_name, existing_reader_entity], user_project: nil, options: {}
+      [bucket_name, existing_reader_entity], user_project: nil, options: {retries: 0}
 
     storage.service.mocked_service = mock
 
@@ -163,7 +163,7 @@ describe Google::Cloud::Storage::Bucket, :acl, :lazy, :mock_storage do
       Google::Apis::StorageV1::BucketAccessControls.from_json(random_bucket_acl_hash(bucket_name).to_json),
       [bucket_name], user_project: "test", options: {}
     mock.expect :delete_bucket_access_control, nil,
-      [bucket_name, existing_reader_entity], user_project: "test", options: {}
+      [bucket_name, existing_reader_entity], user_project: "test", options: {retries: 0}
 
     storage.service.mocked_service = mock
 

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_default_acl_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_default_acl_test.rb
@@ -69,7 +69,7 @@ describe Google::Cloud::Storage::Bucket, :default_acl, :lazy, :mock_storage do
       [bucket_name], user_project: nil, options: {}
     mock.expect :insert_default_object_access_control,
       Google::Apis::StorageV1::BucketAccessControl.from_json(reader_acl.to_json),
-      [bucket_name, Google::Apis::StorageV1::BucketAccessControl.new(entity: reader_entity, role: "READER")], user_project: nil, options: {}
+      [bucket_name, Google::Apis::StorageV1::BucketAccessControl.new(entity: reader_entity, role: "READER")], user_project: nil, options: {retries: 0}
 
     storage.service.mocked_service = mock
 
@@ -105,7 +105,7 @@ describe Google::Cloud::Storage::Bucket, :default_acl, :lazy, :mock_storage do
       [bucket_name], user_project: "test", options: {}
     mock.expect :insert_default_object_access_control,
       Google::Apis::StorageV1::BucketAccessControl.from_json(reader_acl.to_json),
-      [bucket_name, Google::Apis::StorageV1::BucketAccessControl.new(entity: reader_entity, role: "READER")], user_project: "test", options: {}
+      [bucket_name, Google::Apis::StorageV1::BucketAccessControl.new(entity: reader_entity, role: "READER")], user_project: "test", options: {retries: 0}
 
     storage.service.mocked_service = mock
 
@@ -130,7 +130,7 @@ describe Google::Cloud::Storage::Bucket, :default_acl, :lazy, :mock_storage do
       Google::Apis::StorageV1::ObjectAccessControls.from_json(random_default_acl_hash(bucket_name).to_json),
       [bucket_name], user_project: nil, options: {}
     mock.expect :delete_default_object_access_control, nil,
-      [bucket_name, existing_reader_entity], user_project: nil, options: {}
+      [bucket_name, existing_reader_entity], user_project: nil, options: {retries: 0}
 
     storage.service.mocked_service = mock
 
@@ -155,7 +155,7 @@ describe Google::Cloud::Storage::Bucket, :default_acl, :lazy, :mock_storage do
       Google::Apis::StorageV1::ObjectAccessControls.from_json(random_default_acl_hash(bucket_name).to_json),
       [bucket_name], user_project: "test", options: {}
     mock.expect :delete_default_object_access_control, nil,
-      [bucket_name, existing_reader_entity], user_project: "test", options: {}
+      [bucket_name, existing_reader_entity], user_project: "test", options: {retries: 0}
 
     storage.service.mocked_service = mock
 

--- a/google-cloud-storage/test/google/cloud/storage/lazy/file_acl_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/file_acl_test.rb
@@ -77,7 +77,7 @@ describe Google::Cloud::Storage::File, :acl, :lazy, :mock_storage do
       [bucket_name, file_name], user_project: nil, options: {}
     mock.expect :insert_object_access_control,
       Google::Apis::StorageV1::BucketAccessControl.from_json(reader_acl.to_json),
-      [bucket_name, file_name, Google::Apis::StorageV1::BucketAccessControl.new(entity: reader_entity, role: "READER")], generation: nil, user_project: nil, options: {}
+      [bucket_name, file_name, Google::Apis::StorageV1::BucketAccessControl.new(entity: reader_entity, role: "READER")], generation: nil, user_project: nil, options: {retries: 0}
 
     storage.service.mocked_service = mock
 
@@ -115,7 +115,7 @@ describe Google::Cloud::Storage::File, :acl, :lazy, :mock_storage do
       [bucket_name, file_name], user_project: nil, options: {}
     mock.expect :insert_object_access_control,
       Google::Apis::StorageV1::BucketAccessControl.from_json(reader_acl.to_json),
-      [bucket_name, file_name, Google::Apis::StorageV1::BucketAccessControl.new(entity: reader_entity, role: "READER")], generation: generation, user_project: nil, options: {}
+      [bucket_name, file_name, Google::Apis::StorageV1::BucketAccessControl.new(entity: reader_entity, role: "READER")], generation: generation, user_project: nil, options: {retries: 0}
 
     storage.service.mocked_service = mock
 
@@ -152,7 +152,7 @@ describe Google::Cloud::Storage::File, :acl, :lazy, :mock_storage do
       [bucket_name, file_name], user_project: "test", options: {}
     mock.expect :insert_object_access_control,
       Google::Apis::StorageV1::BucketAccessControl.from_json(reader_acl.to_json),
-      [bucket_name, file_name, Google::Apis::StorageV1::BucketAccessControl.new(entity: reader_entity, role: "READER")], generation: nil, user_project: "test", options: {}
+      [bucket_name, file_name, Google::Apis::StorageV1::BucketAccessControl.new(entity: reader_entity, role: "READER")], generation: nil, user_project: "test", options: {retries: 0}
 
     storage.service.mocked_service = mock
 
@@ -178,7 +178,7 @@ describe Google::Cloud::Storage::File, :acl, :lazy, :mock_storage do
       Google::Apis::StorageV1::ObjectAccessControls.from_json(random_file_acl_hash(bucket_name, file_name).to_json),
       [bucket_name, file_name], user_project: nil, options: {}
     mock.expect :delete_object_access_control, nil,
-      [bucket_name, file_name, existing_reader_entity], generation: nil, user_project: nil, options: {}
+      [bucket_name, file_name, existing_reader_entity], generation: nil, user_project: nil, options: {retries: 0}
 
     storage.service.mocked_service = mock
 
@@ -205,7 +205,7 @@ describe Google::Cloud::Storage::File, :acl, :lazy, :mock_storage do
       Google::Apis::StorageV1::ObjectAccessControls.from_json(random_file_acl_hash(bucket_name, file_name).to_json),
       [bucket_name, file_name], user_project: nil, options: {}
     mock.expect :delete_object_access_control, nil,
-      [bucket_name, file_name, existing_reader_entity], generation: generation, user_project: nil, options: {}
+      [bucket_name, file_name, existing_reader_entity], generation: generation, user_project: nil, options: {retries: 0}
 
     storage.service.mocked_service = mock
 
@@ -231,7 +231,7 @@ describe Google::Cloud::Storage::File, :acl, :lazy, :mock_storage do
       Google::Apis::StorageV1::ObjectAccessControls.from_json(random_file_acl_hash(bucket_name, file_name).to_json),
       [bucket_name, file_name], user_project: "test", options: {}
     mock.expect :delete_object_access_control, nil,
-      [bucket_name, file_name, existing_reader_entity], generation: nil, user_project: "test", options: {}
+      [bucket_name, file_name, existing_reader_entity], generation: nil, user_project: "test", options: {retries: 0}
 
     storage.service.mocked_service = mock
 

--- a/google-cloud-storage/test/google/cloud/storage/project_hmac_keys_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/project_hmac_keys_test.rb
@@ -39,7 +39,7 @@ describe Google::Cloud::Storage::Project, :hmac_keys, :mock_storage do
 
   it "creates an HMAC key" do
     mock = Minitest::Mock.new
-    mock.expect :create_project_hmac_key, hmac_key_gapi, ["test", service_account_email], user_project: nil, options: {}
+    mock.expect :create_project_hmac_key, hmac_key_gapi, ["test", service_account_email], user_project: nil, options: {retries: 0}
     storage.service.mocked_service = mock
 
     hmac_key = storage.create_hmac_key service_account_email
@@ -53,7 +53,7 @@ describe Google::Cloud::Storage::Project, :hmac_keys, :mock_storage do
   it "creates an HMAC key with project_id set to another project ID" do
     mock = Minitest::Mock.new
     hmac_key_gapi.metadata.project_id = other_project_id
-    mock.expect :create_project_hmac_key, hmac_key_gapi, [other_project_id, service_account_email], user_project: nil, options: {}
+    mock.expect :create_project_hmac_key, hmac_key_gapi, [other_project_id, service_account_email], user_project: nil, options: {retries: 0}
     storage.service.mocked_service = mock
 
     hmac_key = storage.create_hmac_key service_account_email, project_id: other_project_id
@@ -66,7 +66,7 @@ describe Google::Cloud::Storage::Project, :hmac_keys, :mock_storage do
 
   it "creates an HMAC key with user_project set to another project ID" do
     mock = Minitest::Mock.new
-    mock.expect :create_project_hmac_key, hmac_key_gapi, ["test", service_account_email], user_project: other_project_id, options: {}
+    mock.expect :create_project_hmac_key, hmac_key_gapi, ["test", service_account_email], user_project: other_project_id, options: {retries: 0}
     storage.service.mocked_service = mock
 
     hmac_key = storage.create_hmac_key service_account_email, user_project: other_project_id


### PR DESCRIPTION
Fixes: http://b/232351537 (internal)

This PR implements support for non-idempotent retry operations for Storage. It sets the default value of retries to 0, but gives the user option to override it.

Implements the retry option for the following operations:

- `storage.hmacKey.create`
- `storage.notifications.insert`
- `storage.bucket_acl.insert`
- `storage.bucket_acl.delete`
- `storage.default_object_acl.delete`
- `storage.default_object_acl.insert`
- `storage.object_acl.delete`
- `storage.object_acl.insert`