### PR TITLE
feat(pubsub): Support for universe_domain

### DIFF
--- a/google-cloud-pubsub/.rubocop.yml
+++ b/google-cloud-pubsub/.rubocop.yml
@@ -24,7 +24,7 @@ Metrics/CyclomaticComplexity:
 Metrics/MethodLength:
   Max: 35
 Metrics/PerceivedComplexity:
-  Max: 15
+  Max: 20
 Naming/FileName:
   Exclude:
     - "lib/google-cloud-pubsub.rb"

--- a/google-cloud-pubsub/acceptance/pubsub/service_test.rb
+++ b/google-cloud-pubsub/acceptance/pubsub/service_test.rb
@@ -21,6 +21,7 @@ describe Google::Cloud::PubSub::Service do
   let(:timeout) { 123.4 }
   let(:pubsub) { Google::Cloud::PubSub.new timeout: timeout }
   let(:endpoint) { "pubsub.googleapis.com" }
+  let(:universe_domain) { "googleapis.com" }
   let(:config_metadata) { { "google-cloud-resource-prefix": "projects/#{pubsub.project_id}" } }
 
   let(:subscriber_default_config) do
@@ -49,7 +50,8 @@ describe Google::Cloud::PubSub::Service do
     config = pubsub.service.subscriber.configure
     _(config).must_be_kind_of Google::Cloud::PubSub::V1::Subscriber::Client::Configuration
     _(config.timeout).must_equal timeout
-    _(config.endpoint).must_equal endpoint
+    _(config.endpoint).must_be :nil?
+    _(config.universe_domain).must_equal universe_domain
     _(config.lib_name).must_equal "gccl"
     _(config.lib_version).must_equal Google::Cloud::PubSub::VERSION
     _(config.metadata).must_equal config_metadata
@@ -61,7 +63,8 @@ describe Google::Cloud::PubSub::Service do
     config = pubsub.service.publisher.configure
     _(config).must_be_kind_of Google::Cloud::PubSub::V1::Publisher::Client::Configuration
     _(config.timeout).must_equal timeout
-    _(config.endpoint).must_equal endpoint
+    _(config.endpoint).must_be :nil?
+    _(config.universe_domain).must_equal universe_domain
     _(config.lib_name).must_equal "gccl"
     _(config.lib_version).must_equal Google::Cloud::PubSub::VERSION
     _(config.metadata).must_equal config_metadata
@@ -71,9 +74,10 @@ describe Google::Cloud::PubSub::Service do
   it "configures the V1::IAMPolicy::Client" do
     _(pubsub.project_id).wont_be :empty?
     config = pubsub.service.iam.configure
-    _(config).must_be_kind_of Google::Cloud::PubSub::V1::IAMPolicy::Client::Configuration
+    _(config).must_be_kind_of Google::Iam::V1::IAMPolicy::Client::Configuration
     _(config.timeout).must_equal timeout
     _(config.endpoint).must_equal endpoint
+    _(config.universe_domain).must_equal universe_domain
     _(config.lib_name).must_equal "gccl"
     _(config.lib_version).must_equal Google::Cloud::PubSub::VERSION
     _(config.metadata).must_equal config_metadata
@@ -85,7 +89,8 @@ describe Google::Cloud::PubSub::Service do
     config = pubsub.service.schemas.configure
     _(config).must_be_kind_of Google::Cloud::PubSub::V1::SchemaService::Client::Configuration
     _(config.timeout).must_equal timeout
-    _(config.endpoint).must_equal endpoint
+    _(config.endpoint).must_be :nil?
+    _(config.universe_domain).must_equal universe_domain
     _(config.lib_name).must_equal "gccl"
     _(config.lib_version).must_equal Google::Cloud::PubSub::VERSION
     _(config.metadata).must_equal config_metadata

--- a/google-cloud-pubsub/google-cloud-pubsub.gemspec
+++ b/google-cloud-pubsub/google-cloud-pubsub.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "concurrent-ruby", "~> 1.1"
   gem.add_dependency "google-cloud-core", "~> 1.5"
-  gem.add_dependency "google-cloud-pubsub-v1", "~> 0.8"
+  gem.add_dependency "google-cloud-pubsub-v1", "~> 0.20"
   gem.add_dependency "retriable", "~> 3.1"
 
   gem.add_development_dependency "autotest-suffix", "~> 1.1"

--- a/google-cloud-pubsub/lib/google-cloud-pubsub.rb
+++ b/google-cloud-pubsub/lib/google-cloud-pubsub.rb
@@ -110,7 +110,7 @@ module Google
 end
 
 # Set the default pubsub configuration
-Google::Cloud.configure.add_config! :pubsub do |config|
+Google::Cloud.configure.add_config! :pubsub do |config| # rubocop:disable Metrics/BlockLength
   default_project = Google::Cloud::Config.deferred do
     ENV["PUBSUB_PROJECT"]
   end
