### PR TITLE
chore(main): Improve nightly test reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,4 +73,4 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        toys ci report-failures -v
+        toys ci report-failures --github-action-id=${{ github.run_id }} -v

--- a/.toys/ci.rb
+++ b/.toys/ci.rb
@@ -441,6 +441,6 @@ tool "report-failures" do
     unless github_action_id.nil?
       messages << "The CI logs can be found [here](https://github.com/googleapis/google-cloud-ruby/actions/runs/#{github_action_id})"
     end
-    messages.join("\n\n")
+    messages.join "\n\n"
   end
 end

--- a/.toys/ci.rb
+++ b/.toys/ci.rb
@@ -371,7 +371,6 @@ end
 tool "report-failures" do
   flag :report_path, "--report-path=PATH", default: FAILURES_REPORT_PATH
   flag :github_action_id, "--github-action-id=ACTION_ID" do |f|
-    f.default ""
     f.desc "Github Action ID under which the CI is running. Optional."
   end
 
@@ -437,12 +436,11 @@ tool "report-failures" do
   
   def create_body dir, tasks
     now = Time.now.utc.strftime "%Y-%m-%d %H:%M:%S"
-    if github_action_id
-      action_url = "https://github.com/googleapis/google-cloud-ruby/actions/runs/#{github_action_id}"
+    messages = []
+    messages << "At #{now} UTC, detected failures in #{dir} for: #{tasks.join ', '}."
+    unless github_action_id.nil?
+      messages << "The CI logs can be found [here](https://github.com/googleapis/google-cloud-ruby/actions/runs/#{github_action_id})"
     end
-    [
-      "At #{now} UTC, detected failures in #{dir} for: #{tasks.join ', '}.",
-      "The CI logs can be found [here](#{action_url})."
-    ].join("\n\n")
+    messages.join("\n\n")
   end
 end

--- a/.toys/ci.rb
+++ b/.toys/ci.rb
@@ -370,6 +370,10 @@ end
 
 tool "report-failures" do
   flag :report_path, "--report-path=PATH", default: FAILURES_REPORT_PATH
+  flag :github_action_id, "--github-action-id=ACTION_ID" do |f|
+    f.default ""
+    f.desc "Github Action ID under which the CI is running. Optional."
+  end
 
   include :exec, e: true
   include :terminal
@@ -433,6 +437,12 @@ tool "report-failures" do
   
   def create_body dir, tasks
     now = Time.now.utc.strftime "%Y-%m-%d %H:%M:%S"
-    "At #{now} UTC, detected failures in #{dir} for: #{tasks.join ', '}"
+    if github_action_id
+      action_url = "https://github.com/googleapis/google-cloud-ruby/actions/runs/#{github_action_id}"
+    end
+    [
+      "At #{now} UTC, detected failures in #{dir} for: #{tasks.join ', '}.",
+      "The CI logs can be found [here](#{action_url})."
+    ].join("\n\n")
   end
 end


### PR DESCRIPTION
This is a small PR to improve the debugging workflow for nightly test failures.

### Current Process

- Nightly CI runs are configured to raise an issue in the below image format when they fail.
- To find the cause of a failure, we must manually go to the Actions tab and scroll through all the CI runs. 

<img width="667" alt="6g8qhJnhDn85rh6" src="https://user-images.githubusercontent.com/7530864/233998443-79727196-ae4f-4d5e-bf1e-0df34e0eb19f.png">

### Improvement

- This PR improves the process by automatically linking the issue to the failing CI run. This will make it easier for us to quickly find the cause of a failure.

<img width="621" alt="6RmSWyoVnVoQPW4" src="https://user-images.githubusercontent.com/7530864/233998517-0151b6d3-5557-4150-830a-ebac772c1072.png">

Tested and verified with #21478
