### PR TITLE
fix: fix read rows retry so it doesn't trigger a full table scan in t…

### DIFF
--- a/google-cloud-bigtable/lib/google/cloud/bigtable/read_operations.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/read_operations.rb
@@ -159,10 +159,10 @@ module Google
           rescue *RowsReader::RETRYABLE_ERRORS => e
             rows_reader.retry_count += 1
             raise Google::Cloud::Error.from_error(e) unless rows_reader.retryable?
-            retry_status = rows_reader.retry_options limit, row_set
-            rows_limit = retry_status.rows_limit
-            row_set = retry_status.row_set
-            retry if retry_status.should_retry
+            resumption_option = rows_reader.retry_options limit, row_set
+            rows_limit = resumption_option.rows_limit
+            row_set = resumption_option.row_set
+            retry if resumption_option.is_complete
           end
         end
 

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/read_operations.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/read_operations.rb
@@ -324,7 +324,7 @@ module Google
 
           # Set the row range to full table scan if the row set is empty
           if row_set.empty?
-            return Google::Cloud::Bigtable::V2::RowSet.new row_ranges: []
+            row_set[:row_ranges] = [Google::Cloud::Bigtable::V2::RowRange.new]
           end
 
           Google::Cloud::Bigtable::V2::RowSet.new row_set

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/read_operations.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/read_operations.rb
@@ -162,7 +162,7 @@ module Google
             resumption_option = rows_reader.retry_options limit, row_set
             rows_limit = resumption_option.rows_limit
             row_set = resumption_option.row_set
-            retry if resumption_option.is_complete
+            retry unless resumption_option.complete?
           end
         end
 

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/rows_reader.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/rows_reader.rb
@@ -143,16 +143,12 @@ module Google
           # 1. Remove ranges that have already been read, and reduce ranges that
           # include the last read rows
           if last_key
-            delete_indexes = []
-            row_set.row_ranges.each_with_index do |range, i|
-              if end_key_read? range
-                delete_indexes << i
-              elsif start_key_read? range
+            row_set.row_ranges.reject! { |r| end_key_read? r }
+            row_set.row_ranges.each do |range|
+              if start_key_read? range
                 range.start_key_open = last_key
               end
             end
-
-            delete_indexes.sort.reverse_each { |i| row_set.row_ranges.delete_at i }
           end
 
           # 2. Remove all individual keys before and up to the last read key

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/rows_reader.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/rows_reader.rb
@@ -120,11 +120,11 @@ module Google
         # @return ResumptionOption
         #
         def retry_options rows_limit, row_set
-          return ResumptionOption.new true, rows_limit, row_set unless last_key
+          return ResumptionOption.new false, rows_limit, row_set unless last_key
 
           # Check if we've already read read rows_limit number of rows.
-          # If true, return nil to indicate that the read has succeeded.
-          return ResumptionOption.new false, nil, nil if rows_limit && rows_limit == @rows_count
+          # If true, mark ResumptionOption is_complete to true.
+          return ResumptionOption.new true, nil, nil if rows_limit && rows_limit == @rows_count
 
           # Reduce the limit by the number of already returned responses.
           rows_limit -= @rows_count if rows_limit
@@ -161,14 +161,14 @@ module Google
           # 3. In read_operations, we always add an empty row_range if row_ranges and
           # row_keys are not defined. So if both row_ranges and row_keys are empty,
           # it means that we've already read all the ranges and keys, set ResumptionOption
-          # should_retry to false to indicate that this read is successful.
+          # is_complete to true to indicate that this read is successful.
           if last_key && row_set.row_ranges.empty? && row_set.row_keys.empty?
-            return ResumptionOption.new false, nil, nil
+            return ResumptionOption.new true, nil, nil
           end
 
           @chunk_processor.reset_to_new_row
 
-          ResumptionOption.new true, rows_limit, row_set
+          ResumptionOption.new false, rows_limit, row_set
         end
 
         ##
@@ -235,7 +235,7 @@ module Google
 
         ##
         # returns if this operation should be retried
