### PR TITLE
chore: Use version to specify checkout action

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -21,7 +21,7 @@ jobs:
       APPROVAL_GITHUB_TOKEN: ${{secrets.YOSHI_APPROVER_TOKEN}}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        uses: actions/checkout@v4
       - name: Install Ruby 3.2
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout repo
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      uses: actions/checkout@v4
     - name: Install Ruby ${{ matrix.ruby }}
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/new-library.yml
+++ b/.github/workflows/new-library.yml
@@ -16,7 +16,7 @@ jobs:
       GOOGLEAPIS_GEN_GITHUB_TOKEN: ${{ secrets.YOSHI_APPROVER_PRIVATE_TOKEN }}
     steps:
     - name: Checkout repo
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      uses: actions/checkout@v4
     - name: Install Ruby 3.2
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/obsolete-library.yml
+++ b/.github/workflows/obsolete-library.yml
@@ -18,7 +18,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
     steps:
     - name: Checkout repo
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      uses: actions/checkout@v4
     - name: Install Ruby 3.2
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/owlbot.yml
+++ b/.github/workflows/owlbot.yml
@@ -19,7 +19,7 @@ jobs:
       GOOGLEAPIS_GEN_GITHUB_TOKEN: ${{ secrets.YOSHI_APPROVER_PRIVATE_TOKEN }}
     steps:
     - name: Checkout repo
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      uses: actions/checkout@v4
     - name: Install Ruby 3.2
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/release-please-bootstrap.yml
+++ b/.github/workflows/release-please-bootstrap.yml
@@ -14,7 +14,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        uses: actions/checkout@v4
       - name: Install Ruby 3.2
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/release-please-now.yml
+++ b/.github/workflows/release-please-now.yml
@@ -18,7 +18,7 @@ jobs:
       RELEASE_PLEASE_DISABLE: ${{ secrets.RELEASE_PLEASE_DISABLE }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        uses: actions/checkout@v4
       - name: Install Ruby 3.2
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/storage-retry-conformance-test-against-emulator.yaml
+++ b/.github/workflows/storage-retry-conformance-test-against-emulator.yaml
@@ -23,7 +23,7 @@ jobs:
           - 9000:9000
 
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.2'

--- a/.github/workflows/update-pr.yml
+++ b/.github/workflows/update-pr.yml
@@ -18,7 +18,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
     steps:
     - name: Checkout repo
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      uses: actions/checkout@v4
     - name: Install Ruby 3.2
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/update-release-levels.yml
+++ b/.github/workflows/update-release-levels.yml
@@ -14,7 +14,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        uses: actions/checkout@v4
       - name: Install Ruby 3.2
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
At some point not too long ago, we changed our github actions to specify the checkout action release by SHA instead of version. This was supposedly done for security because it points to a specific, allegedly known good release of the action. However, I'm reverting that decision because:
* It obfuscates the actual semver-major version of the action being used
* It invites dependabot to frequently update it to a different SHA corresponding to a version that we don't know or control anyway
* None of the other actions are specified by SHA so we really haven't established a solid supply chain trail either way.
