### PR TITLE
chore: Remove Ruby 2.6 from CI

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -6,7 +6,6 @@ branchProtectionRules:
   isAdminEnforced: false
   requiredStatusCheckContexts:
     - 'cla/google'
-    - 'CI (ubuntu-latest, 2.6, --test)'
     - 'CI (ubuntu-latest, 2.7, --test)'
     - 'CI (ubuntu-latest, 3.0, --test)'
     - 'CI (ubuntu-latest, 3.1, --test)'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            ruby: "2.6"
-            task: "--test"
-          - os: ubuntu-latest
             ruby: "2.7"
             task: "--test"
           - os: ubuntu-latest


### PR DESCRIPTION
Dropping support for Ruby 2.6