### PR TITLE
feat(bigquery): add method in load_job to set column name character map

### DIFF
--- a/google-cloud-bigquery/google-cloud-bigquery.gemspec
+++ b/google-cloud-bigquery/google-cloud-bigquery.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "bigdecimal", "~> 3.0"
   gem.add_dependency "concurrent-ruby", "~> 1.0"
-  gem.add_dependency "google-apis-bigquery_v2", "~> 0.62"
+  gem.add_dependency "google-apis-bigquery_v2", "~> 0.71"
   gem.add_dependency "google-apis-core", "~> 0.13"
   gem.add_dependency "googleauth", "~> 1.9"
   gem.add_dependency "google-cloud-core", "~> 1.6"

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
@@ -311,9 +311,9 @@ module Google
         end
 
         ##
-        # Converts source format strings to API values.
+        # Converts character map strings to API values.
         #
-        # @return [String] API representation of source format.
+        # @return [String] API representation of character map.
         def self.character_map mapping_version
           val = {
             "default" => "COLUMN_NAME_CHARACTER_MAP_UNSPECIFIED",

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/convert.rb
@@ -314,6 +314,21 @@ module Google
         # Converts source format strings to API values.
         #
         # @return [String] API representation of source format.
+        def self.character_map mapping_version
+          val = {
+            "default" => "COLUMN_NAME_CHARACTER_MAP_UNSPECIFIED",
+            "strict"  => "STRICT",
+            "v1"      => "V1",
+            "v2"      => "V2"
+          }[mapping_version.to_s.downcase]
+          return val unless val.nil?
+          mapping_version
+        end
+
+        ##
+        # Converts source format strings to API values.
+        #
+        # @return [String] API representation of source format.
         def self.source_format format
           val = {
             "csv"                    => "CSV",

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
@@ -1728,6 +1728,24 @@ module Google
           end
 
           ##
+          # Sets the character map for column name conversion. The default value is `Default`.
+          #
+          # The following values are supported:
+          #
+          # * `Default`
+          # * `Strict`
+          # * `V1`
+          # * `V2`
+          #
+          # @param [String] new_character_map The new character map.
+          #
+          # @!group Attributes
+          #
+          def column_name_character_map= new_character_map
+            @gapi.configuration.load.update! column_name_character_map: new_character_map
+          end
+
+          ##
           # Sets the create disposition.
           #
           # This specifies whether the job is allowed to create new tables. The

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
@@ -1728,21 +1728,21 @@ module Google
           end
 
           ##
-          # Sets the character map for column name conversion. The default value is `Default`.
+          # Sets the character map for column name conversion. The default value is `default`.
           #
           # The following values are supported:
           #
-          # * `Default`
-          # * `Strict`
-          # * `V1`
-          # * `V2`
+          # * `default`
+          # * `strict`
+          # * `v1`
+          # * `v2`
           #
           # @param [String] new_character_map The new character map.
           #
           # @!group Attributes
           #
           def column_name_character_map= new_character_map
-            @gapi.configuration.load.update! column_name_character_map: new_character_map
+            @gapi.configuration.load.update! column_name_character_map: Convert.character_map(new_character_map)
           end
 
           ##

--- a/google-cloud-bigquery/test/google/cloud/bigquery/load_job_updater_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/load_job_updater_test.rb
@@ -26,6 +26,29 @@ describe Google::Cloud::Bigquery::LoadJob::Updater do
     Google::Cloud::Bigquery::LoadJob::Updater.new new_job
   end
 
+  it "can set the column name character map" do
+    updater = new_updater
+    updater.column_name_character_map = "default"
+    job_gapi = updater.to_gapi
+    _(job_gapi.configuration.load.column_name_character_map).must_equal "COLUMN_NAME_CHARACTER_MAP_UNSPECIFIED"
+
+    updater.column_name_character_map = "strict"
+    job_gapi = updater.to_gapi
+    _(job_gapi.configuration.load.column_name_character_map).must_equal "STRICT"
+
+    updater.column_name_character_map = "v1"
+    job_gapi = updater.to_gapi
+    _(job_gapi.configuration.load.column_name_character_map).must_equal "V1"
+
+    updater.column_name_character_map = "v2"
+    job_gapi = updater.to_gapi
+    _(job_gapi.configuration.load.column_name_character_map).must_equal "V2"
+
+    updater.column_name_character_map = "SOME_NEW_CHARACTER_MAP"
+    job_gapi = updater.to_gapi
+    _(job_gapi.configuration.load.column_name_character_map).must_equal "SOME_NEW_CHARACTER_MAP"
+  end
+
   it "can set the source format" do
     updater = new_updater
     updater.format = "csv"


### PR DESCRIPTION
closes: [#<issue_number_goes_here>](https://github.com/googleapis/google-cloud-ruby/issues/26134)