### PR TITLE
chore(clientconnectorsservices): delete wrapper dependency to beyond_…

### DIFF
--- a/google-cloud-beyond_corp/.OwlBot.yaml
+++ b/google-cloud-beyond_corp/.OwlBot.yaml
@@ -5,7 +5,5 @@ deep-copy-regex:
     dest: /owl-bot-staging/google-cloud-beyond_corp/google-cloud-beyond_corp-app_connectors/$1
   - source: /google/cloud/beyondcorp/appgateways/[^/]+-ruby/(.*)
     dest: /owl-bot-staging/google-cloud-beyond_corp/google-cloud-beyond_corp-app_gateways/$1
-  - source: /google/cloud/beyondcorp/clientconnectorservices/[^/]+-ruby/(.*)
-    dest: /owl-bot-staging/google-cloud-beyond_corp/google-cloud-beyond_corp-client_connector_services/$1
   - source: /google/cloud/beyondcorp/clientgateways/[^/]+-ruby/(.*)
     dest: /owl-bot-staging/google-cloud-beyond_corp/google-cloud-beyond_corp-client_gateways/$1

--- a/google-cloud-beyond_corp/.owlbot.rb
+++ b/google-cloud-beyond_corp/.owlbot.rb
@@ -17,7 +17,6 @@ OwlBot.prepare_multi_wrapper(
     "google-cloud-beyond_corp-app_connections",
     "google-cloud-beyond_corp-app_connectors",
     "google-cloud-beyond_corp-app_gateways",
-    "google-cloud-beyond_corp-client_connector_services",
     "google-cloud-beyond_corp-client_gateways"
   ],
   pretty_name: "BeyondCorp API"


### PR DESCRIPTION
Part of fixing #22820

Deleting `clientconnectorsservices` from the owl post processing.