### PR TITLE
chore(firestore): updating obsolete region tag

### DIFF
--- a/google-cloud-firestore/samples/get_data.rb
+++ b/google-cloud-firestore/samples/get_data.rb
@@ -121,14 +121,14 @@ def add_subcollection project_id:, collection_path: "cities"
   # collection_path = "cities"
 
   firestore = Google::Cloud::Firestore.new project_id: project_id
-  # [START fs_add_subcollection]
+  # [START firestore_data_add_sub_collection]
   city_ref = firestore.doc "#{collection_path}/SF"
 
   subcollection_ref = city_ref.col "neighborhoods"
 
   added_doc_ref = subcollection_ref.add name: "Marina"
   puts "Added document with ID: #{added_doc_ref.document_id}."
-  # [END fs_add_subcollection]
+  # [END firestore_data_add_sub_collection]
 end
 
 def list_subcollections project_id:, collection_path: "cities"

--- a/google-cloud-firestore/samples/order_limit_data.rb
+++ b/google-cloud-firestore/samples/order_limit_data.rb
@@ -108,11 +108,9 @@ def order_by_name_limit_to_last_query project_id:, collection_path: "cities"
   firestore = Google::Cloud::Firestore.new project_id: project_id
 
   cities_ref = firestore.col collection_path
-  # [START fs_order_by_name_limit_to_last_query]
   # [START firestore_query_order_limit_to_last]
   query = cities_ref.order("name").limit_to_last(3)
   # [END firestore_query_order_limit_to_last]
-  # [END fs_order_by_name_limit_to_last_query]
   query.get do |city|
     puts "Document #{city.document_id} returned by order by name with limit_to_last query."
   end

--- a/google-cloud-firestore/samples/order_limit_data.rb
+++ b/google-cloud-firestore/samples/order_limit_data.rb
@@ -109,7 +109,9 @@ def order_by_name_limit_to_last_query project_id:, collection_path: "cities"
 
   cities_ref = firestore.col collection_path
   # [START fs_order_by_name_limit_to_last_query]
+  # [START firestore_query_order_limit_to_last]
   query = cities_ref.order("name").limit_to_last(3)
+  # [END firestore_query_order_limit_to_last]
   # [END fs_order_by_name_limit_to_last_query]
   query.get do |city|
     puts "Document #{city.document_id} returned by order by name with limit_to_last query."


### PR DESCRIPTION
Updating region tag to use product prefix. Context: [go/firestore-region-tags-normalization-2020q4](https://goto.google.com/firestore-region-tags-normalization-2020q4)