### PR TITLE
chore(storage): Clean up storage test buckets

### DIFF
--- a/google-cloud-storage/acceptance/storage/buckets_test.rb
+++ b/google-cloud-storage/acceptance/storage/buckets_test.rb
@@ -17,12 +17,11 @@ require "storage_helper"
 describe "Storage", :buckets, :storage do
   let(:buckets) do
     bucket_names.map do |b|
-      storage.bucket(b) ||
-      safe_gcs_execute { storage.create_bucket(b) }
+      storage.bucket(b) || safe_gcs_execute { storage.create_bucket(b) }
     end
   end
   let(:bucket_names) { $bucket_names }
-    
+
   before do
     buckets # always create the buckets
   end
@@ -32,12 +31,10 @@ describe "Storage", :buckets, :storage do
     _(first_buckets.next?).must_equal true
     first_buckets.each do |b|
       _(b).must_be_kind_of Google::Cloud::Storage::Bucket
-      _(b.location_type).must_equal "multi-region"
     end
     second_buckets = first_buckets.next
     second_buckets.each do |b|
       _(b).must_be_kind_of Google::Cloud::Storage::Bucket
-      _(b.location_type).must_equal "multi-region"
     end
   end
 
@@ -46,12 +43,10 @@ describe "Storage", :buckets, :storage do
     _(first_buckets.next?).must_equal true
     first_buckets.each do |b|
       _(b).must_be_kind_of Google::Cloud::Storage::Bucket
-      _(b.user_project).must_equal true
     end
     second_buckets = first_buckets.next
     second_buckets.each do |b|
       _(b).must_be_kind_of Google::Cloud::Storage::Bucket
-      _(b.user_project).must_equal true
     end
   end
 

--- a/google-cloud-storage/acceptance/storage/file_test.rb
+++ b/google-cloud-storage/acceptance/storage/file_test.rb
@@ -859,6 +859,11 @@ describe Google::Cloud::Storage::File, :storage do
   end
 
   describe "object retention" do
+    # Note: While it would be best if we could clean up these buckets after
+    # each test, some of them have retention and cannot be deleted without
+    # incurring additional delays. So instead we delete things (including
+    # objects lingering from previous runs) at the end of the entire test run
+    # (see the bottom of storage_helper.rb).
     let(:object_lock_bucket) { storage.create_bucket("object-lock-bucket-#{Time.now.to_i}", enable_object_retention: true) }
     let(:data) { StringIO.new "Hello World!" }
 

--- a/google-cloud-storage/acceptance/storage_helper.rb
+++ b/google-cloud-storage/acceptance/storage_helper.rb
@@ -181,22 +181,23 @@ end
 def clean_up_storage_buckets proj = $storage, names = $bucket_names, user_project: nil
   puts "Cleaning up storage buckets after tests for #{proj.project}."
   names.each do |bucket_name|
-    if b = proj.bucket(bucket_name, user_project: user_project)
-      begin
-        b.files(versions: true).all do |file|
-          file.delete generation: true
-        end
-        # Add one second delay between bucket deletes to avoid rate limiting errors
-        sleep 1
-        safe_gcs_execute { b.delete }
-      rescue => e
-        puts "Error while cleaning up bucket #{b.name}\n\n#{e}"
-      end
-    end
+    bucket = proj.bucket bucket_name, user_project: user_project
+    clean_up_storage_bucket bucket if bucket
   end
 rescue => e
   puts "Error while cleaning up storage buckets after tests.\n\n#{e}"
   raise e
+end
+
+def clean_up_storage_bucket bucket
+  bucket.files(versions: true).all do |file|
+    file.delete generation: true
+  end
+  # Add one second delay between bucket deletes to avoid rate limiting errors
+  sleep 1
+  safe_gcs_execute { bucket.delete }
+rescue => e
+  puts "Error while cleaning up bucket #{bucket.name}\n\n#{e}"
 end
 
 Minitest.after_run do
@@ -209,5 +210,35 @@ Minitest.after_run do
          "are present in the environment: \n" \
          "GCLOUD_TEST_STORAGE_REQUESTER_PAYS_PROJECT and \n" \
          "GCLOUD_TEST_STORAGE_REQUESTER_PAYS_KEYFILE or GCLOUD_TEST_STORAGE_REQUESTER_PAYS_KEYFILE_JSON"
+  end
+
+  # Delete things that are more than a day old
+  time_threshold = Time.now.to_i - 86400
+
+  $storage.buckets(prefix: "object-lock-bucket-", max: 200).each do |bucket|
+    if bucket.name =~ /object-lock-bucket-(\d+)/
+      if Regexp.last_match[1].to_i < time_threshold
+        puts "Cleaning up old test bucket: #{bucket.name} ..."
+        clean_up_storage_bucket bucket
+      end
+    end
+  end
+
+  [
+    "gcloud-ruby-acceptance-",
+    "single_use_gcloud-ruby-acceptance-",
+    "ruby-storage-samples-test-",
+    "ruby-transcoder-samples-test-"
+  ].each do |prefix|
+    $storage.buckets(prefix: prefix, max: 100).each do |bucket|
+      if bucket.name =~ /#{prefix}(\d+-\d+-\d+)t(\d+)-(\d+)-(\d+)z/
+        m = Regexp.last_match
+        bucket_time = DateTime.parse("#{m[1]}t#{m[2]}:#{m[3]}:#{m[4]}z").to_time.to_i
+        if bucket_time < time_threshold
+          puts "Cleaning up old test bucket: #{bucket.name} ..."
+          clean_up_storage_bucket bucket
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Several things in an attempt to deflake bucket-related storage tests:

* Clean up acceptance-test-created buckets that are more than a day old. The hope is this will prevent buckets from accumulating.
* Remove location/region checks in buckets_test because they may pick up other buckets from other tests that don't have those attributes.