### PR TITLE
fix(bigquery): Avoid dataset reload when accessing location

### DIFF
--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -269,7 +269,6 @@ module Google
         #
         def location
           return nil if reference?
-          ensure_full_data!
           @gapi.location
         end
 


### PR DESCRIPTION
fixes #22862.

Optimisation for `Dataset#location()` method.

The `dataset.location()` method does not require a backend call to fetch the full dataset resource because the location information is already available in `@gapi.location`. This is true regardless of whether the dataset contains a partial or full resource representation.