-        def is_complete
+        def complete?
           @is_complete
         end
 

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/rows_reader.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/rows_reader.rb
@@ -189,12 +189,13 @@ module Google
         # @return [Boolean]
         #
         def start_key_read? range
-          if range.start_key_closed.empty? && range.end_key_open.empty?
-            true
-          elsif !range.start_key_closed.empty?
+          if !range.start_key_closed.empty?
             last_key >= range.start_key_closed
+          elsif !range.start_key_open.empty?
+            last_key > range.start_key_closed
           else
-            last_key > range.start_key_open
+            # start is unbounded
+            true
           end
         end
 
@@ -205,12 +206,13 @@ module Google
         # @return [Boolean]
         #
         def end_key_read? range
-          if range.end_key_closed.empty? && range.end_key_open.empty?
-            false
-          elsif !range.end_key_closed.empty?
+          if !range.end_key_closed.empty?
             range.end_key_closed <= last_key
-          else
+          elsif !range.end_key_open.empty?
             range.end_key_open <= last_key
+          else
+            # end is unbounded
+            false
           end
         end
       end
@@ -233,22 +235,13 @@ module Google
           @row_set = row_set
         end
 
+        attr_reader :rows_limit
+        attr_reader :row_set
+
         ##
         # returns if this operation should be retried
         def complete?
           @is_complete
-        end
-
-        ##
-        # returns new new rows_limit for the retry
-        def rows_limit
-          @rows_limit
-        end
-
-        ##
-        # returns new new row_set for the retry
-        def row_set
-          @row_set
         end
       end
     end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/conformance_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/conformance_test.rb
@@ -44,7 +44,7 @@ class ReadRowsTest < MockBigtable
       resp = Google::Cloud::Bigtable::V2::ReadRowsResponse.new chunks: test.chunks.to_a
       mock.expect :read_rows, [resp],
         table_name: table_path(instance_id, table_id),
-        rows: Google::Cloud::Bigtable::V2::RowSet.new,
+        rows: Google::Cloud::Bigtable::V2::RowSet.new(row_ranges: [Google::Cloud::Bigtable::V2::RowRange.new]),
         filter: nil,
         rows_limit: nil,
         app_profile_id: nil

--- a/google-cloud-bigtable/test/google/cloud/bigtable/row_reader_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/row_reader_test.rb
@@ -28,21 +28,22 @@ describe Google::Cloud::Bigtable::RowsReader, :row_reader, :mock_bigtable do
 
     _(rows_reader.last_key).must_equal "3"
 
-    rows_limit, retry_row_set = rows_reader.retry_options(100, row_set)
+    retry_status = rows_reader.retry_options(100, row_set)
 
-    _(rows_limit).must_equal 90
-    _(retry_row_set.row_keys).must_equal ["5"]
+    _(retry_status.rows_limit).must_equal 90
+    _(retry_status.row_set.row_keys).must_equal ["5"]
   end
 
   it "add row range if row set row ranges empty" do
     rows_reader = Google::Cloud::Bigtable::RowsReader.new("dummy-table-client")
     chunk_processor = rows_reader.instance_variable_get("@chunk_processor")
 
-    row_set = Google::Cloud::Bigtable::V2::RowSet.new
+    row_set = Google::Cloud::Bigtable::V2::RowSet.new(row_ranges: [{}])
+    
     chunk_processor.last_key = "3"
 
-    _, retry_row_set = rows_reader.retry_options(100, row_set)
-    row_ranges = retry_row_set.row_ranges
+    retry_status = rows_reader.retry_options(100, row_set)
+    row_ranges = retry_status.row_set.row_ranges
 
     _(row_ranges.length).must_equal 1
     _(row_ranges.first).must_equal Google::Cloud::Bigtable::V2::RowRange.new(start_key_open: "3")
@@ -56,8 +57,8 @@ describe Google::Cloud::Bigtable::RowsReader, :row_reader, :mock_bigtable do
       row_ranges: [{ end_key_closed: "3" }, { end_key_closed: "5" }]
     )
     chunk_processor.last_key = "3"
