### PR TITLE
chore: add OpenStruct to test/helper.rb files via owlbot postprocessor manual run

### DIFF
--- a/google-analytics-admin-v1alpha/test/helper.rb
+++ b/google-analytics-admin-v1alpha/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-analytics-admin/test/helper.rb
+++ b/google-analytics-admin/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-analytics-data-v1beta/test/helper.rb
+++ b/google-analytics-data-v1beta/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-analytics-data/test/helper.rb
+++ b/google-analytics-data/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-apps-meet-v2/test/helper.rb
+++ b/google-apps-meet-v2/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-apps-meet-v2beta/test/helper.rb
+++ b/google-apps-meet-v2beta/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-apps-meet/test/helper.rb
+++ b/google-apps-meet/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-area120-tables-v1alpha1/test/helper.rb
+++ b/google-area120-tables-v1alpha1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-area120-tables/test/helper.rb
+++ b/google-area120-tables/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-access_approval-v1/test/helper.rb
+++ b/google-cloud-access_approval-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-access_approval/test/helper.rb
+++ b/google-cloud-access_approval/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-advisory_notifications-v1/test/helper.rb
+++ b/google-cloud-advisory_notifications-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-advisory_notifications/test/helper.rb
+++ b/google-cloud-advisory_notifications/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-ai_platform-v1/test/helper.rb
+++ b/google-cloud-ai_platform-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-ai_platform/test/helper.rb
+++ b/google-cloud-ai_platform/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-alloy_db-v1/test/helper.rb
+++ b/google-cloud-alloy_db-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-alloy_db-v1alpha/test/helper.rb
+++ b/google-cloud-alloy_db-v1alpha/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-alloy_db-v1beta/test/helper.rb
+++ b/google-cloud-alloy_db-v1beta/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-alloy_db/test/helper.rb
+++ b/google-cloud-alloy_db/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-api_gateway-v1/test/helper.rb
+++ b/google-cloud-api_gateway-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-api_gateway/test/helper.rb
+++ b/google-cloud-api_gateway/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-api_keys-v2/test/helper.rb
+++ b/google-cloud-api_keys-v2/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-api_keys/test/helper.rb
+++ b/google-cloud-api_keys/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-apigee_connect-v1/test/helper.rb
+++ b/google-cloud-apigee_connect-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-apigee_connect/test/helper.rb
+++ b/google-cloud-apigee_connect/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-apigee_registry-v1/test/helper.rb
+++ b/google-cloud-apigee_registry-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-apigee_registry/test/helper.rb
+++ b/google-cloud-apigee_registry/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-app_engine-v1/test/helper.rb
+++ b/google-cloud-app_engine-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-app_engine/test/helper.rb
+++ b/google-cloud-app_engine/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-artifact_registry-v1/test/helper.rb
+++ b/google-cloud-artifact_registry-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-artifact_registry-v1beta2/test/helper.rb
+++ b/google-cloud-artifact_registry-v1beta2/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-artifact_registry/test/helper.rb
+++ b/google-cloud-artifact_registry/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-asset-v1/test/helper.rb
+++ b/google-cloud-asset-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-asset/test/helper.rb
+++ b/google-cloud-asset/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-assured_workloads-v1/test/helper.rb
+++ b/google-cloud-assured_workloads-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-assured_workloads-v1beta1/test/helper.rb
+++ b/google-cloud-assured_workloads-v1beta1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-assured_workloads/test/helper.rb
+++ b/google-cloud-assured_workloads/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-automl-v1/test/helper.rb
+++ b/google-cloud-automl-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-automl-v1beta1/test/helper.rb
+++ b/google-cloud-automl-v1beta1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-automl/test/helper.rb
+++ b/google-cloud-automl/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-bare_metal_solution-v2/test/helper.rb
+++ b/google-cloud-bare_metal_solution-v2/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-bare_metal_solution/test/helper.rb
+++ b/google-cloud-bare_metal_solution/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-batch-v1/test/helper.rb
+++ b/google-cloud-batch-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-batch/test/helper.rb
+++ b/google-cloud-batch/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-beyond_corp-app_connections-v1/test/helper.rb
+++ b/google-cloud-beyond_corp-app_connections-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-beyond_corp-app_connectors-v1/test/helper.rb
+++ b/google-cloud-beyond_corp-app_connectors-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-beyond_corp-app_gateways-v1/test/helper.rb
+++ b/google-cloud-beyond_corp-app_gateways-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-beyond_corp-client_gateways-v1/test/helper.rb
+++ b/google-cloud-beyond_corp-client_gateways-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-beyond_corp/test/helper.rb
+++ b/google-cloud-beyond_corp/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-bigquery-analytics_hub-v1/test/helper.rb
+++ b/google-cloud-bigquery-analytics_hub-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-bigquery-analytics_hub/test/helper.rb
+++ b/google-cloud-bigquery-analytics_hub/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-bigquery-connection-v1/test/helper.rb
+++ b/google-cloud-bigquery-connection-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-bigquery-connection/test/helper.rb
+++ b/google-cloud-bigquery-connection/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-bigquery-data_exchange-v1beta1/test/helper.rb
+++ b/google-cloud-bigquery-data_exchange-v1beta1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-bigquery-data_exchange/test/helper.rb
+++ b/google-cloud-bigquery-data_exchange/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-bigquery-data_policies-v1/test/helper.rb
+++ b/google-cloud-bigquery-data_policies-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-bigquery-data_policies-v1beta1/test/helper.rb
+++ b/google-cloud-bigquery-data_policies-v1beta1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-bigquery-data_policies/test/helper.rb
+++ b/google-cloud-bigquery-data_policies/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-bigquery-data_transfer-v1/test/helper.rb
+++ b/google-cloud-bigquery-data_transfer-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-bigquery-data_transfer/test/helper.rb
+++ b/google-cloud-bigquery-data_transfer/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-bigquery-migration-v2/test/helper.rb
+++ b/google-cloud-bigquery-migration-v2/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-bigquery-migration/test/helper.rb
+++ b/google-cloud-bigquery-migration/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-bigquery-reservation-v1/test/helper.rb
+++ b/google-cloud-bigquery-reservation-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-bigquery-reservation/test/helper.rb
+++ b/google-cloud-bigquery-reservation/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-bigquery-storage-v1/test/helper.rb
+++ b/google-cloud-bigquery-storage-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-bigquery-storage/test/helper.rb
+++ b/google-cloud-bigquery-storage/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-bigtable-admin-v2/test/helper.rb
+++ b/google-cloud-bigtable-admin-v2/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-bigtable-v2/test/helper.rb
+++ b/google-cloud-bigtable-v2/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-billing-budgets-v1/test/helper.rb
+++ b/google-cloud-billing-budgets-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-billing-budgets-v1beta1/test/helper.rb
+++ b/google-cloud-billing-budgets-v1beta1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-billing-budgets/test/helper.rb
+++ b/google-cloud-billing-budgets/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-billing-v1/test/helper.rb
+++ b/google-cloud-billing-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-billing/test/helper.rb
+++ b/google-cloud-billing/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-binary_authorization-v1/test/helper.rb
+++ b/google-cloud-binary_authorization-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-binary_authorization-v1beta1/test/helper.rb
+++ b/google-cloud-binary_authorization-v1beta1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-binary_authorization/test/helper.rb
+++ b/google-cloud-binary_authorization/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-build-v1/test/helper.rb
+++ b/google-cloud-build-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-build-v2/test/helper.rb
+++ b/google-cloud-build-v2/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-build/test/helper.rb
+++ b/google-cloud-build/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-certificate_manager-v1/test/helper.rb
+++ b/google-cloud-certificate_manager-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-certificate_manager/test/helper.rb
+++ b/google-cloud-certificate_manager/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-channel-v1/test/helper.rb
+++ b/google-cloud-channel-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-channel/test/helper.rb
+++ b/google-cloud-channel/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-cloud_controls_partner-v1/test/helper.rb
+++ b/google-cloud-cloud_controls_partner-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-cloud_controls_partner-v1beta/test/helper.rb
+++ b/google-cloud-cloud_controls_partner-v1beta/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-cloud_controls_partner/test/helper.rb
+++ b/google-cloud-cloud_controls_partner/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-cloud_dms-v1/test/helper.rb
+++ b/google-cloud-cloud_dms-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-cloud_dms/test/helper.rb
+++ b/google-cloud-cloud_dms/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-cloud_quotas-v1/test/helper.rb
+++ b/google-cloud-cloud_quotas-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-cloud_quotas/test/helper.rb
+++ b/google-cloud-cloud_quotas/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-commerce-consumer-procurement-v1/test/helper.rb
+++ b/google-cloud-commerce-consumer-procurement-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-commerce-consumer-procurement/test/helper.rb
+++ b/google-cloud-commerce-consumer-procurement/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-compute-v1/test/helper.rb
+++ b/google-cloud-compute-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-compute/test/helper.rb
+++ b/google-cloud-compute/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-confidential_computing-v1/test/helper.rb
+++ b/google-cloud-confidential_computing-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-confidential_computing/test/helper.rb
+++ b/google-cloud-confidential_computing/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-config_service-v1/test/helper.rb
+++ b/google-cloud-config_service-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-config_service/test/helper.rb
+++ b/google-cloud-config_service/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-contact_center_insights-v1/test/helper.rb
+++ b/google-cloud-contact_center_insights-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-contact_center_insights/test/helper.rb
+++ b/google-cloud-contact_center_insights/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-container-v1/test/helper.rb
+++ b/google-cloud-container-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-container-v1beta1/test/helper.rb
+++ b/google-cloud-container-v1beta1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-container/test/helper.rb
+++ b/google-cloud-container/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-container_analysis-v1/test/helper.rb
+++ b/google-cloud-container_analysis-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-container_analysis/test/helper.rb
+++ b/google-cloud-container_analysis/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-data_catalog-lineage-v1/test/helper.rb
+++ b/google-cloud-data_catalog-lineage-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-data_catalog-lineage/test/helper.rb
+++ b/google-cloud-data_catalog-lineage/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-data_catalog-v1/test/helper.rb
+++ b/google-cloud-data_catalog-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-data_catalog-v1beta1/test/helper.rb
+++ b/google-cloud-data_catalog-v1beta1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-data_catalog/test/helper.rb
+++ b/google-cloud-data_catalog/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-data_fusion-v1/test/helper.rb
+++ b/google-cloud-data_fusion-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-data_fusion/test/helper.rb
+++ b/google-cloud-data_fusion/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-data_labeling-v1beta1/test/helper.rb
+++ b/google-cloud-data_labeling-v1beta1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-data_labeling/test/helper.rb
+++ b/google-cloud-data_labeling/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-dataflow-v1beta3/test/helper.rb
+++ b/google-cloud-dataflow-v1beta3/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-dataflow/test/helper.rb
+++ b/google-cloud-dataflow/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-dataform-v1beta1/test/helper.rb
+++ b/google-cloud-dataform-v1beta1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-dataform/test/helper.rb
+++ b/google-cloud-dataform/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-dataplex-v1/test/helper.rb
+++ b/google-cloud-dataplex-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-dataplex/test/helper.rb
+++ b/google-cloud-dataplex/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-dataproc-v1/test/helper.rb
+++ b/google-cloud-dataproc-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-dataproc/test/helper.rb
+++ b/google-cloud-dataproc/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-dataqna-v1alpha/test/helper.rb
+++ b/google-cloud-dataqna-v1alpha/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-dataqna/test/helper.rb
+++ b/google-cloud-dataqna/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-datastore-admin-v1/test/helper.rb
+++ b/google-cloud-datastore-admin-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-datastore-admin/test/helper.rb
+++ b/google-cloud-datastore-admin/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-datastore-v1/test/helper.rb
+++ b/google-cloud-datastore-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-datastore/test/helper.rb
+++ b/google-cloud-datastore/test/helper.rb
@@ -19,6 +19,7 @@ require "minitest/autorun"
 require "minitest/focus"
 require "minitest/rg"
 require "google/cloud/datastore"
