### PR TITLE
feat(cloud-storage): support match_glob for Object.list

### DIFF
--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -1265,7 +1265,7 @@ module Google
         #   `prefixes` are omitted.
         # @param [String] token A previously-returned page token representing
         #   part of the larger set of results to view.
-        # @param [String] matchGlob A glob pattern used to filter results returned in items (for example, foo*bar).
+        # @param [String] match_glob A glob pattern used to filter results returned in items (for example, foo*bar).
         #    The string value must be UTF-8 encoded. See:
         #    https://cloud.google.com/storage/docs/json_api/v1/objects/list#list-object-glob
         # @param [Integer] max Maximum number of items plus prefixes to return.

--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -1265,6 +1265,9 @@ module Google
         #   `prefixes` are omitted.
         # @param [String] token A previously-returned page token representing
         #   part of the larger set of results to view.
+        # @param [String] matchGlob A glob pattern used to filter results returned in items (for example, foo*bar).
+        #    The string value must be UTF-8 encoded. See:
+        #    https://cloud.google.com/storage/docs/json_api/v1/objects/list#list-object-glob
         # @param [Integer] max Maximum number of items plus prefixes to return.
         #   As duplicate prefixes are omitted, fewer total results may be
         #   returned than requested. The default value of this parameter is
@@ -1299,14 +1302,14 @@ module Google
         #     puts file.name
         #   end
         #
-        def files prefix: nil, delimiter: nil, token: nil, max: nil,
+        def files prefix: nil, delimiter: nil, token: nil, match_glob: nil, max: nil,
                   versions: nil
           ensure_service!
           gapi = service.list_files name, prefix: prefix, delimiter: delimiter,
-                                          token: token, max: max,
+                                          token: token, match_glob: match_glob, max: max,
                                           versions: versions,
                                           user_project: user_project
-          File::List.from_gapi gapi, service, name, prefix, delimiter, max,
+          File::List.from_gapi gapi, service, name, prefix, delimiter, match_glob, max,
                                versions, user_project: user_project
         end
         alias find_files files

--- a/google-cloud-storage/lib/google/cloud/storage/file/list.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/list.rb
@@ -81,11 +81,12 @@ module Google
             gapi = @service.list_files @bucket, prefix: @prefix,
                                                 delimiter: @delimiter,
                                                 token: @token,
+                                                match_glob: @match_glob,
                                                 max: @max,
                                                 versions: @versions,
                                                 user_project: @user_project
             File::List.from_gapi gapi, @service, @bucket, @prefix,
-                                 @delimiter, @max, @versions,
+                                 @delimiter, @match_glob, @max, @versions,
                                  user_project: @user_project
           end
 
@@ -162,7 +163,7 @@ module Google
           # @private New File::List from a Google API Client
           # Google::Apis::StorageV1::Objects object.
           def self.from_gapi gapi_list, service, bucket = nil, prefix = nil,
-                             delimiter = nil, max = nil, versions = nil,
+                             delimiter = nil, match_glob = nil, max = nil, versions = nil,
                              user_project: nil
             files = new(Array(gapi_list.items).map do |gapi_object|
               File.from_gapi gapi_object, service, user_project: user_project
@@ -173,6 +174,7 @@ module Google
             files.instance_variable_set :@bucket, bucket
             files.instance_variable_set :@prefix, prefix
             files.instance_variable_set :@delimiter, delimiter
+            files.instance_variable_set :@match_glob, match_glob
             files.instance_variable_set :@max, max
             files.instance_variable_set :@versions, versions
             files.instance_variable_set :@user_project, user_project

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -347,12 +347,12 @@ module Google
 
         ##
         # Retrieves a list of files matching the criteria.
-        def list_files bucket_name, delimiter: nil, max: nil, token: nil,
+        def list_files bucket_name, delimiter: nil, match_glob: nil, max: nil, token: nil,
                        prefix: nil, versions: nil, user_project: nil,
                        options: {}
           execute do
             service.list_objects \
-              bucket_name, delimiter: delimiter, max_results: max,
+              bucket_name, delimiter: delimiter, match_glob: match_glob, max_results: max,
                            page_token: token, prefix: prefix,
                            versions: versions,
                            user_project: user_project(user_project),

--- a/google-cloud-storage/test/google/cloud/storage/bucket_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_test.rb
@@ -636,7 +636,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(num_files),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
 
     bucket.service.mocked_service = mock
 
@@ -656,7 +656,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(num_files),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
 
     bucket.service.mocked_service = mock
 
@@ -674,7 +674,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
   it "lists files with prefix set" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, nil, ["/prefix/path1/", "/prefix/path2/"]),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: nil, prefix: "/prefix/", versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: nil, prefix: "/prefix/", versions: nil, user_project: nil, options: {}
 
     bucket.service.mocked_service = mock
 
