### PR TITLE
chore: Fix regex in library generator to extract gem name

### DIFF
--- a/.toys/new-library.rb
+++ b/.toys/new-library.rb
@@ -189,7 +189,7 @@ def gem_name
   @gem_name ||= begin
     build_file_path = File.join bazel_base_dir, proto_namespace, "BUILD.bazel"
     bazel_rules_content = File.read build_file_path
-    if bazel_rules_content =~ /"ruby-cloud-gem-name=([\w-]+)",/
+    if bazel_rules_content =~ /"ruby-cloud-gem-name=([\w-]+)"/
       Regexp.last_match[1]
     else
       error "Unable to find gem name rule in #{build_file_path}"


### PR DESCRIPTION
Fixes an issue noticed during #21482.

In the new library generator, the [present regex](https://github.com/googleapis/google-cloud-ruby/blob/fec29674e458d45b03acb18bfbfa64e0116ab257/.toys/new-library.rb#L192) cannot match the following gem pattern:

```
["ruby-cloud-gem-name=google-cloud-storageinsights-v1"],
```

I'm guessing `extra_protoc_parameters` field is expected to have either multiple values, in which case the trailing comma makes sense before the `]`. But that doesn't seem to be the case for all gems. This PR fixes it by only looking for values within double quotes.