### PR TITLE
fix(pubsub): wait for successful receipt modack when exactly once delivery enabled

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
@@ -302,14 +302,14 @@ module Google
 
           def create_receipt_modack_for_eos received_messages
             received_messages.each do |rec_msg_grpc|
-              callback = Proc.new do |result|
+              callback = proc do |result|
                 if result.succeeded?
                   synchronize { @inventory.add rec_msg_grpc }
-                  rec_msg = ReceivedMessage.from_grpc(rec_msg_grpc, self)
+                  rec_msg = ReceivedMessage.from_grpc rec_msg_grpc, self
                   register_callback rec_msg
                 end
               end
-              @subscriber.buffer.modify_ack_deadline @subscriber.deadline, [rec_msg_grpc.ack_id], callback 
+              @subscriber.buffer.modify_ack_deadline @subscriber.deadline, [rec_msg_grpc.ack_id], callback
             end
           end
 

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/timed_unary_buffer_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/timed_unary_buffer_test.rb
@@ -78,6 +78,9 @@ describe Google::Cloud::PubSub::Subscriber, :stream, :mock_pubsub do
     stub = StreamingPullStub.new response_groups
     called = false  
     def stub.modify_ack_deadline subscription:, ack_ids:, ack_deadline_seconds:
+      if @modify_ack_deadline_requests.count == 0
+        return  @modify_ack_deadline_requests << [subscription, ack_ids.sort, ack_deadline_seconds]
+      end
       @modify_ack_deadline_requests << [subscription, ack_ids.sort, ack_deadline_seconds]
       begin
         raise GRPC::InvalidArgument.new "test"
@@ -102,7 +105,7 @@ describe Google::Cloud::PubSub::Subscriber, :stream, :mock_pubsub do
     end
      
     sleep 5
-    assert stub.modify_ack_deadline_requests.length > 1
+    assert stub.modify_ack_deadline_requests.length > 2
     subscriber.stop
     subscriber.wait!
   end
@@ -118,6 +121,9 @@ describe Google::Cloud::PubSub::Subscriber, :stream, :mock_pubsub do
     called = false  
     errors = []
     def stub.modify_ack_deadline subscription:, ack_ids:, ack_deadline_seconds:
+      if @modify_ack_deadline_requests.count == 0
+        return  @modify_ack_deadline_requests << [subscription, ack_ids.sort, ack_deadline_seconds]
+      end
       raise StandardError.new "Test failure"
     end
   
@@ -245,6 +251,9 @@ describe Google::Cloud::PubSub::Subscriber, :stream, :mock_pubsub do
     called = false  
     errors = []
     def stub.modify_ack_deadline subscription:, ack_ids:, ack_deadline_seconds:
+      if @modify_ack_deadline_requests.count == 0
+        return  @modify_ack_deadline_requests << ["ack_ids"]
+      end
       raise Google::Cloud::PermissionDeniedError.new "Test failure"
     end
   
@@ -329,6 +338,9 @@ describe Google::Cloud::PubSub::Subscriber, :stream, :mock_pubsub do
     called = false  
     errors = []
     def stub.modify_ack_deadline subscription:, ack_ids:, ack_deadline_seconds:
+      if @modify_ack_deadline_requests.count == 0
+        return  @modify_ack_deadline_requests << ["ack_ids"]
+      end
       raise Google::Cloud::FailedPreconditionError.new "Test failure"
     end
   

--- a/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/timed_unary_buffer_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/subscriber/timed_unary_buffer_test.rb
@@ -79,7 +79,7 @@ describe Google::Cloud::PubSub::Subscriber, :stream, :mock_pubsub do
     called = false  
     def stub.modify_ack_deadline subscription:, ack_ids:, ack_deadline_seconds:
       if @modify_ack_deadline_requests.count == 0
-        return  @modify_ack_deadline_requests << [subscription, ack_ids.sort, ack_deadline_seconds]
+        return @modify_ack_deadline_requests << [subscription, ack_ids.sort, ack_deadline_seconds]
       end
       @modify_ack_deadline_requests << [subscription, ack_ids.sort, ack_deadline_seconds]
       begin
@@ -122,7 +122,7 @@ describe Google::Cloud::PubSub::Subscriber, :stream, :mock_pubsub do
     errors = []
     def stub.modify_ack_deadline subscription:, ack_ids:, ack_deadline_seconds:
       if @modify_ack_deadline_requests.count == 0
-        return  @modify_ack_deadline_requests << [subscription, ack_ids.sort, ack_deadline_seconds]
+        return @modify_ack_deadline_requests << [subscription, ack_ids.sort, ack_deadline_seconds]
       end
       raise StandardError.new "Test failure"
     end
@@ -252,7 +252,7 @@ describe Google::Cloud::PubSub::Subscriber, :stream, :mock_pubsub do
     errors = []
     def stub.modify_ack_deadline subscription:, ack_ids:, ack_deadline_seconds:
       if @modify_ack_deadline_requests.count == 0
-        return  @modify_ack_deadline_requests << ["ack_ids"]
+        return @modify_ack_deadline_requests << ["ack_ids"]
       end
       raise Google::Cloud::PermissionDeniedError.new "Test failure"
     end
@@ -339,7 +339,7 @@ describe Google::Cloud::PubSub::Subscriber, :stream, :mock_pubsub do
     errors = []
     def stub.modify_ack_deadline subscription:, ack_ids:, ack_deadline_seconds:
       if @modify_ack_deadline_requests.count == 0
-        return  @modify_ack_deadline_requests << ["ack_ids"]
+        return @modify_ack_deadline_requests << ["ack_ids"]
       end
       raise Google::Cloud::FailedPreconditionError.new "Test failure"
     end


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-ruby/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea.
- [ ] Follow the instructions in [CONTRIBUTING](CONTRIBUTING.md). Most importantly, ensure the tests and linter pass by running `bundle exec rake ci` in the gem subdirectory.
- [ ] Update code documentation if necessary.

closes: #20899