### PR TITLE
test: Fix grpc segfault in tests for vision and asset

### DIFF
--- a/google-cloud-asset-v1/test/google/cloud/asset/v1/additional_paths_test.rb
+++ b/google-cloud-asset-v1/test/google/cloud/asset/v1/additional_paths_test.rb
@@ -14,8 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "simplecov"
-require "minitest/autorun"
+require "helper"
 
 require "google/cloud/asset/v1"
 

--- a/google-cloud-vision-v1/owlbot-templates/image_annotator_helpers_test.erb
+++ b/google-cloud-vision-v1/owlbot-templates/image_annotator_helpers_test.erb
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "simplecov"
-require "minitest/autorun"
+require "helper"
 
 require "google/cloud/vision/v1"
 

--- a/google-cloud-vision-v1/test/google/cloud/vision/v1/image_annotator_helpers_test.rb
+++ b/google-cloud-vision-v1/test/google/cloud/vision/v1/image_annotator_helpers_test.rb
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "simplecov"
-require "minitest/autorun"
+require "helper"
 
 require "google/cloud/vision/v1"
 

--- a/google-cloud-vision-v1p3beta1/owlbot-templates/image_annotator_helpers_test.erb
+++ b/google-cloud-vision-v1p3beta1/owlbot-templates/image_annotator_helpers_test.erb
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "simplecov"
-require "minitest/autorun"
+require "helper"
 
 require "google/cloud/vision/v1p3beta1"
 

--- a/google-cloud-vision-v1p3beta1/test/google/cloud/vision/v1p3beta1/image_annotator_helpers_test.rb
+++ b/google-cloud-vision-v1p3beta1/test/google/cloud/vision/v1p3beta1/image_annotator_helpers_test.rb
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "simplecov"
-require "minitest/autorun"
+require "helper"
 
 require "google/cloud/vision/v1p3beta1"
 

--- a/google-cloud-vision-v1p4beta1/owlbot-templates/image_annotator_helpers_test.erb
+++ b/google-cloud-vision-v1p4beta1/owlbot-templates/image_annotator_helpers_test.erb
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "simplecov"
-require "minitest/autorun"
+require "helper"
 
 require "google/cloud/vision/v1p4beta1"
 

--- a/google-cloud-vision-v1p4beta1/test/google/cloud/vision/v1p4beta1/image_annotator_helpers_test.rb
+++ b/google-cloud-vision-v1p4beta1/test/google/cloud/vision/v1p4beta1/image_annotator_helpers_test.rb
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "simplecov"
-require "minitest/autorun"
+require "helper"
 
 require "google/cloud/vision/v1p4beta1"
 


### PR DESCRIPTION
The segfault is due to https://github.com/grpc/grpc/issues/34297 and seems to happen when protobuf is required before grpc. The `helper.rb` files for tests have all been updated to prevent this, but we have a few tests that aren't using `helper.rb`. This PR updates those tests.

Fixes #23381
Fixes #23382
Fixes #23383
Fixes #23384
