### PR TITLE
fix(pubsub-v1): Subscriber and publisher configs honor the base default configs from the high-level pubsub client

### DIFF
--- a/google-cloud-pubsub-v1/lib/google/cloud/pubsub/v1/publisher/helpers.rb
+++ b/google-cloud-pubsub-v1/lib/google/cloud/pubsub/v1/publisher/helpers.rb
@@ -15,11 +15,33 @@
 # limitations under the License.
 
 
-Google::Cloud::PubSub::V1::Publisher::Client.configure do |config|
-  config.channel_args ||= {}
-  config.channel_args["grpc.max_send_message_length"] = -1
-  config.channel_args["grpc.max_receive_message_length"] = -1
-  config.channel_args["grpc.keepalive_time_ms"] = 300_000
-  # Set max metadata size to 4 MB.
-  config.channel_args["grpc.max_metadata_size"] = 4 * 1024 * 1024
+module Google
+  module Cloud
+    module PubSub
+      module V1
+        module Publisher
+          class Client # rubocop:disable Style/Documentation
+            class << self
+              alias configure_internal configure
+
+              def configure
+                @configure ||= begin
+                  config = configure_internal
+                  config.channel_args ||= {}
+                  config.channel_args["grpc.max_send_message_length"] = -1
+                  config.channel_args["grpc.max_receive_message_length"] = -1
+                  config.channel_args["grpc.keepalive_time_ms"] = 300_000
+                  # Set max metadata size to 4 MB.
+                  config.channel_args["grpc.max_metadata_size"] = 4 * 1024 * 1024
+                  config
+                end
+                yield @configure if block_given?
+                @configure
+              end
+            end
+          end
+        end
+      end
+    end
+  end
 end

--- a/google-cloud-pubsub-v1/lib/google/cloud/pubsub/v1/subscriber/helpers.rb
+++ b/google-cloud-pubsub-v1/lib/google/cloud/pubsub/v1/subscriber/helpers.rb
@@ -15,11 +15,33 @@
 # limitations under the License.
 
 
-Google::Cloud::PubSub::V1::Subscriber::Client.configure do |config|
-  config.channel_args ||= {}
-  config.channel_args["grpc.max_send_message_length"] = -1
-  config.channel_args["grpc.max_receive_message_length"] = -1
-  config.channel_args["grpc.keepalive_time_ms"] = 300_000
-  # Set max metadata size to 4 MB.
-  config.channel_args["grpc.max_metadata_size"] = 4 * 1024 * 1024
+module Google
+  module Cloud
+    module PubSub
+      module V1
+        module Subscriber
+          class Client # rubocop:disable Style/Documentation
+            class << self
+              alias configure_internal configure
+
+              def configure
+                @configure ||= begin
+                  config = configure_internal
+                  config.channel_args ||= {}
+                  config.channel_args["grpc.max_send_message_length"] = -1
+                  config.channel_args["grpc.max_receive_message_length"] = -1
+                  config.channel_args["grpc.keepalive_time_ms"] = 300_000
+                  # Set max metadata size to 4 MB.
+                  config.channel_args["grpc.max_metadata_size"] = 4 * 1024 * 1024
+                  config
+                end
+                yield @configure if block_given?
+                @configure
+              end
+            end
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This fixes an apparently longstanding issue with client configs in google-cloud-pubsub where the publisher and subscriber services (but not the iam and schema services) wouldn't pick up custom configs set in `Google::Cloud::PubSub.configure`.

The issue is that some config customization is being done in these helper files. Unfortunately the way these are done causes the configurations to materialize early, before the `Google::Cloud::PubSub.configure` method is defined. As a result, the configurations skip anything defined in `Google::Cloud::PubSub.configure`. We fix this by deferring materialization of the configuration, adding the customizations lazily rather than eagerly.

This should fix test failures caught in the universe_domain work.