### PR TITLE
chore(toys): Support running owlbot with bazelisk

### DIFF
--- a/.toys/new-library.rb
+++ b/.toys/new-library.rb
@@ -52,6 +52,9 @@ end
 flag :bootstrap_releases, "--[no-]bootstrap-releases" do
   desc "Also add release-please configuration for the newly-created library"
 end
+flag :enable_bazelisk, "--bazelisk" do
+  desc "Enable running bazel commands with bazelisk"
+end
 
 static :config_name, "release-please-config.json"
 static :manifest_name, ".release-please-manifest.json"
@@ -127,6 +130,7 @@ def call_owlbot
   cmd << "--protos-path" << protos_path if protos_path
   cmd << "--source-path" << source_path if source_path
   cmd << "--piper-client" << piper_client if piper_client
+  cmd << "--bazelisk" if enable_bazelisk
   cmd += verbosity_flags
   exec_tool cmd
 end

--- a/.toys/owlbot.rb
+++ b/.toys/owlbot.rb
@@ -76,6 +76,9 @@ end
 flag :enable_tests, "--test" do
   desc "Run CI on each library"
 end
+flag :enable_bazelisk, "--bazelisk" do
+  desc "Enable running bazel commands with bazelisk"
+end
 
 OWLBOT_CONFIG_FILE_NAME = ".OwlBot.yaml"
 OWLBOT_CLI_IMAGE = "gcr.io/cloud-devrel-public-resources/owlbot-cli"
@@ -199,12 +202,13 @@ def determine_bazel_target library_path
 end
 
 def run_bazel gem_info
+  bazel_alias = enable_bazelisk ? "bazelisk" : "bazel"
   gem_info.each_value do |info|
     info[:bazel_targets].each do |library_path, bazel_target|
-      exec ["bazel", "build", "//#{library_path}:#{bazel_target}"], chdir: bazel_base_dir
+      exec [bazel_alias, "build", "//#{library_path}:#{bazel_target}"], chdir: bazel_base_dir
     end
   end
-  source_dir = capture(["bazel", "info", "bazel-bin"], chdir: bazel_base_dir).chomp
+  source_dir = capture([bazel_alias, "info", "bazel-bin"], chdir: bazel_base_dir).chomp
   temp_dir = Dir.mktmpdir
   at_exit { FileUtils.rm_rf temp_dir }
   results_dir = File.join temp_dir, "bazel-bin"


### PR DESCRIPTION
For some reason running `bazel` directly errors with:

`Error: 'apple_common' value has no field or method 'multi_arch_split'` (from Linux x86_64)

Adding the option to run `bazelisk` as a flag, which fixes my issue.