-    _, retry_row_set = rows_reader.retry_options(100, row_set)
-    row_ranges = retry_row_set.row_ranges
+    retry_status = rows_reader.retry_options(100, row_set)
+    row_ranges = retry_status.row_set.row_ranges
 
     _(row_ranges.length).must_equal 1
     _(row_ranges.first.end_key_closed).must_equal "5"
@@ -71,11 +72,35 @@ describe Google::Cloud::Bigtable::RowsReader, :row_reader, :mock_bigtable do
       row_ranges: [{ end_key_closed: "5" }]
     )
     chunk_processor.last_key = "3"
-    _, retry_row_set = rows_reader.retry_options(100, row_set)
-    row_ranges = retry_row_set.row_ranges
+    retry_status = rows_reader.retry_options(100, row_set)
+    row_ranges = retry_status.row_set.row_ranges
 
     _(row_ranges.length).must_equal 1
     _(row_ranges.first).must_equal Google::Cloud::Bigtable::V2::RowRange.new(start_key_open: "3", end_key_closed: "5")
+  end
+
+  it "start key is updated correctly" do
+    rows_reader = Google::Cloud::Bigtable::RowsReader.new("dummy-table-client")
+    chunk_processor = rows_reader.instance_variable_get("@chunk_processor")
+
+    row_set = Google::Cloud::Bigtable::V2::RowSet.new(
+      row_ranges: [{ start_key_closed: "3" }]
+    )
+    chunk_processor.last_key = "3"
+    retry_status = rows_reader.retry_options(100, row_set)
+    row_ranges = retry_status.row_set.row_ranges
+
+    _(row_ranges.length).must_equal 1
+    _(row_ranges.first).must_equal Google::Cloud::Bigtable::V2::RowRange.new(start_key_open: "3")
+
+    row_set = Google::Cloud::Bigtable::V2::RowSet.new(
+      row_ranges: [{ start_key_open: "3" }]
+    )
+    retry_status = rows_reader.retry_options(100, row_set)
+
+    row_ranges = retry_status.row_set.row_ranges
+    _(row_ranges.length).must_equal 1
+    _(row_ranges.first).must_equal Google::Cloud::Bigtable::V2::RowRange.new(start_key_open: "3")
   end
 
   it "increment and check read is retryable" do
@@ -87,5 +112,59 @@ describe Google::Cloud::Bigtable::RowsReader, :row_reader, :mock_bigtable do
       rows_reader.retry_count += 1
       _(rows_reader.retryable?).must_equal expected_value
     end
+  end
+
+  it "row limit is nil after rows limit number of rows are read" do
+    rows_reader = Google::Cloud::Bigtable::RowsReader.new("dummy-table-client")
+
+    chunk_processor = rows_reader.instance_variable_get("@chunk_processor")
+    chunk_processor.last_key = "3"
+    rows_reader.instance_variable_set("@rows_count", 10)
+
+    _(rows_reader.last_key).must_equal "3"
+
+    retry_status = rows_reader.retry_options(10, Google::Cloud::Bigtable::V2::RowSet.new())
+
+    _(retry_status.should_retry).must_equal false
+  end
+
+  it "row limit is nil after all the row ranges are read" do
+    rows_reader = Google::Cloud::Bigtable::RowsReader.new("dummy-table-client")
+
+    row_set = Google::Cloud::Bigtable::V2::RowSet.new(
+      row_ranges: [{ end_key_closed: "3" }]
+    )
+
+    chunk_processor = rows_reader.instance_variable_get("@chunk_processor")
+    chunk_processor.last_key = "3"
+    rows_reader.instance_variable_set("@rows_count", 10)
+
+    _(rows_reader.last_key).must_equal "3"
+
+    retry_status = rows_reader.retry_options(100, Google::Cloud::Bigtable::V2::RowSet.new(
+      row_ranges: [{ end_key_closed: "3" }]
+    ))
+    _(retry_status.should_retry).must_equal false
+
+    retry_status = rows_reader.retry_options(100, Google::Cloud::Bigtable::V2::RowSet.new(
+      row_ranges: [{ end_key_open: "3" }]
+    ))
+    _(retry_status.should_retry).must_equal false
+  end
+
+  it "row limit is nil after all the row keys are read" do
+    rows_reader = Google::Cloud::Bigtable::RowsReader.new("dummy-table-client")
+
+    row_set = Google::Cloud::Bigtable::V2::RowSet.new(row_keys: %w[1 2 3])
+
+    chunk_processor = rows_reader.instance_variable_get("@chunk_processor")
+    chunk_processor.last_key = "3"
+    rows_reader.instance_variable_set("@rows_count", 10)
+
+    _(rows_reader.last_key).must_equal "3"
+
+    retry_status = rows_reader.retry_options(100, row_set)
+
+    _(retry_status.should_retry).must_equal false
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/row_reader_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/row_reader_test.rb
@@ -28,10 +28,10 @@ describe Google::Cloud::Bigtable::RowsReader, :row_reader, :mock_bigtable do
 
     _(rows_reader.last_key).must_equal "3"
 
