### PR TITLE
chore: Clean up a few rubocop warnings

### DIFF
--- a/google-cloud-bigtable/Rakefile
+++ b/google-cloud-bigtable/Rakefile
@@ -178,7 +178,7 @@ desc "Run rubocop on yard examples."
 task :rubocop_yard_examples do
   YARD.parse "lib/**/*.rb"
   registry = YARD::Registry.load_all
-  examples = registry.all.map { |object| object.tags(:example) }.flatten
+  examples = registry.all.map { |object| object.tags :example }.flatten
 
   dir_name = "rubocop_yard_examples"
   rm_rf dir_name

--- a/google-cloud-video-transcoder/samples/acceptance/job_template_test.rb
+++ b/google-cloud-video-transcoder/samples/acceptance/job_template_test.rb
@@ -78,7 +78,7 @@ describe "Transcoder Snippets" do
 
     it "lists the job templates" do
       expect {
-        list_job_templates(project_id: project_id, location: location_id)
+        list_job_templates project_id: project_id, location: location_id
       }.must_output(%r{Job templates:(.*\s)*projects/#{project_number}/locations/#{location_id}/jobTemplates/#{template_id}})
     end
 

--- a/google-cloud-video-transcoder/samples/acceptance/job_test.rb
+++ b/google-cloud-video-transcoder/samples/acceptance/job_test.rb
@@ -212,7 +212,7 @@ describe "Transcoder Snippets" do
 
     it "lists a job" do
       expect {
-        list_jobs(project_id: project_id, location: location_id)
+        list_jobs project_id: project_id, location: location_id
       }.must_output(%r{Jobs:(.*\s)*projects/#{project_number}/locations/#{location_id}/jobs/#{job_id}})
     end
   end


### PR DESCRIPTION
Probably due to a new version of Rubocop