### PR TITLE
docs(live_stream): Add Live Stream samples and tests

### DIFF
--- a/google-cloud-video-live_stream/samples/acceptance/create_channel_event_test.rb
+++ b/google-cloud-video-live_stream/samples/acceptance/create_channel_event_test.rb
@@ -1,0 +1,33 @@
+# Copyright 2022 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "helper"
+
+describe "#create_channel_event", :live_stream_snippet do
+  it "creates a channel event" do
+    sample = SampleLoader.load "create_channel_event.rb"
+
+    refute_nil input
+    refute_nil started_channel
+    @input_created = true
+    @channel_created_started = true
+
+    out, _err = capture_io do
+      sample.run project_id: project_id, location: location_id, channel_id: channel_id, event_id: event_id
+    end
+    @event_created = true
+    event_id_regex = Regexp.escape event_id
+    assert_match %r{Channel event: projects/\S+/locations/#{location_id}/channels/#{channel_id}/events/#{event_id_regex}}, out
+  end
+end

--- a/google-cloud-video-live_stream/samples/acceptance/create_channel_with_backup_input_test.rb
+++ b/google-cloud-video-live_stream/samples/acceptance/create_channel_with_backup_input_test.rb
@@ -1,0 +1,33 @@
+# Copyright 2022 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "helper"
+
+describe "#create_channel_with_backup_input", :live_stream_snippet do
+  it "creates a channel with a backup input" do
+    sample = SampleLoader.load "create_channel_with_backup_input.rb"
+
+    refute_nil input
+    refute_nil update_input
+    @input_created = true
+    @update_input_created = true
+
+    out, _err = capture_io do
+      sample.run project_id: project_id, location: location_id, channel_id: channel_id, primary_input_id: input_id, backup_input_id: update_input_id, output_uri: output_uri
+    end
+    @channel_created_stopped = true
+    channel_id_regex = Regexp.escape channel_id
+    assert_match %r{Channel: projects/\S+/locations/#{location_id}/channels/#{channel_id_regex}}, out
+  end
+end

--- a/google-cloud-video-live_stream/samples/acceptance/delete_channel_event_test.rb
+++ b/google-cloud-video-live_stream/samples/acceptance/delete_channel_event_test.rb
@@ -1,0 +1,36 @@
+# Copyright 2022 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "helper"
+
+describe "#delete_channel_event", :live_stream_snippet do
+  it "deletes a channel event" do
+    sample = SampleLoader.load "delete_channel_event.rb"
+
+    refute_nil input
+    refute_nil started_channel_with_event
+    @input_created = true
+    @channel_created_started = true
+
+    client.get_event name: event_name
+
+    assert_output(/Deleted channel event/) do
+      sample.run project_id: project_id, location: location_id, channel_id: channel_id, event_id: event_id
+    end
+
+    assert_raises Google::Cloud::NotFoundError do
+      client.get_event name: event_name
+    end
+  end
+end

--- a/google-cloud-video-live_stream/samples/acceptance/event_definition.rb
+++ b/google-cloud-video-live_stream/samples/acceptance/event_definition.rb
@@ -1,0 +1,12 @@
+require "google/cloud/video/live_stream"
+
+def event_def
+  {
+    ad_break: {
+      duration: {
+        seconds: 100
+      }
+    },
+    execute_now: true
+  }
+end

--- a/google-cloud-video-live_stream/samples/acceptance/get_channel_event_test.rb
+++ b/google-cloud-video-live_stream/samples/acceptance/get_channel_event_test.rb
@@ -1,0 +1,31 @@
+# Copyright 2022 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "helper"
+
+describe "#get_channel_event", :live_stream_snippet do
+  it "gets a channel event" do
+    sample = SampleLoader.load "get_channel_event.rb"
+
+    refute_nil input
+    refute_nil started_channel_with_event
+    @input_created = true
+    @channel_created_started = true
+    @event_created = true
+
+    assert_output(/Channel event: #{event_name}/) do
+      sample.run project_id: project_id, location: location_id, channel_id: channel_id, event_id: event_id
+    end
+  end
+end

--- a/google-cloud-video-live_stream/samples/acceptance/helper.rb
+++ b/google-cloud-video-live_stream/samples/acceptance/helper.rb
@@ -21,6 +21,7 @@ require "google/cloud/video/live_stream"
 require_relative "../../../.toys/.lib/sample_loader"
 require_relative "channel_definition"
 require_relative "input_definition"
+require_relative "event_definition"
 
 DELETION_THRESHOLD_TIME_HOURS_IN_MILLISECONDS = 10_800_000
 
@@ -43,16 +44,21 @@ class LiveStreamSnippetSpec < Minitest::Spec
   let(:channel_name) { "projects/#{project_id}/locations/#{location_id}/channels/#{channel_id}" }
   let(:output_uri) { "gs://my-bucket/my-output-folder/" }
 
+  let(:event_id) { "my-event" }
+  let(:event_name) { "#{channel_name}/events/#{event_id}" }
+
   attr_writer :channel_created_started
   attr_writer :channel_created_stopped
   attr_writer :input_created
   attr_writer :update_input_created
+  attr_writer :event_created
 
   before do
     @channel_created_started = false
     @channel_created_stopped = false
     @input_created = false
     @update_input_created = false
+    @event_created = false
     # Remove old channels and inputs in the test project if they exist
     response = client.list_channels parent: location_path
     response.each do |channel|
@@ -60,6 +66,12 @@ class LiveStreamSnippetSpec < Minitest::Spec
       create_time = tmp.last.to_i
       now = (Time.now.to_f * 1000).to_i # Milliseconds, preserves float value for precision
       next if create_time >= (now - DELETION_THRESHOLD_TIME_HOURS_IN_MILLISECONDS)
+      begin
+        event_name = "#{channel.name}/events/#{event_id}"
+        client.delete_event name: event_name
+      rescue Google::Cloud::NotFoundError, Google::Cloud::FailedPreconditionError => e
+        puts "Rescued: #{e.inspect}"
+      end
       begin
         operation = client.stop_channel name: channel.name.to_s
         operation.wait_until_done!
@@ -125,8 +137,24 @@ class LiveStreamSnippetSpec < Minitest::Spec
     operation.response
   end
 
+  let :started_channel_with_event do
+    input_path = client.input_path project: project_id, location: location_id, input: input_id
+    operation = client.create_channel parent: location_path, channel: channel_def(input_path, output_uri), channel_id: channel_id
+    operation.wait_until_done!
+    start = client.start_channel name: channel_name
+    start.wait_until_done!
+    client.create_event parent: channel_name, event: event_def, event_id: event_id
+    operation.response
+  end
 
   after do
+    if @event_created
+      begin
+        client.delete_event name: event_name
+      rescue Google::Cloud::NotFoundError, Google::Cloud::FailedPreconditionError => e
+        puts "Rescued: #{e.inspect}"
+      end
+    end
     if @channel_created_started
       begin
         operation = client.stop_channel name: channel_name

--- a/google-cloud-video-live_stream/samples/acceptance/list_channel_events_test.rb
+++ b/google-cloud-video-live_stream/samples/acceptance/list_channel_events_test.rb
@@ -1,0 +1,31 @@
+# Copyright 2022 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "helper"
+
+describe "#list_channel_events", :live_stream_snippet do
+  it "lists the channel events" do
+    sample = SampleLoader.load "list_channel_events.rb"
+
+    refute_nil input
+    refute_nil started_channel_with_event
+    @input_created = true
+    @channel_created_started = true
+    @event_created = true
+
+    assert_output(/Channel events:\n#{event_name}/) do
+      sample.run project_id: project_id, location: location_id, channel_id: channel_id
+    end
+  end
+end

--- a/google-cloud-video-live_stream/samples/create_channel_event.rb
+++ b/google-cloud-video-live_stream/samples/create_channel_event.rb
@@ -1,0 +1,48 @@
+# Copyright 2022 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START livestream_create_channel_event]
+require "google/cloud/video/live_stream"
+
+##
+# Create a channel event
+#
+# @param project_id [String] Your Google Cloud project (e.g. "my-project")
+# @param location [String] The location (e.g. "us-central1")
+# @param channel_id [String] Your channel name (e.g. "my-channel")
+# @param event_id [String] Your event name (e.g. "my-event")
+#
+def create_channel_event project_id:, location:, channel_id:, event_id:
+  # Create a Live Stream client.
+  client = Google::Cloud::Video::LiveStream.livestream_service
+
+  # Build the resource name of the parent.
+  parent = client.channel_path project: project_id, location: location, channel: channel_id
+
+  # Set the event fields.
+  new_event = {
+    ad_break: {
+      duration: {
+        seconds: 100
+      }
+    },
+    execute_now: true
+  }
+
+  response = client.create_event parent: parent, event: new_event, event_id: event_id
+
+  # Print the channel event name.
+  puts "Channel event: #{response.name}"
+end
+# [END livestream_create_channel_event]

--- a/google-cloud-video-live_stream/samples/create_channel_with_backup_input.rb
+++ b/google-cloud-video-live_stream/samples/create_channel_with_backup_input.rb
@@ -1,0 +1,125 @@
+# Copyright 2022 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START livestream_create_channel_with_backup_input]
+require "google/cloud/video/live_stream"
+
+##
+# Create a channel with a failover backup input
+#
+# @param project_id [String] Your Google Cloud project (e.g. "my-project")
+# @param location [String] The location (e.g. "us-central1")
+# @param channel_id [String] Your channel name (e.g. "my-channel")
+# @param primary_input_id [String] Your primary input name (e.g. "my-primary-input")
+# @param backup_input_id [String] Your backup input name (e.g. "my-backup-input")
+# @param output_uri [String] Uri of the channel output folder in a Cloud Storage
+#     bucket. (e.g. "gs://my-bucket/my-output-folder/";)
+#
+def create_channel_with_backup_input project_id:, location:, channel_id:, primary_input_id:, backup_input_id:, output_uri:
+  # Create a Live Stream client.
+  client = Google::Cloud::Video::LiveStream.livestream_service
+
+  # Build the resource name of the parent.
+  parent = client.location_path project: project_id, location: location
+  # Build the resource name of the inputs.
+  primary_input_path = client.input_path project: project_id, location: location, input: primary_input_id
+  backup_input_path = client.input_path project: project_id, location: location, input: backup_input_id
+
+  # Set the channel fields.
+  new_channel = {
+    input_attachments: [
+      {
+        key: "my-primary-input",
+        input: primary_input_path,
+        automatic_failover: {
+          input_keys: ["my-backup-input"]
+        }
+      },
+      {
+        key: "my-backup-input",
+        input: backup_input_path
+      }
+    ],
+    output: {
+      uri: output_uri
+    },
+    elementary_streams: [
+      {
+        key: "es_video",
+        video_stream: {
+          h264: {
+            profile: "high",
+            bitrate_bps: 3_000_000,
+            frame_rate: 30,
+            height_pixels: 720,
+            width_pixels: 1280
+          }
+        }
+      },
+      {
+        key: "es_audio",
+        audio_stream: {
+          codec: "aac",
+          channel_count: 2,
+          bitrate_bps: 160_000
+        }
+      }
+    ],
+    mux_streams: [
+      {
+        key: "mux_video",
+        elementary_streams: [
+          "es_video"
+        ],
+        segment_settings: {
+          segment_duration: {
+            seconds: 2
+          }
+        }
+      },
+      {
+        key: "mux_audio",
+        elementary_streams: [
+          "es_audio"
+        ],
+        segment_settings: {
+          segment_duration: {
+            seconds: 2
+          }
+        }
+      }
+    ],
+    manifests: [
+      {
+        file_name: "main.m3u8",
+        type: Google::Cloud::Video::LiveStream::V1::Manifest::ManifestType::HLS,
+        mux_streams: [
+          "mux_video", "mux_audio"
+        ],
+        max_segment_count: 5
+      }
+    ]
+  }
+
+  operation = client.create_channel parent: parent, channel: new_channel, channel_id: channel_id
+
+  # The returned object is of type Gapic::Operation. You can use this
+  # object to check the status of an operation, cancel it, or wait
+  # for results. Here is how to block until completion:
+  operation.wait_until_done!
+
+  # Print the channel name.
+  puts "Channel: #{operation.response.name}"
+end
+# [END livestream_create_channel_with_backup_input]

--- a/google-cloud-video-live_stream/samples/delete_channel_event.rb
+++ b/google-cloud-video-live_stream/samples/delete_channel_event.rb
@@ -1,0 +1,39 @@
+# Copyright 2022 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START livestream_delete_channel_event]
+require "google/cloud/video/live_stream"
+
+##
+# Delete a channel event
+#
+# @param project_id [String] Your Google Cloud project (e.g. "my-project")
+# @param location [String] The location (e.g. "us-central1")
+# @param channel_id [String] Your channel name (e.g. "my-channel")
+# @param event_id [String] Your event name (e.g. "my-event")
+#
+def delete_channel_event project_id:, location:, channel_id:, event_id:
+  # Create a Live Stream client.
+  client = Google::Cloud::Video::LiveStream.livestream_service
+
+  # Build the resource name of the channel event.
+  name = client.event_path project: project_id, location: location, channel: channel_id, event: event_id
+
+  # Delete the channel event.
+  client.delete_event name: name
+
+  # Print a success message.
+  puts "Deleted channel event"
+end
+# [END livestream_delete_channel_event]

--- a/google-cloud-video-live_stream/samples/get_channel_event.rb
+++ b/google-cloud-video-live_stream/samples/get_channel_event.rb
@@ -1,0 +1,39 @@
+# Copyright 2022 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START livestream_get_channel_event]
+require "google/cloud/video/live_stream"
+
+##
+# Get a channel event
+#
+# @param project_id [String] Your Google Cloud project (e.g. "my-project")
+# @param location [String] The location (e.g. "us-central1")
+# @param channel_id [String] Your channel name (e.g. "my-channel")
+# @param event_id [String] Your event name (e.g. "my-event")
+#
+def get_channel_event project_id:, location:, channel_id:, event_id:
+  # Create a Live Stream client.
+  client = Google::Cloud::Video::LiveStream.livestream_service
+
+  # Build the resource name of the channel event.
+  name = client.event_path project: project_id, location: location, channel: channel_id, event: event_id
+
+  # Get the channel event.
+  event = client.get_event name: name
+
+  # Print the channel event name.
+  puts "Channel event: #{event.name}"
+end
+# [END livestream_get_channel_event]

--- a/google-cloud-video-live_stream/samples/list_channel_events.rb
+++ b/google-cloud-video-live_stream/samples/list_channel_events.rb
@@ -1,0 +1,41 @@
+# Copyright 2022 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START livestream_list_channel_events]
+require "google/cloud/video/live_stream"
+
+##
+# List the channel events
+#
+# @param project_id [String] Your Google Cloud project (e.g. "my-project")
+# @param location [String] The location (e.g. "us-central1")
+# @param channel_id [String] Your channel name (e.g. "my-channel")
+#
+def list_channel_events project_id:, location:, channel_id:
+  # Create a Live Stream client.
+  client = Google::Cloud::Video::LiveStream.livestream_service
+
+  # Build the resource name of the parent.
+  parent = client.channel_path project: project_id, location: location, channel: channel_id
+
+  # Get the list of channel events.
+  response = client.list_events parent: parent
+
+  puts "Channel events:"
+  # Print out all channel events.
+  response.each do |event|
+    puts event.name.to_s
+  end
+end
+# [END livestream_list_channel_events]


### PR DESCRIPTION
b:241866780

Part 3 of 3: Channel events (https://cloud.google.com/livestream/docs/how-to/create-channel-events) and create a channel with a backup input (https://cloud.google.com/livestream/docs/how-to/configure-backup-stream).