### PR TITLE
chore: new scripts for tombstone-ing and obsolete-ing a library

### DIFF
--- a/.github/workflows/obsolete-library.yml
+++ b/.github/workflows/obsolete-library.yml
@@ -1,0 +1,33 @@
+name: OwlBot Manual Run
+
+on:
+  workflow_dispatch:
+    inputs:
+      gem:
+        description: "gem name to obsolete"
+        required: true
+      flags:
+        description: "Extra flags to pass to toys obsolete-library"
+        required: false
+
+jobs:
+  OwlBot:
+    if: ${{ github.repository == 'googleapis/google-cloud-ruby' }}
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+    - name: Install Ruby 3.2
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: "3.2"
+    - name: Install tools
+      run: |
+        git config --global user.email "70984784+yoshi-code-bot@users.noreply.github.com"
+        git config --global user.name "Yoshi Code Bot"
+        gem install --no-document toys
+    - name: Obsolete-library
+      run: |
+        toys obsolete-library -v --remote=origin ${{ github.event.inputs.flags }} ${{ github.event.inputs.gem }}

--- a/.kokoro/tombstone-gem.cfg
+++ b/.kokoro/tombstone-gem.cfg
@@ -24,7 +24,7 @@ env_vars: {
 
 env_vars: {
   key: "TRAMPOLINE_BUILD_FILE"
-  value: ".kokoro/reserve-gem.sh"
+  value: ".kokoro/tombstone-gem.sh"
 }
 
 env_vars: {

--- a/.kokoro/tombstone-gem.sh
+++ b/.kokoro/tombstone-gem.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -eo pipefail
+
+# Install gems in the user directory because the default install directory
+# is in a read-only location.
+export GEM_HOME=$HOME/.gem
+export PATH=$GEM_HOME/bin:$PATH
+
+gem install --no-document toys
+toys tombstone-gem -v --release --info-url=$INFO_URL $RELEASE_PACKAGE < /dev/null

--- a/.toys/obsolete-library.rb
+++ b/.toys/obsolete-library.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+desc "A tool that obsoletes a client library"
+
+required_arg :gem_name
+
+flag :git_remote, "--remote=NAME" do
+  desc "The name of the git remote to use as the pull request head. If omitted, does not open a pull request."
+end
+
+include :fileutils
+include :exec, e: true
+include "yoshi-pr-generator"
+
+def run
+  cd context_directory
+  branch_name = "pr/delete/#{gem_name}"
+  message = "chore: obsolete #{gem_name}"
+  result = yoshi_pr_generator.capture enabled: !git_remote.nil?,
+                                      remote: git_remote,
+                                      branch_name: branch_name,
+                                      commit_message: message do
+    remove_release_manifest
+    remove_release_config
+    remove_owlbot_config
+    remove_directory
+  end
+end
+
+def remove_release_manifest
+  content = File.read ".release-please-manifest.json"
+  content.sub!(/\n  "#{gem_name}": "\d+\.\d+\.\d+",\n/, "\n")
+  content.sub! ",\n  \"#{gem_name}+FILLER\": \"0.0.0\"", ""
+  File.write ".release-please-manifest.json", content
+end
+
+def remove_release_config
+  config_json = JSON.parse File.read "release-please-config.json"
+  config_json["packages"].delete gem_name
+  File.write "release-please-config.json", "#{JSON.pretty_generate config_json}\n"
+end
+
+def remove_owlbot_config
+  rm_f "#{gem_name}/.OwlBot.yaml"
+  rm_f "#{gem_name}/.owlbot-manifest.json"
+  rm_f "#{gem_name}/.owlbot.rb"
+end
+
+def remove_directory
+  mv gem_name, "obsolete/#{gem_name}"
+end

--- a/.toys/tombstone-gem/.data/gemspec-template.erb
+++ b/.toys/tombstone-gem/.data/gemspec-template.erb
@@ -1,0 +1,27 @@
+require File.expand_path("<%= namespace_dir %>/version", __dir__)
+
+Gem::Specification.new do |gem|
+  gem.name = "<%= gem_name %>"
+  gem.version = <%= namespace %>::VERSION
+  gem.authors = ["Google LLC"]
+  gem.email = "googleapis-packages@google.com"
+  gem.description =
+    "This gem is obsolete because the related Google backend is turned down. " \
+    "For more information, see <%= info_url %>."
+  gem.summary = "This gem is obsolete because the related backend is turned down."
+  gem.post_install_message = <<~MESSAGE
+
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    The <%= gem_name %> gem is OBSOLETE.
+    For more information, see:
+    <%= info_url %>
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  MESSAGE
+  gem.homepage = "https://github.com/googleapis/google-cloud-ruby"
+  gem.license = "Apache-2.0"
+  gem.platform = Gem::Platform::RUBY
+  gem.files = ["README.md", "LICENSE.md", "<%= namespace_dir %>/version.rb"]
+  gem.require_paths = ["lib"]
+  gem.required_ruby_version = ">= 2.0"
+end

--- a/.toys/tombstone-gem/.data/license-template.erb
+++ b/.toys/tombstone-gem/.data/license-template.erb
@@ -1,0 +1,201 @@
+                                  Apache License
+                            Version 2.0, January 2004
+                         http://www.apache.org/licenses/
+
+    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+    1. Definitions.
+
+       "License" shall mean the terms and conditions for use, reproduction,
+       and distribution as defined by Sections 1 through 9 of this document.
+
+       "Licensor" shall mean the copyright owner or entity authorized by
+       the copyright owner that is granting the License.
+
+       "Legal Entity" shall mean the union of the acting entity and all
+       other entities that control, are controlled by, or are under common
+       control with that entity. For the purposes of this definition,
+       "control" means (i) the power, direct or indirect, to cause the
+       direction or management of such entity, whether by contract or
+       otherwise, or (ii) ownership of fifty percent (50%) or more of the
+       outstanding shares, or (iii) beneficial ownership of such entity.
+
+       "You" (or "Your") shall mean an individual or Legal Entity
+       exercising permissions granted by this License.
+
+       "Source" form shall mean the preferred form for making modifications,
+       including but not limited to software source code, documentation
+       source, and configuration files.
+
+       "Object" form shall mean any form resulting from mechanical
+       transformation or translation of a Source form, including but
+       not limited to compiled object code, generated documentation,
+       and conversions to other media types.
+
+       "Work" shall mean the work of authorship, whether in Source or
+       Object form, made available under the License, as indicated by a
+       copyright notice that is included in or attached to the work
+       (an example is provided in the Appendix below).
+
+       "Derivative Works" shall mean any work, whether in Source or Object
+       form, that is based on (or derived from) the Work and for which the
+       editorial revisions, annotations, elaborations, or other modifications
+       represent, as a whole, an original work of authorship. For the purposes
+       of this License, Derivative Works shall not include works that remain
+       separable from, or merely link (or bind by name) to the interfaces of,
+       the Work and Derivative Works thereof.
+
+       "Contribution" shall mean any work of authorship, including
+       the original version of the Work and any modifications or additions
+       to that Work or Derivative Works thereof, that is intentionally
+       submitted to Licensor for inclusion in the Work by the copyright owner
+       or by an individual or Legal Entity authorized to submit on behalf of
+       the copyright owner. For the purposes of this definition, "submitted"
+       means any form of electronic, verbal, or written communication sent
+       to the Licensor or its representatives, including but not limited to
+       communication on electronic mailing lists, source code control systems,
+       and issue tracking systems that are managed by, or on behalf of, the
+       Licensor for the purpose of discussing and improving the Work, but
+       excluding communication that is conspicuously marked or otherwise
+       designated in writing by the copyright owner as "Not a Contribution."
+
+       "Contributor" shall mean Licensor and any individual or Legal Entity
+       on behalf of whom a Contribution has been received by Licensor and
+       subsequently incorporated within the Work.
+
+    2. Grant of Copyright License. Subject to the terms and conditions of
+       this License, each Contributor hereby grants to You a perpetual,
+       worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+       copyright license to reproduce, prepare Derivative Works of,
+       publicly display, publicly perform, sublicense, and distribute the
+       Work and such Derivative Works in Source or Object form.
+
+    3. Grant of Patent License. Subject to the terms and conditions of
+       this License, each Contributor hereby grants to You a perpetual,
+       worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+       (except as stated in this section) patent license to make, have made,
+       use, offer to sell, sell, import, and otherwise transfer the Work,
+       where such license applies only to those patent claims licensable
+       by such Contributor that are necessarily infringed by their
+       Contribution(s) alone or by combination of their Contribution(s)
+       with the Work to which such Contribution(s) was submitted. If You
+       institute patent litigation against any entity (including a
+       cross-claim or counterclaim in a lawsuit) alleging that the Work
+       or a Contribution incorporated within the Work constitutes direct
+       or contributory patent infringement, then any patent licenses
+       granted to You under this License for that Work shall terminate
+       as of the date such litigation is filed.
+
+    4. Redistribution. You may reproduce and distribute copies of the
+       Work or Derivative Works thereof in any medium, with or without
+       modifications, and in Source or Object form, provided that You
+       meet the following conditions:
+
+       (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+       (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+       (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+       (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+       You may add Your own copyright statement to Your modifications and
+       may provide additional or different license terms and conditions
+       for use, reproduction, or distribution of Your modifications, or
+       for any such Derivative Works as a whole, provided Your use,
+       reproduction, and distribution of the Work otherwise complies with
+       the conditions stated in this License.
+
+    5. Submission of Contributions. Unless You explicitly state otherwise,
+       any Contribution intentionally submitted for inclusion in the Work
+       by You to the Licensor shall be under the terms and conditions of
+       this License, without any additional terms or conditions.
+       Notwithstanding the above, nothing herein shall supersede or modify
+       the terms of any separate license agreement you may have executed
+       with Licensor regarding such Contributions.
+
+    6. Trademarks. This License does not grant permission to use the trade
+       names, trademarks, service marks, or product names of the Licensor,
+       except as required for reasonable and customary use in describing the
+       origin of the Work and reproducing the content of the NOTICE file.
+
+    7. Disclaimer of Warranty. Unless required by applicable law or
+       agreed to in writing, Licensor provides the Work (and each
+       Contributor provides its Contributions) on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+       implied, including, without limitation, any warranties or conditions
+       of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+       PARTICULAR PURPOSE. You are solely responsible for determining the
+       appropriateness of using or redistributing the Work and assume any
+       risks associated with Your exercise of permissions under this License.
+
+    8. Limitation of Liability. In no event and under no legal theory,
+       whether in tort (including negligence), contract, or otherwise,
+       unless required by applicable law (such as deliberate and grossly
+       negligent acts) or agreed to in writing, shall any Contributor be
+       liable to You for damages, including any direct, indirect, special,
+       incidental, or consequential damages of any character arising as a
+       result of this License or out of the use or inability to use the
+       Work (including but not limited to damages for loss of goodwill,
+       work stoppage, computer failure or malfunction, or any and all
+       other commercial damages or losses), even if such Contributor
+       has been advised of the possibility of such damages.
+
+    9. Accepting Warranty or Additional Liability. While redistributing
+       the Work or Derivative Works thereof, You may choose to offer,
+       and charge a fee for, acceptance of support, warranty, indemnity,
+       or other liability obligations and/or rights consistent with this
+       License. However, in accepting such obligations, You may act only
+       on Your own behalf and on Your sole responsibility, not on behalf
+       of any other Contributor, and only if You agree to indemnify,
+       defend, and hold each Contributor harmless for any liability
+       incurred by, or claims asserted against, such Contributor by reason
+       of your accepting any such warranty or additional liability.
+
+    END OF TERMS AND CONDITIONS
+
+    APPENDIX: How to apply the Apache License to your work.
+
+       To apply the Apache License to your work, attach the following
+       boilerplate notice, with the fields enclosed by brackets "[]"
+       replaced with your own identifying information. (Don't include
+       the brackets!)  The text should be enclosed in the appropriate
+       comment syntax for the file format. We also recommend that a
+       file or class name and description of purpose be included on the
+       same "printed page" as the copyright notice for easier
+       identification within third-party archives.
+
+    Copyright [yyyy] [name of copyright owner]
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.

--- a/.toys/tombstone-gem/.data/readme-template.erb
+++ b/.toys/tombstone-gem/.data/readme-template.erb
@@ -1,0 +1,4 @@
+# Tombstone for Ruby gem <%= gem_name %>
+
+This gem is obsolete because the related Google backend is turned down.
+For more information, see <%= info_url %>.

--- a/.toys/tombstone-gem/.data/version-template.erb
+++ b/.toys/tombstone-gem/.data/version-template.erb
@@ -1,0 +1,15 @@
+# Copyright <%= cur_year %> Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+<%= version_lines %>

--- a/.toys/tombstone-gem/.toys.rb
+++ b/.toys/tombstone-gem/.toys.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+desc "Tombstone a gem in RubyGems after we think it's no longer useful"
+
+required_arg :gem_name
+optional_arg :gem_version
+flag :info_url, "--info-url=URL", default: ""
+flag :rubygems_api_token, "--rubygems-api-token=TOKEN"
+flag :release, "--[no-]release"
+flag :tmpdir, "--tmpdir=PATH"
+
+include :exec, e: true
+include :terminal
+include :fileutils
+
+DEFAULT_INFO_URL = "https://cloud.google.com/terms/deprecation"
+
+def run
+  cd context_directory
+  load_kokoro_env
+  ensure_gem_version
+  set :tmpdir, "tmp" if !tmpdir && !release
+  set :info_url, DEFAULT_INFO_URL if info_url.to_s.empty?
+  if tmpdir
+    mkdir_p tmpdir
+    cd tmpdir do
+      generate_files
+      build_gem
+      release_gem if release
+    end
+  else
+    require "tmpdir"
+    Dir.mktmpdir do |gem_dir|
+      cd gem_dir do
+        generate_files
+        build_gem
+        release_gem if release
+      end
+    end
+  end
+end
+
+def load_kokoro_env
+  kokoro_gfile_dir = ENV["KOKORO_GFILE_DIR"]
+  return unless kokoro_gfile_dir
+  filename = File.join kokoro_gfile_dir, "ruby_env_vars.json"
+  raise "#{filename} is not a file" unless File.file? filename
+  env_vars = JSON.parse File.read filename
+  env_vars.each { |k, v| ENV[k] ||= v }
+end
+
+def ensure_gem_version
+  return if gem_version
+  require "json"
+  content = capture ["curl", "https://rubygems.org/api/v1/gems/#{gem_name}.json"], err: :null
+  last_version = JSON.parse(content)["version"]
+  puts "Last released version for #{gem_name} was #{last_version}"
+  last_version = last_version.split(".").first.to_i
+  set :gem_version, "#{last_version + 1}.0.0"
+  puts "Going to release #{gem_version}"
+end
+
+def generate_files
+  require "erb"
+  puts "Generating files for #{gem_name} in #{Dir.getwd}", :bold
+  template = File.read find_data "readme-template.erb"
+  File.write "README.md", ERB.new(template).result(binding)
+  template = File.read find_data "license-template.erb"
+  File.write "LICENSE.md", ERB.new(template).result(binding)
+  template = File.read find_data "gemspec-template.erb"
+  File.write "#{gem_name}.gemspec", ERB.new(template).result(binding)
+  mkdir_p namespace_dir
+  template = File.read find_data "version-template.erb"
+  File.write "#{namespace_dir}/version.rb", ERB.new(template).result(binding)
+end
+
+def build_gem
+  puts "Building #{gem_name}-#{gem_version}.gem", :bold
+  exec ["gem", "build", "#{gem_name}.gemspec", "--output", "#{gem_name}-#{gem_version}.gem"]
+end
+
+def release_gem
+  puts "Releasing #{gem_name}-#{gem_version}.gem", :bold
+  env = {
+    "GEM_HOST_API_KEY" => rubygems_api_token || ENV["RUBYGEMS_API_TOKEN"]
+  }
+  exec ["gem", "push", "#{gem_name}-#{gem_version}.gem"], env: env
+end
+
+def cur_year
+  Time.now.year.to_s
+end
+
+def namespace_modules
+  @namespace_modules ||= gem_name.split("-").map { |segment| segment.split("_").map(&:capitalize).join }
+end
+
+def namespace
+  @namespace ||= namespace_modules.join "::"
+end
+
+def namespace_dir
+  @namespace_dir ||= "lib-#{gem_name}".tr "-", "/"
+end
+
+def version_lines
+  lines = []
+  indent = 0
+  namespace_modules.each do |mod|
+    lines << "#{' ' * indent}module #{mod}"
+    indent += 2
+  end
+  lines << "#{' ' * indent}VERSION = \"#{gem_version}\""
+  while indent > 0
+    indent -= 2
+    lines << "#{' ' * indent}end"
+  end
+  lines.join "\n"
+end

--- a/.trampolinerc
+++ b/.trampolinerc
@@ -18,7 +18,15 @@ required_envvars+=(
 
 # Add env vars which are passed down into the container here.
 pass_down_envvars+=(
-    "AUTORELEASE_PR" "RELEASE_DRY_RUN" "RELEASE_PACKAGE" "KOKORO_GIT_COMMIT" "RUBY_VERSIONS" "EXTRA_CI_ARGS" "LIBRARIES_VERSIONS" "DEBUG_SSH_KEY"
+    "AUTORELEASE_PR"
+    "DEBUG_SSH_KEY"
+    "EXTRA_CI_ARGS"
+    "INFO_URL"
+    "KOKORO_GIT_COMMIT"
+    "LIBRARIES_VERSIONS"
+    "RELEASE_DRY_RUN"
+    "RELEASE_PACKAGE"
+    "RUBY_VERSIONS"
 )
 
 # Prevent unintentional override on the default image.


### PR DESCRIPTION
Two new scripts/workflows to handle library turndown (which we need to do for google-cloud-debugger and google-cloud-debugger-v2).

**obsolete-library** is the opposite of new-library. It removes the library's owlbot configuration (if there is one), removes the library from the release-please configuration, and moves the library's code to the obsolete directory. There is a toys-based cli, and a corresponding github action.

**tombstone-gem** is similar to reserve-gem. It publishes an empty "tombstone" gem with a major version bump, intended for when the gem is no longer useful at all (e.g. because the corresponding backend has been turned down). It does not affect the code in google-cloud-ruby (if any); use the obsolete-library script for that. There is a toys-based cli, and a corresponding kokoro job (we need kokoro in order to publish to rubygems). There will also need to be a separate internal CL to create the kokoro job.

There will also be a separate internal CL to document playbooks under the ruby-cloud g3docs.