### PR TITLE
chore(firestore): Fix firestore acceptance test warning

### DIFF
--- a/google-cloud-firestore/acceptance/firestore/document_test.rb
+++ b/google-cloud-firestore/acceptance/firestore/document_test.rb
@@ -103,7 +103,7 @@ describe "Document", :firestore_acceptance do
 
     doc_ref.set({nullField: nil}, merge: true)
     doc_snp = doc_ref.get
-    _(doc_snp[:nullField]).must_equal nil
+    _(doc_snp[:nullField]).must_be :nil?
   end
 
   it "supports server timestamps" do


### PR DESCRIPTION
Small PR to fix the following warning in Firestore acceptance test runs:
```
DEPRECATED: Use assert_nil if expecting nil from workspace/google-cloud-firestore/acceptance/firestore/document_test.rb:106. This will fail in Minitest 6.
```