### PR TITLE
chore(bigtable): fix acceptance test cleanup

### DIFF
--- a/google-cloud-bigtable/acceptance/bigtable/backup_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/backup_test.rb
@@ -22,11 +22,12 @@ describe Google::Cloud::Bigtable::Table, :bigtable do
   let(:instance_2) { bigtable_instance_2 }
   let(:cluster) { instance.clusters.first }
   let(:table) { bigtable_read_table }
-  let(:backup_id) { "test-backup-#{random_str}" }
+  let(:backup_id) { "test-backup-#{Time.now.to_i}-#{random_str}" }
   let(:now) { Time.now.round 0 }
   let(:expire_time) { now + 60 * 60 * 7 }
   let(:expire_time_2) { now + 60 * 60 * 8 }
-  let(:restore_table_id) { "test-table-#{random_str}" }
+  let(:restore_table_id) { "test-table-#{Time.now.to_i}-#{random_str}" }
+  let(:restore_table_id_2) { "test-table-#{Time.now.to_i}-#{random_str}" }
   let(:service_account) { bigtable.service.credentials.client.issuer }
   let(:roles) { ["bigtable.backups.delete", "bigtable.backups.get"] }
   let(:role) { "roles/bigtable.user" }
@@ -130,13 +131,13 @@ describe Google::Cloud::Bigtable::Table, :bigtable do
       _(restore_job.optimize_table_operation_name).must_include restore_table_id
 
       # restore to another instance
-      restore_job = backup.restore restore_table_id, instance: instance_2
+      restore_job = backup.restore restore_table_id_2, instance: instance_2
       _(restore_job).must_be_kind_of Google::Cloud::Bigtable::Table::RestoreJob
       restore_job.wait_until_done!
       _(restore_job.error).must_be :nil?
       restore_table_2 = restore_job.table
       _(restore_table_2).must_be_kind_of Google::Cloud::Bigtable::Table
-      _(restore_table_2.name).must_equal restore_table_id
+      _(restore_table_2.name).must_equal restore_table_id_2
       _(restore_table_2.instance_id).must_equal instance_2.instance_id
     ensure
       # delete

--- a/google-cloud-bigtable/acceptance/bigtable/column_family_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/column_family_test.rb
@@ -19,7 +19,7 @@ require "bigtable_helper"
 
 describe Google::Cloud::Bigtable::Table, :column_families, :bigtable do
   let(:instance_id) { bigtable_instance_id }
-  let(:table_id) { "test-table-#{random_str}" }
+  let(:table_id) { "test-table-#{Time.now.to_i}-#{random_str}" }
   let(:table){
     add_table_to_cleanup_list(table_id)
 

--- a/google-cloud-bigtable/acceptance/bigtable/table_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/table_test.rb
@@ -22,7 +22,7 @@ describe "Instance Tables", :bigtable do
   let(:cluster_id) { bigtable_cluster_id }
 
   it "create, list all, get table and delete table" do
-    table_id = "test-table-#{random_str}"
+    table_id = "test-table-#{Time.now.to_i}-#{random_str}"
 
     table = bigtable.create_table(instance_id, table_id) do |cfs|
       cfs.add("cf", gc_rule: Google::Cloud::Bigtable::GcRule.max_versions(3))
@@ -45,7 +45,7 @@ describe "Instance Tables", :bigtable do
   end
 
   it "create table with initial splits and granularity" do
-    table_id = "test-table-#{random_str}"
+    table_id = "test-table-#{Time.now.to_i}-#{random_str}"
     initial_splits = ["customer-001", "customer-005", "customer-010"]
 
     table = bigtable.create_table(
@@ -79,7 +79,7 @@ describe "Instance Tables", :bigtable do
   end
 
   it "creates a table with column families" do
-    table_id = "test-table-#{random_str}"
+    table_id = "test-table-#{Time.now.to_i}-#{random_str}"
 
     table = bigtable.create_table(instance_id, table_id) do |cfs|
       cfs.add("cf1") # default service value for GcRule


### PR DESCRIPTION
Fixes for failing bigtable acceptance tests:

1. The `encryption_test.rb` was failing because it tried to create a test instance that is already present. I altered the logic so the test instance is persistent, created if not present but otherwise just reused.
2. The `backup_test.rb` was failing because, _I think_, it tried to reuse the same table name for the two restorations of the backup, and the one overwrote the other. I changed it so the two names are different.

Additionally, since we're reusing instance resources, it's possible for transient test tables to accumulate if cleanup failed for some reason. (Indeed, one instance had 45 old test tables when I checked on 2023-07-13.) I updated the global cleanup to clean up any old test tables created more than a day ago. This was done by introducing a naming convention that includes the timestamp so we can tell when a particular transient table was created.