### PR TITLE
feat(firestore): Support REST transport

### DIFF
--- a/google-cloud-firestore/Rakefile
+++ b/google-cloud-firestore/Rakefile
@@ -67,7 +67,8 @@ task :acceptance, :project, :keyfile do |t, args|
   ENV["FIRESTORE_PROJECT"] = project
   ENV["FIRESTORE_KEYFILE_JSON"] = keyfile
 
-  Rake::Task["acceptance:run"].invoke
+  Rake::Task["acceptance:grpc"].invoke
+  Rake::Task["acceptance:rest"].invoke
 end
 
 namespace :acceptance do
@@ -124,10 +125,12 @@ namespace :acceptance do
     end
   end
 
-  Rake::TestTask.new :run do |t|
-    t.libs << "acceptance"
-    t.test_files = FileList["acceptance/**/*_test.rb"]
-    t.warning = false
+  ["grpc", "rest"].each do |transport|
+    Rake::TestTask.new transport do |t|
+      t.libs << "acceptance"
+      t.test_files = FileList["acceptance/init_#{transport}.rb", "acceptance/**/*_test.rb"]
+      t.warning = false
+    end
   end
 end
 

--- a/google-cloud-firestore/acceptance/firestore/aggregate_query_test.rb
+++ b/google-cloud-firestore/acceptance/firestore/aggregate_query_test.rb
@@ -15,6 +15,13 @@
 require "firestore_helper"
 
 describe "Aggregate Query", :firestore_acceptance do
+  let :expected_error_class do
+    if Google::Cloud.configure.firestore.transport == :rest
+      Gapic::Rest::Error
+    else
+      GRPC::InvalidArgument
+    end
+  end
 
   it "returns count for non-zero records" do
     rand_query_col = firestore.col "#{root_path}/query/#{SecureRandom.hex(4)}"
@@ -134,7 +141,7 @@ describe "Aggregate Query", :firestore_acceptance do
                        .add_count(aggregate_alias: 'one')
                        .add_count(aggregate_alias: 'one')
 
-    expect { snapshot = aq.get.first }.must_raise GRPC::InvalidArgument
+    expect { snapshot = aq.get.first }.must_raise expected_error_class
   end
 
 
@@ -181,7 +188,7 @@ describe "Aggregate Query", :firestore_acceptance do
     # aggregate object with no added aggregate (ex: aq.add_count)
     aq = rand_query_col.aggregate_query
 
-    expect { snapshot = aq.get.first }.must_raise GRPC::InvalidArgument
+    expect { snapshot = aq.get.first }.must_raise expected_error_class
   end
 
   it "returns count inside a transaction" do

--- a/google-cloud-firestore/acceptance/firestore/document_test.rb
+++ b/google-cloud-firestore/acceptance/firestore/document_test.rb
@@ -270,6 +270,7 @@ describe "Document", :firestore_acceptance do
   end
 
   it "has collections method" do
+    skip if Google::Cloud.configure.firestore.transport == :rest
     collections_doc_ref = root_col.add
 
     collections = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"]
@@ -294,6 +295,7 @@ describe "Document", :firestore_acceptance do
   end
 
   it "has collections method with read time" do
+    skip if Google::Cloud.configure.firestore.transport == :rest
     collections_doc_ref = root_col.add
 
     collections = ["a", "b", "c", "d", "e"]

--- a/google-cloud-firestore/acceptance/firestore/firestore_test.rb
+++ b/google-cloud-firestore/acceptance/firestore/firestore_test.rb
@@ -16,6 +16,7 @@ require "firestore_helper"
 
 describe "Firestore", :firestore_acceptance do
   it "paginates root collections" do
+    skip if Google::Cloud.configure.firestore.transport == :rest
     root_col.add # call to ensure that the collection exists
     cols = firestore.collections
     _(cols).must_be_kind_of Enumerator

--- a/google-cloud-firestore/acceptance/firestore/service_test.rb
+++ b/google-cloud-firestore/acceptance/firestore/service_test.rb
@@ -27,7 +27,13 @@ describe Google::Cloud::Firestore::Service, :firestore_acceptance do
   it "passes the correct configuration to its v1 client" do
     _(firestore.project_id).wont_be :empty?
     config = firestore.service.firestore.configure