@@ -695,7 +695,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
   it "lists files with delimiter set" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, nil, ["/prefix/path1/", "/prefix/path2/"]),
-      [bucket.name], delimiter: "/", max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: "/", match_glob: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
 
     bucket.service.mocked_service = mock
 
@@ -713,10 +713,29 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
     end
   end
 
+  it "lists files with match_glob set" do
+    mock = Minitest::Mock.new
+    mock.expect :list_objects, list_files_gapi(2),
+      [bucket.name], delimiter: nil, match_glob: "/foo/**/bar/", max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
+    
+    bucket.service.mocked_service = mock
+    
+    files = bucket.files match_glob: "/foo/**/bar/"
+
+    mock.verify
+
+    _(files.count).must_equal 2
+    files.each do |file|
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
+    end
+
+  end
+
   it "lists files with max set" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name], delimiter: nil, max_results: 3, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: 3, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
 
     bucket.service.mocked_service = mock
 
@@ -736,7 +755,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
   it "lists files with versions set" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: true, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: nil, prefix: nil, versions: true, user_project: nil, options: {}
 
     bucket.service.mocked_service = mock
 
@@ -756,7 +775,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
 
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(num_files),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: "test", options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: "test", options: {}
 
     bucket_user_project.service.mocked_service = mock
 
@@ -774,9 +793,9 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
   it "paginates files" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
     mock.expect :list_objects, list_files_gapi(2),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil, options: {}
 
     bucket.service.mocked_service = mock
 
@@ -804,9 +823,9 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
   it "paginates files with next? and next" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
     mock.expect :list_objects, list_files_gapi(2),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil, options: {}
 
     bucket.service.mocked_service = mock
 
@@ -833,9 +852,9 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
   it "paginates files with next? and next and prefix set" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: nil, prefix: "/prefix/", versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: nil, prefix: "/prefix/", versions: nil, user_project: nil, options: {}
     mock.expect :list_objects, list_files_gapi(2),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: "next_page_token", prefix: "/prefix/", versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: "next_page_token", prefix: "/prefix/", versions: nil, user_project: nil, options: {}
 
     bucket.service.mocked_service = mock
 
@@ -862,9 +881,9 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
   it "paginates files with next? and next and delimiter set" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name], delimiter: "/", max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: "/", match_glob: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
     mock.expect :list_objects, list_files_gapi(2),
-      [bucket.name], delimiter: "/", max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: "/", match_glob: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil, options: {}
 
     bucket.service.mocked_service = mock
 
@@ -891,9 +910,9 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
   it "paginates files with next? and next and max set" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name], delimiter: nil, max_results: 3, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: 3, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
     mock.expect :list_objects, list_files_gapi(2),
-      [bucket.name], delimiter: nil, max_results: 3, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: 3, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil, options: {}
 
     bucket.service.mocked_service = mock
 
@@ -920,9 +939,9 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
   it "paginates files with next? and next and versions set" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: true, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: nil, prefix: nil, versions: true, user_project: nil, options: {}
     mock.expect :list_objects, list_files_gapi(2),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: true, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: true, user_project: nil, options: {}
 
     bucket.service.mocked_service = mock
 
