### PR TITLE
fix(core): Allow dependency on google-cloud-env 2.x

### DIFF
--- a/google-cloud-core/Gemfile
+++ b/google-cloud-core/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
+gem "googleauth", "~> 1.0"
 gem "google-cloud-errors", path: "../google-cloud-errors"
-gem "google-gax", "~> 1.0"
 
 gem "rake"

--- a/google-cloud-core/google-cloud-core.gemspec
+++ b/google-cloud-core/google-cloud-core.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.5"
 
-  gem.add_dependency "google-cloud-env", "~> 1.0"
+  gem.add_dependency "google-cloud-env", ">= 1.0", "< 3.a"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 
   gem.add_development_dependency "autotest-suffix", "~> 1.1"

--- a/google-cloud-core/test/google/cloud/credentials_test.rb
+++ b/google-cloud-core/test/google/cloud/credentials_test.rb
@@ -31,7 +31,7 @@ describe Google::Cloud::Credentials, :private do
   end
 
   it "uses a default scope" do
-    mocked_signet = MiniTest::Mock.new
+    mocked_signet = Minitest::Mock.new
     mocked_signet.expect :fetch_access_token!, true
 
     stubbed_signet = ->(options, scope: nil) {
@@ -52,7 +52,7 @@ describe Google::Cloud::Credentials, :private do
   end
 
   it "uses a custom scope" do
-    mocked_signet = MiniTest::Mock.new
+    mocked_signet = Minitest::Mock.new
     mocked_signet.expect :fetch_access_token!, true
 
     stubbed_signet = ->(options, scope: nil) {


### PR DESCRIPTION
google-cloud-env 1.x and 2.x have compatible interfaces for the surface used by client libraries. Expanding the support to include 2.x is needed for universe domain support in googleauth.

Also included a bit of cleanup: google-gax is very old and not needed for the testing bundle, but googleauth is. And the misspelling of Minitest is not supported in recent versions.