### PR TITLE
chore(video-stitcher): Change samples tests to account for multiple projects

### DIFF
--- a/google-cloud-video-stitcher/samples/acceptance/list_cdn_keys_test.rb
+++ b/google-cloud-video-stitcher/samples/acceptance/list_cdn_keys_test.rb
@@ -21,8 +21,11 @@ describe "#list_cdn_keys", :stitcher_snippet do
     refute_nil cloud_cdn_key
     @cloud_cdn_key_created = true
 
-    assert_output(/CDN keys:\n#{cloud_cdn_key_name}/) do
+    output, _ = capture_io do
       sample.run project_id: project_id, location: location_id
     end
+
+    assert output.start_with? "CDN keys:"
+    assert output.include? cloud_cdn_key_name
   end
 end

--- a/google-cloud-video-stitcher/samples/acceptance/list_cdn_keys_test.rb
+++ b/google-cloud-video-stitcher/samples/acceptance/list_cdn_keys_test.rb
@@ -26,6 +26,6 @@ describe "#list_cdn_keys", :stitcher_snippet do
     end
 
     assert output.start_with? "CDN keys:"
-    assert output.include? cloud_cdn_key_name
+    assert_includes output, cloud_cdn_key_name
   end
 end

--- a/google-cloud-video-stitcher/samples/acceptance/list_cdn_keys_test.rb
+++ b/google-cloud-video-stitcher/samples/acceptance/list_cdn_keys_test.rb
@@ -21,7 +21,7 @@ describe "#list_cdn_keys", :stitcher_snippet do
     refute_nil cloud_cdn_key
     @cloud_cdn_key_created = true
 
-    output, _ = capture_io do
+    output, = capture_io do
       sample.run project_id: project_id, location: location_id
     end
 

--- a/google-cloud-video-stitcher/samples/acceptance/list_live_configs_test.rb
+++ b/google-cloud-video-stitcher/samples/acceptance/list_live_configs_test.rb
@@ -29,6 +29,6 @@ describe "#list_live_configs", :stitcher_snippet do
     end
 
     assert output.start_with? "Live configs:"
-    assert output.include? live_config_name
+    assert_includes output, live_config_name
   end
 end

--- a/google-cloud-video-stitcher/samples/acceptance/list_live_configs_test.rb
+++ b/google-cloud-video-stitcher/samples/acceptance/list_live_configs_test.rb
@@ -24,8 +24,11 @@ describe "#list_live_configs", :stitcher_snippet do
     refute_nil live_config
     @live_config_created = true
 
-    assert_output(/Live configs:\n#{live_config_name}/) do
+    output, _ = capture_io do
       sample.run project_id: project_id, location: location_id
     end
+
+    assert output.start_with? "Live configs:"
+    assert output.include? live_config_name
   end
 end

--- a/google-cloud-video-stitcher/samples/acceptance/list_live_configs_test.rb
+++ b/google-cloud-video-stitcher/samples/acceptance/list_live_configs_test.rb
@@ -24,7 +24,7 @@ describe "#list_live_configs", :stitcher_snippet do
     refute_nil live_config
     @live_config_created = true
 
-    output, _ = capture_io do
+    output, = capture_io do
       sample.run project_id: project_id, location: location_id
     end
 

--- a/google-cloud-video-stitcher/samples/acceptance/list_slates_test.rb
+++ b/google-cloud-video-stitcher/samples/acceptance/list_slates_test.rb
@@ -26,6 +26,6 @@ describe "#list_slates", :stitcher_snippet do
     end
 
     assert output.start_with? "Slates:"
-    assert output.include? slate_name
+    assert_includes output, slate_name
   end
 end

--- a/google-cloud-video-stitcher/samples/acceptance/list_slates_test.rb
+++ b/google-cloud-video-stitcher/samples/acceptance/list_slates_test.rb
@@ -21,7 +21,7 @@ describe "#list_slates", :stitcher_snippet do
     refute_nil slate
     @slate_created = true
 
-    output, _ = capture_io do
+    output, = capture_io do
       sample.run project_id: project_id, location: location_id
     end
 

--- a/google-cloud-video-stitcher/samples/acceptance/list_slates_test.rb
+++ b/google-cloud-video-stitcher/samples/acceptance/list_slates_test.rb
@@ -21,8 +21,11 @@ describe "#list_slates", :stitcher_snippet do
     refute_nil slate
     @slate_created = true
 
-    assert_output(/Slates:\n#{slate_name}/) do
+    output, _ = capture_io do
       sample.run project_id: project_id, location: location_id
     end
+
+    assert output.start_with? "Slates:"
+    assert output.include? slate_name
   end
 end


### PR DESCRIPTION
This was meant to unblock PR #25983. 

The samples tests fail from time to time if more than one project id is part of the list. An example failure can be seen in fusion (internal) with id: 7cd4c8d0-8311-4852-9543-8a56b9ba299c