@@ -136,5 +136,6 @@ Google::Cloud.configure.add_config! :pubsub do |config|
   config.add_field! :timeout, nil, match: Numeric
   config.add_field! :emulator_host, default_emulator, match: String, allow_nil: true
   config.add_field! :on_error, nil, match: Proc
-  config.add_field! :endpoint, "pubsub.googleapis.com", match: String
+  config.add_field! :endpoint, nil, match: String
+  config.add_field! :universe_domain, nil, match: String
 end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/project.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/project.rb
@@ -77,6 +77,15 @@ module Google
         alias project project_id
 
         ##
+        # The universe domain the client is connected to
+        #
+        # @return [String]
+        #
+        def universe_domain
+          service.universe_domain
+        end
+
+        ##
         # Retrieves topic by name.
         #
         # @param [String] topic_name Name of a topic. The value can be a simple

--- a/google-cloud-pubsub/test/google/cloud/pubsub/service_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/service_test.rb
@@ -32,6 +32,8 @@ describe Google::Cloud::PubSub::Service do
   let(:timeout) { 123.4 }
   let(:endpoint) { "pubsub.googleapis.com" }
   let(:endpoint_2) { "localhost:4567" }
+  let(:universe_domain) { "googleapis.com" }
+  let(:universe_domain_2) { "mydomain.com" }
 
   # Values below are hardcoded in Service.
   let(:lib_name) { "gccl" }
@@ -70,31 +72,35 @@ describe Google::Cloud::PubSub::Service do
           config = service.subscriber.configure
           _(config).must_be_kind_of Google::Cloud::PubSub::V1::Subscriber::Client::Configuration
           _(config.timeout).must_be :nil?
-          _(config.endpoint).must_equal endpoint
+          _(config.endpoint).must_be :nil?
+          _(config.universe_domain).must_equal universe_domain
           _(config.lib_name).must_equal lib_name
           _(config.lib_version).must_equal lib_version
           _(config.metadata).must_equal expected_metadata
           assert_config_rpcs_equals subscriber_default_config.rpcs, 16, config.rpcs
+          _(service.universe_domain).must_equal universe_domain
         end
       end
     end
   end
 
-  it "configures the V1::Subscriber::Client with host and timeout" do
+  it "configures the V1::Subscriber::Client with host, universe_domain, and timeout" do
     # Clear all environment variables
     ENV.stub :[], nil do
       Google::Auth::Credentials.stub :default, credentials do
         Gapic::ServiceStub.stub :new, dummy_stub do
-          service = Google::Cloud::PubSub::Service.new project, nil, host: endpoint_2, timeout: timeout
+          service = Google::Cloud::PubSub::Service.new project, nil, host: endpoint_2, timeout: timeout, universe_domain: universe_domain_2
           _(service.project).must_equal project
           config = service.subscriber.configure
           _(config).must_be_kind_of Google::Cloud::PubSub::V1::Subscriber::Client::Configuration
           _(config.timeout).must_equal timeout
           _(config.endpoint).must_equal endpoint_2
+          _(config.universe_domain).must_equal universe_domain_2
           _(config.lib_name).must_equal lib_name
           _(config.lib_version).must_equal lib_version
           _(config.metadata).must_equal expected_metadata
           assert_config_rpcs_equals subscriber_default_config.rpcs, 16, config.rpcs, timeout: timeout
+          _(service.universe_domain).must_equal universe_domain_2
         end
       end
     end
@@ -110,11 +116,13 @@ describe Google::Cloud::PubSub::Service do
           config = service.publisher.configure
           _(config).must_be_kind_of Google::Cloud::PubSub::V1::Publisher::Client::Configuration
           _(config.timeout).must_be :nil?
-          _(config.endpoint).must_equal endpoint
+          _(config.endpoint).must_be :nil?
+          _(config.universe_domain).must_equal universe_domain
           _(config.lib_name).must_equal lib_name
           _(config.lib_version).must_equal lib_version
           _(config.metadata).must_equal expected_metadata
           assert_config_rpcs_equals publisher_default_config.rpcs, 9, config.rpcs
+          _(service.universe_domain).must_equal universe_domain
         end
       end
     end
@@ -125,56 +133,18 @@ describe Google::Cloud::PubSub::Service do
     ENV.stub :[], nil do
       Google::Auth::Credentials.stub :default, credentials do
         Gapic::ServiceStub.stub :new, dummy_stub do
-          service = Google::Cloud::PubSub::Service.new project, nil, host: endpoint_2, timeout: timeout
+          service = Google::Cloud::PubSub::Service.new project, nil, host: endpoint_2, timeout: timeout, universe_domain: universe_domain_2
           _(service.project).must_equal project
           config = service.publisher.configure
           _(config).must_be_kind_of Google::Cloud::PubSub::V1::Publisher::Client::Configuration
           _(config.timeout).must_equal timeout
           _(config.endpoint).must_equal endpoint_2
