### PR TITLE
feat(datastore): Support query count for Datastore

### DIFF
--- a/google-cloud-datastore/acceptance/datastore/aggregate_query_test.rb
+++ b/google-cloud-datastore/acceptance/datastore/aggregate_query_test.rb
@@ -136,7 +136,6 @@ describe "Aggregate Queries", :datastore do
 
   describe "via AggregateQuery" do
     
-    focus;
     it "returns 0 for no records" do
       dataset.delete *characters
       query = Google::Cloud::Datastore.new.
@@ -148,7 +147,6 @@ describe "Aggregate Queries", :datastore do
       _(res.get('count')).must_equal 0
     end
 
-    focus;
     it "returns count for non-zero records" do
       query = Google::Cloud::Datastore.new.
         query("Character").
@@ -159,7 +157,6 @@ describe "Aggregate Queries", :datastore do
       _(res.get('count')).must_equal 8
     end
 
-    focus;
     it "returns count on filter" do
       query = Google::Cloud::Datastore.new.
         query("Character").
@@ -171,7 +168,6 @@ describe "Aggregate Queries", :datastore do
       _(res.get('count')).must_equal 4
     end
 
-    focus;
     it "returns count on limit" do
       query = Google::Cloud::Datastore.new.
         query("Character").
@@ -183,7 +179,6 @@ describe "Aggregate Queries", :datastore do
       _(res.get('count')).must_equal 5
     end
 
-    focus;
     it "returns count with a custom alias" do
       query = Google::Cloud::Datastore.new.
         query("Character").
@@ -194,7 +189,6 @@ describe "Aggregate Queries", :datastore do
       _(res.get('total')).must_equal 8
     end
 
-    focus;
     it "returns count with multiple custom aliases" do
       query = Google::Cloud::Datastore.new.
         query("Character").
@@ -207,7 +201,6 @@ describe "Aggregate Queries", :datastore do
       _(res.get('total_2')).must_equal 8
     end
 
-    focus;
     it "returns count with unspecified aliases" do
       query = Google::Cloud::Datastore.new.
         query("Character").
@@ -218,7 +211,6 @@ describe "Aggregate Queries", :datastore do
       _(res.get('unspecified_alias')).must_be :nil?
     end
 
-    focus;
     it "throws error when duplicating aliases" do
       query = Google::Cloud::Datastore.new.
         query("Character").
@@ -229,7 +221,6 @@ describe "Aggregate Queries", :datastore do
       expect { res = dataset.run_aggregation aggregate_query }.must_raise Google::Cloud::InvalidArgumentError
     end
 
-    focus;
     it "returns different count when data changes" do
       query = Google::Cloud::Datastore.new.
         query("Character").
@@ -243,7 +234,6 @@ describe "Aggregate Queries", :datastore do
       _(res.get('count')).must_equal 7
     end
     
-    focus;
     it "throws error when no aggregate is added" do
       query = Google::Cloud::Datastore.new.
         query("Character").
@@ -252,7 +242,6 @@ describe "Aggregate Queries", :datastore do
       expect { res = dataset.run_aggregation aggregate_query }.must_raise Google::Cloud::InvalidArgumentError
     end
 
-    focus;
     it "returns count inside a transaction" do
       query = Google::Cloud::Datastore.new.
         query("Character").
@@ -267,21 +256,18 @@ describe "Aggregate Queries", :datastore do
   end
 
   describe "via GQL" do
-    focus
     it "returns count for non-zero records" do
       gql = dataset.gql "SELECT COUNT(*) AS total FROM Character"
       res = dataset.run_aggregation gql
       _(res.get('total')).must_equal 8
     end
   
-    focus
     it "returns count with a filter" do
       gql = dataset.gql "SELECT COUNT(*) AS total_alive FROM Character WHERE alive = @alive", alive: true
       res = dataset.run_aggregation gql
       _(res.get('total_alive')).must_equal 4
     end
 
-    focus;
     it "returns count inside a transaction" do
       dataset.read_only_transaction do |tx|
         gql = dataset.gql "SELECT COUNT(*) AS total FROM Character"

--- a/google-cloud-datastore/acceptance/datastore/aggregate_query_test.rb
+++ b/google-cloud-datastore/acceptance/datastore/aggregate_query_test.rb
@@ -1,0 +1,276 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "datastore_helper"
+
+describe "Aggregate Queries", :datastore do
+
+  let(:prefix) { "#{Time.now.utc.iso8601.gsub ":", "_"}_#{SecureRandom.hex(4)}" }
+
+  let(:book) do
+    book = Google::Cloud::Datastore::Entity.new.tap do |e|
+      e["title"] = "Game of Thrones"
+    end
+    book.key = Google::Cloud::Datastore::Key.new "Book", "#{prefix}_GoT"
+    book
+  end
+
+  let(:rickard) do
+    character = Google::Cloud::Datastore::Entity.new.tap do |e|
+      e["name"]        = "Rickard"
+      e["family"]      = "Stark"
+      e["appearances"] = 0
+      e["alive"]       = false
+    end
+    character.key = Google::Cloud::Datastore::Key.new "Character", "Rickard"
+    character.key.parent = book
+    character
+  end
+
+  let(:eddard) do
+    character = Google::Cloud::Datastore::Entity.new.tap do |e|
+      e["name"]        = "Eddard"
+      e["family"]      = "Stark"
+      e["appearances"] = 9
+      e["alive"]       = false
+    end
+    character.key = Google::Cloud::Datastore::Key.new "Character", "Eddard"
+    character.key.parent = rickard
+    character
+  end
+
+  let(:catelyn) do
+    character = Google::Cloud::Datastore::Entity.new.tap do |e|
+      e["name"]        = "Catelyn"
+      e["family"]      = "Stark"
+      e["appearances"] = 26
+      e["alive"]       = false
+    end
+    character.key = Google::Cloud::Datastore::Key.new "Character", "Catelyn"
+    character.key.parent = book
+    character
+  end
+
+  let(:arya) do
+    character = Google::Cloud::Datastore::Entity.new.tap do |e|
+      e["name"]        = "Arya"
+      e["family"]      = "Stark"
+      e["appearances"] = 33
+      e["alive"]       = true
+    end
+    character.key = Google::Cloud::Datastore::Key.new "Character", "Arya"
+    character.key.parent = eddard
+    character
+  end
+
+  let(:sansa) do
+    character = Google::Cloud::Datastore::Entity.new.tap do |e|
+      e["name"]        = "Sansa"
+      e["family"]      = "Stark"
+      e["appearances"] = 31
+      e["alive"]       = true
+    end
+    character.key = Google::Cloud::Datastore::Key.new "Character", "Sansa"
+    character.key.parent = eddard
+    character
+  end
+
+  let(:robb) do
+    character = Google::Cloud::Datastore::Entity.new.tap do |e|
+      e["name"]        = "Robb"
+      e["family"]      = "Stark"
+      e["appearances"] = 22
+      e["alive"]       = false
+    end
+    character.key = Google::Cloud::Datastore::Key.new "Character", "Robb"
+    character.key.parent = eddard
+    character
+  end
+
+  let(:bran) do
+    character = Google::Cloud::Datastore::Entity.new.tap do |e|
+      e["name"]        = "Bran"
+      e["family"]      = "Stark"
+      e["appearances"] = 25
+      e["alive"]       = true
+    end
+    character.key = Google::Cloud::Datastore::Key.new "Character", "Bran"
+    character.key.parent = eddard
+    character
+  end
+
+  let(:jon) do
+    character = Google::Cloud::Datastore::Entity.new.tap do |e|
+      e["name"]        = "Jon"
+      e["family"]      = "Targaryen"
+      e["appearances"] = 32
+      e["alive"]       = true
+    end
+    character.key = Google::Cloud::Datastore::Key.new "Character", "Jon"
+    character.key.parent = eddard
+    character
+  end
+
+  let(:characters) do
+    [rickard, eddard, catelyn, arya, sansa, robb, bran, jon]
+  end
+
+  before do
+    dataset.transaction { |tx| tx.save *characters }
+  end
+
+  after do
+    dataset.delete *characters
+  end
+
+  describe "via AggregateQuery" do
+    
+    focus;
+    it "returns 0 for no records" do
+      dataset.delete *characters
+      query = Google::Cloud::Datastore.new.
+        query("Character").
+        ancestor(book)
+      aggregate_query = query.aggregate_query
+                            .add_count
+      res = dataset.run_aggregation aggregate_query
+      _(res.get('count')).must_equal 0
+
+    end
+
+    focus;
+    it "returns count for non-zero records" do
+      query = Google::Cloud::Datastore.new.
+        query("Character").
+        ancestor(book)
+      aggregate_query = query.aggregate_query
+                            .add_count
+      res = dataset.run_aggregation aggregate_query
+      _(res.get('count')).must_equal 8
+    end
+
+    focus;
+    it "returns count on filter" do
+      query = Google::Cloud::Datastore.new.
+        query("Character").
+        ancestor(book).
+        where("alive", "=", true)
+      aggregate_query = query.aggregate_query
+                            .add_count
+      res = dataset.run_aggregation aggregate_query
+      _(res.get('count')).must_equal 4
+    end
+
+    focus;
+    it "returns count on limit" do
+      query = Google::Cloud::Datastore.new.
+        query("Character").
+        ancestor(book).
+        limit(5)
+      aggregate_query = query.aggregate_query
+                            .add_count
+      res = dataset.run_aggregation aggregate_query
+      _(res.get('count')).must_equal 5
+    end
+
+    focus;
+    it "returns count with a custom alias" do
+      query = Google::Cloud::Datastore.new.
+        query("Character").
+        ancestor(book)
+      aggregate_query = query.aggregate_query
+                            .add_count(aggregate_alias: "total")
+      res = dataset.run_aggregation aggregate_query
+      _(res.get('total')).must_equal 8
+    end
+
+    focus;
+    it "returns count with multiple custom aliases" do
+      query = Google::Cloud::Datastore.new.
+        query("Character").
+        ancestor(book)
+      aggregate_query = query.aggregate_query
+                            .add_count(aggregate_alias: "total_1")
+                            .add_count(aggregate_alias: "total_2")
+      res = dataset.run_aggregation aggregate_query
+      _(res.get('total_1')).must_equal 8
+      _(res.get('total_2')).must_equal 8
+    end
+
+    focus;
+    it "returns count with unspecified aliases" do
+      query = Google::Cloud::Datastore.new.
+        query("Character").
+        ancestor(book)
+      aggregate_query = query.aggregate_query
+                            .add_count
+      res = dataset.run_aggregation aggregate_query
+      _(res.get('unspecified_alias')).must_be :nil?
+    end
+
+    focus;
+    it "throws error when duplicating aliases" do
+      query = Google::Cloud::Datastore.new.
+        query("Character").
+        ancestor(book)
+      aggregate_query = query.aggregate_query
+                            .add_count(aggregate_alias: 'total')
+                            .add_count(aggregate_alias: 'total')
+      expect { res = dataset.run_aggregation aggregate_query }.must_raise Google::Cloud::InvalidArgumentError
+    end
+
+    focus;
+    it "returns different count when data changes" do
+      query = Google::Cloud::Datastore.new.
+        query("Character").
+        ancestor(book)
+      aggregate_query = query.aggregate_query
+                            .add_count
+      res = dataset.run_aggregation aggregate_query
+      _(res.get('count')).must_equal 8
+      dataset.delete jon.key
+      res = dataset.run_aggregation aggregate_query
+      _(res.get('count')).must_equal 7
+    end
+    
+    focus;
+    it "throws error when no aggregate is added" do
+      query = Google::Cloud::Datastore.new.
+        query("Character").
+        ancestor(book)
+      aggregate_query = query.aggregate_query
+      expect { res = dataset.run_aggregation aggregate_query }.must_raise Google::Cloud::InvalidArgumentError
+    end
+
+  end
+
+  describe "via GQL" do
+    
+    focus
+    it "aggregates simple gql query" do
+      gql = dataset.gql "SELECT COUNT(*) AS total FROM Character"
+      res = dataset.run_aggregation gql
+      _(res.get('total')).must_equal 8
+    end
+  
+    focus
+    it "aggregates gql query with a filter" do
+      gql = dataset.gql "SELECT COUNT(*) AS total_alive FROM Character WHERE alive = @alive", alive: true
+      res = dataset.run_aggregation gql
+      _(res.get('total_alive')).must_equal 4
+    end
+
+  end
+
+end

