### PR TITLE
fix(firestore): Change "aggregate_alias" to optional param

### DIFF
--- a/google-cloud-firestore/acceptance/firestore/aggregate_query_test.rb
+++ b/google-cloud-firestore/acceptance/firestore/aggregate_query_test.rb
@@ -26,7 +26,7 @@ describe "Aggregate Query", :firestore_acceptance do
                        .add_count
 
     snapshot = aq.get.first
-    _(snapshot.get('count')).must_equal 3
+    _(snapshot.get).must_equal 3
   end
 
   it "returns 0 for no records" do
@@ -36,7 +36,7 @@ describe "Aggregate Query", :firestore_acceptance do
                        .add_count
 
     snapshot = aq.get.first
-    _(snapshot.get('count')).must_equal 0
+    _(snapshot.get).must_equal 0
   end
 
   it "returns count on filter" do
@@ -50,7 +50,7 @@ describe "Aggregate Query", :firestore_acceptance do
               .add_count
 
     snapshot = aq.get.first
-    _(snapshot.get('count')).must_equal 1
+    _(snapshot.get).must_equal 1
   end
 
   it "returns count on limit" do
@@ -65,7 +65,7 @@ describe "Aggregate Query", :firestore_acceptance do
               .add_count
 
     snapshot = aq.get.first
-    _(snapshot.get('count')).must_equal 2
+    _(snapshot.get).must_equal 2
   end
 
   it "returns count with a custom alias" do
@@ -78,6 +78,7 @@ describe "Aggregate Query", :firestore_acceptance do
                        .add_count aggregate_alias: 'one'
 
     snapshot = aq.get.first
+    _(snapshot.get).must_equal 3
     _(snapshot.get('one')).must_equal 3
   end
 
@@ -109,6 +110,20 @@ describe "Aggregate Query", :firestore_acceptance do
     _(snapshot.get('unspecified_alias')).must_be :nil?
   end
 
+  it "throws error when custom alias isn't specified for multiple aliases" do
+    rand_query_col = firestore.col "#{root_path}/query/#{SecureRandom.hex(4)}"
+    rand_query_col.add({foo: "a"})
+    rand_query_col.add({bar: "b"})
+    rand_query_col.add({qux: "c"})
+
+    aq = rand_query_col.aggregate_query
+                       .add_count(aggregate_alias: 'one')
+                       .add_count(aggregate_alias: 'two')
+
+    snapshot = aq.get.first
+    expect { snapshot.get }.must_raise ArgumentError
+  end
+
   it "throws error when duplicating aliases" do
     rand_query_col = firestore.col "#{root_path}/query/#{SecureRandom.hex(4)}"
     rand_query_col.add({foo: "a"})
@@ -133,10 +148,10 @@ describe "Aggregate Query", :firestore_acceptance do
                        .add_count
 
     snapshot = aq.get.first
-    _(snapshot.get('count')).must_equal 3
+    _(snapshot.get).must_equal 3
 
     snapshot = aq.get.first
-    _(snapshot.get('count')).must_equal 3
+    _(snapshot.get).must_equal 3
   end
 
   it "returns different count when data changes" do
@@ -149,12 +164,12 @@ describe "Aggregate Query", :firestore_acceptance do
                        .add_count
 
     snapshot = aq.get.first
-    _(snapshot.get('count')).must_equal 3
+    _(snapshot.get).must_equal 3
 
     rand_query_col.doc("doc4").create({foo: "d"})
 
     snapshot = aq.get.first
-    _(snapshot.get('count')).must_equal 4
+    _(snapshot.get).must_equal 4
   end
   
   it "throws error when no aggregate is added" do
@@ -183,6 +198,6 @@ describe "Aggregate Query", :firestore_acceptance do
     end
 
     snapshot = results.first
-    _(snapshot.get('count')).must_equal 3
+    _(snapshot.get).must_equal 3
   end
 end

--- a/google-cloud-firestore/lib/google/cloud/firestore/aggregate_query.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/aggregate_query.rb
@@ -38,7 +38,7 @@ module Google
       #                          .add_count
       #
       #   aggregate_query.get do |aggregate_snapshot|
-      #     puts aggregate_snapshot.get('count')
+      #     puts aggregate_snapshot.get
       #   end
       #
       # @example Alias an aggregate query
@@ -102,7 +102,7 @@ module Google
         #                          .add_count
         #
         #   aggregate_query.get do |aggregate_snapshot|
-        #     puts aggregate_snapshot.get('count')
+        #     puts aggregate_snapshot.get
         #   end
         #
         def add_count aggregate_alias: nil
@@ -135,7 +135,7 @@ module Google
         #                          .add_count
         #
         #   aggregate_query.get do |aggregate_snapshot|
-        #     puts aggregate_snapshot.get('count')
+        #     puts aggregate_snapshot.get
         #   end
         #
         def get