-    _(config).must_be_kind_of Google::Cloud::Firestore::V1::Firestore::Client::Configuration
+    config_class =
+      if Google::Cloud.configure.firestore.transport == :rest
+        Google::Cloud::Firestore::V1::Firestore::Rest::Client::Configuration
+      else
+        Google::Cloud::Firestore::V1::Firestore::Client::Configuration
+      end
+    _(config).must_be_kind_of config_class
     _(config.lib_name).must_equal "gccl"
     _(config.lib_version).must_equal Google::Cloud::Firestore::VERSION
     _(config.metadata).must_equal config_metadata

--- a/google-cloud-firestore/acceptance/firestore/watch_test.rb
+++ b/google-cloud-firestore/acceptance/firestore/watch_test.rb
@@ -15,6 +15,8 @@
 require "firestore_helper"
 
 describe "Watch", :firestore_acceptance do
+  before { skip if Google::Cloud.configure.firestore.transport == :rest }
+
   it "watches a limit query" do
     watch_col = root_col.doc("watch-limit-#{SecureRandom.hex(4)}").col("watch-query")
 

--- a/google-cloud-firestore/acceptance/init_grpc.rb
+++ b/google-cloud-firestore/acceptance/init_grpc.rb
@@ -1,0 +1,18 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "google/cloud/firestore"
+
+puts "**** Running tests for gRPC transport ****"
+Google::Cloud.configure.firestore.transport = :grpc

--- a/google-cloud-firestore/acceptance/init_rest.rb
+++ b/google-cloud-firestore/acceptance/init_rest.rb
@@ -1,0 +1,18 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "google/cloud/firestore"
+
+puts "**** Running tests for REST transport ****"
+Google::Cloud.configure.firestore.transport = :rest

--- a/google-cloud-firestore/google-cloud-firestore.gemspec
+++ b/google-cloud-firestore/google-cloud-firestore.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.6"
 
   gem.add_dependency "google-cloud-core", "~> 1.5"
-  gem.add_dependency "google-cloud-firestore-v1", "~> 0.8"
+  gem.add_dependency "google-cloud-firestore-v1", "~> 0.10"
   gem.add_dependency "concurrent-ruby", "~> 1.0"
   gem.add_dependency "rbtree", "~> 0.4.2"
 

--- a/google-cloud-firestore/lib/google-cloud-firestore.rb
+++ b/google-cloud-firestore/lib/google-cloud-firestore.rb
@@ -44,6 +44,8 @@ module Google
     # @param [Integer] timeout Default timeout to use in requests. Optional.
     # @param [String] database_id Identifier for a Firestore database. If not
     #   present, the default database of the project is used.
+    # @param [:grpc,:rest] transport Which transport to use to communicate
+    #   with the server. Defaults to `:grpc`.
     #
     # @return [Google::Cloud::Firestore::Client]
     #
@@ -67,8 +69,16 @@ module Google
     #   database_id = "my-todo-database"
     #   firestore = gcloud.firestore database_id: database_id
     #
-    def firestore scope: nil, timeout: nil, database_id: nil
-      Google::Cloud.firestore @project, @keyfile, scope: scope, timeout: (timeout || @timeout), database_id: database_id
+    def firestore scope: nil,
+                  timeout: nil,
+                  database_id: nil,
+                  transport: nil
+      transport ||= Google::Cloud.configure.firestore.transport
+      Google::Cloud.firestore @project, @keyfile,
+                              scope: scope,
+                              timeout: (timeout || @timeout),
+                              database_id: database_id,
+                              transport: transport
     end
 
     ##
@@ -94,6 +104,8 @@ module Google
     # @param [Integer] timeout Default timeout to use in requests. Optional.
     # @param [String] database_id Identifier for a Firestore database. If not
     #   present, the default database of the project is used.
+    # @param [:grpc,:rest] transport Which transport to use to communicate
+    #   with the server. Defaults to `:grpc`.
     #
     # @return [Google::Cloud::Firestore::Client]
     #
@@ -102,16 +114,25 @@ module Google
     #
     #   firestore = Google::Cloud.firestore
     #
-    def self.firestore project_id = nil, credentials = nil, scope: nil, timeout: nil, database_id: nil
+    def self.firestore project_id = nil,
+                       credentials = nil,
+                       scope: nil,
+                       timeout: nil,
+                       database_id: nil,
+                       transport: nil
       require "google/cloud/firestore"
+      transport ||= Google::Cloud.configure.firestore.transport
       Google::Cloud::Firestore.new project_id: project_id,
                                    credentials: credentials,
                                    scope: scope,
                                    timeout: timeout,
-                                   database_id: database_id
+                                   database_id: database_id,
+                                   transport: transport
     end
   end
 end
