### PR TITLE
fix(main): Fix new_library toys script

### DIFF
--- a/.toys/new-library.rb
+++ b/.toys/new-library.rb
@@ -153,8 +153,9 @@ def gem_version_file
 end
 
 def add_fillers manifest
-  manifest.keys.each do |key|
-    manifest["#{key}+FILLER"] = "0.0.0" unless key.end_with? "+FILLER"
+  non_filler_keys = manifest.keys.filter { |k| !k.end_with? '+FILLER' }
+  non_filler_keys.each do |key|
+    manifest["#{key}+FILLER"] = "0.0.0"
   end
   manifest
 end

--- a/.toys/new-library.rb
+++ b/.toys/new-library.rb
@@ -153,7 +153,7 @@ def gem_version_file
 end
 
 def add_fillers manifest
-  non_filler_keys = manifest.keys.filter { |k| !k.end_with? '+FILLER' }
+  non_filler_keys = manifest.keys.filter { |k| !k.end_with? "+FILLER" }
   non_filler_keys.each do |key|
     manifest["#{key}+FILLER"] = "0.0.0"
   end

--- a/.toys/new-library.rb
+++ b/.toys/new-library.rb
@@ -153,7 +153,7 @@ def gem_version_file
 end
 
 def add_fillers manifest
-  manifest.each_key do |key|
+  manifest.keys.each do |key|
     manifest["#{key}+FILLER"] = "0.0.0" unless key.end_with? "+FILLER"
   end
   manifest


### PR DESCRIPTION
We can't add a new key into a hash while iterating it. Due to this, the toys script for `new_library` generation was broken. 