### PR TITLE
chore(automl): Ensure backward compatibility when the auto_ml factory method name changes

### DIFF
--- a/google-cloud-automl/.owlbot-manifest.json
+++ b/google-cloud-automl/.owlbot-manifest.json
@@ -21,6 +21,7 @@
   "static": [
     ".OwlBot.yaml",
     "MIGRATING.md",
-    "acceptance/google/cloud/automl/v1beta1/automl_service_smoke_test.rb"
+    "acceptance/google/cloud/automl/v1beta1/automl_service_smoke_test.rb",
+    "lib/google/cloud/automl/helpers.rb"
   ]
 }

--- a/google-cloud-automl/lib/google/cloud/automl/helpers.rb
+++ b/google-cloud-automl/lib/google/cloud/automl/helpers.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Cloud
+    module AutoML
+      class << self
+        # Backwards-compatibility hack: Define "auto_ml" as an alternative name
+        # for the "automl" method. The generator changed this name due to
+        # https://github.com/googleapis/gapic-generator-ruby/pull/935.
+        if public_method_defined?(:automl) && !public_method_defined?(:auto_ml)
+          alias auto_ml automl
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This protects backward compatibility for the auto_ml method after https://github.com/googleapis/gapic-generator-ruby/pull/935 goes into effect.