@@ -949,9 +968,9 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
   it "paginates files with user_project set to true" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: "test", options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: "test", options: {}
     mock.expect :list_objects, list_files_gapi(2),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: "test", options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: "test", options: {}
 
     bucket_user_project.service.mocked_service = mock
 
@@ -979,9 +998,9 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
   it "paginates files with all" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
     mock.expect :list_objects, list_files_gapi(2),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil, options: {}
 
     bucket.service.mocked_service = mock
 
@@ -999,9 +1018,9 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
   it "paginates files with all and prefix set" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: nil, prefix: "/prefix/", versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: nil, prefix: "/prefix/", versions: nil, user_project: nil, options: {}
     mock.expect :list_objects, list_files_gapi(2),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: "next_page_token", prefix: "/prefix/", versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: "next_page_token", prefix: "/prefix/", versions: nil, user_project: nil, options: {}
 
     bucket.service.mocked_service = mock
 
@@ -1019,9 +1038,9 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
   it "paginates files with all and delimiter set" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name], delimiter: "/", max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: "/", match_glob: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
     mock.expect :list_objects, list_files_gapi(2),
-      [bucket.name], delimiter: "/", max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: "/", match_glob: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil, options: {}
 
     bucket.service.mocked_service = mock
 
@@ -1039,9 +1058,9 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
   it "paginates files with all and max set" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name], delimiter: nil, max_results: 3, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: 3, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
     mock.expect :list_objects, list_files_gapi(2),
-      [bucket.name], delimiter: nil, max_results: 3, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: 3, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil, options: {}
 
     bucket.service.mocked_service = mock
 
@@ -1059,9 +1078,9 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
   it "paginates files with all and versions set" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: true, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: nil, prefix: nil, versions: true, user_project: nil, options: {}
     mock.expect :list_objects, list_files_gapi(2),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: true, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: true, user_project: nil, options: {}
 
     bucket.service.mocked_service = mock
 
@@ -1079,9 +1098,9 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
   it "paginates files with all using Enumerator" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
     mock.expect :list_objects, list_files_gapi(3, "second_page_token"),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil, options: {}
 
     bucket.service.mocked_service = mock
 
@@ -1099,9 +1118,9 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
   it "paginates files with all and request_limit set" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
     mock.expect :list_objects, list_files_gapi(3, "second_page_token"),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil, options: {}
 
     bucket.service.mocked_service = mock
 
@@ -1119,9 +1138,9 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
   it "paginates files with all and user_project set to true" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket_user_project.name], delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: "test", options: {}
+      [bucket_user_project.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: "test", options: {}
     mock.expect :list_objects, list_files_gapi(3, "second_page_token"),
-      [bucket_user_project.name], delimiter: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: "test", options: {}
+      [bucket_user_project.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: "test", options: {}
 
     bucket_user_project.service.mocked_service = mock
 

--- a/google-cloud-storage/test/google/cloud/storage/file_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_test.rb
@@ -1489,7 +1489,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
     mock.expect :get_object, Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket.name, file_name, generations[0]).to_json),
       [bucket.name, file_name], **get_object_args
     mock.expect :list_objects, Google::Apis::StorageV1::Objects.new(kind: "storage#objects", items: file_gapis),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: nil, prefix: file_name, versions: true, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: nil, prefix: file_name, versions: true, user_project: nil, options: {}
 
     bucket.service.mocked_service = mock
     file.service.mocked_service = mock
@@ -1515,7 +1515,7 @@ describe Google::Cloud::Storage::File, :mock_storage do
     mock.expect :get_object, Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket_user_project.name, file_name, generations[0]).to_json),
       [bucket_user_project.name, file_name], **get_object_args(user_project: "test")
     mock.expect :list_objects, Google::Apis::StorageV1::Objects.new(kind: "storage#objects", items: file_gapis),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: nil, prefix: file_name, versions: true, user_project: "test", options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: nil, prefix: file_name, versions: true, user_project: "test", options: {}
 
     bucket_user_project.service.mocked_service = mock
     file.service.mocked_service = mock

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_test.rb
@@ -369,7 +369,7 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(num_files),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
 
     bucket.service.mocked_service = mock
 
