### PR TITLE
chore(storage): Implement exponential backoff to retry failed acceptance tests

### DIFF
--- a/google-cloud-storage/acceptance/storage/bucket_acl_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_acl_test.rb
@@ -22,6 +22,10 @@ describe Google::Cloud::Storage::Bucket, :acl, :storage do
   end
   let(:user_val) { "user-test@example.com" }
 
+  before(:each) do
+    sleep 1
+  end
+
   before do
     # always reset the bucket permissions
     bucket.acl.private!

--- a/google-cloud-storage/acceptance/storage/bucket_default_acl_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_default_acl_test.rb
@@ -22,6 +22,10 @@ describe Google::Cloud::Storage::Bucket, :default_acl, :storage do
   end
   let(:user_val) { "user-test@example.com" }
 
+  before(:each) do
+    sleep 1
+  end
+
   before do
     # always reset the bucket permissions
     bucket.default_acl.private!

--- a/google-cloud-storage/acceptance/storage/bucket_uniform_bucket_level_access_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_uniform_bucket_level_access_test.rb
@@ -29,6 +29,10 @@ describe Google::Cloud::Storage::Bucket, :uniform_bucket_level_access, :storage 
 
   let(:user_val) { "user-test@example.com" }
 
+  before(:each) do
+    sleep 1
+  end
+
   after do
     # always reset the uniform_bucket_level_access and public_access_prevention
     # always reset the bucket permissions

--- a/google-cloud-storage/acceptance/storage/buckets_test.rb
+++ b/google-cloud-storage/acceptance/storage/buckets_test.rb
@@ -22,7 +22,11 @@ describe "Storage", :buckets, :storage do
     end
   end
   let(:bucket_names) { $bucket_names }
-
+  
+  before(:each) do
+    sleep 1
+  end
+  
   before do
     buckets # always create the buckets
   end

--- a/google-cloud-storage/acceptance/storage/file_acl_test.rb
+++ b/google-cloud-storage/acceptance/storage/file_acl_test.rb
@@ -29,6 +29,10 @@ describe Google::Cloud::Storage::File, :acl, :storage do
 
   let(:user_val) { "user-test@example.com" }
 
+  before(:each) do
+    sleep 1
+  end
+
   before do
     # always create the bucket and set default acl to auth
     bucket.default_acl.auth!

--- a/google-cloud-storage/acceptance/storage_helper.rb
+++ b/google-cloud-storage/acceptance/storage_helper.rb
@@ -114,8 +114,7 @@ def safe_gcs_execute retries: 8
       raise unless current_retries >= retries
       
       current_retries += 1
-      max_sleep_seconds = Float(2 ** current_retries)
-      sleep rand(0..max_sleep_seconds)
+      sleep 2 ** current_retries
     end
   end
 end

--- a/google-cloud-storage/acceptance/storage_helper.rb
+++ b/google-cloud-storage/acceptance/storage_helper.rb
@@ -105,16 +105,17 @@ module Acceptance
   end
 end
 
-def safe_gcs_execute retries: 20, delay: 2
+def safe_gcs_execute retries: 7
   current_retries = 0
   loop do
     begin
       return yield
     rescue Google::Cloud::ResourceExhaustedError
       raise unless current_retries >= retries
-
-      sleep delay
+      
       current_retries += 1
+      max_sleep_seconds = Float(2 ** current_retries)
+      sleep rand(0..max_sleep_seconds)
     end
   end
 end

--- a/google-cloud-storage/acceptance/storage_helper.rb
+++ b/google-cloud-storage/acceptance/storage_helper.rb
@@ -110,9 +110,9 @@ def safe_gcs_execute retries: 10
   max_retries = 10
   Retriable.retriable(
     on: Google::Cloud::ResourceExhaustedError,
-    multiplier: 2,
+    multiplier: 3,
     tries: [retries, max_retries].min,
-    max_interval: 30
+    max_interval: 40
   ) do
     return yield
   end

--- a/google-cloud-storage/acceptance/storage_helper.rb
+++ b/google-cloud-storage/acceptance/storage_helper.rb
@@ -107,11 +107,11 @@ module Acceptance
 end
 
 def safe_gcs_execute retries: 10
-  MAX_RETRIES = 10
+  max_retries = 10
   Retriable.retriable(
     on: Google::Cloud::ResourceExhaustedError,
     multiplier: 2,
-    tries: [retries, MAX_RETRIES].min,
+    tries: [retries, max_retries].min,
     max_interval: 30
   ) do
     return yield

--- a/google-cloud-storage/acceptance/storage_helper.rb
+++ b/google-cloud-storage/acceptance/storage_helper.rb
@@ -105,7 +105,7 @@ module Acceptance
   end
 end
 
-def safe_gcs_execute retries: 7
+def safe_gcs_execute retries: 8
   current_retries = 0
   loop do
     begin

--- a/google-cloud-storage/acceptance/storage_helper.rb
+++ b/google-cloud-storage/acceptance/storage_helper.rb
@@ -114,9 +114,20 @@ def safe_gcs_execute retries: 8
       raise unless current_retries >= retries
       
       current_retries += 1
-      sleep 2 ** current_retries
+      sleep get_retry_delay(current_retries)
+      # random_adder = rand(0.0..3.0)
+      # sleep (2 ** current_retries) + random_adder
+      # max_sleep_seconds = Float(2 ** current_retries)
+      # sleep rand(0..max_sleep_seconds)
     end
   end
+end
+
+def get_retry_delay current_retries, delay_multiplier: 3
+  random_adder = rand(0.0..3.0)
+  wait_time = (delay_multiplier ** current_retries) + 1 + random_adder
+  max_allowed_delay = 75.0
+  [wait_time, max_allowed_delay].min
 end
 
 # Create buckets to be shared with all the tests

--- a/google-cloud-storage/google-cloud-storage.gemspec
+++ b/google-cloud-storage/google-cloud-storage.gemspec
@@ -36,4 +36,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9"
   gem.add_development_dependency "yard-doctest", "~> 0.1.13"
+  gem.add_development_dependency "retriable", "~> 3.1.2"
 end


### PR DESCRIPTION
An attempt to fix the rate limit errors that are causing failures in Storage's acceptance tests. Implements exponential backoff.

Inspired by: https://nathanmlong.com/2015/02/exponential-backoff-in-ruby/