### PR TITLE
fix(pubsub): set x-goog-request-params for streaming pull request

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
@@ -240,8 +240,8 @@ module Google
                           return_immediately: return_immediately
         end
 
-        def streaming_pull request_enum
-          subscriber.streaming_pull request_enum
+        def streaming_pull request_enum, options = {}
+          subscriber.streaming_pull request_enum, options
         end
 
         ##

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscriber/stream.rb
@@ -231,7 +231,8 @@ module Google
             end
 
             # Call the StreamingPull API to get the response enumerator
-            enum = @subscriber.service.streaming_pull @request_queue.each
+            options = { :"metadata" => { :"x-goog-request-params" =>  @subscriber.subscription_name } }
+            enum = @subscriber.service.streaming_pull @request_queue.each, options
 
             loop do
               synchronize do
@@ -253,7 +254,7 @@ module Google
                 # Use synchronize so changes happen atomically
                 synchronize do
                   update_min_duration_per_lease_extension new_exactly_once_delivery_enabled
-                  @exactly_once_delivery_enabled = new_exactly_once_delivery_enabled unless new_exactly_once_delivery_enabled.nil? 
+                  @exactly_once_delivery_enabled = new_exactly_once_delivery_enabled unless new_exactly_once_delivery_enabled.nil?
                   @subscriber.exactly_once_delivery_enabled = @exactly_once_delivery_enabled
 
                   # Create receipt of received messages reception
@@ -271,7 +272,7 @@ module Google
                   # No need to synchronize the callback future
                   register_callback rec_msg
                 end if !@exactly_once_delivery_enabled # Exactly once delivery scenario is handled by callback
-                
+
                 synchronize { pause_streaming! }
               rescue StopIteration
                 break


### PR DESCRIPTION
This is usually set within the auto-generated code, but since streaming pull doesn't have an http path associated with it, it does not get auto-generated.