+          _(config.universe_domain).must_equal universe_domain_2
           _(config.lib_name).must_equal lib_name
           _(config.lib_version).must_equal lib_version
           _(config.metadata).must_equal expected_metadata
           assert_config_rpcs_equals publisher_default_config.rpcs, 9, config.rpcs, timeout: timeout
-        end
-      end
-    end
-  end
-
-  it "configures the V1::IAMPolicy::Client" do
-    # Clear all environment variables
-    ENV.stub :[], nil do
-      Google::Auth::Credentials.stub :default, credentials do
-        Gapic::ServiceStub.stub :new, dummy_stub do
-          service = Google::Cloud::PubSub::Service.new project, nil
-          _(service.project).must_equal project
-          config = service.iam.configure
-          _(config).must_be_kind_of Google::Cloud::PubSub::V1::IAMPolicy::Client::Configuration
-          _(config.timeout).must_be :nil?
-          _(config.endpoint).must_equal endpoint
-          _(config.lib_name).must_equal lib_name
-          _(config.lib_version).must_equal lib_version
-          _(config.metadata).must_equal expected_metadata
-          assert_config_rpcs_equals iam_policy_default_config.rpcs, 3, config.rpcs
-        end
-      end
-    end
-  end
-
-  it "configures the V1::IAMPolicy::Client with host and timeout" do
-    # Clear all environment variables
-    ENV.stub :[], nil do
-      Google::Auth::Credentials.stub :default, credentials do
-        Gapic::ServiceStub.stub :new, dummy_stub do
-          service = Google::Cloud::PubSub::Service.new project, nil, host: endpoint_2, timeout: timeout
-          _(service.project).must_equal project
-          config = service.iam.configure
-          _(config).must_be_kind_of Google::Cloud::PubSub::V1::IAMPolicy::Client::Configuration
-          _(config.timeout).must_equal timeout
-          _(config.endpoint).must_equal endpoint_2
-          _(config.lib_name).must_equal lib_name
-          _(config.lib_version).must_equal lib_version
-          _(config.metadata).must_equal expected_metadata
-          assert_config_rpcs_equals iam_policy_default_config.rpcs, 3, config.rpcs, timeout: timeout
+          _(service.universe_domain).must_equal universe_domain_2
         end
       end
     end
@@ -190,11 +160,13 @@ describe Google::Cloud::PubSub::Service do
           config = service.schemas.configure
           _(config).must_be_kind_of Google::Cloud::PubSub::V1::SchemaService::Client::Configuration
           _(config.timeout).must_be :nil?
-          _(config.endpoint).must_equal endpoint
+          _(config.endpoint).must_be :nil?
+          _(config.universe_domain).must_equal universe_domain
           _(config.lib_name).must_equal lib_name
           _(config.lib_version).must_equal lib_version
           _(config.metadata).must_equal expected_metadata
           assert_config_rpcs_equals schema_service_default_config.rpcs, 10, config.rpcs
+          _(service.universe_domain).must_equal universe_domain
         end
       end
     end
@@ -205,16 +177,18 @@ describe Google::Cloud::PubSub::Service do
     ENV.stub :[], nil do
       Google::Auth::Credentials.stub :default, credentials do
         Gapic::ServiceStub.stub :new, dummy_stub do
-          service = Google::Cloud::PubSub::Service.new project, nil, host: endpoint_2, timeout: timeout
+          service = Google::Cloud::PubSub::Service.new project, nil, host: endpoint_2, timeout: timeout, universe_domain: universe_domain_2
           _(service.project).must_equal project
           config = service.schemas.configure
           _(config).must_be_kind_of Google::Cloud::PubSub::V1::SchemaService::Client::Configuration
           _(config.timeout).must_equal timeout
           _(config.endpoint).must_equal endpoint_2
+          _(config.universe_domain).must_equal universe_domain_2
           _(config.lib_name).must_equal lib_name
           _(config.lib_version).must_equal lib_version
           _(config.metadata).must_equal expected_metadata
           assert_config_rpcs_equals schema_service_default_config.rpcs, 10, config.rpcs, timeout: timeout
+          _(service.universe_domain).must_equal universe_domain_2
         end
       end
     end


### PR DESCRIPTION
Specifically:

* Depends on google-cloud-pubsub-v1 0.20 or later to ensure universe_domain support in the GAPIC layer
* Sets the default endpoint config (which is treated as an endpoint override) to nil so the "templated" endpoint with universe domain substitution is used.
* Adds universe_domain to the toplevel pubsub config
* Updates the `Google::Cloud::Pubsub.new` factory method to take universe_domain and pass it down into all underlying low-level clients
* Provides a universe_domain accessor on the project object
* Switches the IAM client to use the mixin rather than the deprecated embedded client