+require "ostruct"
 
 class MockDatastore < Minitest::Spec
   let(:project) { "my-todo-project" }

--- a/google-cloud-datastream-v1/test/helper.rb
+++ b/google-cloud-datastream-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-datastream-v1alpha1/test/helper.rb
+++ b/google-cloud-datastream-v1alpha1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-datastream/test/helper.rb
+++ b/google-cloud-datastream/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-deploy-v1/test/helper.rb
+++ b/google-cloud-deploy-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-deploy/test/helper.rb
+++ b/google-cloud-deploy/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-dialogflow-cx-v3/test/helper.rb
+++ b/google-cloud-dialogflow-cx-v3/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-dialogflow-cx/test/helper.rb
+++ b/google-cloud-dialogflow-cx/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-dialogflow-v2/test/helper.rb
+++ b/google-cloud-dialogflow-v2/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-dialogflow/test/helper.rb
+++ b/google-cloud-dialogflow/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-discovery_engine-v1/test/helper.rb
+++ b/google-cloud-discovery_engine-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-discovery_engine-v1beta/test/helper.rb
+++ b/google-cloud-discovery_engine-v1beta/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-discovery_engine/test/helper.rb
+++ b/google-cloud-discovery_engine/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-dlp-v2/test/helper.rb
+++ b/google-cloud-dlp-v2/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-dlp/test/helper.rb
+++ b/google-cloud-dlp/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-document_ai-v1/test/helper.rb
+++ b/google-cloud-document_ai-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-document_ai-v1beta3/test/helper.rb
+++ b/google-cloud-document_ai-v1beta3/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-document_ai/test/helper.rb
+++ b/google-cloud-document_ai/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-domains-v1/test/helper.rb
+++ b/google-cloud-domains-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-domains-v1beta1/test/helper.rb
+++ b/google-cloud-domains-v1beta1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-domains/test/helper.rb
+++ b/google-cloud-domains/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-edge_network-v1/test/helper.rb
+++ b/google-cloud-edge_network-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-edge_network/test/helper.rb
+++ b/google-cloud-edge_network/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-error_reporting-v1beta1/test/helper.rb
+++ b/google-cloud-error_reporting-v1beta1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-essential_contacts-v1/test/helper.rb
+++ b/google-cloud-essential_contacts-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-essential_contacts/test/helper.rb
+++ b/google-cloud-essential_contacts/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-eventarc-publishing-v1/test/helper.rb
+++ b/google-cloud-eventarc-publishing-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-eventarc-publishing/test/helper.rb
+++ b/google-cloud-eventarc-publishing/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-eventarc-v1/test/helper.rb
+++ b/google-cloud-eventarc-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-eventarc/test/helper.rb
+++ b/google-cloud-eventarc/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-filestore-v1/test/helper.rb
+++ b/google-cloud-filestore-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-filestore/test/helper.rb
+++ b/google-cloud-filestore/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-firestore-admin-v1/test/helper.rb
+++ b/google-cloud-firestore-admin-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-firestore-admin/test/helper.rb
+++ b/google-cloud-firestore-admin/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-firestore-v1/test/helper.rb
+++ b/google-cloud-firestore-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-firestore/test/helper.rb
+++ b/google-cloud-firestore/test/helper.rb
@@ -21,6 +21,7 @@ require "minitest/rg"
 require "google/cloud/firestore"
 require "google/cloud/firestore/rate_limiter"
 require "grpc"
