### PR TITLE
tests(video-live_stream): Fix flake in list_channels sample test

### DIFF
--- a/google-cloud-video-live_stream/samples/acceptance/list_channels_test.rb
+++ b/google-cloud-video-live_stream/samples/acceptance/list_channels_test.rb
@@ -23,7 +23,7 @@ describe "#list_channels", :live_stream_snippet do
     @input_created = true
     @channel_created_stopped = true
 
-    assert_output(/Channels:\n#{channel.name}/) do
+    assert_output(/\n#{channel.name}/) do
       sample.run project_id: project_id, location: location_id
     end
   end


### PR DESCRIPTION
Fixed a flake that probably happens when multiple tests run concurrently, and the list_channels sample test shows channels from other test runs. Now we just assert that the channel we're concerned about appears in the list, but we no longer require that it appears first. See https://source.cloud.google.com/results/invocations/b3927a36-183d-4759-aa02-d76bf904ea3d/log for a flake log.