--- a/google-cloud-datastore/acceptance/datastore/aggregate_query_test.rb
+++ b/google-cloud-datastore/acceptance/datastore/aggregate_query_test.rb
@@ -78,30 +78,30 @@ describe "Aggregate Queries", :datastore do
     
     it "returns 0 for no records" do
       dataset.delete *characters
-      query = Google::Cloud::Datastore.new.
-        query("Character").
-        ancestor(book)
+      query = Google::Cloud::Datastore.new
+                .query("Character")
+                .ancestor(book)
       aggregate_query = query.aggregate_query
-                            .add_count
+                             .add_count
       res = dataset.run_aggregation aggregate_query
       _(res.get).must_equal 0
     end
 
     it "returns count for non-zero records" do
-      query = Google::Cloud::Datastore.new.
-        query("Character").
-        ancestor(book)
+      query = Google::Cloud::Datastore.new
+                .query("Character")
+                .ancestor(book)
       aggregate_query = query.aggregate_query
-                            .add_count
+                             .add_count
       res = dataset.run_aggregation aggregate_query
       _(res.get).must_equal 3
     end
 
     it "returns count on filter" do
-      query = Google::Cloud::Datastore.new.
-        query("Character").
-        ancestor(book).
-        where("alive", "=", false)
+      query = Google::Cloud::Datastore.new
+                .query("Character")
+                .ancestor(book)
+                .where("alive", "=", false)
       aggregate_query = query.aggregate_query
                             .add_count
       res = dataset.run_aggregation aggregate_query
@@ -109,34 +109,34 @@ describe "Aggregate Queries", :datastore do
     end
 
     it "returns count on limit" do
-      query = Google::Cloud::Datastore.new.
-        query("Character").
-        ancestor(book).
-        limit(2)
+      query = Google::Cloud::Datastore.new
+                .query("Character")
+                .ancestor(book)
+                .limit(2)
       aggregate_query = query.aggregate_query
-                            .add_count
+                             .add_count
       res = dataset.run_aggregation aggregate_query
       _(res.get).must_equal 2
     end
 
     it "returns count with a custom alias" do
-      query = Google::Cloud::Datastore.new.
-        query("Character").
-        ancestor(book)
+      query = Google::Cloud::Datastore.new
+                .query("Character")
+                .ancestor(book)
       aggregate_query = query.aggregate_query
-                            .add_count(aggregate_alias: "total")
+                             .add_count(aggregate_alias: "total")
       res = dataset.run_aggregation aggregate_query
       _(res.get).must_equal 3
       _(res.get('total')).must_equal 3
     end
 
     it "returns count with multiple custom aliases" do
-      query = Google::Cloud::Datastore.new.
-        query("Character").
-        ancestor(book)
+      query = Google::Cloud::Datastore.new
+                .query("Character")
+                .ancestor(book)
       aggregate_query = query.aggregate_query
-                            .add_count(aggregate_alias: "total_1")
-                            .add_count(aggregate_alias: "total_2")
+                             .add_count(aggregate_alias: "total_1")
+                             .add_count(aggregate_alias: "total_2")
       res = dataset.run_aggregation aggregate_query
       _(res.get('total_1')).must_equal 3
       _(res.get('total_2')).must_equal 3
@@ -147,38 +147,38 @@ describe "Aggregate Queries", :datastore do
         query("Character").
         ancestor(book)
       aggregate_query = query.aggregate_query
-                            .add_count
+                             .add_count
       res = dataset.run_aggregation aggregate_query
       _(res.get('unspecified_alias')).must_be :nil?
     end
 
     it "throws error when duplicating aliases" do
-      query = Google::Cloud::Datastore.new.
-        query("Character").
-        ancestor(book)
+      query = Google::Cloud::Datastore.new
+                .query("Character")
+                .ancestor(book)
       aggregate_query = query.aggregate_query
-                            .add_count(aggregate_alias: 'total')
-                            .add_count(aggregate_alias: 'total')
+                             .add_count(aggregate_alias: 'total')
+                             .add_count(aggregate_alias: 'total')
       expect { res = dataset.run_aggregation aggregate_query }.must_raise Google::Cloud::InvalidArgumentError
     end
 
     it "throws error when custom alias isn't specified for multiple aliases" do
-      query = Google::Cloud::Datastore.new.
-        query("Character").
-        ancestor(book)
+      query = Google::Cloud::Datastore.new
+                .query("Character")
+                .ancestor(book)
       aggregate_query = query.aggregate_query
-                            .add_count(aggregate_alias: 'total_1')
-                            .add_count(aggregate_alias: 'total_2')
+                             .add_count(aggregate_alias: 'total_1')
+                             .add_count(aggregate_alias: 'total_2')
       res = dataset.run_aggregation aggregate_query
       expect { res.get }.must_raise ArgumentError
     end
 
     it "returns different count when data changes" do
-      query = Google::Cloud::Datastore.new.
-        query("Character").
-        ancestor(book)
+      query = Google::Cloud::Datastore.new
+                .query("Character")
+                .ancestor(book)
       aggregate_query = query.aggregate_query
-                            .add_count
+                             .add_count
       res = dataset.run_aggregation aggregate_query
       _(res.get).must_equal 3
       dataset.delete bran.key
@@ -187,17 +187,17 @@ describe "Aggregate Queries", :datastore do
     end
     
     it "throws error when no aggregate is added" do
-      query = Google::Cloud::Datastore.new.
-        query("Character").
-        ancestor(book)
+      query = Google::Cloud::Datastore.new
+                .query("Character")
+                .ancestor(book)
       aggregate_query = query.aggregate_query
       expect { res = dataset.run_aggregation aggregate_query }.must_raise Google::Cloud::InvalidArgumentError
     end
 
     it "returns count inside a transaction" do
-      query = Google::Cloud::Datastore.new.
-        query("Character").
-        ancestor(book)
+      query = Google::Cloud::Datastore.new
+                .query("Character")
+                .ancestor(book)
       dataset.read_only_transaction do |tx|
         aggregate_query = query.aggregate_query
                                .add_count

--- a/google-cloud-datastore/acceptance/datastore/aggregate_query_test.rb
+++ b/google-cloud-datastore/acceptance/datastore/aggregate_query_test.rb
@@ -146,7 +146,6 @@ describe "Aggregate Queries", :datastore do
                             .add_count
       res = dataset.run_aggregation aggregate_query
       _(res.get('count')).must_equal 0
-
     end
 
     focus;

--- a/google-cloud-datastore/acceptance/datastore/aggregate_query_test.rb
+++ b/google-cloud-datastore/acceptance/datastore/aggregate_query_test.rb
@@ -257,20 +257,23 @@ describe "Aggregate Queries", :datastore do
 
   describe "via GQL" do
     it "returns count for non-zero records" do
-      gql = dataset.gql "SELECT COUNT(*) AS total FROM Character"
+      gql = dataset.gql "SELECT COUNT(*) AS total FROM Character WHERE __key__ HAS ANCESTOR @bookKey",
+                        bookKey: book.key
       res = dataset.run_aggregation gql
       _(res.get('total')).must_equal 8
     end
   
     it "returns count with a filter" do
-      gql = dataset.gql "SELECT COUNT(*) AS total_alive FROM Character WHERE alive = @alive", alive: true
+      gql = dataset.gql "SELECT COUNT(*) AS total_alive FROM Character WHERE __key__ HAS ANCESTOR @bookKey AND alive = @alive",
+                        alive: true, bookKey: book.key
       res = dataset.run_aggregation gql
       _(res.get('total_alive')).must_equal 4
     end
 
     it "returns count inside a transaction" do
       dataset.read_only_transaction do |tx|
-        gql = dataset.gql "SELECT COUNT(*) AS total FROM Character"
+        gql = dataset.gql "SELECT COUNT(*) AS total FROM Character WHERE __key__ HAS ANCESTOR @bookKey",
+                          bookKey: book.key
         res = dataset.run_aggregation gql
         _(res.get('total')).must_equal 8
       end

--- a/google-cloud-datastore/acceptance/datastore/datastore_test.rb
+++ b/google-cloud-datastore/acceptance/datastore/datastore_test.rb
@@ -662,6 +662,20 @@ describe Google::Cloud::Datastore::Dataset, :datastore do
       _(entities.count).must_equal 2
     end
 
+    focus
+    it "aggregates simple gql query" do
+      gql = dataset.gql "SELECT COUNT(*) AS total FROM Character"
+      res = dataset.run_aggregation gql
+      _(res.get('total')).must_equal 8
+    end
+
+    focus
+    it "aggregates gql query with a filter" do
+      gql = dataset.gql "SELECT COUNT(*) AS total_alive FROM Character WHERE alive = @alive", alive: true
+      res = dataset.run_aggregation gql
+      _(res.get('total_alive')).must_equal 4
+    end
+
     it "should filter queries with simple indexes using GQL and named bindings" do
       gql = dataset.gql "SELECT * FROM Character WHERE __key__ HAS ANCESTOR @bookKey AND appearances >= @appearanceCount",
                         bookKey: book.key, appearanceCount: 20