+
+# rubocop:disable Metrics/BlockLength
 
 # Set the default firestore configuration
 Google::Cloud.configure.add_config! :firestore do |config|
@@ -141,4 +162,7 @@ Google::Cloud.configure.add_config! :firestore do |config|
   config.add_field! :emulator_host, default_emulator, match: String, allow_nil: true
   config.add_field! :endpoint, "firestore.googleapis.com", match: String
   config.add_field! :database_id, "(default)", match: String
+  config.add_field! :transport, :grpc, match: Symbol
 end
+
+# rubocop:enable Metrics/BlockLength

--- a/google-cloud-firestore/lib/google/cloud/firestore.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore.rb
@@ -61,6 +61,8 @@ module Google
       #   If the param is nil, uses the value of the `emulator_host` config.
       # @param [String] database_id Identifier for a Firestore database. If not
       #   present, the default database of the project is used.
+      # @param [:grpc,:rest] transport Which transport to use to communicate
+      #   with the server. Defaults to `:grpc`.
       # @param [String] project Alias for the `project_id` argument. Deprecated.
       # @param [String] keyfile Alias for the `credentials` argument.
       #   Deprecated.
@@ -79,6 +81,7 @@ module Google
                    endpoint: nil,
                    emulator_host: nil,
                    database_id: nil,
+                   transport: nil,
                    project: nil,
                    keyfile: nil
         project_id ||= (project || default_project_id)
@@ -87,13 +90,14 @@ module Google
         endpoint ||= configure.endpoint
         emulator_host ||= configure.emulator_host
         database_id ||= configure.database_id
+        transport ||= configure.transport
 
         if emulator_host
           project_id = project_id.to_s
           raise ArgumentError, "project_id is missing" if project_id.empty?
 
           service = Firestore::Service.new project_id, :this_channel_is_insecure, host: emulator_host,
-                                           timeout: timeout, database: database_id
+                                           timeout: timeout, database: database_id, transport: transport
           return Firestore::Client.new service
         end
 
@@ -109,7 +113,7 @@ module Google
         raise ArgumentError, "project_id is missing" if project_id.empty?
 
         service = Firestore::Service.new project_id, credentials, host: endpoint,
-                                         timeout: timeout, database: database_id
+                                         timeout: timeout, database: database_id, transport: transport
         Firestore::Client.new service
       end
 

--- a/google-cloud-firestore/lib/google/cloud/firestore/service.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/service.rb
@@ -34,17 +34,19 @@ module Google
 
         ##
         # Creates a new Service instance.
-        def initialize project, credentials, host: nil, timeout: nil, database: nil
+        def initialize project, credentials, host: nil, timeout: nil, database: nil, transport: :grpc
           @project = project
           @credentials = credentials
           @host = host
           @timeout = timeout
           @database = database
+          @transport = transport
         end
 
         def firestore
-          @firestore ||= \
-            V1::Firestore::Client.new do |config|
+          @firestore ||= begin
+            client_class = @transport == :rest ? V1::Firestore::Rest::Client : V1::Firestore::Client
+            client_class.new do |config|
               config.credentials = credentials if credentials
               config.timeout = timeout if timeout
               config.endpoint = host if host
@@ -52,6 +54,7 @@ module Google
               config.lib_version = Google::Cloud::Firestore::VERSION
               config.metadata = { "google-cloud-resource-prefix": "projects/#{@project}/databases/#{@database}" }
             end
+          end
         end
 
         def get_documents document_paths, mask: nil, transaction: nil, read_time: nil

--- a/google-cloud-firestore/samples/Rakefile
+++ b/google-cloud-firestore/samples/Rakefile
@@ -14,7 +14,16 @@
 
 require "rake/testtask"
 
-Rake::TestTask.new "test" do |t|
+namespace :test do
+  ["grpc", "rest"].each do |transport|
+    Rake::TestTask.new transport do |t|
+      t.test_files = FileList["acceptance/init_#{transport}.rb", "**/*_test.rb"]
+      t.warning = false
+    end
+  end
+end
+
+task :test do
   project = ENV["FIRESTORE_TEST_PROJECT"] || ENV["GCLOUD_TEST_PROJECT"]
   keyfile = ENV["FIRESTORE_TEST_KEYFILE"] || ENV["FIRESTORE_TEST_KEYFILE_JSON"] ||
             ENV["GCLOUD_TEST_KEYFILE"] || ENV["GCLOUD_TEST_KEYFILE_JSON"]