@@ -389,7 +389,7 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(num_files),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
     bucket.service.mocked_service = mock
 
     files = bucket.find_files
@@ -406,7 +406,7 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
   it "lists files with prefix set" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, nil, ["/prefix/path1/", "/prefix/path2/"]),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: nil, prefix: "/prefix/", versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: nil, prefix: "/prefix/", versions: nil, user_project: nil, options: {}
 
     bucket.service.mocked_service = mock
 
@@ -427,7 +427,7 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
   it "lists files with delimiter set" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, nil, ["/prefix/path1/", "/prefix/path2/"]),
-      [bucket.name], delimiter: "/", max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: "/", match_glob: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
     bucket.service.mocked_service = mock
 
     files = bucket.files delimiter: "/"
@@ -444,10 +444,29 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
     end
   end
 
+  it "lists files with match_glob set" do
+    mock = Minitest::Mock.new
+    mock.expect :list_objects, list_files_gapi(2),
+      [bucket.name], delimiter: nil, match_glob: "/foo/**/bar/", max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
+
+    bucket.service.mocked_service = mock
+    
+    files = bucket.files match_glob: "/foo/**/bar/"
+
+    mock.verify
+
+    _(files.count).must_equal 2
+    files.each do |file|
+      _(file).must_be_kind_of Google::Cloud::Storage::File
+      _(file.user_project).must_be :nil?
+    end
+
+  end
+
   it "lists files with max set" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name], delimiter: nil, max_results: 3, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: 3, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
 
     bucket.service.mocked_service = mock
 
@@ -467,7 +486,7 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
   it "lists files with versions set" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: true, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: nil, prefix: nil, versions: true, user_project: nil, options: {}
 
     bucket.service.mocked_service = mock
 
@@ -487,7 +506,7 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
 
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(num_files),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: "test", options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: "test", options: {}
 
     bucket_user_project.service.mocked_service = mock
 
@@ -505,9 +524,9 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
   it "paginates files" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
     mock.expect :list_objects, list_files_gapi(2),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil, options: {}
 
     bucket.service.mocked_service = mock
 
@@ -535,9 +554,9 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
   it "paginates files with next? and next" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
     mock.expect :list_objects, list_files_gapi(2),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil, options: {}
     bucket.service.mocked_service = mock
 
     first_files = bucket.files
@@ -563,9 +582,9 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
   it "paginates files with next? and next and prefix set" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: nil, prefix: "/prefix/", versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: nil, prefix: "/prefix/", versions: nil, user_project: nil, options: {}
     mock.expect :list_objects, list_files_gapi(2),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: "next_page_token", prefix: "/prefix/", versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: "next_page_token", prefix: "/prefix/", versions: nil, user_project: nil, options: {}
 
     bucket.service.mocked_service = mock
 
@@ -592,9 +611,9 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
   it "paginates files with next? and next and delimiter set" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name], delimiter: "/", max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: "/", match_glob: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
     mock.expect :list_objects, list_files_gapi(2),
-      [bucket.name], delimiter: "/", max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: "/", match_glob: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil, options: {}
 
     bucket.service.mocked_service = mock
 
@@ -621,9 +640,9 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
   it "paginates files with next? and next and max set" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name], delimiter: nil, max_results: 3, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: 3, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
     mock.expect :list_objects, list_files_gapi(2),
-      [bucket.name], delimiter: nil, max_results: 3, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: 3, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil, options: {}
     bucket.service.mocked_service = mock
 
     first_files = bucket.files max: 3
@@ -649,9 +668,9 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
   it "paginates files with next? and next and versions set" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: true, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: nil, prefix: nil, versions: true, user_project: nil, options: {}
     mock.expect :list_objects, list_files_gapi(2),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: true, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: true, user_project: nil, options: {}
 
     bucket.service.mocked_service = mock
 
@@ -678,9 +697,9 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
   it "paginates files with user_project set to true" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: "test", options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: "test", options: {}
     mock.expect :list_objects, list_files_gapi(2),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: "test", options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: "test", options: {}
 
     bucket_user_project.service.mocked_service = mock
 