--- a/google-cloud-datastore/acceptance/datastore/datastore_test.rb
+++ b/google-cloud-datastore/acceptance/datastore/datastore_test.rb
@@ -662,6 +662,27 @@ describe Google::Cloud::Datastore::Dataset, :datastore do
       _(entities.count).must_equal 2
     end
 
+    focus;
+    it "aggregates a simple query" do
+      query = Google::Cloud::Datastore.new.
+        query("Character").
+        ancestor(book)
+      aggregate_query = query.aggregate_query.add_count
+      res = dataset.run_aggregation aggregate_query
+      _(res.get('count')).must_equal 8
+    end
+
+    focus;
+    it "aggregates a query with filter" do
+      query = Google::Cloud::Datastore.new.
+        query("Character").
+        ancestor(book).
+        where("alive", "=", true)
+      aggregate_query = query.aggregate_query.add_count
+      res = dataset.run_aggregation aggregate_query
+      _(res.get('count')).must_equal 4
+    end
+
     focus
     it "aggregates simple gql query" do
       gql = dataset.gql "SELECT COUNT(*) AS total FROM Character"

--- a/google-cloud-datastore/acceptance/datastore/datastore_test.rb
+++ b/google-cloud-datastore/acceptance/datastore/datastore_test.rb
@@ -662,41 +662,6 @@ describe Google::Cloud::Datastore::Dataset, :datastore do
       _(entities.count).must_equal 2
     end
 
-    focus;
-    it "aggregates a simple query" do
-      query = Google::Cloud::Datastore.new.
-        query("Character").
-        ancestor(book)
-      aggregate_query = query.aggregate_query.add_count
-      res = dataset.run_aggregation aggregate_query
-      _(res.get('count')).must_equal 8
-    end
-
-    focus;
-    it "aggregates a query with filter" do
-      query = Google::Cloud::Datastore.new.
-        query("Character").
-        ancestor(book).
-        where("alive", "=", true)
-      aggregate_query = query.aggregate_query.add_count
-      res = dataset.run_aggregation aggregate_query
-      _(res.get('count')).must_equal 4
-    end
-
-    focus
-    it "aggregates simple gql query" do
-      gql = dataset.gql "SELECT COUNT(*) AS total FROM Character"
-      res = dataset.run_aggregation gql
-      _(res.get('total')).must_equal 8
-    end
-
-    focus
-    it "aggregates gql query with a filter" do
-      gql = dataset.gql "SELECT COUNT(*) AS total_alive FROM Character WHERE alive = @alive", alive: true
-      res = dataset.run_aggregation gql
-      _(res.get('total_alive')).must_equal 4
-    end
-
     it "should filter queries with simple indexes using GQL and named bindings" do
       gql = dataset.gql "SELECT * FROM Character WHERE __key__ HAS ANCESTOR @bookKey AND appearances >= @appearanceCount",
                         bookKey: book.key, appearanceCount: 20

--- a/google-cloud-datastore/lib/google/cloud/datastore/aggregate_query.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/aggregate_query.rb
@@ -15,47 +15,131 @@
 
 require "google/cloud/datastore/v1"
 
-class AggregateQuery
-  ##
-  # @private The Google::Cloud::Datastore::V1::Query object.
-  attr_reader :query
+module Google
+  module Cloud
+    module Datastore
+      ##
+      # # AggregateQuery
+      #
+      # An aggregate query can be used to fetch aggregate values (ex: count) for a query
+      #
+      # @example
+      #   require "google/cloud/datastore"
+      #
+      #   datastore = Google::Cloud::Datastore.new
+      #
+      #   query = Google::Cloud::Datastore::Query.new
+      #   query.kind("Task").
+      #     where("done", "=", false)
+      #
+      #   Create an aggregate query
+      #   aggregate_query = query.aggregate_query
+      #                          .add_count
+      #
+      #   aggregate_query_results = dataset.run_aggregation aggregate_query
+      #   puts aggregate_query_results.get('count')
+      #
+      # @example Alias an aggregate query
+      #   require "google/cloud/datastore"
+      #
+      #   datastore = Google::Cloud::Datastore.new
+      #
+      #   query = Google::Cloud::Datastore::Query.new
+      #   query.kind("Task").
+      #     where("done", "=", false)
+      #
+      #   Create an aggregate query
+      #   aggregate_query = query.aggregate_query
+      #                          .add_count aggregate_alias: 'total'
+      #
+      #   aggregate_query_results = dataset.run_aggregation aggregate_query
+      #   puts aggregate_query_results.get('total')
+      #
+      class AggregateQuery
+        ##
+        # @private The Google::Cloud::Datastore::V1::Query object.
+        attr_reader :query
 
-  ##
-  # @private Array of Google::Cloud::Datastore::V1::AggregationQuery::Aggregation objects
-  attr_reader :aggregates
+        ##
+        # @private Array of Google::Cloud::Datastore::V1::AggregationQuery::Aggregation objects
+        attr_reader :aggregates
 
-  def initialize query, aggregates: []
-    @query = query
-    @aggregates = aggregates
+        ##
+        # @private Creates a new AggregateQuery
+        def initialize query, aggregates: []
+          @query = query
+          @aggregates = aggregates
+        end
+
+        ##
+        # Adds a count aggregate.
+        #
+        # @param [aggregate_alias] Alias to refer to the aggregate. Optional
+        #
+        # @return [AggregateQuery] The modified aggregate query object with the added count aggregate.
+        #
+        # @example
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
+        #   query = Google::Cloud::Datastore::Query.new
+        #   query.kind("Task").
+        #     where("done", "=", false)
+        #
+        #   Create an aggregate query
+        #   aggregate_query = query.aggregate_query
+        #                          .add_count
+        #
+        #   aggregate_query_results = dataset.run_aggregation aggregate_query
+        #   puts aggregate_query_results.get('count')
+        #
+        # @example Alias an aggregate query
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
+        #   query = Google::Cloud::Datastore::Query.new
+        #   query.kind("Task").
+        #     where("done", "=", false)
+        #
+        #   Create an aggregate query
+        #   aggregate_query = query.aggregate_query
+        #                          .add_count aggregate_alias: 'total'
+        #
+        #   aggregate_query_results = dataset.run_aggregation aggregate_query
+        #   puts aggregate_query_results.get('total')
+        #
+        def add_count aggregate_alias: nil
+          aggregate_alias ||= ALIASES[:count]
+          new_aggregates = @aggregates.dup
+          new_aggregates << Google::Cloud::Datastore::V1::AggregationQuery::Aggregation.new(
+            count: Google::Cloud::Datastore::V1::AggregationQuery::Aggregation::Count.new,
+            alias: aggregate_alias
+          )
+          AggregateQuery.start query, new_aggregates
+        end
+
+        ##
+        # @private Start a new AggregateQuery.
+        def self.start query, aggregates
+          new query, aggregates: aggregates
+        end
+
+        # @private
+        def to_grpc
+          Google::Cloud::Datastore::V1::AggregationQuery.new(
+            nested_query: query,
+            aggregations: aggregates
+          )
+        end
+
+        ##
+        # @private
+        ALIASES = {
+          count: "count"
+        }.freeze
+      end
+    end
   end
-
-  def add_count aggregate_alias: nil
-    aggregate_alias ||= ALIASES[:count]
-    new_aggregates = @aggregates.dup
-    new_aggregates << Google::Cloud::Datastore::V1::AggregationQuery::Aggregation.new(
-      count: Google::Cloud::Datastore::V1::AggregationQuery::Aggregation::Count.new,
-      alias: aggregate_alias
-    )
-    AggregateQuery.start query, new_aggregates
-  end
-
-  ##
-  # @private Start a new AggregateQuery.
-  def self.start query, aggregates
-    new query, aggregates: aggregates
-  end
-
-  # @private
-  def to_grpc
-    Google::Cloud::Datastore::V1::AggregationQuery.new(
-      nested_query: query,
-      aggregations: aggregates
-    )
-  end
-
-  ##
-  # @private
-  ALIASES = {
-    count: "count"
-  }.freeze
 end

--- a/google-cloud-datastore/lib/google/cloud/datastore/aggregate_query.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/aggregate_query.rb
@@ -1,3 +1,18 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 require "google/cloud/datastore/v1"
 
 class AggregateQuery

--- a/google-cloud-datastore/lib/google/cloud/datastore/aggregate_query.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/aggregate_query.rb
@@ -16,7 +16,6 @@
 require "google/cloud/datastore/v1"
 
 class AggregateQuery
-
   ##
   # @private The Google::Cloud::Datastore::V1::Query object.
   attr_reader :query
@@ -53,8 +52,6 @@ class AggregateQuery
       aggregations: aggregates
     )
   end
-
-  protected
 
   ##
   # @private

--- a/google-cloud-datastore/lib/google/cloud/datastore/aggregate_query.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/aggregate_query.rb
@@ -66,9 +66,9 @@ module Google
 
         ##
         # @private Creates a new AggregateQuery
-        def initialize query, aggregates: []
+        def initialize query
           @query = query
-          @aggregates = aggregates
+          @aggregates = []
         end
 
         ##
@@ -112,18 +112,12 @@ module Google
         #
         def add_count aggregate_alias: nil
           aggregate_alias ||= ALIASES[:count]
