### PR TITLE
feat(cloud-storage): support match_glob for Object.list

### DIFF
--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -1265,6 +1265,9 @@ module Google
         #   `prefixes` are omitted.
         # @param [String] token A previously-returned page token representing
         #   part of the larger set of results to view.
+        # @param [String] matchGlob A glob pattern used to filter results returned in items (for example, foo*bar).
+        #    The string value must be UTF-8 encoded. See:
+        #    https://cloud.google.com/storage/docs/json_api/v1/objects/list#list-object-glob
         # @param [Integer] max Maximum number of items plus prefixes to return.
         #   As duplicate prefixes are omitted, fewer total results may be
         #   returned than requested. The default value of this parameter is
@@ -1299,14 +1302,14 @@ module Google
         #     puts file.name
         #   end
         #
-        def files prefix: nil, delimiter: nil, token: nil, max: nil,
+        def files prefix: nil, delimiter: nil, token: nil, match_glob: nil, max: nil,
                   versions: nil
           ensure_service!
           gapi = service.list_files name, prefix: prefix, delimiter: delimiter,
-                                          token: token, max: max,
+                                          token: token, match_glob: match_glob, max: max,
                                           versions: versions,
                                           user_project: user_project
-          File::List.from_gapi gapi, service, name, prefix, delimiter, max,
+          File::List.from_gapi gapi, service, name, prefix, delimiter, match_glob, max,
                                versions, user_project: user_project
         end
         alias find_files files

--- a/google-cloud-storage/lib/google/cloud/storage/file/list.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/list.rb
@@ -81,6 +81,7 @@ module Google
             gapi = @service.list_files @bucket, prefix: @prefix,
                                                 delimiter: @delimiter,
                                                 token: @token,
+                                                match_glob: @match_glob,
                                                 max: @max,
                                                 versions: @versions,
                                                 user_project: @user_project
@@ -162,7 +163,7 @@ module Google
           # @private New File::List from a Google API Client
           # Google::Apis::StorageV1::Objects object.
           def self.from_gapi gapi_list, service, bucket = nil, prefix = nil,
-                             delimiter = nil, max = nil, versions = nil,
+                             delimiter = nil, match_glob = nil, max = nil, versions = nil,
                              user_project: nil
             files = new(Array(gapi_list.items).map do |gapi_object|
               File.from_gapi gapi_object, service, user_project: user_project
@@ -173,6 +174,7 @@ module Google
             files.instance_variable_set :@bucket, bucket
             files.instance_variable_set :@prefix, prefix
             files.instance_variable_set :@delimiter, delimiter
+            files.instance_variable_set :@match_glob, match_glob
             files.instance_variable_set :@max, max
             files.instance_variable_set :@versions, versions
             files.instance_variable_set :@user_project, user_project

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -347,12 +347,12 @@ module Google
 
         ##
         # Retrieves a list of files matching the criteria.
-        def list_files bucket_name, delimiter: nil, max: nil, token: nil,
+        def list_files bucket_name, delimiter: nil, match_glob: nil, max: nil, token: nil,
                        prefix: nil, versions: nil, user_project: nil,
                        options: {}
           execute do
             service.list_objects \
-              bucket_name, delimiter: delimiter, max_results: max,
+              bucket_name, delimiter: delimiter, match_glob: match_glob, max_results: max,
                            page_token: token, prefix: prefix,
                            versions: versions,
                            user_project: user_project(user_project),

--- a/google-cloud-storage/test/google/cloud/storage/bucket_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_test.rb
@@ -713,6 +713,24 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
     end
   end
 
+  it "lists files with match_glob set" do
+    mock = Minitest::Mock.new
+    mock.expect :list_objects, list_files_gapi(2),
+      [bucket.name], delimiter: nil, match_glob: "/foo/**/bar/", max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
+    
+    files = bucket.files match_glob: "/foo/**/bar/"
+
+    mock.verify
+
+    _(files.count).must_equal 2
+    _(files.match_glob).must_equal "/foo/**/bar/"
+    files.each do |file|
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
+    end
+
+  end
+
   it "lists files with max set" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_test.rb
@@ -444,6 +444,24 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
     end
   end
 
+  it "lists files with match_glob set" do
+    mock = Minitest::Mock.new
+    mock.expect :list_objects, list_files_gapi(2),
+      [bucket.name], delimiter: nil, match_glob: "/foo/**/bar/", max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
+    
+    files = bucket.files match_glob: "/foo/**/bar/"
+
+    mock.verify
+
+    _(files.count).must_equal 2
+    _(files.match_glob).must_equal "/foo/**/bar/"
+    files.each do |file|
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
+    end
+
+  end
+
   it "lists files with max set" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),


### PR DESCRIPTION
Introduce `match_glob` parameter to `Bucket.files`, with required changes to the service method and storing instance variables for pagination in `File::List`.

More info at https://cloud.google.com/storage/docs/json_api/v1/objects/list

closes: #21906