### PR TITLE
chore: add a test case with multiple messages in details

### DIFF
--- a/google-cloud-errors/test/google/cloud/errors/error_cause_test.rb
+++ b/google-cloud-errors/test/google/cloud/errors/error_cause_test.rb
@@ -29,10 +29,10 @@ describe Google::Cloud::Error, :cause do
   # These tests show Google::Cloud::Error#cause is available, even on ruby 2.0
 
   it "always has a cause" do
-    error = wrapped_std_error "yo"
+    error = wrapped_std_error "cause_message"
 
     _(error).must_be_kind_of Google::Cloud::Error
-    _(error.message).must_equal "yo"
+    _(error.message).must_equal "cause_message"
 
     _(error.status_code).must_be :nil?
     _(error.body).must_be :nil?
@@ -44,14 +44,14 @@ describe Google::Cloud::Error, :cause do
 
     _(error.cause).wont_be :nil?
     _(error.cause).must_be_kind_of StandardError
-    _(error.cause.message).must_equal "yo"
+    _(error.cause.message).must_equal "cause_message"
   end
 
   it "can have a nil cause" do
-    error = Google::Cloud::Error.new "sup"
+    error = Google::Cloud::Error.new "nil_cause_message"
 
     _(error).must_be_kind_of Google::Cloud::Error
-    _(error.message).must_equal "sup"
+    _(error.message).must_equal "nil_cause_message"
 
     _(error.status_code).must_be :nil?
     _(error.body).must_be :nil?

--- a/google-cloud-errors/test/google/cloud/errors/wrapped_gax_test.rb
+++ b/google-cloud-errors/test/google/cloud/errors/wrapped_gax_test.rb
@@ -36,7 +36,12 @@ describe Google::Cloud::Error, :wrapped_gax do
     Google::Rpc::Help.new links: [link]
   end
 
-  def encoded_protobuf extended_details = false
+  ##
+  # Construct a new Google::Rpc::Status object and return its binary encoding
+  #
+  # @param extended_details [Boolean] 
+  #    Whether to encode multiple error details. Default is one DebugInfo message.
+  def encoded_protobuf extended_details: false
     any_debug = Google::Protobuf::Any.new
     any_debug.pack debug_info
 
@@ -75,8 +80,12 @@ describe Google::Cloud::Error, :wrapped_gax do
     GRPC::BadStatus.new status, msg, metadata
   end
 
-  it "contains multiple details" do
-    error = wrapped_error 1, "cancelled", { "foo" => "bar", "grpc-status-details-bin" => encoded_protobuf(true) }
+  # This test confirms that a whole array of any-wrapped detail messages
+  # containing various messages from the `google/rpc/error_details.proto`
+  # will be correctly deserialized and surfaced to the end-user
+  # in the `status_details` field
+  it "contains multiple detail messages" do
+    error = wrapped_error 1, "cancelled", { "foo" => "bar", "grpc-status-details-bin" => encoded_protobuf(extended_details: true) }
     di = error.status_details.find {|entry| entry.is_a?(Google::Rpc::DebugInfo)} 
     _(di).must_equal debug_info
 


### PR DESCRIPTION
We were missing a unit test case where multiple messages from error_details.proto are present in details. This PR adds such a test and does a minor cleanup of test values.