-    retry_status = rows_reader.retry_options(100, row_set)
+    resumption_option = rows_reader.retry_options(100, row_set)
 
-    _(retry_status.rows_limit).must_equal 90
-    _(retry_status.row_set.row_keys).must_equal ["5"]
+    _(resumption_option.rows_limit).must_equal 90
+    _(resumption_option.row_set.row_keys).must_equal ["5"]
   end
 
   it "add row range if row set row ranges empty" do
@@ -42,8 +42,8 @@ describe Google::Cloud::Bigtable::RowsReader, :row_reader, :mock_bigtable do
     
     chunk_processor.last_key = "3"
 
-    retry_status = rows_reader.retry_options(100, row_set)
-    row_ranges = retry_status.row_set.row_ranges
+    resumption_option = rows_reader.retry_options(100, row_set)
+    row_ranges = resumption_option.row_set.row_ranges
 
     _(row_ranges.length).must_equal 1
     _(row_ranges.first).must_equal Google::Cloud::Bigtable::V2::RowRange.new(start_key_open: "3")
@@ -57,8 +57,8 @@ describe Google::Cloud::Bigtable::RowsReader, :row_reader, :mock_bigtable do
       row_ranges: [{ end_key_closed: "3" }, { end_key_closed: "5" }]
     )
     chunk_processor.last_key = "3"
-    retry_status = rows_reader.retry_options(100, row_set)
-    row_ranges = retry_status.row_set.row_ranges
+    resumption_option = rows_reader.retry_options(100, row_set)
+    row_ranges = resumption_option.row_set.row_ranges
 
     _(row_ranges.length).must_equal 1
     _(row_ranges.first.end_key_closed).must_equal "5"
@@ -72,8 +72,8 @@ describe Google::Cloud::Bigtable::RowsReader, :row_reader, :mock_bigtable do
       row_ranges: [{ end_key_closed: "5" }]
     )
     chunk_processor.last_key = "3"
-    retry_status = rows_reader.retry_options(100, row_set)
-    row_ranges = retry_status.row_set.row_ranges
+    resumption_option = rows_reader.retry_options(100, row_set)
+    row_ranges = resumption_option.row_set.row_ranges
 
     _(row_ranges.length).must_equal 1
     _(row_ranges.first).must_equal Google::Cloud::Bigtable::V2::RowRange.new(start_key_open: "3", end_key_closed: "5")
@@ -87,8 +87,8 @@ describe Google::Cloud::Bigtable::RowsReader, :row_reader, :mock_bigtable do
       row_ranges: [{ start_key_closed: "3" }]
     )
     chunk_processor.last_key = "3"
-    retry_status = rows_reader.retry_options(100, row_set)
-    row_ranges = retry_status.row_set.row_ranges
+    resumption_option = rows_reader.retry_options(100, row_set)
+    row_ranges = resumption_option.row_set.row_ranges
 
     _(row_ranges.length).must_equal 1
     _(row_ranges.first).must_equal Google::Cloud::Bigtable::V2::RowRange.new(start_key_open: "3")
