### PR TITLE
chore(dataplex-v1): Extend camelcase pattern variable fix to additional service

### DIFF
--- a/google-cloud-dataplex-v1/.owlbot.rb
+++ b/google-cloud-dataplex-v1/.owlbot.rb
@@ -16,10 +16,14 @@
 # See https://github.com/googleapis/gapic-generator-ruby/issues/894
 paths = [
   "lib/google/cloud/dataplex/v1/data_scan_service/paths.rb",
-  "test/google/cloud/dataplex/v1/data_scan_service_paths_test.rb"
+  "lib/google/cloud/dataplex/v1/data_taxonomy_service/paths.rb",
+  "test/google/cloud/dataplex/v1/data_scan_service_paths_test.rb",
+  "test/google/cloud/dataplex/v1/data_taxonomy_service_paths_test.rb"
 ]
 OwlBot.modifier path: paths do |content|
-  content.gsub(/dataScan(?=[^s])/, "data_scan")
+  content
+    .gsub(/dataScan(?=[^s])/, "data_scan")
+    .gsub(/dataTaxonomy(?=[^s])/, "data_taxonomy")
 end
 
 OwlBot.move_files


### PR DESCRIPTION
Temporary fix for the codegen issues in #22585. (The permanent fix is tracked by https://github.com/googleapis/gapic-generator-ruby/issues/894)