### PR TITLE
chore(datastore): Refactor unit tests for AggregateQuery

### DIFF
--- a/google-cloud-datastore/lib/google/cloud/datastore/aggregate_query.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/aggregate_query.rb
@@ -57,18 +57,20 @@ module Google
       #
       class AggregateQuery
         ##
-        # @private The Google::Cloud::Datastore::V1::Query object.
-        attr_reader :query
+        # @private The Google::Cloud::Datastore::V1::AggregationQuery object.
+        attr_reader :grpc
 
         ##
-        # @private Array of Google::Cloud::Datastore::V1::AggregationQuery::Aggregation objects
-        attr_reader :aggregates
-
-        ##
-        # @private Creates a new AggregateQuery
+        # @private
+        #
+        # Returns a new AggregateQuery object
+        #
+        # @param query [Google::Cloud::Datastore::V1::Query]
         def initialize query
-          @query = query
-          @aggregates = []
+          @grpc = Google::Cloud::Datastore::V1::AggregationQuery.new(
+            nested_query: query,
+            aggregations: []
+          )
         end
 
         ##
@@ -112,7 +114,7 @@ module Google
         #
         def add_count aggregate_alias: nil
           aggregate_alias ||= ALIASES[:count]
-          aggregates << Google::Cloud::Datastore::V1::AggregationQuery::Aggregation.new(
+          @grpc.aggregations << Google::Cloud::Datastore::V1::AggregationQuery::Aggregation.new(
             count: Google::Cloud::Datastore::V1::AggregationQuery::Aggregation::Count.new,
             alias: aggregate_alias
           )
@@ -122,10 +124,7 @@ module Google
 
         # @private
         def to_grpc
-          Google::Cloud::Datastore::V1::AggregationQuery.new(
-            nested_query: query,
-            aggregations: aggregates
-          )
+          @grpc
         end
 
         ##


### PR DESCRIPTION
This refactoring PR is in preparation for further aggregates I'm working on. NO breaking changes.

The unit tests I wrote in #20039 for the COUNT aggregate were write hard to read/maintain. So I changed the structure of existing tests, and removed others which are best covered by acceptance tests (already part of the codebase).

I made some changes to the user-facing `AggregateQuery` class, but they only modify the internal behaviour.