--- a/google-cloud-firestore/lib/google/cloud/firestore/aggregate_query_snapshot.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/aggregate_query_snapshot.rb
@@ -96,7 +96,7 @@ module Google
           if @aggregate_fields.count > 1 && aggregate_alias.nil?
             raise ArgumentError, "Required param aggregate_alias for AggregateQuery with multiple aggregate fields"
           end
-          aggregate_alias = @aggregate_fields.keys.first if aggregate_alias.nil?
+          aggregate_alias ||= @aggregate_fields.keys.first
           @aggregate_fields[aggregate_alias]
         end
 

--- a/google-cloud-firestore/lib/google/cloud/firestore/aggregate_query_snapshot.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/aggregate_query_snapshot.rb
@@ -34,16 +34,31 @@ module Google
       #                          .add_count
       #
       #   aggregate_query.get do |aggregate_snapshot|
-      #     puts aggregate_snapshot.get('count')
+      #     puts aggregate_snapshot.get
       #   end
+      # @return [Integer] The aggregate value.
       #
+      # @example Alias an aggregate query
+      #   require "google/cloud/firestore"
+      #
+      #   firestore = Google::Cloud::Firestore.new
+      #
+      #   query = firestore.col "cities"
+      #
+      #   # Create an aggregate query
+      #   aggregate_query = query.aggregate_query
+      #                          .add_count aggregate_alias: 'total'
+      #
+      #   aggregate_query.get do |aggregate_snapshot|
+      #     puts aggregate_snapshot.get('total')
+      #   end
       class AggregateQuerySnapshot
         ##
         # Retrieves the aggregate data.
         #
-        # @param [String] aggregate_alias The alias used
-        #   to access the aggregate value. For count, the
-        #   default value is "count".
+        # @param aggregate_alias [String] The alias used to access
+        #   the aggregate value. For an AggregateQuery with a
+        #   single aggregate field, this parameter can be omitted.
         #
         # @return [Integer] The aggregate value.
         #
@@ -59,9 +74,29 @@ module Google
         #                          .add_count
         #
         #   aggregate_query.get do |aggregate_snapshot|
-        #     puts aggregate_snapshot.get('count')
+        #     puts aggregate_snapshot.get
         #   end
-        def get aggregate_alias
+        # @return [Integer] The aggregate value.
+        #
+        # @example Alias an aggregate query
+        #   require "google/cloud/firestore"
+        #
+        #   firestore = Google::Cloud::Firestore.new
+        #
+        #   query = firestore.col "cities"
+        #
+        #   # Create an aggregate query
+        #   aggregate_query = query.aggregate_query
+        #                          .add_count aggregate_alias: 'total'
+        #
+        #   aggregate_query.get do |aggregate_snapshot|
+        #     puts aggregate_snapshot.get('total')
+        #   end
+        def get aggregate_alias = nil
+          if @aggregate_fields.count > 1 && aggregate_alias.nil?
+            raise ArgumentError, "Required param aggregate_alias for AggregateQuery with multiple aggregate fields"
+          end
+          aggregate_alias = @aggregate_fields.keys.first if aggregate_alias.nil?
           @aggregate_fields[aggregate_alias]
         end
 

--- a/google-cloud-firestore/lib/google/cloud/firestore/transaction.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/transaction.rb
@@ -286,9 +286,15 @@ module Google
         #
         #   firestore = Google::Cloud::Firestore.new
         #
+        #   query = firestore.col "cities"
+        #
+        #   # Create an aggregate query
+        #   aq = query.aggregate_query
+        #             .add_count
+        #
         #   firestore.transaction do |tx|
         #     tx.get_aggregate aq do |aggregate_snapshot|
-        #       puts aggregate_snapshot.get('count')
+        #       puts aggregate_snapshot.get
         #     end
         #   end
         #

--- a/google-cloud-firestore/test/google/cloud/firestore/aggregate_query/get_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/aggregate_query/get_test.rb
@@ -56,7 +56,7 @@ describe Google::Cloud::Firestore::AggregateQuery, :add_count, :mock_firestore d
     _(results.count).must_equal 1
     results.each do |result|
       _(result).must_be_kind_of Google::Cloud::Firestore::AggregateQuerySnapshot 
-      _(result.get('count')).must_equal 3
+      _(result.get).must_equal 3
     end
   end
 
@@ -92,6 +92,7 @@ describe Google::Cloud::Firestore::AggregateQuery, :add_count, :mock_firestore d
     _(results.count).must_equal 1
     results.each do |result|
       _(result).must_be_kind_of Google::Cloud::Firestore::AggregateQuerySnapshot 
+      _(result.get).must_equal 3
       _(result.get('total_score')).must_equal 3
     end
   end


### PR DESCRIPTION
This Firestore PR is a follow up to the discussion in a related Datastore PR i.e; https://github.com/googleapis/google-cloud-ruby/pull/20039#discussion_r1084674395. The parameter `aggregate_alias` param is made optional to facilitate easier access of a single-aggregate query responses.