### PR TITLE
fix(bigquery): remove unnecessary warning 

### DIFF
--- a/google-cloud-bigquery/lib/google-cloud-bigquery.rb
+++ b/google-cloud-bigquery/lib/google-cloud-bigquery.rb
@@ -139,5 +139,5 @@ Google::Cloud.configure.add_config! :bigquery do |config|
   config.add_field! :quota_project, nil, match: String
   config.add_field! :retries, nil, match: Integer
   config.add_field! :timeout, nil, match: Integer
-  config.add_field! :endpoint, default_endpoint, match: String
+  config.add_field! :endpoint, default_endpoint, match: String, allow_nil: true
 end


### PR DESCRIPTION
Hi there,

this PR removes the unnecessary `Invalid value nil for key :endpoint. Setting anyway.` warning when the optional env variable `BIGQUERY_EMULATOR_HOST` (which was introduced in https://github.com/googleapis/google-cloud-ruby/pull/22866) is not set.

Allowing `nil` in this case, enables backward compatibility with previous versions which set `nil` explicitly and thereby triggered falling back to the default configuration without any warning message.

closes: #22896