### PR TITLE
docs(pubsub): Correct default value for streams

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber.rb
@@ -53,7 +53,7 @@ module Google
       # @attr_reader [Boolean] message_ordering Whether message ordering has
       #   been enabled.
       # @attr_reader [Integer] streams The number of concurrent streams to open
-      #   to pull messages from the subscription. Default is 4.
+      #   to pull messages from the subscription. Default is 2.
       # @attr_reader [Integer] callback_threads The number of threads used to
       #   handle the received messages. Default is 8.
       # @attr_reader [Integer] push_threads The number of threads to handle

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -937,7 +937,7 @@ module Google
         #   the default message_ordering value for the subscription when this
         #   argument is not provided. See {#reference?}.
         # @param [Integer] streams The number of concurrent streams to open to
-        #   pull messages from the subscription. Default is 4. Optional.
+        #   pull messages from the subscription. Default is 2. Optional.
         # @param [Hash, Integer] inventory The settings to control how received messages are to be handled by the
         #   subscriber. When provided as an Integer instead of a Hash only `max_outstanding_messages` will be set.
         #   Optional.


### PR DESCRIPTION
The default value is 2, when to doc is saying that it's 4.