### PR TITLE
chore(scheduler): update region tag typo

### DIFF
--- a/google-cloud-scheduler/samples/app.rb
+++ b/google-cloud-scheduler/samples/app.rb
@@ -16,7 +16,7 @@
 
 $stdout.sync = true
 
-# [START cloud_scheduler_app]
+# [START cloudscheduler_app]
 require "sinatra"
 
 # Define relative URI for job endpoint
@@ -26,7 +26,7 @@ post "/log_payload" do
   puts "Received job with payload: #{data}"
   "Printed job payload: #{data}"
 end
-# [END cloud_scheduler_app]
+# [END cloudscheduler_app]
 
 get "/" do
   # Basic index to verify app is serving

--- a/google-cloud-scheduler/samples/app.yaml
+++ b/google-cloud-scheduler/samples/app.yaml
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START cloud_scheduler_yaml]
+# [START cloudscheduler_yaml]
 runtime: ruby
 service: my-service
 env: flex
 entrypoint: bundle exec ruby app.rb
-# [END cloud_scheduler_yaml]
+# [END cloudscheduler_yaml]

--- a/google-cloud-scheduler/samples/create_job.rb
+++ b/google-cloud-scheduler/samples/create_job.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 def create_job project_id:, location_id:, service_id:
-  # [START cloud_scheduler_create_job]
+  # [START cloudscheduler_create_job]
   require "google/cloud/scheduler"
 
   # Create a client.
@@ -47,6 +47,6 @@ def create_job project_id:, location_id:, service_id:
   response = client.create_job parent: parent, job: job
 
   puts "Created job: #{response.name}"
-  # [END cloud_scheduler_create_job]
+  # [END cloudscheduler_create_job]
   response.name
 end

--- a/google-cloud-scheduler/samples/delete_job.rb
+++ b/google-cloud-scheduler/samples/delete_job.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 def delete_job project_id:, location_id:, job_name:
-  # [START cloud_scheduler_create_job]
+  # [START cloud_scheduler_delete_job]
   require "google/cloud/scheduler"
 
   # Create a client.
@@ -33,5 +33,5 @@ def delete_job project_id:, location_id:, job_name:
   client.delete_job name: job
 
   puts "Job deleted."
-  # [END cloud_scheduler_create_job]
+  # [END cloud_scheduler_delete_job]
 end

--- a/google-cloud-scheduler/samples/delete_job.rb
+++ b/google-cloud-scheduler/samples/delete_job.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 def delete_job project_id:, location_id:, job_name:
-  # [START cloud_scheduler_delete_job]
+  # [START cloudscheduler_delete_job]
   require "google/cloud/scheduler"
 
   # Create a client.
@@ -33,5 +33,5 @@ def delete_job project_id:, location_id:, job_name:
   client.delete_job name: job
 
   puts "Job deleted."
-  # [END cloud_scheduler_delete_job]
+  # [END cloudscheduler_delete_job]
 end


### PR DESCRIPTION
This sample has a duplicate region tag (https://github.com/googleapis/google-cloud-ruby/blob/main/google-cloud-scheduler/samples/create_job.rb) because of a typo; this sample actually _deletes_ a job, so updating the region tag to match.