### PR TITLE
fix(datastore): fixed request limit

### DIFF
--- a/google-cloud-datastore/Gemfile
+++ b/google-cloud-datastore/Gemfile
@@ -7,3 +7,4 @@ gem "google-cloud-datastore-v1", path: "../google-cloud-datastore-v1"
 gem "google-cloud-errors", path: "../google-cloud-errors"
 
 gem "rake"
+gem "minitest-hooks", "~> 1.5"

--- a/google-cloud-datastore/Gemfile
+++ b/google-cloud-datastore/Gemfile
@@ -6,5 +6,5 @@ gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-datastore-v1", path: "../google-cloud-datastore-v1"
 gem "google-cloud-errors", path: "../google-cloud-errors"
 
-gem "rake"
 gem "minitest-hooks", "~> 1.5"
+gem "rake"

--- a/google-cloud-datastore/acceptance/datastore/datastore_test.rb
+++ b/google-cloud-datastore/acceptance/datastore/datastore_test.rb
@@ -402,12 +402,6 @@ describe Google::Cloud::Datastore::Dataset, :datastore do
       [rickard, eddard, catelyn, arya, sansa, robb, bran, jon]
     end
 
-    let(:post) do
-      Google::Cloud::Datastore::Entity.new.tap do |e|
-        e["title"]       = "How to make the perfect pizza in your grill"
-      end
-    end
-
     before do
       dataset.transaction { |tx| tx.save *characters }
     end
@@ -849,7 +843,7 @@ describe Google::Cloud::Datastore::Dataset, :datastore do
       end
     end
 
-    focus; it "should limit results when limit > 300 in query" do
+    it "should limit results when limit > 300 in query" do
       # Testing limit with query
       query = dataset.query(kind_val).limit(limit)
       entities_count = 0

--- a/google-cloud-datastore/acceptance/datastore/datastore_test.rb
+++ b/google-cloud-datastore/acceptance/datastore/datastore_test.rb
@@ -402,6 +402,12 @@ describe Google::Cloud::Datastore::Dataset, :datastore do
       [rickard, eddard, catelyn, arya, sansa, robb, bran, jon]
     end
 
+    let(:post) do
+      Google::Cloud::Datastore::Entity.new.tap do |e|
+        e["title"]       = "How to make the perfect pizza in your grill"
+      end
+    end
+
     before do
       dataset.transaction { |tx| tx.save *characters }
     end
@@ -422,6 +428,47 @@ describe Google::Cloud::Datastore::Dataset, :datastore do
       query.offset 10
       entities = dataset.run query
       _(entities.count).must_equal 0
+    end
+
+    it "should limit results when limit > 300" do
+      kind_val = "Post_#{SecureRandom.hex(4)}"
+      limit = 700
+
+      # Add 1000 entities of the same kind to the datastore
+      1000.times.each do |id|
+        post_temp = post.dup
+        post_temp.key = Google::Cloud::Datastore::Key.new kind_val, "Post_#{id+1}"
+        dataset.save post_temp
+      end
+
+      # Testing limit with query
+      query = dataset.query(kind_val).limit(limit)
+      entities_count = 0
+      results = dataset.run query
+      loop do
+        entities_count += results.count
+        break unless results.next?
+        results = results.next
+      end
+      _(entities_count).must_equal limit
+
+      # Testing limit with GQL query
+      query_gql = dataset.gql "SELECT * FROM #{kind_val} LIMIT @limit", {limit: limit}
+      entities_count = 0
+      results = dataset.run query_gql
+      loop do
+        entities_count += results.count
+        break unless results.next?
+        results = results.next
+      end
+      _(entities_count).must_equal limit
+
+      # Delete the entities added
+      1000.times.each do |id|
+        post_temp = post.dup
+        post_temp.key = Google::Cloud::Datastore::Key.new kind_val, "Post_#{id+1}"
+        dataset.delete post_temp
+      end
     end
 
     it "should filter queries with simple indexes" do

--- a/google-cloud-datastore/acceptance/datastore_helper.rb
+++ b/google-cloud-datastore/acceptance/datastore_helper.rb
@@ -20,6 +20,7 @@ require "minitest/focus"
 require "minitest/rg"
 require "google/cloud/datastore"
 require "securerandom"
+require "minitest/hooks/default"
 
 # Create shared dataset object so we don't create new for each test
 $dataset = Google::Cloud.new.datastore
@@ -62,7 +63,7 @@ module Acceptance
     def self.run_one_method klass, method_name, reporter
       result = nil
       reporter.prerecord klass, method_name
-      (1..3).each do |try|
+      (1..1).each do |try|
         result = Minitest.run_one_method(klass, method_name)
         break if (result.passed? || result.skipped?)
         puts "Retrying #{klass}##{method_name} (#{try})"

--- a/google-cloud-datastore/acceptance/datastore_helper.rb
+++ b/google-cloud-datastore/acceptance/datastore_helper.rb
@@ -63,7 +63,7 @@ module Acceptance
     def self.run_one_method klass, method_name, reporter
       result = nil
       reporter.prerecord klass, method_name
-      (1..1).each do |try|
+      (1..3).each do |try|
         result = Minitest.run_one_method(klass, method_name)
         break if (result.passed? || result.skipped?)
         puts "Retrying #{klass}##{method_name} (#{try})"

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset/query_results.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset/query_results.rb
@@ -159,8 +159,8 @@ module Google
             query.start_cursor = cursor.to_grpc # should always be a Cursor...
             query.offset = 0 # Never carry an offset across batches
             unless query.limit.nil?
-              # Reduce the limit by number of entities returned in the current batch
-              query.limit.value -= self.count
+              # Reduce the limit by the number of entities returned in the current batch
+              query.limit.value -= count
             end
             query_res = service.run_query query, namespace
             self.class.from_grpc query_res, service, namespace, query

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset/query_results.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset/query_results.rb
@@ -158,6 +158,10 @@ module Google
             ensure_service!
             query.start_cursor = cursor.to_grpc # should always be a Cursor...
             query.offset = 0 # Never carry an offset across batches
+            unless query.limit.nil?
+              # Reduce the limit by number of entities returned in the current batch
+              query.limit.value -= self.count
+            end
             query_res = service.run_query query, namespace
             self.class.from_grpc query_res, service, namespace, query
           end


### PR DESCRIPTION
Maximum number of entities returned in a single batch for any query is 300. 
So incase of result limit > 300 in a query, results had to be fetched in multiple batches and we were carrying the same result limit across batches. 
This resulted in entire result set being fetched. 