-          new_aggregates = @aggregates.dup
-          new_aggregates << Google::Cloud::Datastore::V1::AggregationQuery::Aggregation.new(
+          aggregates << Google::Cloud::Datastore::V1::AggregationQuery::Aggregation.new(
             count: Google::Cloud::Datastore::V1::AggregationQuery::Aggregation::Count.new,
             alias: aggregate_alias
           )
-          AggregateQuery.start query, new_aggregates
-        end
 
-        ##
-        # @private Start a new AggregateQuery.
-        def self.start query, aggregates
-          new query, aggregates: aggregates
+          self
         end
 
         # @private

--- a/google-cloud-datastore/lib/google/cloud/datastore/aggregate_query.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/aggregate_query.rb
@@ -29,8 +29,8 @@ module Google
       #   datastore = Google::Cloud::Datastore.new
       #
       #   query = Google::Cloud::Datastore::Query.new
-      #   query.kind("Task").
-      #     where("done", "=", false)
+      #   query.kind("Task")
+      #        .where("done", "=", false)
       #
       #   Create an aggregate query
       #   aggregate_query = query.aggregate_query
@@ -45,8 +45,8 @@ module Google
       #   datastore = Google::Cloud::Datastore.new
       #
       #   query = Google::Cloud::Datastore::Query.new
-      #   query.kind("Task").
-      #     where("done", "=", false)
+      #   query.kind("Task")
+      #        .where("done", "=", false)
       #
       #   Create an aggregate query
       #   aggregate_query = query.aggregate_query
@@ -84,8 +84,8 @@ module Google
         #   datastore = Google::Cloud::Datastore.new
         #
         #   query = Google::Cloud::Datastore::Query.new
-        #   query.kind("Task").
-        #     where("done", "=", false)
+        #   query.kind("Task")
+        #        .where("done", "=", false)
         #
         #   Create an aggregate query
         #   aggregate_query = query.aggregate_query
@@ -100,8 +100,8 @@ module Google
         #   datastore = Google::Cloud::Datastore.new
         #
         #   query = Google::Cloud::Datastore::Query.new
-        #   query.kind("Task").
-        #     where("done", "=", false)
+        #   query.kind("Task")
+        #        .where("done", "=", false)
         #
         #   Create an aggregate query
         #   aggregate_query = query.aggregate_query

--- a/google-cloud-datastore/lib/google/cloud/datastore/aggregate_query.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/aggregate_query.rb
@@ -74,7 +74,7 @@ module Google
         ##
         # Adds a count aggregate.
         #
-        # @param [aggregate_alias] Alias to refer to the aggregate. Optional
+        # @param aggregate_alias [String] Alias to refer to the aggregate. Optional
         #
         # @return [AggregateQuery] The modified aggregate query object with the added count aggregate.
         #

--- a/google-cloud-datastore/lib/google/cloud/datastore/aggregate_query.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/aggregate_query.rb
@@ -37,7 +37,7 @@ module Google
       #                          .add_count
       #
       #   aggregate_query_results = dataset.run_aggregation aggregate_query
-      #   puts aggregate_query_results.get('count')
+      #   puts aggregate_query_results.get
       #
       # @example Alias an aggregate query
       #   require "google/cloud/datastore"
@@ -92,7 +92,7 @@ module Google
         #                          .add_count
         #
         #   aggregate_query_results = dataset.run_aggregation aggregate_query
-        #   puts aggregate_query_results.get('count')
+        #   puts aggregate_query_results.get
         #
         # @example Alias an aggregate query
         #   require "google/cloud/datastore"

--- a/google-cloud-datastore/lib/google/cloud/datastore/aggregate_query.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/aggregate_query.rb
@@ -1,0 +1,49 @@
+require "google/cloud/datastore/v1"
+
+class AggregateQuery
+
+  ##
+  # @private The Google::Cloud::Datastore::V1::Query object.
+  attr_reader :query
+
+  ##
+  # @private Array of Google::Cloud::Datastore::V1::AggregationQuery::Aggregation objects
+  attr_reader :aggregates
+
+  def initialize query, aggregates: []
+    @query = query
+    @aggregates = aggregates
+  end
+
+  def add_count aggregate_alias: nil
+    aggregate_alias ||= ALIASES[:count]
+    new_aggregates = @aggregates.dup
+    new_aggregates << Google::Cloud::Datastore::V1::AggregationQuery::Aggregation.new(
+      count: Google::Cloud::Datastore::V1::AggregationQuery::Aggregation::Count.new,
+      alias: aggregate_alias
+    )
+    AggregateQuery.start query, new_aggregates
+  end
+
+  ##
+  # @private Start a new AggregateQuery.
+  def self.start query, aggregates
+    new query, aggregates: aggregates
+  end
+
+  # @private
+  def to_grpc
+    Google::Cloud::Datastore::V1::AggregationQuery.new(
+      nested_query: query,
+      aggregations: aggregates
+    )
+  end
+
+  protected
+
+  ##
+  # @private
+  ALIASES = {
+    count: "count"
+  }.freeze
+end

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset.rb
@@ -454,15 +454,15 @@ module Google
         end
         alias run_query run
 
-        def run_aggregation query, namespace: nil, consistency: nil
+        def run_aggregation aggregate_query, namespace: nil, consistency: nil
           ensure_service!
-          unless query.is_a?(Query) || query.is_a?(GqlQuery)
-            raise ArgumentError, "Cannot run a #{query.class} object."
+          unless aggregate_query.is_a?(AggregateQuery) || aggregate_query.is_a?(GqlQuery)
+            raise ArgumentError, "Cannot run a #{aggregate_query.class} object."
           end
           check_consistency! consistency
-          query_res = service.run_aggregation_query query.to_grpc, namespace,
+          aggregate_query_results = service.run_aggregation_query aggregate_query.to_grpc, namespace,
                                         consistency: consistency
-          AggregateQueryResults.from_grpc query_res
+          AggregateQueryResults.from_grpc aggregate_query_results
         end
 
         ##

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset.rb
@@ -24,6 +24,7 @@ require "google/cloud/datastore/gql_query"
 require "google/cloud/datastore/cursor"
 require "google/cloud/datastore/dataset/lookup_results"
 require "google/cloud/datastore/dataset/query_results"
+require "google/cloud/datastore/dataset/aggregate_query_results"
 require "google/cloud/datastore/transaction"
 require "google/cloud/datastore/read_only_transaction"
 
@@ -452,6 +453,17 @@ module Google
                                  query.to_grpc.dup
         end
         alias run_query run
+
+        def run_aggregation query, namespace: nil, consistency: nil
+          ensure_service!
+          unless query.is_a?(Query) || query.is_a?(GqlQuery)
+            raise ArgumentError, "Cannot run a #{query.class} object."
+          end
+          check_consistency! consistency
+          query_res = service.run_aggregation_query query.to_grpc, namespace,
+                                        consistency: consistency
+          AggregateQueryResults.from_grpc query_res
+        end
 
         ##
         # Creates a Datastore Transaction.

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset.rb
@@ -461,7 +461,7 @@ module Google
           end
           check_consistency! consistency
           aggregate_query_results = service.run_aggregation_query aggregate_query.to_grpc, namespace,
-                                        consistency: consistency
+                                                                  consistency: consistency
           AggregateQueryResults.from_grpc aggregate_query_results
         end
 

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset.rb
@@ -475,8 +475,8 @@ module Google
         #
         #   datastore = Google::Cloud::Datastore.new
         #
-        #   query = datastore.query("Task").
-        #     where("done", "=", false)
+        #   query = datastore.query("Task")
+        #                    .where("done", "=", false)
         #
         #   aggregate_query = query.aggregate_query
         #
@@ -488,8 +488,8 @@ module Google
         #   datastore = Google::Cloud::Datastore.new
         #
         #   task_list_key = datastore.key "TaskList", "default"
-        #   query = datastore.query.kind("Task").
-        #     ancestor(task_list_key)
+        #   query = datastore.query.kind("Task")
+        #                    .ancestor(task_list_key)
         #
         #   aggregate_query = query.aggregate_query
         #
@@ -500,8 +500,8 @@ module Google
         #
         #   datastore = Google::Cloud::Datastore.new
         #
-        #   query = datastore.query("Task").
-        #     where("done", "=", false)
+        #   query = datastore.query("Task")
+        #                    .where("done", "=", false)
         #
         #   aggregate_query = query.aggregate_query
         #

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset.rb
@@ -454,15 +454,86 @@ module Google
         end
         alias run_query run
 
+        ##
+        # Retrieve aggregate results specified by an AggregateQuery.
+        #
+        # @param [AggregateQuery, GqlQuery] query The object with the aggregate criteria.
+        # @param [String] namespace The namespace the query is to run within.
+        # @param [Symbol] consistency The non-transactional read consistency to
+        #   use. Cannot be set to `:strong` for global queries. Accepted values
+        #   are `:eventual` and `:strong`.
+        #
+        #   The default consistency depends on the type of query used. See
+        #   [Eventual Consistency in Google Cloud
+        #   Datastore](https://cloud.google.com/datastore/docs/articles/balancing-strong-and-eventual-consistency-with-google-cloud-datastore/#h.tf76fya5nqk8)
+        #   for more information.
+        #
+        # @return [Google::Cloud::Datastore::Dataset::AggregateQueryResults]
+        #
+        # @example
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
+        #   query = datastore.query("Task").
+        #     where("done", "=", false)
+        #
+        #   aggregate_query = query.aggregate_query
+        #
+        #   res = datastore.run_aggregation aggregate_query
+        #
+        # @example Run an aggregate ancestor query with eventual consistency:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
+        #   task_list_key = datastore.key "TaskList", "default"
+        #   query = datastore.query.kind("Task").
+        #     ancestor(task_list_key)
+        #
+        #   aggregate_query = query.aggregate_query
+        #
+        #   res = datastore.run_aggregation aggregate_query, consistency: :eventual
+        #
+        # @example Run the aggregate query within a namespace with the `namespace` option:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
+        #   query = datastore.query("Task").
+        #     where("done", "=", false)
+        #
+        #   aggregate_query = query.aggregate_query
+        #
+        #   res = datastore.run_aggregation aggregate_query, namespace: "example-ns"
+        #
+        # @example Run the aggregate query with a GQL string.
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
+        #   gql_query = datastore.gql "SELECT COUNT(*) FROM Task WHERE done = @done",
+        #                             done: false
+        #   res = datastore.run_aggregation gql_query
+        #
+        # @example Run the aggregate GQL query within a namespace with `namespace` option:
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
+        #   gql_query = datastore.gql "SELECT COUNT(*) FROM Task WHERE done = @done",
+        #                             done: false
+        #   res = datastore.run_aggregation gql_query, namespace: "example-ns"
+        #
         def run_aggregation aggregate_query, namespace: nil, consistency: nil
           ensure_service!
           unless aggregate_query.is_a?(AggregateQuery) || aggregate_query.is_a?(GqlQuery)
             raise ArgumentError, "Cannot run a #{aggregate_query.class} object."
           end
           check_consistency! consistency
-          aggregate_query_results = service.run_aggregation_query aggregate_query.to_grpc, namespace,
-                                                                  consistency: consistency
-          AggregateQueryResults.from_grpc aggregate_query_results
+          aggregate_query_res = service.run_aggregation_query aggregate_query.to_grpc, namespace,
+                                                              consistency: consistency
+          AggregateQueryResults.from_grpc aggregate_query_res
         end
 
         ##

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset/aggregate_query_results.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset/aggregate_query_results.rb
@@ -89,7 +89,7 @@ module Google
             if @aggregate_fields.count > 1 && aggregate_alias.nil?
               raise ArgumentError, "Required param aggregate_alias for AggregateQuery with multiple aggregate fields"
             end
-            aggregate_alias = @aggregate_fields.keys.first if aggregate_alias.nil?
+            aggregate_alias ||= @aggregate_fields.keys.first
             @aggregate_fields[aggregate_alias]
           end
 

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset/aggregate_query_results.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset/aggregate_query_results.rb
@@ -12,24 +12,84 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+module Google
+  module Cloud
+    module Datastore
+      class Dataset
+        ##
+        # # AggregateQueryResults
+        #
+        # An AggregateQueryResult object is a representation for
+        # a result of an AggregateQuery or a GqlQuery.
+        #
+        # @example
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
+        #   query = Google::Cloud::Datastore::Query.new
+        #   query.kind("Task").
+        #     where("done", "=", false)
+        #
+        #   Create an aggregate query
+        #   aggregate_query = query.aggregate_query
+        #                          .add_count
+        #
+        #   aggregate_query_results = dataset.run_aggregation aggregate_query
+        #   puts aggregate_query_results.get('count')
+        #
+        class AggregateQueryResults
+          ##
+          # Read timestamp the query was done on the database at.
+          #
+          # @return Google::Protobuf::Timestamp
+          attr_reader :read_time
 
-class AggregateQueryResults
-  attr_reader :read_time
+          ##
+          # Retrieves the aggregate data.
+          #
+          # @param [String] aggregate_alias The alias used
+          #   to access the aggregate value. For count, the
+          #   default value is "count".
+          #
+          # @return [Integer] The aggregate value.
+          #
+          # @example
+          #   require "google/cloud/datastore"
+          #
+          #   datastore = Google::Cloud::Datastore.new
+          #
+          #   query = Google::Cloud::Datastore::Query.new
+          #   query.kind("Task").
+          #     where("done", "=", false)
+          #
+          #   Create an aggregate query
+          #   aggregate_query = query.aggregate_query
+          #                          .add_count
+          #
+          #   aggregate_query_results = dataset.run_aggregation aggregate_query
+          #   puts aggregate_query_results.get('count')
+          def get aggregate_alias
+            @aggregate_fields[aggregate_alias]
+          end
 
-  def self.from_grpc aggregate_query_results
-    aggregate_fields = aggregate_query_results
-                       .batch
-                       .aggregation_results[0]
-                       .aggregate_properties
-                       .to_h
-                       .transform_values { |v| v[:integer_value] }
-    new.tap do |s|
-      s.instance_variable_set :@aggregate_fields, aggregate_fields
-      s.instance_variable_set :@read_time, aggregate_query_results.batch.read_time
+          ##
+          # @private New AggregateQueryResults from a
+          # Google::Cloud::Datastore::V1::RunAggregationQueryResponse object.
+          def self.from_grpc aggregate_query_response
+            aggregate_fields = aggregate_query_response
+                               .batch
+                               .aggregation_results[0]
+                               .aggregate_properties
+                               .to_h
+                               .transform_values { |v| v[:integer_value] }
+            new.tap do |s|
+              s.instance_variable_set :@aggregate_fields, aggregate_fields
+              s.instance_variable_set :@read_time, aggregate_query_response.batch.read_time
+            end
+          end
+        end
+      end
     end
-  end
-
-  def get aggregate_alias
-    @aggregate_fields[aggregate_alias]
   end
 end

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset/aggregate_query_results.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset/aggregate_query_results.rb
@@ -1,0 +1,17 @@
+class AggregateQueryResults
+  def self.from_grpc query_res
+    aggregate_fields = query_res
+                        .batch
+                        .aggregation_results[0]
+                        .aggregate_properties
+                        .to_h
+                        .transform_values { |v| v[:integer_value] }
+    new.tap do |s|
+      s.instance_variable_set :@aggregate_fields, aggregate_fields
+    end
+  end
+
+  def get aggregate_alias
+    @aggregate_fields[aggregate_alias]
+  end
+end

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset/aggregate_query_results.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset/aggregate_query_results.rb
@@ -1,6 +1,21 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 class AggregateQueryResults
-  def self.from_grpc query_res
-    aggregate_fields = query_res
+  def self.from_grpc aggregate_query_results
+    aggregate_fields = aggregate_query_results
                         .batch
                         .aggregation_results[0]
                         .aggregate_properties

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset/aggregate_query_results.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset/aggregate_query_results.rb
@@ -14,6 +14,9 @@
 
 
 class AggregateQueryResults
+
+  attr_reader :read_time
+
   def self.from_grpc aggregate_query_results
     aggregate_fields = aggregate_query_results
                         .batch
@@ -23,6 +26,7 @@ class AggregateQueryResults
                         .transform_values { |v| v[:integer_value] }
     new.tap do |s|
       s.instance_variable_set :@aggregate_fields, aggregate_fields
+      s.instance_variable_set :@read_time, aggregate_query_results.batch.read_time
     end
   end
 

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset/aggregate_query_results.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset/aggregate_query_results.rb
@@ -28,8 +28,8 @@ module Google
         #   datastore = Google::Cloud::Datastore.new
         #
         #   query = Google::Cloud::Datastore::Query.new
-        #   query.kind("Task").
-        #     where("done", "=", false)
+        #   query.kind("Task")
+        #        .where("done", "=", false)
         #
         #   Create an aggregate query
         #   aggregate_query = query.aggregate_query
@@ -60,8 +60,8 @@ module Google
           #   datastore = Google::Cloud::Datastore.new
           #
           #   query = Google::Cloud::Datastore::Query.new
-          #   query.kind("Task").
-          #     where("done", "=", false)
+          #   query.kind("Task")
+          #        .where("done", "=", false)
           #
           #   Create an aggregate query
           #   aggregate_query = query.aggregate_query

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset/aggregate_query_results.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset/aggregate_query_results.rb
@@ -69,7 +69,10 @@ module Google
           #
           #   aggregate_query_results = dataset.run_aggregation aggregate_query
           #   puts aggregate_query_results.get('count')
-          def get aggregate_alias
+          def get aggregate_alias = nil
+            return @aggregate_fields[aggregate_alias] unless aggregate_alias.nil?
+            raise ArgumentError unless @aggregate_fields.count == 1
+            aggregate_alias = @aggregate_fields.keys.first
             @aggregate_fields[aggregate_alias]
           end
 

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset/aggregate_query_results.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset/aggregate_query_results.rb
@@ -14,16 +14,15 @@
 
 
 class AggregateQueryResults
-
   attr_reader :read_time
 
   def self.from_grpc aggregate_query_results
     aggregate_fields = aggregate_query_results
-                        .batch
-                        .aggregation_results[0]
-                        .aggregate_properties
-                        .to_h
-                        .transform_values { |v| v[:integer_value] }
+                       .batch
+                       .aggregation_results[0]
+                       .aggregate_properties
+                       .to_h
+                       .transform_values { |v| v[:integer_value] }
     new.tap do |s|
       s.instance_variable_set :@aggregate_fields, aggregate_fields
       s.instance_variable_set :@read_time, aggregate_query_results.batch.read_time

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset/aggregate_query_results.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset/aggregate_query_results.rb
@@ -36,7 +36,7 @@ module Google
         #                          .add_count
         #
         #   aggregate_query_results = dataset.run_aggregation aggregate_query
-        #   puts aggregate_query_results.get('count')
+        #   puts aggregate_query_results.get
         #
         class AggregateQueryResults
           ##
@@ -48,9 +48,9 @@ module Google
           ##
           # Retrieves the aggregate data.
           #
-          # @param [String] aggregate_alias The alias used
-          #   to access the aggregate value. For count, the
-          #   default value is "count".
+          # @param aggregate_alias [String] The alias used to access
+          #   the aggregate value. For an AggregateQuery with a
+          #   single aggregate field, this parameter can be omitted.
           #
           # @return [Integer] The aggregate value.
           #
@@ -68,10 +68,26 @@ module Google
           #                          .add_count
           #
           #   aggregate_query_results = dataset.run_aggregation aggregate_query
-          #   puts aggregate_query_results.get('count')
+          #   puts aggregate_query_results.get
+          #
+          # @example Alias an aggregate query
+          #   require "google/cloud/datastore"
+          #
+          #   datastore = Google::Cloud::Datastore.new
+          #
+          #   query = Google::Cloud::Datastore::Query.new
+          #   query.kind("Task")
+          #        .where("done", "=", false)
+          #
+          #   Create an aggregate query
+          #   aggregate_query = query.aggregate_query
+          #                          .add_count aggregate_alias: 'total'
+          #
+          #   aggregate_query_results = dataset.run_aggregation aggregate_query
+          #   puts aggregate_query_results.get('total')
           def get aggregate_alias = nil
             if @aggregate_fields.count > 1 && aggregate_alias.nil?
-              raise ArgumentError, "Alias should be specified when multiple aggregates are present"
+              raise ArgumentError, "Required param aggregate_alias for AggregateQuery with multiple aggregate fields"
             end
             aggregate_alias = @aggregate_fields.keys.first if aggregate_alias.nil?
             @aggregate_fields[aggregate_alias]

--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset/aggregate_query_results.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset/aggregate_query_results.rb
@@ -70,9 +70,10 @@ module Google
           #   aggregate_query_results = dataset.run_aggregation aggregate_query
           #   puts aggregate_query_results.get('count')
           def get aggregate_alias = nil
-            return @aggregate_fields[aggregate_alias] unless aggregate_alias.nil?
-            raise ArgumentError unless @aggregate_fields.count == 1
-            aggregate_alias = @aggregate_fields.keys.first
+            if @aggregate_fields.count > 1 && aggregate_alias.nil?
+              raise ArgumentError, "Alias should be specified when multiple aggregates are present"
+            end
+            aggregate_alias = @aggregate_fields.keys.first if aggregate_alias.nil?
             @aggregate_fields[aggregate_alias]
           end
 

--- a/google-cloud-datastore/lib/google/cloud/datastore/query.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/query.rb
@@ -324,6 +324,10 @@ module Google
           self
         end
 
+        def aggregate_query
+          AggregateQuery.new @grpc
+        end
+
         ##
         # Set the cursor to start the results at.
         #

--- a/google-cloud-datastore/lib/google/cloud/datastore/query.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/query.rb
@@ -437,10 +437,8 @@ module Google
         #   datastore = Google::Cloud::Datastore.new
         #
         #   query = Google::Cloud::Datastore::Query.new
-        #   query.kind("Task").
-        #     where("done", "=", false).
-        #     where("priority", ">=", 4).
-        #     order("priority", :desc)
+        #   query.kind("Task")
+        #        .where("done", "=", false)
         #
         #   Create an aggregate query
         #   aggregate_query = query.aggregate_query

--- a/google-cloud-datastore/lib/google/cloud/datastore/query.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/query.rb
@@ -325,10 +325,6 @@ module Google
           self
         end
 
-        def aggregate_query
-          AggregateQuery.new @grpc
-        end
-
         ##
         # Set the cursor to start the results at.
         #
@@ -429,6 +425,29 @@ module Google
           self
         end
         alias distinct_on group_by
+
+        ##
+        # Creates an AggregateQuery object for the query.
+        #
+        # @return [AggregateQuery] New empty aggregate query.
+        #
+        # @example
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
+        #   query = Google::Cloud::Datastore::Query.new
+        #   query.kind("Task").
+        #     where("done", "=", false).
+        #     where("priority", ">=", 4).
+        #     order("priority", :desc)
+        #
+        #   Create an aggregate query
+        #   aggregate_query = query.aggregate_query
+        #
+        def aggregate_query
+          AggregateQuery.new @grpc
+        end
 
         # @private
         def to_grpc

--- a/google-cloud-datastore/lib/google/cloud/datastore/query.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/query.rb
@@ -15,6 +15,7 @@
 
 require "google/cloud/datastore/entity"
 require "google/cloud/datastore/key"
+require "google/cloud/datastore/aggregate_query"
 
 module Google
   module Cloud

--- a/google-cloud-datastore/lib/google/cloud/datastore/read_only_transaction.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/read_only_transaction.rb
@@ -162,7 +162,7 @@ module Google
           unless aggregate_query.is_a?(AggregateQuery) || aggregate_query.is_a?(GqlQuery)
             raise ArgumentError, "Cannot run a #{aggregate_query.class} object."
           end
-          aggregate_query_results = service.run_aggregation_query aggregate_query.to_grpc, namespace
+          aggregate_query_results = service.run_aggregation_query aggregate_query.to_grpc, namespace, transaction: @id
           AggregateQueryResults.from_grpc aggregate_query_results
         end
 

--- a/google-cloud-datastore/lib/google/cloud/datastore/read_only_transaction.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/read_only_transaction.rb
@@ -157,6 +157,15 @@ module Google
         end
         alias run_query run
 
+        def run_aggregation aggregate_query, namespace: nil
+          ensure_service!
+          unless aggregate_query.is_a?(AggregateQuery) || aggregate_query.is_a?(GqlQuery)
+            raise ArgumentError, "Cannot run a #{aggregate_query.class} object."
+          end
+          aggregate_query_results = service.run_aggregation_query aggregate_query.to_grpc, namespace
+          AggregateQueryResults.from_grpc aggregate_query_results
+        end
+
         ##
         # Begins a transaction.
         # This method is run when a new ReadOnlyTransaction is created.

--- a/google-cloud-datastore/lib/google/cloud/datastore/read_only_transaction.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/read_only_transaction.rb
@@ -172,9 +172,10 @@ module Google
         #   datastore = Google::Cloud::Datastore.new
         #
         #   datastore.read_only_transaction do |tx|
-        #     query = tx.query("Task").
-        #       where("done", "=", false)
+        #     query = tx.query("Task")
+        #               .where("done", "=", false)
         #     aggregate_query = query.aggregate_query
+        #                            .add_count
         #     res = tx.run_aggregation aggregate_query
         #   end
         #

--- a/google-cloud-datastore/lib/google/cloud/datastore/read_only_transaction.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/read_only_transaction.rb
@@ -157,13 +157,34 @@ module Google
         end
         alias run_query run
 
+        ##
+        # Retrieve aggregate query results specified by an AggregateQuery. The query is run within the
+        # transaction.
+        #
+        # @param [AggregateQuery, GqlQuery] query The Query object with the search criteria.
+        # @param [String] namespace The namespace the query is to run within.
+        #
+        # @return [Google::Cloud::Datastore::Dataset::AggregateQueryResults]
+        #
+        # @example
+        #   require "google/cloud/datastore"
+        #
+        #   datastore = Google::Cloud::Datastore.new
+        #
+        #   datastore.read_only_transaction do |tx|
+        #     query = tx.query("Task").
+        #       where("done", "=", false)
+        #     aggregate_query = query.aggregate_query
+        #     res = tx.run_aggregation aggregate_query
+        #   end
+        #
         def run_aggregation aggregate_query, namespace: nil
           ensure_service!
           unless aggregate_query.is_a?(AggregateQuery) || aggregate_query.is_a?(GqlQuery)
             raise ArgumentError, "Cannot run a #{aggregate_query.class} object."
           end
           aggregate_query_results = service.run_aggregation_query aggregate_query.to_grpc, namespace, transaction: @id
-          AggregateQueryResults.from_grpc aggregate_query_results
+          Dataset::AggregateQueryResults.from_grpc aggregate_query_results
         end
 
         ##

--- a/google-cloud-datastore/lib/google/cloud/datastore/service.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/service.rb
@@ -88,6 +88,27 @@ module Google
                             gql_query: gql_query
         end
 
+        ## Query for aggregates
+        def run_aggregation_query query, namespace = nil, consistency: nil, transaction: nil
+          gql_query = nil
+          if query.is_a? Google::Cloud::Datastore::V1::GqlQuery
+            gql_query = query
+            query = nil
+          end
+          read_options = generate_read_options consistency, transaction
+          if namespace
+            partition_id = Google::Cloud::Datastore::V1::PartitionId.new(
+              namespace_id: namespace
+            )
+          end
+
+          service.run_aggregation_query project_id: project,
+                                        partition_id: partition_id,
+                                        read_options: read_options,
+                                        aggregation_query: query,
+                                        gql_query: gql_query
+        end
+
         ##
         # Begin a new transaction.
         def begin_transaction read_only: nil, previous_transaction: nil

--- a/google-cloud-datastore/test/google/cloud/aggregate_query_test.rb
+++ b/google-cloud-datastore/test/google/cloud/aggregate_query_test.rb
@@ -39,7 +39,6 @@ describe "Aggregate Query", :mock_datastore do
     dataset.service.mocked_service.verify
   end
 
-  focus
   it "creates an aggregate query with default alias" do
     expected_aggregation_query = aggregation_query_factory('count')
     aggr_resp = aggregation_query_response_factory('count': 4)
@@ -52,7 +51,6 @@ describe "Aggregate Query", :mock_datastore do
     _(res.get('count')).must_equal 4
   end
 
-  focus
   it "creates an aggregate query with custom alias" do
     expected_aggregation_query = aggregation_query_factory('total')
     aggr_resp = aggregation_query_response_factory('total': 4)
@@ -65,7 +63,6 @@ describe "Aggregate Query", :mock_datastore do
     _(res.get('total')).must_equal 4
   end
 
-  focus
   it "creates an aggregate query with multiple aliases" do
     expected_aggregation_query = aggregation_query_factory('total_1', 'total_2')
     aggr_resp = aggregation_query_response_factory('total_1': 4, 'total_2': 4)
@@ -79,7 +76,6 @@ describe "Aggregate Query", :mock_datastore do
     _(res.get('total_2')).must_equal 4
   end
 
-  focus
   it "creates an aggregate query with unspecified alias" do
     expected_aggregation_query = aggregation_query_factory('count')
     aggr_resp = aggregation_query_response_factory
@@ -92,7 +88,6 @@ describe "Aggregate Query", :mock_datastore do
     _(res.get('unspecified_alias')).must_be :nil?
   end
 
-  focus
   it "creates aggregate via gql query" do
     expected_aggregation_query = gql_aggregation_query_factory "SELECT COUNT(*) AS total FROM User"
     aggr_resp = gql_query_response_factory('total': 4)

--- a/google-cloud-datastore/test/google/cloud/aggregate_query_test.rb
+++ b/google-cloud-datastore/test/google/cloud/aggregate_query_test.rb
@@ -30,87 +30,6 @@ describe "Aggregate Query", :mock_datastore do
       offset: 0
     )
   end