@@ -32,6 +41,6 @@ Rake::TestTask.new "test" do |t|
   ENV["FIRESTORE_PROJECT"] = project
   ENV["FIRESTORE_KEYFILE_JSON"] = keyfile
 
-  t.test_files = FileList["**/*_test.rb"]
-  t.warning = false
+  Rake::Task["test:grpc"].invoke
+  Rake::Task["test:rest"].invoke
 end

--- a/google-cloud-firestore/samples/acceptance/get_data_test.rb
+++ b/google-cloud-firestore/samples/acceptance/get_data_test.rb
@@ -88,6 +88,7 @@ describe "Google Cloud Firestore API samples - Get Data" do
   end
 
   it "list_subcollections" do
+    skip if Google::Cloud.configure.firestore.transport == :rest
     # Setup
     capture_io do
       add_subcollection project_id: @firestore_project, collection_path: @collection_path

--- a/google-cloud-firestore/samples/acceptance/init_grpc.rb
+++ b/google-cloud-firestore/samples/acceptance/init_grpc.rb
@@ -1,0 +1,18 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "google/cloud/firestore"
+
+puts "**** Running tests for gRPC transport ****"
+Google::Cloud.configure.firestore.transport = :grpc

--- a/google-cloud-firestore/samples/acceptance/init_rest.rb
+++ b/google-cloud-firestore/samples/acceptance/init_rest.rb
@@ -1,0 +1,18 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "google/cloud/firestore"
+
+puts "**** Running tests for REST transport ****"
+Google::Cloud.configure.firestore.transport = :rest

--- a/google-cloud-firestore/samples/acceptance/query_watch_test.rb
+++ b/google-cloud-firestore/samples/acceptance/query_watch_test.rb
@@ -17,6 +17,7 @@ require_relative "../query_watch"
 
 describe "Google Cloud Firestore API samples - Query Data" do
   before do
+    skip if Google::Cloud.configure.firestore.transport == :rest
     @firestore_project = ENV["FIRESTORE_PROJECT"]
     @collection_path = random_name "cities"
   end

--- a/google-cloud-firestore/test/google/cloud/firestore_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore_test.rb
@@ -25,7 +25,7 @@ describe Google::Cloud do
   describe "#firestore" do
     it "calls out to Google::Cloud.firestore" do
       gcloud = Google::Cloud.new
