### PR TITLE
chore(datastore): Add a missing type so cloud-rad doesn't complain

### DIFF
--- a/google-cloud-datastore/lib/google/cloud/datastore/dataset.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/dataset.rb
@@ -987,8 +987,8 @@ module Google
         #
         # @param name [String] The property to filter by.
         # @param operator [String] The operator to filter by. Defaults to nil.
-        # @param value The value to compare the property to. Defaults to nil.
-        #       Possible values are:
+        # @param value [Object] The value to compare the property to. Defaults
+        #       to nil. Possible values are:
         #         - Integer
         #         - Float/BigDecimal
         #         - String


### PR DESCRIPTION
Fixes the syntax that was causing https://github.com/googleapis/doc-pipeline/issues/423.