-  let(:expected_aq_object) do
-    Google::Cloud::Datastore::V1::AggregationQuery.new(
-      nested_query: expected_query,
-      aggregations: [
-        Google::Cloud::Datastore::V1::AggregationQuery::Aggregation.new(
-          alias: "count",
-          count: Google::Cloud::Datastore::V1::AggregationQuery::Aggregation::Count.new
-        )
-      ]
-    )
-  end
-  let(:aggregate_query_res) do
-    Google::Cloud::Datastore::V1::RunAggregationQueryResponse.new(
-      batch: Google::Cloud::Datastore::V1::AggregationResultBatch.new(
-        read_time: Google::Protobuf::Timestamp.new(seconds: 1673852227, nanos: 370563000),
-        more_results: :NO_MORE_RESULTS,
-        aggregation_results: [
-          Google::Cloud::Datastore::V1::AggregationResult.new(
-            aggregate_properties: { "count" => Google::Cloud::Datastore::V1::Value.new(meaning: 0, exclude_from_indexes: false, integer_value: 4) }
-          )
-        ]
-      )
-    )
-  end
-
-  let(:expected_aq_object_with_alias) do
-    Google::Cloud::Datastore::V1::AggregationQuery.new(
-      nested_query: expected_query,
-      aggregations: [
-        Google::Cloud::Datastore::V1::AggregationQuery::Aggregation.new(
-          alias: "total",
-          count: Google::Cloud::Datastore::V1::AggregationQuery::Aggregation::Count.new
-        )
-      ]
-    )
-  end
-  let(:aggregate_query_res_with_alias) do
-    Google::Cloud::Datastore::V1::RunAggregationQueryResponse.new(
-      batch: Google::Cloud::Datastore::V1::AggregationResultBatch.new(
-        read_time: Google::Protobuf::Timestamp.new(seconds: 1673852227, nanos: 370563000),
-        more_results: :NO_MORE_RESULTS,
-        aggregation_results: [
-          Google::Cloud::Datastore::V1::AggregationResult.new(
-            aggregate_properties: { "total" => Google::Cloud::Datastore::V1::Value.new(meaning: 0, exclude_from_indexes: false, integer_value: 4) }
-          )
-        ]
-      )
-    )
-  end
-
-  let(:expected_aq_object_with_multiple_aliases) do
-    Google::Cloud::Datastore::V1::AggregationQuery.new(
-      nested_query: expected_query,
-      aggregations: [
-        Google::Cloud::Datastore::V1::AggregationQuery::Aggregation.new(
-          alias: "total_1",
-          count: Google::Cloud::Datastore::V1::AggregationQuery::Aggregation::Count.new
-        ),
-        Google::Cloud::Datastore::V1::AggregationQuery::Aggregation.new(
-          alias: "total_2",
-          count: Google::Cloud::Datastore::V1::AggregationQuery::Aggregation::Count.new
-        )
-      ]
-    )
-  end
-  let(:aggregate_query_res_with_multiple_aliases) do
-    Google::Cloud::Datastore::V1::RunAggregationQueryResponse.new(
-      batch: Google::Cloud::Datastore::V1::AggregationResultBatch.new(
-        read_time: Google::Protobuf::Timestamp.new(seconds: 1673852227, nanos: 370563000),
-        more_results: :NO_MORE_RESULTS,
-        aggregation_results: [
-          Google::Cloud::Datastore::V1::AggregationResult.new(
-            aggregate_properties: {
-              "total_1" => Google::Cloud::Datastore::V1::Value.new(meaning: 0, exclude_from_indexes: false, integer_value: 4),
-              "total_2" => Google::Cloud::Datastore::V1::Value.new(meaning: 0, exclude_from_indexes: false, integer_value: 4)
-            }
-          )
-        ]
-      )
-    )
-  end
 
   before do
     dataset.service.mocked_service = Minitest::Mock.new