-      stubbed_firestore = ->(project, keyfile, scope: nil, timeout: nil, host: nil, database_id: "(default)"){
+      stubbed_firestore = ->(project, keyfile, scope: nil, timeout: nil, host: nil, database_id: "(default)", transport: nil){
         _(project).must_be :nil?
         _(keyfile).must_be :nil?
         _(scope).must_be :nil?
@@ -41,7 +41,7 @@ describe Google::Cloud do
 
     it "passes project and keyfile to Google::Cloud.firestore" do
       gcloud = Google::Cloud.new "project-id", "keyfile-path"
-      stubbed_firestore = ->(project, keyfile, scope: nil, timeout: nil, host: nil, database_id: "(default)"){
+      stubbed_firestore = ->(project, keyfile, scope: nil, timeout: nil, host: nil, database_id: "(default)", transport: nil){
         _(project).must_equal "project-id"
         _(keyfile).must_equal "keyfile-path"
         _(scope).must_be :nil?
@@ -57,7 +57,7 @@ describe Google::Cloud do
 
     it "passes project and keyfile and options to Google::Cloud.firestore" do
       gcloud = Google::Cloud.new "project-id", "keyfile-path"
-      stubbed_firestore = ->(project, keyfile, scope: nil, timeout: nil, host: nil, database_id: "(default)"){
+      stubbed_firestore = ->(project, keyfile, scope: nil, timeout: nil, host: nil, database_id: "(default)", transport: nil){
         _(project).must_equal "project-id"
         _(keyfile).must_equal "keyfile-path"
         _(scope).must_equal "http://example.com/scope"
@@ -104,7 +104,7 @@ describe Google::Cloud do
         _(scope).must_equal default_scope
         "firestore-credentials"
       }
-      stubbed_service = ->(project, credentials, timeout: nil, host: nil, database: "(default)") {
+      stubbed_service = ->(project, credentials, timeout: nil, host: nil, database: "(default)", transport: :grpc) {
         _(project).must_equal "project-id"
         _(credentials).must_equal "firestore-credentials"
         _(timeout).must_be :nil?
@@ -164,7 +164,7 @@ describe Google::Cloud do
         _(scope).must_equal default_scope
         "firestore-credentials"
       }
-      stubbed_service = ->(project, credentials, timeout: nil, host: nil, database: "(default)") {
+      stubbed_service = ->(project, credentials, timeout: nil, host: nil, database: "(default)", transport: :grpc) {
         _(project).must_equal "project-id"
         _(credentials).must_equal "firestore-credentials"
         _(timeout).must_be :nil?
@@ -197,7 +197,7 @@ describe Google::Cloud do
         _(scope).must_equal default_scope
         "firestore-credentials"
       }
-      stubbed_service = ->(project, credentials, timeout: nil, host: nil, database: "(default)") {
+      stubbed_service = ->(project, credentials, timeout: nil, host: nil, database: "(default)", transport: :grpc) {
         _(project).must_equal "project-id"
         _(credentials).must_equal "firestore-credentials"
         _(timeout).must_be :nil?
@@ -226,7 +226,7 @@ describe Google::Cloud do
 
     it "uses provided endpoint" do
       endpoint = "firestore-endpoint2.example.com"
-      stubbed_service = ->(project, credentials, timeout: nil, host: nil, database: "(default)") {
+      stubbed_service = ->(project, credentials, timeout: nil, host: nil, database: "(default)", transport: :grpc) {
         _(project).must_equal "project-id"
         _(credentials).must_equal default_credentials
         _(timeout).must_be :nil?
@@ -287,7 +287,7 @@ describe Google::Cloud do
         _(scope).must_equal default_scope
         OpenStruct.new project_id: "project-id"
       }
-      stubbed_service = ->(project, credentials, timeout: nil, host: nil, database: "(default)") {
+      stubbed_service = ->(project, credentials, timeout: nil, host: nil, database: "(default)", transport: :grpc) {
         _(project).must_equal "project-id"
         _(credentials).must_be_kind_of OpenStruct
         _(credentials.project_id).must_equal "project-id"
@@ -331,7 +331,7 @@ describe Google::Cloud do
         _(scope).must_equal default_scope
         "firestore-credentials"
       }
-      stubbed_service = ->(project, credentials, timeout: nil, host: nil, database: "(default)") {
+      stubbed_service = ->(project, credentials, timeout: nil, host: nil, database: "(default)", transport: :grpc) {
         _(project).must_equal "project-id"
         _(credentials).must_equal "firestore-credentials"
         _(timeout).must_be :nil?
@@ -369,7 +369,7 @@ describe Google::Cloud do
         _(scope).must_equal default_scope
         "firestore-credentials"
       }
-      stubbed_service = ->(project, credentials, timeout: nil, host: nil, database: "(default)") {
+      stubbed_service = ->(project, credentials, timeout: nil, host: nil, database: "(default)", transport: :grpc) {
         _(project).must_equal "project-id"
         _(credentials).must_equal "firestore-credentials"
         _(timeout).must_be :nil?
@@ -407,7 +407,7 @@ describe Google::Cloud do
         _(scope).must_equal default_scope
         "firestore-credentials"
       }
-      stubbed_service = ->(project, credentials, timeout: nil, host: nil, database: "(default)") {
+      stubbed_service = ->(project, credentials, timeout: nil, host: nil, database: "(default)", transport: :grpc) {
         _(project).must_equal "project-id"
         _(credentials).must_equal "firestore-credentials"
         _(timeout).must_equal 42
@@ -445,7 +445,7 @@ describe Google::Cloud do
         _(scope).must_equal default_scope
         "firestore-credentials"
       }
-      stubbed_service = ->(project, credentials, timeout: nil, host: nil, database: "(default)") {
+      stubbed_service = ->(project, credentials, timeout: nil, host: nil, database: "(default)", transport: :grpc) {
         _(project).must_equal "project-id"
         _(credentials).must_equal "firestore-credentials"
         _(timeout).must_equal 42
@@ -483,7 +483,7 @@ describe Google::Cloud do
         _(scope).must_equal default_scope
         "firestore-credentials"
       }
-      stubbed_service = ->(project, credentials, timeout: nil, host: nil, database: "(default)") {
+      stubbed_service = ->(project, credentials, timeout: nil, host: nil, database: "(default)", transport: :grpc) {
         _(project).must_equal "project-id"
         _(credentials).must_equal "firestore-credentials"
         _(timeout).must_be :nil?


### PR DESCRIPTION
The main goal here is actually to get integration tests running for REST transport. We picked Firestore because there are streaming calls. But this PR effectively adds REST support to the handwritten layer.