### PR TITLE
chore: Resolve BigDecimal warnings

### DIFF
--- a/google-cloud-bigquery/google-cloud-bigquery.gemspec
+++ b/google-cloud-bigquery/google-cloud-bigquery.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.7"
 
+  gem.add_dependency "bigdecimal", "~> 3.0"
   gem.add_dependency "concurrent-ruby", "~> 1.0"
   gem.add_dependency "google-apis-bigquery_v2", "~> 0.62"
   gem.add_dependency "google-apis-core", "~> 0.13"

--- a/google-cloud-firestore/google-cloud-firestore.gemspec
+++ b/google-cloud-firestore/google-cloud-firestore.gemspec
@@ -19,8 +19,9 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.7"
 
+  gem.add_dependency "bigdecimal", "~> 3.0"
+  gem.add_dependency "concurrent-ruby", "~> 1.0"
   gem.add_dependency "google-cloud-core", "~> 1.5"
   gem.add_dependency "google-cloud-firestore-v1", "~> 0.10"
-  gem.add_dependency "concurrent-ruby", "~> 1.0"
   gem.add_dependency "rbtree", "~> 0.4.2"
 end

--- a/google-cloud-pubsub/Gemfile
+++ b/google-cloud-pubsub/Gemfile
@@ -4,6 +4,7 @@ gemspec
 
 gem "autotest-suffix", "~> 1.1"
 gem "avro", "~> 1.10"
+gem "bigdecimal", "~> 3.0"
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-errors", path: "../google-cloud-errors"
 gem "google-cloud-pubsub-v1", path: "../google-cloud-pubsub-v1"


### PR DESCRIPTION
This PR updates the gemspecs to add an explicit dependency on the [bigdecimal gem](https://rubygems.org/gems/bigdecimal) for all gems that call `require "bigdecimal"`. This resolves the following warning:

```
warning: bigdecimal was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add bigdecimal to your Gemfile or gemspec.
```

closes: #25461