@@ -122,19 +41,24 @@ describe "Aggregate Query", :mock_datastore do
 
   focus
   it "creates an aggregate query with default alias" do
+    expected_aggregation_query = aggregation_query_factory('count')
+    mocked_response = aggregation_query_response_factory({'count' => 4})
     dataset.service.mocked_service.expect :run_aggregation_query,
-      aggregate_query_res,
-      **aggregate_query_args(project_id: project_id, aggregation_query: expected_aq_object)
+      mocked_response,
+      **aggregate_query_args(project_id: project_id, aggregation_query: expected_aggregation_query)
     aq = query.aggregate_query
               .add_count
-    dataset.run_aggregation aq
+    res = dataset.run_aggregation aq
+    _(res.get('count')).must_equal 4
   end
 
   focus
   it "creates an aggregate query with custom alias" do
+    expected_aggregation_query = aggregation_query_factory('total')
+    mocked_response = aggregation_query_response_factory({'total' => 4})
     dataset.service.mocked_service.expect :run_aggregation_query,
-      aggregate_query_res_with_alias,
-      **aggregate_query_args(project_id: project_id, aggregation_query: expected_aq_object_with_alias)
+      mocked_response,
+      **aggregate_query_args(project_id: project_id, aggregation_query: expected_aggregation_query)
     aq = query.aggregate_query
               .add_count(aggregate_alias: 'total')
     res = dataset.run_aggregation aq
