### PR TITLE
feat: Bump version to 1.0.0

### DIFF
--- a/google-cloud-deploy/CHANGELOG.md
+++ b/google-cloud-deploy/CHANGELOG.md
@@ -24,3 +24,4 @@
 #### Features
 
 * Initial generation of google-cloud-deploy
+

--- a/google-cloud-vm_migration/CHANGELOG.md
+++ b/google-cloud-vm_migration/CHANGELOG.md
@@ -24,3 +24,4 @@
 #### Features
 
 * Initial generation of google-cloud-vm_migration
+


### PR DESCRIPTION
Testing alternate bump-version strategy for google-cloud-deploy and google-cloud-vm_migration wrappers