### PR TITLE
feat(bigquery): Support accessing storage_ billing_model field in a dataset

### DIFF
--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -412,12 +412,50 @@ module Google
           patch_gapi! :default_encryption_configuration
         end
 
+        ##
+        # Gets the Storage Billing Model for the dataset.
+        #
+        # @see https://cloud.google.com/blog/products/data-analytics/new-bigquery-billing-model-helps-reduce-physical-storage-costs
+        #
+        # @return [String, nil] A string containing the storage billing model,
+        #   or `nil` if the object is a reference (see {#reference?}).
+        #   Possible values of the string are `LOGICAL`, `PHYSICAL`
+        #   and `STORAGE_BILLING_MODEL_UNSPECIFIED`.
+        #
+        # @example
+        #
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #
+        #   storage_billing_model = dataset.storage_billing_model
+        #
+        # @!group Attributes
+        #
         def storage_billing_model
           return nil if reference?
           ensure_full_data!
           @gapi.storage_billing_model
         end
 
+        ##
+        # Sets the Storage Billing Model for the dataset.
+        #
+        # @see https://cloud.google.com/blog/products/data-analytics/new-bigquery-billing-model-helps-reduce-physical-storage-costs
+        #
+        # @param value [String] The new storage billing model. Accepted values
+        #   are `LOGICAL` and `PHYSICAL`.
+        #
+        # @example
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #   storage_billing_model = dataset.storage_billing_model "LOGICAL"
+        #
+        # @!group Attributes
+        #
         def storage_billing_model= value
           ensure_full_data!
           @gapi.storage_billing_model = value

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -412,6 +412,18 @@ module Google
           patch_gapi! :default_encryption_configuration
         end
 
+        def storage_billing_model
+          return nil if reference?
+          ensure_full_data!
+          @gapi.storage_billing_model
+        end
+
+        def storage_billing_model= value
+          ensure_full_data!
+          @gapi.storage_billing_model = value
+          patch_gapi! :storage_billing_model
+        end
+
         ##
         # Retrieves the access rules for a Dataset. The rules can be updated
         # when passing a block, see {Dataset::Access} for all the methods

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_attributes_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_attributes_test.rb
@@ -64,6 +64,18 @@ describe Google::Cloud::Bigquery::Dataset, :attributes, :mock_bigquery do
     mock.verify
   end
 
+  it "gets full data for storage_billing_model" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :get_dataset, dataset_full_gapi, [project, dataset_id]
+
+    _(dataset.storage_billing_model).must_be_nil
+
+    # A second call to attribute does not make a second HTTP API call
+    _(dataset.storage_billing_model).must_be_nil
+    mock.verify
+  end
+
   it "gets full data for tags" do
     mock = Minitest::Mock.new
     bigquery.service.mocked_service = mock

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_reference_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_reference_test.rb
@@ -49,6 +49,7 @@ describe Google::Cloud::Bigquery::Dataset, :reference, :mock_bigquery do
     _(dataset.modified_at).must_be_nil
 
     _(dataset.default_encryption).must_be_nil
+    _(dataset.storage_billing_model).must_be_nil
   end
 
   it "can test its existence" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_reference_update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_reference_update_test.rb
@@ -123,4 +123,23 @@ describe Google::Cloud::Bigquery::Dataset, :reference, :update, :mock_bigquery d
     _(dataset.default_encryption).must_be :frozen?
     mock.verify
   end
+
+  it "updates its storage_billing_model" do
+    storage_billing_model = "LOGICAL"
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    mock.expect :get_dataset, dataset_gapi, [project, dataset_id]
+    updated_gapi = dataset_gapi.dup
+    updated_gapi.storage_billing_model = storage_billing_model
+    patch_gapi = Google::Apis::BigqueryV2::Dataset.new storage_billing_model: storage_billing_model, etag: dataset_gapi.etag
+    mock.expect :patch_dataset, updated_gapi, [project, dataset_id, patch_gapi], options: {header: {"If-Match" => dataset_gapi.etag}}
+
+    _(dataset.storage_billing_model).must_be_nil
+
+    dataset.storage_billing_model = storage_billing_model
+
+    _(dataset.storage_billing_model).must_equal storage_billing_model
+    mock.verify
+  end
 end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_update_test.rb
@@ -128,4 +128,22 @@ describe Google::Cloud::Bigquery::Dataset, :update, :mock_bigquery do
     _(dataset.default_encryption).must_be :frozen?
     mock.verify
   end
+
+  it "updates its storage_billing_model" do
+    storage_billing_model = "LOGICAL"
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    updated_gapi = dataset_gapi.dup
+    updated_gapi.storage_billing_model = storage_billing_model
+    patch_gapi = Google::Apis::BigqueryV2::Dataset.new storage_billing_model: storage_billing_model, etag: dataset_gapi.etag
+    mock.expect :patch_dataset, updated_gapi, [project, dataset_id, patch_gapi], options: {header: {"If-Match" => dataset_gapi.etag}}
+
+    _(dataset.storage_billing_model).must_be_nil
+
+    dataset.storage_billing_model = storage_billing_model
+
+    _(dataset.storage_billing_model).must_equal storage_billing_model
+    mock.verify
+  end
 end


### PR DESCRIPTION
closes: #23476

**Note**: Don't merge until the internal discussion around the behaviour of default value is resolved.