### PR TITLE
chore(ci): Dir.exists? method is deprecated and removed in Ruby 3.2

### DIFF
--- a/.toys/ci.rb
+++ b/.toys/ci.rb
@@ -275,7 +275,7 @@ def find_changed_directories files
       dirs << dir
       if dir =~ %r{^(.+)-v\d[^-]*$}
         wrapper_dir = Regexp.last_match[1]
-        if Dir.exists? wrapper_dir
+        if Dir.exist? wrapper_dir
           dirs << wrapper_dir
         end
       end


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-ruby/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea.
- [ ] Follow the instructions in [CONTRIBUTING](CONTRIBUTING.md). Most importantly, ensure the tests and linter pass by running `bundle exec rake ci` in the gem subdirectory.
- [ ] Update code documentation if necessary.

closes: #<issue_number_goes_here>