@@ -708,9 +727,9 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
   it "paginates files with all" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
     mock.expect :list_objects, list_files_gapi(2),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil, options: {}
     bucket.service.mocked_service = mock
 
     files = bucket.files.all.to_a
@@ -727,9 +746,9 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
   it "paginates files with all and prefix set" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: nil, prefix: "/prefix/", versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: nil, prefix: "/prefix/", versions: nil, user_project: nil, options: {}
     mock.expect :list_objects, list_files_gapi(2),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: "next_page_token", prefix: "/prefix/", versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: "next_page_token", prefix: "/prefix/", versions: nil, user_project: nil, options: {}
 
     bucket.service.mocked_service = mock
 
@@ -747,9 +766,9 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
   it "paginates files with all and delimiter set" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name], delimiter: "/", max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: "/", match_glob: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
     mock.expect :list_objects, list_files_gapi(2),
-      [bucket.name], delimiter: "/", max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: "/", match_glob: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil, options: {}
 
     bucket.service.mocked_service = mock
 
@@ -767,9 +786,9 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
   it "paginates files with all and max set" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name], delimiter: nil, max_results: 3, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: 3, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
     mock.expect :list_objects, list_files_gapi(2),
-      [bucket.name], delimiter: nil, max_results: 3, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: 3, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil, options: {}
 
     bucket.service.mocked_service = mock
 
@@ -787,9 +806,9 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
   it "paginates files with all and versions set" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: true, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: nil, prefix: nil, versions: true, user_project: nil, options: {}
     mock.expect :list_objects, list_files_gapi(2),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: true, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: true, user_project: nil, options: {}
 
     bucket.service.mocked_service = mock
 
@@ -807,9 +826,9 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
   it "paginates files with all using Enumerator" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
     mock.expect :list_objects, list_files_gapi(3, "second_page_token"),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil, options: {}
 
     bucket.service.mocked_service = mock
 
@@ -827,9 +846,9 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
   it "paginates files with all and request_limit set" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
     mock.expect :list_objects, list_files_gapi(3, "second_page_token"),
-      [bucket.name], delimiter: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: nil, options: {}
 
     bucket.service.mocked_service = mock
 
@@ -847,9 +866,9 @@ describe Google::Cloud::Storage::Bucket, :lazy, :mock_storage do
   it "paginates files with all and user_project set to true" do
     mock = Minitest::Mock.new
     mock.expect :list_objects, list_files_gapi(3, "next_page_token"),
-      [bucket_user_project.name], delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: "test", options: {}
+      [bucket_user_project.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: "test", options: {}
     mock.expect :list_objects, list_files_gapi(3, "second_page_token"),
-      [bucket_user_project.name], delimiter: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: "test", options: {}
+      [bucket_user_project.name], delimiter: nil, match_glob: nil, max_results: nil, page_token: "next_page_token", prefix: nil, versions: nil, user_project: "test", options: {}
 
     bucket_user_project.service.mocked_service = mock
 

--- a/google-cloud-storage/test/google/cloud/storage/project_anonymous_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/project_anonymous_test.rb
@@ -63,7 +63,7 @@ describe Google::Cloud::Storage::Project, :anonymous, :mock_storage do
     mock = Minitest::Mock.new
     mock.expect :get_bucket, find_bucket_gapi(bucket_name), [bucket_name], **get_bucket_args
     mock.expect :list_objects, list_files_gapi(num_files),
-      [bucket_name], delimiter: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
+      [bucket_name], delimiter: nil, match_glob: nil, max_results: nil, page_token: nil, prefix: nil, versions: nil, user_project: nil, options: {}
     anonymous_storage.service.mocked_service = mock
 
     bucket = anonymous_storage.bucket bucket_name


### PR DESCRIPTION
Introduce `match_glob` parameter to `Bucket.files`, with required changes to the service method and storing instance variables for pagination in `File::List`.

More info at https://cloud.google.com/storage/docs/json_api/v1/objects/list

closes: #21906 