### PR TITLE
fix(firestore): Replace legacy header `google-cloud-resource-prefix` with `x-goog-request-params`

### DIFF
--- a/google-cloud-firestore/acceptance/firestore/service_test.rb
+++ b/google-cloud-firestore/acceptance/firestore/service_test.rb
@@ -20,7 +20,7 @@ require "firestore_helper"
 describe Google::Cloud::Firestore::Service, :firestore_acceptance do
   let :config_metadata do
     {
-      "google-cloud-resource-prefix": "projects/#{firestore.project_id}/databases/(default)"
+      "x-goog-request-params": "projects/#{firestore.project_id}/databases/(default)"
     }
   end
 

--- a/google-cloud-firestore/lib/google/cloud/firestore/service.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/service.rb
@@ -52,7 +52,7 @@ module Google
               config.endpoint = host if host
               config.lib_name = "gccl"
               config.lib_version = Google::Cloud::Firestore::VERSION
-              config.metadata = { "google-cloud-resource-prefix": "projects/#{@project}/databases/#{@database}" }
+              config.metadata = { "x-goog-request-params": "projects/#{@project}/databases/#{@database}" }
             end
           end
         end


### PR DESCRIPTION
This PR replaces the legacy header `google-cloud-resource-prefix` with the preferred header `x-goog-request-params`. See [this](http://shortn/_04mzUJ90Qh) (internal) for more info.

**Note**: Firestore doesn't yet accept the header value of `x-goog-request-params` in the format `projects/{project_id/databases/{database_id}`. So this PR shouldn't be merged until the backend release (see [here](http://shortn/_JUvGJaX66X)).