### PR TITLE
test(monitoring): Try not to hide the actual failure for a test flake

### DIFF
--- a/google-cloud-monitoring/samples/acceptance/metrics_test.rb
+++ b/google-cloud-monitoring/samples/acceptance/metrics_test.rb
@@ -22,6 +22,8 @@ describe "metrics", :monitoring do
   describe "create_metric_descriptor" do
     after do
       client.delete_metric_descriptor name: metric_name
+    rescue StandardError => e
+      warn "Unexpectedly failed to delete newly created metric: #{e}"
     end
 
     it "creates a metric descriptor" do


### PR DESCRIPTION
#19988 describes a test flake in the cleanup code. I suspect that failure is masking the true failure which is happening elsewhere in the test, so let's not let the cleanup failure raise an exception.