@@ -96,9 +96,9 @@ describe Google::Cloud::Bigtable::RowsReader, :row_reader, :mock_bigtable do
     row_set = Google::Cloud::Bigtable::V2::RowSet.new(
       row_ranges: [{ start_key_open: "3" }]
     )
-    retry_status = rows_reader.retry_options(100, row_set)
+    resumption_option = rows_reader.retry_options(100, row_set)
 
-    row_ranges = retry_status.row_set.row_ranges
+    row_ranges = resumption_option.row_set.row_ranges
     _(row_ranges.length).must_equal 1
     _(row_ranges.first).must_equal Google::Cloud::Bigtable::V2::RowRange.new(start_key_open: "3")
   end
@@ -123,9 +123,9 @@ describe Google::Cloud::Bigtable::RowsReader, :row_reader, :mock_bigtable do
 
     _(rows_reader.last_key).must_equal "3"
 
-    retry_status = rows_reader.retry_options(10, Google::Cloud::Bigtable::V2::RowSet.new())
+    resumption_option = rows_reader.retry_options(10, Google::Cloud::Bigtable::V2::RowSet.new())
 
-    _(retry_status.should_retry).must_equal false
+    _(resumption_option.is_complete).must_equal false
   end
 
   it "row limit is nil after all the row ranges are read" do
@@ -141,15 +141,15 @@ describe Google::Cloud::Bigtable::RowsReader, :row_reader, :mock_bigtable do
 
     _(rows_reader.last_key).must_equal "3"
 