+require "ostruct"
 
 ##
 # Monkey-Patch CallOptions to support Mocks

--- a/google-cloud-functions-v1/test/helper.rb
+++ b/google-cloud-functions-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-functions-v2/test/helper.rb
+++ b/google-cloud-functions-v2/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-functions/test/helper.rb
+++ b/google-cloud-functions/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-gke_backup-v1/test/helper.rb
+++ b/google-cloud-gke_backup-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-gke_backup/test/helper.rb
+++ b/google-cloud-gke_backup/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-gke_connect-gateway-v1beta1/test/helper.rb
+++ b/google-cloud-gke_connect-gateway-v1beta1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-gke_connect-gateway/test/helper.rb
+++ b/google-cloud-gke_connect-gateway/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-gke_hub-v1/test/helper.rb
+++ b/google-cloud-gke_hub-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-gke_hub-v1beta1/test/helper.rb
+++ b/google-cloud-gke_hub-v1beta1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-gke_hub/test/helper.rb
+++ b/google-cloud-gke_hub/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-gke_multi_cloud-v1/test/helper.rb
+++ b/google-cloud-gke_multi_cloud-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-gke_multi_cloud/test/helper.rb
+++ b/google-cloud-gke_multi_cloud/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-gsuite_add_ons-v1/test/helper.rb
+++ b/google-cloud-gsuite_add_ons-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-gsuite_add_ons/test/helper.rb
+++ b/google-cloud-gsuite_add_ons/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-iap-v1/test/helper.rb
+++ b/google-cloud-iap-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-iap/test/helper.rb
+++ b/google-cloud-iap/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-ids-v1/test/helper.rb
+++ b/google-cloud-ids-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-ids/test/helper.rb
+++ b/google-cloud-ids/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-kms-inventory-v1/test/helper.rb
+++ b/google-cloud-kms-inventory-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-kms-inventory/test/helper.rb
+++ b/google-cloud-kms-inventory/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-kms-v1/test/helper.rb
+++ b/google-cloud-kms-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-kms/test/helper.rb
+++ b/google-cloud-kms/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-language-v1/test/helper.rb
+++ b/google-cloud-language-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-language-v1beta2/test/helper.rb
+++ b/google-cloud-language-v1beta2/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-language-v2/test/helper.rb
+++ b/google-cloud-language-v2/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-language/test/helper.rb
+++ b/google-cloud-language/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-life_sciences-v2beta/test/helper.rb
+++ b/google-cloud-life_sciences-v2beta/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-life_sciences/test/helper.rb
+++ b/google-cloud-life_sciences/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-location/test/helper.rb
+++ b/google-cloud-location/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-logging-v2/test/helper.rb
+++ b/google-cloud-logging-v2/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-managed_identities-v1/test/helper.rb
+++ b/google-cloud-managed_identities-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-managed_identities/test/helper.rb
+++ b/google-cloud-managed_identities/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-media_translation-v1beta1/test/helper.rb
+++ b/google-cloud-media_translation-v1beta1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-media_translation/test/helper.rb
+++ b/google-cloud-media_translation/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-memcache-v1/test/helper.rb
+++ b/google-cloud-memcache-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-memcache-v1beta2/test/helper.rb
+++ b/google-cloud-memcache-v1beta2/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-memcache/test/helper.rb
+++ b/google-cloud-memcache/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-metastore-v1/test/helper.rb
+++ b/google-cloud-metastore-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-metastore-v1beta/test/helper.rb
+++ b/google-cloud-metastore-v1beta/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-metastore/test/helper.rb
+++ b/google-cloud-metastore/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-migration_center-v1/test/helper.rb
+++ b/google-cloud-migration_center-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-migration_center/test/helper.rb
+++ b/google-cloud-migration_center/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-monitoring-dashboard-v1/test/helper.rb
+++ b/google-cloud-monitoring-dashboard-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-monitoring-metrics_scope-v1/test/helper.rb
+++ b/google-cloud-monitoring-metrics_scope-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-monitoring-v3/test/helper.rb
+++ b/google-cloud-monitoring-v3/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-monitoring/test/helper.rb
+++ b/google-cloud-monitoring/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-netapp-v1/test/helper.rb
+++ b/google-cloud-netapp-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-netapp/test/helper.rb
+++ b/google-cloud-netapp/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-network_connectivity-v1/test/helper.rb
+++ b/google-cloud-network_connectivity-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-network_connectivity-v1alpha1/test/helper.rb
+++ b/google-cloud-network_connectivity-v1alpha1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-network_connectivity/test/helper.rb
+++ b/google-cloud-network_connectivity/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-network_management-v1/test/helper.rb
+++ b/google-cloud-network_management-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-network_management/test/helper.rb
+++ b/google-cloud-network_management/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-network_security-v1beta1/test/helper.rb
+++ b/google-cloud-network_security-v1beta1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-network_security/test/helper.rb
+++ b/google-cloud-network_security/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-notebooks-v1/test/helper.rb
+++ b/google-cloud-notebooks-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-notebooks-v1beta1/test/helper.rb
+++ b/google-cloud-notebooks-v1beta1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-notebooks-v2/test/helper.rb
+++ b/google-cloud-notebooks-v2/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-notebooks/test/helper.rb
+++ b/google-cloud-notebooks/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-optimization-v1/test/helper.rb
+++ b/google-cloud-optimization-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-optimization/test/helper.rb
+++ b/google-cloud-optimization/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-orchestration-airflow-service-v1/test/helper.rb
+++ b/google-cloud-orchestration-airflow-service-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-orchestration-airflow-service/test/helper.rb
+++ b/google-cloud-orchestration-airflow-service/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-org_policy-v2/test/helper.rb
+++ b/google-cloud-org_policy-v2/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-org_policy/test/helper.rb
+++ b/google-cloud-org_policy/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-os_config-v1/test/helper.rb
+++ b/google-cloud-os_config-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-os_config-v1alpha/test/helper.rb
+++ b/google-cloud-os_config-v1alpha/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-os_config/test/helper.rb
+++ b/google-cloud-os_config/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-os_login-v1/test/helper.rb
+++ b/google-cloud-os_login-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-os_login-v1beta/test/helper.rb
+++ b/google-cloud-os_login-v1beta/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-os_login/test/helper.rb
+++ b/google-cloud-os_login/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-phishing_protection-v1beta1/test/helper.rb
+++ b/google-cloud-phishing_protection-v1beta1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-phishing_protection/test/helper.rb
+++ b/google-cloud-phishing_protection/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-policy_simulator-v1/test/helper.rb
+++ b/google-cloud-policy_simulator-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-policy_simulator/test/helper.rb
+++ b/google-cloud-policy_simulator/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-policy_troubleshooter-iam-v3/test/helper.rb
+++ b/google-cloud-policy_troubleshooter-iam-v3/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-policy_troubleshooter-v1/test/helper.rb
+++ b/google-cloud-policy_troubleshooter-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-policy_troubleshooter/test/helper.rb
+++ b/google-cloud-policy_troubleshooter/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-private_catalog-v1beta1/test/helper.rb
+++ b/google-cloud-private_catalog-v1beta1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-private_catalog/test/helper.rb
+++ b/google-cloud-private_catalog/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-profiler-v2/test/helper.rb
+++ b/google-cloud-profiler-v2/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-profiler/test/helper.rb
+++ b/google-cloud-profiler/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-pubsub-v1/test/helper.rb
+++ b/google-cloud-pubsub-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-rapid_migration_assessment-v1/test/helper.rb
+++ b/google-cloud-rapid_migration_assessment-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-rapid_migration_assessment/test/helper.rb
+++ b/google-cloud-rapid_migration_assessment/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-recaptcha_enterprise-v1/test/helper.rb
+++ b/google-cloud-recaptcha_enterprise-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-recaptcha_enterprise-v1beta1/test/helper.rb
+++ b/google-cloud-recaptcha_enterprise-v1beta1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-recaptcha_enterprise/test/helper.rb
+++ b/google-cloud-recaptcha_enterprise/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-recommendation_engine-v1beta1/test/helper.rb
+++ b/google-cloud-recommendation_engine-v1beta1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-recommendation_engine/test/helper.rb
+++ b/google-cloud-recommendation_engine/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-recommender-v1/test/helper.rb
+++ b/google-cloud-recommender-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-recommender/test/helper.rb
+++ b/google-cloud-recommender/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-redis-cluster-v1/test/helper.rb
+++ b/google-cloud-redis-cluster-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-redis-cluster/test/helper.rb
+++ b/google-cloud-redis-cluster/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-redis-v1/test/helper.rb
+++ b/google-cloud-redis-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-redis-v1beta1/test/helper.rb
+++ b/google-cloud-redis-v1beta1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-redis/test/helper.rb
+++ b/google-cloud-redis/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-resource_manager-v3/test/helper.rb
+++ b/google-cloud-resource_manager-v3/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-resource_settings-v1/test/helper.rb
+++ b/google-cloud-resource_settings-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-resource_settings/test/helper.rb
+++ b/google-cloud-resource_settings/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-retail-v2/test/helper.rb
+++ b/google-cloud-retail-v2/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-retail/test/helper.rb
+++ b/google-cloud-retail/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-run-client/test/helper.rb
+++ b/google-cloud-run-client/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-run-v2/test/helper.rb
+++ b/google-cloud-run-v2/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-scheduler-v1/test/helper.rb
+++ b/google-cloud-scheduler-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-scheduler-v1beta1/test/helper.rb
+++ b/google-cloud-scheduler-v1beta1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-scheduler/test/helper.rb
+++ b/google-cloud-scheduler/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-secret_manager-v1/test/helper.rb
+++ b/google-cloud-secret_manager-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-secret_manager-v1beta1/test/helper.rb
+++ b/google-cloud-secret_manager-v1beta1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-secret_manager-v1beta2/test/helper.rb
+++ b/google-cloud-secret_manager-v1beta2/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-secret_manager/test/helper.rb
+++ b/google-cloud-secret_manager/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-secure_source_manager-v1/test/helper.rb
+++ b/google-cloud-secure_source_manager-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-secure_source_manager/test/helper.rb
+++ b/google-cloud-secure_source_manager/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-security-private_ca-v1/test/helper.rb
+++ b/google-cloud-security-private_ca-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-security-private_ca-v1beta1/test/helper.rb
+++ b/google-cloud-security-private_ca-v1beta1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-security-private_ca/test/helper.rb
+++ b/google-cloud-security-private_ca/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-security-public_ca-v1beta1/test/helper.rb
+++ b/google-cloud-security-public_ca-v1beta1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-security-public_ca/test/helper.rb
+++ b/google-cloud-security-public_ca/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-security_center-v1/test/helper.rb
+++ b/google-cloud-security_center-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-security_center-v1p1beta1/test/helper.rb
+++ b/google-cloud-security_center-v1p1beta1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-security_center/test/helper.rb
+++ b/google-cloud-security_center/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-service_control-v1/test/helper.rb
+++ b/google-cloud-service_control-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-service_control/test/helper.rb
+++ b/google-cloud-service_control/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-service_directory-v1/test/helper.rb
+++ b/google-cloud-service_directory-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-service_directory-v1beta1/test/helper.rb
+++ b/google-cloud-service_directory-v1beta1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-service_directory/test/helper.rb
+++ b/google-cloud-service_directory/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-service_health-v1/test/helper.rb
+++ b/google-cloud-service_health-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-service_health/test/helper.rb
+++ b/google-cloud-service_health/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-service_management-v1/test/helper.rb
+++ b/google-cloud-service_management-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-service_management/test/helper.rb
+++ b/google-cloud-service_management/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-service_usage-v1/test/helper.rb
+++ b/google-cloud-service_usage-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-service_usage/test/helper.rb
+++ b/google-cloud-service_usage/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-shell-v1/test/helper.rb
+++ b/google-cloud-shell-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-shell/test/helper.rb
+++ b/google-cloud-shell/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-spanner-admin-database-v1/test/helper.rb
+++ b/google-cloud-spanner-admin-database-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-spanner-admin-instance-v1/test/helper.rb
+++ b/google-cloud-spanner-admin-instance-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-spanner-v1/test/helper.rb
+++ b/google-cloud-spanner-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-speech-v1/test/helper.rb
+++ b/google-cloud-speech-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-speech-v1p1beta1/test/helper.rb
+++ b/google-cloud-speech-v1p1beta1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-speech-v2/test/helper.rb
+++ b/google-cloud-speech-v2/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-speech/test/helper.rb
+++ b/google-cloud-speech/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-storage_insights-v1/test/helper.rb
+++ b/google-cloud-storage_insights-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-storage_insights/test/helper.rb
+++ b/google-cloud-storage_insights/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-storage_transfer-v1/test/helper.rb
+++ b/google-cloud-storage_transfer-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-storage_transfer/test/helper.rb
+++ b/google-cloud-storage_transfer/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-support-v2/test/helper.rb
+++ b/google-cloud-support-v2/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-support/test/helper.rb
+++ b/google-cloud-support/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-talent-v4/test/helper.rb
+++ b/google-cloud-talent-v4/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-talent-v4beta1/test/helper.rb
+++ b/google-cloud-talent-v4beta1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-talent/test/helper.rb
+++ b/google-cloud-talent/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-tasks-v2/test/helper.rb
+++ b/google-cloud-tasks-v2/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-tasks-v2beta2/test/helper.rb
+++ b/google-cloud-tasks-v2beta2/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-tasks-v2beta3/test/helper.rb
+++ b/google-cloud-tasks-v2beta3/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-tasks/test/helper.rb
+++ b/google-cloud-tasks/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-telco_automation-v1/test/helper.rb
+++ b/google-cloud-telco_automation-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-telco_automation/test/helper.rb
+++ b/google-cloud-telco_automation/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-text_to_speech-v1/test/helper.rb
+++ b/google-cloud-text_to_speech-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-text_to_speech-v1beta1/test/helper.rb
+++ b/google-cloud-text_to_speech-v1beta1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-text_to_speech/test/helper.rb
+++ b/google-cloud-text_to_speech/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-tpu-v1/test/helper.rb
+++ b/google-cloud-tpu-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-tpu/test/helper.rb
+++ b/google-cloud-tpu/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-trace-v1/test/helper.rb
+++ b/google-cloud-trace-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-trace-v2/test/helper.rb
+++ b/google-cloud-trace-v2/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-translate-v3/test/helper.rb
+++ b/google-cloud-translate-v3/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-translate/test/helper.rb
+++ b/google-cloud-translate/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-video-live_stream-v1/test/helper.rb
+++ b/google-cloud-video-live_stream-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-video-live_stream/test/helper.rb
+++ b/google-cloud-video-live_stream/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-video-stitcher-v1/test/helper.rb
+++ b/google-cloud-video-stitcher-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-video-stitcher/test/helper.rb
+++ b/google-cloud-video-stitcher/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-video-transcoder-v1/test/helper.rb
+++ b/google-cloud-video-transcoder-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-video-transcoder/test/helper.rb
+++ b/google-cloud-video-transcoder/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-video_intelligence-v1/test/helper.rb
+++ b/google-cloud-video_intelligence-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-video_intelligence-v1beta2/test/helper.rb
+++ b/google-cloud-video_intelligence-v1beta2/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-video_intelligence-v1p1beta1/test/helper.rb
+++ b/google-cloud-video_intelligence-v1p1beta1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-video_intelligence-v1p2beta1/test/helper.rb
+++ b/google-cloud-video_intelligence-v1p2beta1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-video_intelligence-v1p3beta1/test/helper.rb
+++ b/google-cloud-video_intelligence-v1p3beta1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-video_intelligence/test/helper.rb
+++ b/google-cloud-video_intelligence/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-vision-v1/test/helper.rb
+++ b/google-cloud-vision-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-vision-v1p3beta1/test/helper.rb
+++ b/google-cloud-vision-v1p3beta1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-vision-v1p4beta1/test/helper.rb
+++ b/google-cloud-vision-v1p4beta1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-vision/test/helper.rb
+++ b/google-cloud-vision/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-vm_migration-v1/test/helper.rb
+++ b/google-cloud-vm_migration-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-vm_migration/test/helper.rb
+++ b/google-cloud-vm_migration/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-vmware_engine-v1/test/helper.rb
+++ b/google-cloud-vmware_engine-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-vmware_engine/test/helper.rb
+++ b/google-cloud-vmware_engine/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-vpc_access-v1/test/helper.rb
+++ b/google-cloud-vpc_access-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-vpc_access/test/helper.rb
+++ b/google-cloud-vpc_access/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-web_risk-v1/test/helper.rb
+++ b/google-cloud-web_risk-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-web_risk-v1beta1/test/helper.rb
+++ b/google-cloud-web_risk-v1beta1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-web_risk/test/helper.rb
+++ b/google-cloud-web_risk/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-web_security_scanner-v1/test/helper.rb
+++ b/google-cloud-web_security_scanner-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-web_security_scanner-v1beta/test/helper.rb
+++ b/google-cloud-web_security_scanner-v1beta/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-web_security_scanner/test/helper.rb
+++ b/google-cloud-web_security_scanner/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-workflows-executions-v1/test/helper.rb
+++ b/google-cloud-workflows-executions-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-workflows-executions-v1beta/test/helper.rb
+++ b/google-cloud-workflows-executions-v1beta/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-workflows-v1/test/helper.rb
+++ b/google-cloud-workflows-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-workflows-v1beta/test/helper.rb
+++ b/google-cloud-workflows-v1beta/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-cloud-workflows/test/helper.rb
+++ b/google-cloud-workflows/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-iam-client/test/helper.rb
+++ b/google-iam-client/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-iam-credentials-v1/test/helper.rb
+++ b/google-iam-credentials-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-iam-credentials/test/helper.rb
+++ b/google-iam-credentials/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-iam-v1/test/helper.rb
+++ b/google-iam-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-iam-v1beta/test/helper.rb
+++ b/google-iam-v1beta/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-iam-v2/test/helper.rb
+++ b/google-iam-v2/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-identity-access_context_manager-v1/test/helper.rb
+++ b/google-identity-access_context_manager-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-identity-access_context_manager/test/helper.rb
+++ b/google-identity-access_context_manager/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-shopping-merchant-inventories-v1beta/test/helper.rb
+++ b/google-shopping-merchant-inventories-v1beta/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-shopping-merchant-inventories/test/helper.rb
+++ b/google-shopping-merchant-inventories/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-shopping-merchant-reports-v1beta/test/helper.rb
+++ b/google-shopping-merchant-reports-v1beta/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/google-shopping-merchant-reports/test/helper.rb
+++ b/google-shopping-merchant-reports/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/grafeas-v1/test/helper.rb
+++ b/grafeas-v1/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"

--- a/grafeas/test/helper.rb
+++ b/grafeas/test/helper.rb
@@ -21,3 +21,5 @@ require "minitest/focus"
 require "minitest/rg"
 
 require "grpc"
+
+require "ostruct"


### PR DESCRIPTION
Steps:

1. Build docker image via `toys build` using post-processor PR in [ruby-common-tools](https://github.com/googleapis/ruby-common-tools/pull/317).
2. Change `POSTPROCESSOR_IMAGE` in `.toys/owlbot.rb` to reference local image (i.e. `owlbot-postprocessor-test`)
3. Run `toys owlbot --all` in `google-cloud-ruby`.
4. Add all relevant files via `git status --porcelain | grep .*/test/helper.rb | awk {'print $2'} | xargs -I % git add %`
5. Remove others via `git clean -fd`
6. Manual fixes to `datastore` and `firestore` gems.