@@ -143,15 +67,43 @@ describe "Aggregate Query", :mock_datastore do
 
   focus
   it "creates an aggregate query with multiple aliases" do
+    expected_aggregation_query = aggregation_query_factory('total_1', 'total_2')
+    mocked_response = aggregation_query_response_factory({'total_1' => 4, 'total_2' => 4})
     dataset.service.mocked_service.expect :run_aggregation_query,
-      aggregate_query_res_with_multiple_aliases,
-      **aggregate_query_args(project_id: project_id, aggregation_query: expected_aq_object_with_multiple_aliases)
+    mocked_response,
+      **aggregate_query_args(project_id: project_id, aggregation_query: expected_aggregation_query)
     aq = query.aggregate_query
               .add_count(aggregate_alias: 'total_1')
               .add_count(aggregate_alias: 'total_2')
     res = dataset.run_aggregation aq
     _(res.get('total_1')).must_equal 4
     _(res.get('total_2')).must_equal 4
+  end
+
+  def aggregation_query_factory *aliases
+    Google::Cloud::Datastore::V1::AggregationQuery.new(
+      nested_query: expected_query,
+      aggregations: aliases.map do |a|
+        Google::Cloud::Datastore::V1::AggregationQuery::Aggregation.new(
+          alias: a,
+          count: Google::Cloud::Datastore::V1::AggregationQuery::Aggregation::Count.new
+        )
+      end
+    )
+  end
+
+  def aggregation_query_response_factory props
+    Google::Cloud::Datastore::V1::RunAggregationQueryResponse.new(
+      batch: Google::Cloud::Datastore::V1::AggregationResultBatch.new(
+        read_time: Google::Protobuf::Timestamp.new(seconds: 1673852227, nanos: 370563000),
+        more_results: :NO_MORE_RESULTS,
+        aggregation_results: [
+          Google::Cloud::Datastore::V1::AggregationResult.new(
+            aggregate_properties: props.transform_values { |v| Google::Cloud::Datastore::V1::Value.new(meaning: 0, exclude_from_indexes: false, integer_value: v) }
+          )
+        ]
+      )
+    )
   end
 
   def aggregate_query_args project_id: nil,

--- a/google-cloud-datastore/test/google/cloud/aggregate_query_test.rb
+++ b/google-cloud-datastore/test/google/cloud/aggregate_query_test.rb
@@ -1,0 +1,170 @@
+# Copyright 2014 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe "Aggregate Query", :mock_datastore do
+  let(:project_id) { "my-todo-project" }
+  let(:credentials) { OpenStruct.new }
+  let(:dataset) { Google::Cloud::Datastore::Dataset.new(Google::Cloud::Datastore::Service.new(project_id, credentials)) }
+  let(:query) { Google::Cloud::Datastore::Query.new.kind("User") }
+  let(:expected_query) do
+    Google::Cloud::Datastore::V1::Query.new(
+      projection: [],
+      kind: [Google::Cloud::Datastore::V1::KindExpression.new(name: "User")],
+      order: [],
+      distinct_on: [],
+      start_cursor: "",
+      end_cursor: "",
+      offset: 0
+    )
+  end
+  let(:expected_aq_object) do
+    Google::Cloud::Datastore::V1::AggregationQuery.new(
+      nested_query: expected_query,
+      aggregations: [
+        Google::Cloud::Datastore::V1::AggregationQuery::Aggregation.new(
+          alias: "count",
+          count: Google::Cloud::Datastore::V1::AggregationQuery::Aggregation::Count.new
+        )
+      ]
+    )
+  end
+  let(:aggregate_query_res) do
+    Google::Cloud::Datastore::V1::RunAggregationQueryResponse.new(
+      batch: Google::Cloud::Datastore::V1::AggregationResultBatch.new(
+        read_time: Google::Protobuf::Timestamp.new(seconds: 1673852227, nanos: 370563000),
+        more_results: :NO_MORE_RESULTS,
+        aggregation_results: [
+          Google::Cloud::Datastore::V1::AggregationResult.new(
+            aggregate_properties: { "count" => Google::Cloud::Datastore::V1::Value.new(meaning: 0, exclude_from_indexes: false, integer_value: 4) }
+          )
+        ]
+      )
+    )
+  end
+
+  let(:expected_aq_object_with_alias) do
+    Google::Cloud::Datastore::V1::AggregationQuery.new(
+      nested_query: expected_query,
+      aggregations: [
+        Google::Cloud::Datastore::V1::AggregationQuery::Aggregation.new(
+          alias: "total",
+          count: Google::Cloud::Datastore::V1::AggregationQuery::Aggregation::Count.new
+        )
+      ]
+    )
+  end
+  let(:aggregate_query_res_with_alias) do
+    Google::Cloud::Datastore::V1::RunAggregationQueryResponse.new(
+      batch: Google::Cloud::Datastore::V1::AggregationResultBatch.new(
+        read_time: Google::Protobuf::Timestamp.new(seconds: 1673852227, nanos: 370563000),
+        more_results: :NO_MORE_RESULTS,
+        aggregation_results: [
+          Google::Cloud::Datastore::V1::AggregationResult.new(
+            aggregate_properties: { "total" => Google::Cloud::Datastore::V1::Value.new(meaning: 0, exclude_from_indexes: false, integer_value: 4) }
+          )
+        ]
+      )
+    )
+  end
+
+  let(:expected_aq_object_with_multiple_aliases) do
+    Google::Cloud::Datastore::V1::AggregationQuery.new(
+      nested_query: expected_query,
+      aggregations: [
+        Google::Cloud::Datastore::V1::AggregationQuery::Aggregation.new(
+          alias: "total_1",
+          count: Google::Cloud::Datastore::V1::AggregationQuery::Aggregation::Count.new
+        ),
+        Google::Cloud::Datastore::V1::AggregationQuery::Aggregation.new(
+          alias: "total_2",
+          count: Google::Cloud::Datastore::V1::AggregationQuery::Aggregation::Count.new
+        )
+      ]
+    )
+  end
+  let(:aggregate_query_res_with_multiple_aliases) do
+    Google::Cloud::Datastore::V1::RunAggregationQueryResponse.new(
+      batch: Google::Cloud::Datastore::V1::AggregationResultBatch.new(
+        read_time: Google::Protobuf::Timestamp.new(seconds: 1673852227, nanos: 370563000),
+        more_results: :NO_MORE_RESULTS,
+        aggregation_results: [
+          Google::Cloud::Datastore::V1::AggregationResult.new(
+            aggregate_properties: {
+              "total_1" => Google::Cloud::Datastore::V1::Value.new(meaning: 0, exclude_from_indexes: false, integer_value: 4),
+              "total_2" => Google::Cloud::Datastore::V1::Value.new(meaning: 0, exclude_from_indexes: false, integer_value: 4)
+            }
+          )
+        ]
+      )
+    )
+  end
+
+  before do
+    dataset.service.mocked_service = Minitest::Mock.new
+  end
+
+  after do
+    dataset.service.mocked_service.verify
+  end
+
+  focus
+  it "creates an aggregate query with default alias" do
+    dataset.service.mocked_service.expect :run_aggregation_query,
+      aggregate_query_res,
+      **aggregate_query_args(project_id: project_id, aggregation_query: expected_aq_object)
+    aq = query.aggregate_query
+              .add_count
+    dataset.run_aggregation aq
+  end
+
+  focus
+  it "creates an aggregate query with custom alias" do
+    dataset.service.mocked_service.expect :run_aggregation_query,
+      aggregate_query_res_with_alias,
+      **aggregate_query_args(project_id: project_id, aggregation_query: expected_aq_object_with_alias)
+    aq = query.aggregate_query
+              .add_count(aggregate_alias: 'total')
+    res = dataset.run_aggregation aq
+    _(res.get('total')).must_equal 4
+  end
+
+  focus
+  it "creates an aggregate query with multiple aliases" do
+    dataset.service.mocked_service.expect :run_aggregation_query,
+      aggregate_query_res_with_multiple_aliases,
+      **aggregate_query_args(project_id: project_id, aggregation_query: expected_aq_object_with_multiple_aliases)
+    aq = query.aggregate_query
+              .add_count(aggregate_alias: 'total_1')
+              .add_count(aggregate_alias: 'total_2')
+    res = dataset.run_aggregation aq
+    _(res.get('total_1')).must_equal 4
+    _(res.get('total_2')).must_equal 4
+  end
+
+  def aggregate_query_args project_id: nil,
+                           partition_id: nil,
+                           read_options: nil,
+                           aggregation_query: nil,
+                           gql_query: nil
+    {
+      project_id: project_id,
+      partition_id: partition_id,
+      read_options: read_options,
+      aggregation_query: aggregation_query,
+      gql_query: gql_query
+    }
+  end
+end

