### PR TITLE
chore: Fix for minitest-rg issue in toys new_library

### DIFF
--- a/.toys/new-library.rb
+++ b/.toys/new-library.rb
@@ -153,8 +153,9 @@ def gem_version_file
 end
 
 def add_fillers manifest
-  manifest.keys.each do |key|
-    manifest["#{key}+FILLER"] = "0.0.0" unless key.end_with? "+FILLER"
+  non_filler_keys = manifest.keys.filter { |k| !k.end_with? '+FILLER' }
+  non_filler_keys.each do |key|
+    manifest["#{key}+FILLER"] = "0.0.0"
   end
   manifest
 end

--- a/.toys/new-library.rb
+++ b/.toys/new-library.rb
@@ -63,6 +63,11 @@ include :git_cache
 include "yoshi-pr-generator"
 
 def run
+  # Temporary hack to allow minitest-rg 5.2.0 to work in minitest 5.19 or
+  # later. This should be removed if we have a better solution or decide to
+  # drop rg.
+  ENV["MT_COMPAT"] = "true"
+
   setup
   set :branch_name, "gen/#{gem_name}" unless branch_name
   commit_message = "feat: Initial generation of #{gem_name}"

--- a/.toys/new-library.rb
+++ b/.toys/new-library.rb
@@ -153,7 +153,7 @@ def gem_version_file
 end
 
 def add_fillers manifest
-  non_filler_keys = manifest.keys.filter { |k| !k.end_with? '+FILLER' }
+  non_filler_keys = manifest.keys.filter { |k| !k.end_with? "+FILLER" }
   non_filler_keys.each do |key|
     manifest["#{key}+FILLER"] = "0.0.0"
   end

--- a/.toys/new-library.rb
+++ b/.toys/new-library.rb
@@ -153,7 +153,7 @@ def gem_version_file
 end
 
 def add_fillers manifest
-  manifest.each_key do |key|
+  manifest.keys.each do |key|
     manifest["#{key}+FILLER"] = "0.0.0" unless key.end_with? "+FILLER"
   end
   manifest


### PR DESCRIPTION
Temporary fix for minitest-rg issue. Similar to the [PR](https://github.com/googleapis/google-cloud-ruby/pull/22605). 