-    retry_status = rows_reader.retry_options(100, Google::Cloud::Bigtable::V2::RowSet.new(
+    resumption_option = rows_reader.retry_options(100, Google::Cloud::Bigtable::V2::RowSet.new(
       row_ranges: [{ end_key_closed: "3" }]
     ))
-    _(retry_status.should_retry).must_equal false
+    _(resumption_option.is_complete).must_equal false
 
-    retry_status = rows_reader.retry_options(100, Google::Cloud::Bigtable::V2::RowSet.new(
+    resumption_option = rows_reader.retry_options(100, Google::Cloud::Bigtable::V2::RowSet.new(
       row_ranges: [{ end_key_open: "3" }]
     ))
-    _(retry_status.should_retry).must_equal false
+    _(resumption_option.is_complete).must_equal false
   end
 
   it "row limit is nil after all the row keys are read" do
@@ -163,8 +163,8 @@ describe Google::Cloud::Bigtable::RowsReader, :row_reader, :mock_bigtable do
 
     _(rows_reader.last_key).must_equal "3"
 
-    retry_status = rows_reader.retry_options(100, row_set)
+    resumption_option = rows_reader.retry_options(100, row_set)
 
-    _(retry_status.should_retry).must_equal false
+    _(resumption_option.is_complete).must_equal false
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/row_reader_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/row_reader_test.rb
@@ -114,7 +114,7 @@ describe Google::Cloud::Bigtable::RowsReader, :row_reader, :mock_bigtable do
     end
   end
 
-  it "row limit is nil after rows limit number of rows are read" do
+  it "resumption option is complete after limit number of rows are read" do
     rows_reader = Google::Cloud::Bigtable::RowsReader.new("dummy-table-client")
 
     chunk_processor = rows_reader.instance_variable_get("@chunk_processor")
@@ -125,10 +125,10 @@ describe Google::Cloud::Bigtable::RowsReader, :row_reader, :mock_bigtable do
 
     resumption_option = rows_reader.retry_options(10, Google::Cloud::Bigtable::V2::RowSet.new())
 
-    _(resumption_option.is_complete).must_equal false
+    _(resumption_option.complete?).must_equal true
   end
 
-  it "row limit is nil after all the row ranges are read" do
+  it "resumption option is complete after all the row ranges are read" do
     rows_reader = Google::Cloud::Bigtable::RowsReader.new("dummy-table-client")
 
     row_set = Google::Cloud::Bigtable::V2::RowSet.new(
@@ -144,15 +144,15 @@ describe Google::Cloud::Bigtable::RowsReader, :row_reader, :mock_bigtable do
     resumption_option = rows_reader.retry_options(100, Google::Cloud::Bigtable::V2::RowSet.new(
       row_ranges: [{ end_key_closed: "3" }]
     ))
-    _(resumption_option.is_complete).must_equal false
+    _(resumption_option.complete?).must_equal true
 
     resumption_option = rows_reader.retry_options(100, Google::Cloud::Bigtable::V2::RowSet.new(
       row_ranges: [{ end_key_open: "3" }]
     ))
-    _(resumption_option.is_complete).must_equal false
+    _(resumption_option.complete?).must_equal true
   end
 
-  it "row limit is nil after all the row keys are read" do
+  it "resumption option is complete after all the row set are read" do
     rows_reader = Google::Cloud::Bigtable::RowsReader.new("dummy-table-client")
 
     row_set = Google::Cloud::Bigtable::V2::RowSet.new(row_keys: %w[1 2 3])
@@ -165,6 +165,6 @@ describe Google::Cloud::Bigtable::RowsReader, :row_reader, :mock_bigtable do
 
     resumption_option = rows_reader.retry_options(100, row_set)
 
-    _(resumption_option.is_complete).must_equal false
+    _(resumption_option.complete?).must_equal true
   end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/read_rows_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/read_rows_test.rb
@@ -272,4 +272,166 @@ describe Google::Cloud::Bigtable::Table, :read_rows, :mock_bigtable do
     filter = table.filter.key("user-*")
     table.read_rows(filter: filter).map {|v| v}
   end
+
+  it "no retry after reading all the rows" do
+    cf = Google::Protobuf::StringValue.new(:value => "cf")
+    q = Google::Protobuf::BytesValue.new(:value => "q")
+    cell_chunk = Google::Cloud::Bigtable::V2::ReadRowsResponse::CellChunk.new(
+      :row_key => "a",
+      :family_name => cf,
+      :qualifier => q,
+      :value => "v",
+      :timestamp_micros => -1,
+      :commit_row => true
+    )
+
+    read_response = [Google::Cloud::Bigtable::V2::ReadRowsResponse.new(chunks: [cell_chunk]), "error"]
+
+    mock_itr = OpenStruct.new(
+      read_response: read_response,
+    )
+
+    def mock_itr.each
+      read_response.each do |res|
+        if res == "error"
+          raise GRPC::DeadlineExceeded, "Deadline exceeded"
+        else
+          yield res
+        end
+      end
+    end
+
+    mock = OpenStruct.new(
+      mock_itr: mock_itr,
+      retry_count: 0
+    )
+
+    def mock.read_rows _args
+      self.retry_count += 1
+      mock_itr
+    end
+
+    expected_row = Google::Cloud::Bigtable::Row.new("a")
+    expected_row.cells["cf"] << Google::Cloud::Bigtable::Row::Cell.new(
+      "cf", "q", -1, "v"
+    )
+
+    bigtable.service.mocked_client = mock
+    table = bigtable.table(instance_id, table_id)
+
+    rows = table.read_rows(keys: ["A"]).map {|v| v}
+
+    _(mock.retry_count).must_equal 1
+    _(rows.length).must_equal 1
+    _(rows.first).must_equal expected_row
+  end
+
+  it "no retry after reading all the ranges" do
+    cf = Google::Protobuf::StringValue.new(:value => "cf")
+    q = Google::Protobuf::BytesValue.new(:value => "q")
+    cell_chunk = Google::Cloud::Bigtable::V2::ReadRowsResponse::CellChunk.new(
+      :row_key => "g",
+      :family_name => cf,
+      :qualifier => q,
+      :value => "v",
+      :timestamp_micros => -1,
+      :commit_row => true
+    )
+
+    read_response = [Google::Cloud::Bigtable::V2::ReadRowsResponse.new(chunks: [cell_chunk]), "error"]
+
+    mock_itr = OpenStruct.new(
+      read_response: read_response,
+    )
+
+    def mock_itr.each
+      read_response.each do |res|
+        if res == "error"
+          raise GRPC::DeadlineExceeded, "Deadline exceeded"
+        else
+          yield res
+        end
+      end
+    end
+
+    mock = OpenStruct.new(
+      mock_itr: mock_itr,
+      retry_count: 0
+    )
+
+    def mock.read_rows _args
+      self.retry_count += 1
+      mock_itr
+    end
+
+    expected_row = Google::Cloud::Bigtable::Row.new("g")
+    expected_row.cells["cf"] << Google::Cloud::Bigtable::Row::Cell.new(
+      "cf", "q", -1, "v"
+    )
+
+    bigtable.service.mocked_client = mock
+    table = bigtable.table(instance_id, table_id)
+
+    range1 = table.new_row_range.from("a").to("b")
+    range2 = table.new_row_range.between("d", "f")
+
+    rows = table.read_rows(ranges: [range1, range2]).map {|v| v}
+
+    _(mock.retry_count).must_equal 1
+    _(rows.length).must_equal 1
+    _(rows.first).must_equal expected_row
+  end
+
+  it "no retry after reading limit number of rows" do
+    cf = Google::Protobuf::StringValue.new(:value => "cf")
+    q = Google::Protobuf::BytesValue.new(:value => "q")
+    cell_chunk = Google::Cloud::Bigtable::V2::ReadRowsResponse::CellChunk.new(
+      :row_key => "a",
+      :family_name => cf,
+      :qualifier => q,
+      :value => "v",
+      :timestamp_micros => -1,
+      :commit_row => true
+    )
+
+    read_response = [Google::Cloud::Bigtable::V2::ReadRowsResponse.new(chunks: [cell_chunk]), "error"]
+
+    mock_itr = OpenStruct.new(
+      read_response: read_response,
+    )
+
+    def mock_itr.each
+      read_response.each do |res|
+        if res == "error"
+          raise GRPC::DeadlineExceeded, "Deadline exceeded"
+        else
+          yield res
+        end
+      end
+    end
+
+    mock = OpenStruct.new(
+      mock_itr: mock_itr,
+      retry_count: 0
+    )
+
+    def mock.read_rows _args
+      self.retry_count += 1
+      mock_itr
+    end
+
+    expected_row = Google::Cloud::Bigtable::Row.new("a")
+    expected_row.cells["cf"] << Google::Cloud::Bigtable::Row::Cell.new(
+      "cf", "q", -1, "v"
+    )
+
+    bigtable.service.mocked_client = mock
+    table = bigtable.table(instance_id, table_id)
+
+    rows = table.read_rows(limit: 1).map {|v| v}
+
+    _(mock.retry_count).must_equal 1
+    _(rows.length).must_equal 1
+    _(rows.first).must_equal expected_row
+  end
 end

--- a/google-cloud-bigtable/test/google/cloud/bigtable/table/read_rows_test.rb
+++ b/google-cloud-bigtable/test/google/cloud/bigtable/table/read_rows_test.rb
@@ -42,7 +42,7 @@ describe Google::Cloud::Bigtable::Table, :read_rows, :mock_bigtable do
 
     mock.expect :read_rows, get_res,
                 table_name: table_path(instance_id, table_id),
-                rows: Google::Cloud::Bigtable::V2::RowSet.new,
+                rows: Google::Cloud::Bigtable::V2::RowSet.new(row_ranges: [Google::Cloud::Bigtable::V2::RowRange.new]),
                 filter: nil,
                 rows_limit: nil,
                 app_profile_id: nil


### PR DESCRIPTION
…he end

When a read is done and received a retryable error at the end of the stream, the current implementation will trigger a full table scan because the row resumption logic will strip away all of seen keys & ranges, leaving the retry request empty, which causes a full table scan.