--- a/google-cloud-datastore/test/google/cloud/aggregate_query_test.rb
+++ b/google-cloud-datastore/test/google/cloud/aggregate_query_test.rb
@@ -48,6 +48,7 @@ describe "Aggregate Query", :mock_datastore do
               .add_count
     res = dataset.run_aggregation aq
 
+    _(res.get).must_equal 4
     _(res.get('count')).must_equal 4
   end
 
@@ -60,6 +61,7 @@ describe "Aggregate Query", :mock_datastore do
               .add_count(aggregate_alias: 'total')
     res = dataset.run_aggregation aq
 
+    _(res.get).must_equal 4
     _(res.get('total')).must_equal 4
   end
 
@@ -89,12 +91,12 @@ describe "Aggregate Query", :mock_datastore do
   end
 
   it "creates aggregate via gql query" do
-    expected_aggregation_query = gql_aggregation_query_factory "SELECT COUNT(*) AS total FROM User"
-    aggr_resp = gql_query_response_factory('total': 4)
+    expected_aggregation_query = gql_aggregation_query_factory "SELECT COUNT(*) FROM User"
+    aggr_resp = gql_query_response_factory('count': 4)
     dataset.service.mocked_service.expect :run_aggregation_query, aggr_resp, **aggr_args(project_id: project_id, gql_query: expected_aggregation_query)
-    gql = dataset.gql "SELECT COUNT(*) AS total FROM User"
+    gql = dataset.gql "SELECT COUNT(*) FROM User"
     res = dataset.run_aggregation gql
-    _(res.get('total')).must_equal 4
+    _(res.get).must_equal 4
   end
 
   def aggregation_query_factory *aliases

--- a/google-cloud-datastore/test/google/cloud/datastore/read_only_transaction_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/read_only_transaction_test.rb
@@ -56,6 +56,63 @@ describe Google::Cloud::Datastore::ReadOnlyTransaction, :mock_datastore do
       )
     )
   end
+  let(:query_grpc) do
+    Google::Cloud::Datastore::V1::Query.new(
+      projection: [],
+      kind: [Google::Cloud::Datastore::V1::KindExpression.new(name: "User")],
+      order: [],
+      distinct_on: [],
+      start_cursor: "",
+      end_cursor: "",
+      offset: 0
+    )
+  end
+  let(:run_aggregation_query_res) do
+    aggregation_results = [
+      Google::Cloud::Datastore::V1::AggregationResult.new(
+        aggregate_properties: {
+          'count' => Google::Cloud::Datastore::V1::Value.new(meaning: 0, exclude_from_indexes: false, integer_value: 2)
+        }
+      )
+    ]
+    Google::Cloud::Datastore::V1::RunAggregationQueryResponse.new(
+      batch: Google::Cloud::Datastore::V1::AggregationResultBatch.new(
+        read_time: Google::Protobuf::Timestamp.new(seconds: 1673852227, nanos: 370563000),
+        more_results: :NO_MORE_RESULTS,
+        aggregation_results: aggregation_results
+      )
+    )
+  end
+  let(:aggregate_query_grpc) do
+    aggregations = [
+      Google::Cloud::Datastore::V1::AggregationQuery::Aggregation.new(
+        alias: 'count',
+        count: Google::Cloud::Datastore::V1::AggregationQuery::Aggregation::Count.new
+      )
+    ]
+    Google::Cloud::Datastore::V1::AggregationQuery.new(nested_query: query_grpc, aggregations: aggregations)
+  end
+  let(:aggregate_gql_query_res) do
+    aggregation_results = [
+      Google::Cloud::Datastore::V1::AggregationResult.new(aggregate_properties: { 'total' => Google::Cloud::Datastore::V1::Value.new(meaning: 0, exclude_from_indexes: false, integer_value: 2) })
+    ]
+    Google::Cloud::Datastore::V1::RunAggregationQueryResponse.new(
+      batch: Google::Cloud::Datastore::V1::AggregationResultBatch.new(
+        read_time: Google::Protobuf::Timestamp.new(seconds: 1673852227, nanos: 370563000),
+        more_results: :NO_MORE_RESULTS,
+        aggregation_results: aggregation_results
+      ),
+      query: Google::Cloud::Datastore::V1::AggregationQuery.new(
+        nested_query: query_grpc,
+        aggregations: [
+          Google::Cloud::Datastore::V1::AggregationQuery::Aggregation.new(
+            alias: "total",
+            count: Google::Cloud::Datastore::V1::AggregationQuery::Aggregation::Count.new
+          )
+        ]
+      )
+    )
+  end
   let(:query_cursor) { Google::Cloud::Datastore::Cursor.new "c3VwZXJhd2Vzb21lIQ==" }
   let(:begin_tx_res) do
     Google::Cloud::Datastore::V1::BeginTransactionResponse.new(transaction: tx_id)
@@ -63,6 +120,7 @@ describe Google::Cloud::Datastore::ReadOnlyTransaction, :mock_datastore do
   let(:tx_id) { "giterdone".encode("ASCII-8BIT") }
   let(:read_options) { Google::Cloud::Datastore::V1::ReadOptions.new(transaction: tx_id) }
   let(:gql_query_grpc) { Google::Cloud::Datastore::V1::GqlQuery.new(query_string: "SELECT * FROM Task") }
+  let(:gql_aggregate_query_grpc) { Google::Cloud::Datastore::V1::GqlQuery.new(query_string: "SELECT COUNT(*) as total FROM Task") }
 
   after do
     transaction.service.mocked_service.verify
@@ -143,6 +201,24 @@ describe Google::Cloud::Datastore::ReadOnlyTransaction, :mock_datastore do
     refute entities.more_after_limit?
     refute entities.more_after_cursor?
     refute entities.no_more?
+  end
+
+  focus
+  it "run_aggregate will fulfill an aggregate query" do
+    transaction.service.mocked_service.expect :run_aggregation_query, run_aggregation_query_res, project_id: project, partition_id: nil, read_options: read_options, aggregation_query: aggregate_query_grpc, gql_query: nil
+    query = Google::Cloud::Datastore::Query.new.kind("User")
+    aq = query.aggregate_query
+              .add_count
+    res = transaction.run_aggregation aq
+    _(res.get('count')).must_equal 2
+  end
+
+  focus
+  it "run_aggregate will fulfill an aggregate gql query" do
+    transaction.service.mocked_service.expect :run_aggregation_query, aggregate_gql_query_res, project_id: project, partition_id: nil, read_options: read_options, aggregation_query: nil, gql_query: gql_aggregate_query_grpc
+    gql = dataset.gql "SELECT COUNT(*) as total FROM Task"
+    res = transaction.run_aggregation gql
+    _(res.get('total')).must_equal 2
   end
 
   describe "error handling" do

--- a/google-cloud-datastore/test/google/cloud/datastore/read_only_transaction_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/read_only_transaction_test.rb
@@ -202,7 +202,6 @@ describe Google::Cloud::Datastore::ReadOnlyTransaction, :mock_datastore do
     refute entities.no_more?
   end
 
-  # focus
   it "run_aggregate will fulfill an aggregate query" do
     transaction.service.mocked_service.expect :run_aggregation_query, run_aggregation_query_res, project_id: project, partition_id: nil, read_options: read_options, aggregation_query: aggregate_query_grpc, gql_query: nil
     query = Google::Cloud::Datastore::Query.new.kind("User")
@@ -212,7 +211,6 @@ describe Google::Cloud::Datastore::ReadOnlyTransaction, :mock_datastore do
     _(res.get('count')).must_equal 2
   end
 
-  # focus
   it "run_aggregate will fulfill an aggregate gql query" do
     transaction.service.mocked_service.expect :run_aggregation_query, aggregate_gql_query_res, project_id: project, partition_id: nil, read_options: read_options, aggregation_query: nil, gql_query: gql_aggregate_query_grpc
     gql = dataset.gql "SELECT COUNT(*) as total FROM Task"

--- a/google-cloud-datastore/test/google/cloud/datastore/read_only_transaction_test.rb
+++ b/google-cloud-datastore/test/google/cloud/datastore/read_only_transaction_test.rb
@@ -154,7 +154,6 @@ describe Google::Cloud::Datastore::ReadOnlyTransaction, :mock_datastore do
   end
 
   it "run will fulfill a query" do
-    query_grpc = Google::Cloud::Datastore::Query.new.kind("User").to_grpc
     transaction.service.mocked_service.expect :run_query, run_query_res, project_id: project, partition_id: nil, read_options: read_options, query: query_grpc, gql_query: nil
 
     query = Google::Cloud::Datastore::Query.new.kind("User")
@@ -203,7 +202,7 @@ describe Google::Cloud::Datastore::ReadOnlyTransaction, :mock_datastore do
     refute entities.no_more?
   end
 
-  focus
+  # focus
   it "run_aggregate will fulfill an aggregate query" do
     transaction.service.mocked_service.expect :run_aggregation_query, run_aggregation_query_res, project_id: project, partition_id: nil, read_options: read_options, aggregation_query: aggregate_query_grpc, gql_query: nil
     query = Google::Cloud::Datastore::Query.new.kind("User")
@@ -213,7 +212,7 @@ describe Google::Cloud::Datastore::ReadOnlyTransaction, :mock_datastore do
     _(res.get('count')).must_equal 2
   end
 
-  focus
+  # focus
   it "run_aggregate will fulfill an aggregate gql query" do
     transaction.service.mocked_service.expect :run_aggregation_query, aggregate_gql_query_res, project_id: project, partition_id: nil, read_options: read_options, aggregation_query: nil, gql_query: gql_aggregate_query_grpc
     gql = dataset.gql "SELECT COUNT(*) as total FROM Task"


### PR DESCRIPTION
This PR adds support for Datastore's Aggregate Query Count feature.

Similar implementation for Firestore has been done previously in #19457