### PR TITLE
chore: Update github tokens

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -18,14 +18,14 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
-      APPROVAL_GITHUB_TOKEN: ${{secrets.YOSHI_APPROVER_TOKEN}}
+      APPROVAL_GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-      - name: Install Ruby 3.2
+      - name: Install Ruby 3.3
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.3"
       - name: Install tools
         run: |
           gem install --no-document toys

--- a/.github/workflows/new-library.yml
+++ b/.github/workflows/new-library.yml
@@ -13,14 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
-      GOOGLEAPIS_GEN_GITHUB_TOKEN: ${{ secrets.YOSHI_APPROVER_PRIVATE_TOKEN }}
+      GOOGLEAPIS_GEN_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4
-    - name: Install Ruby 3.2
+    - name: Install Ruby 3.3
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "3.2"
+        ruby-version: "3.3"
     - name: Install tools
       run: |
         gem install --no-document toys

--- a/.github/workflows/obsolete-library.yml
+++ b/.github/workflows/obsolete-library.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4
-    - name: Install Ruby 3.2
+    - name: Install Ruby 3.3
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "3.2"
+        ruby-version: "3.3"
     - name: Install tools
       run: |
         gem install --no-document toys

--- a/.github/workflows/owlbot.yml
+++ b/.github/workflows/owlbot.yml
@@ -16,14 +16,14 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
-      GOOGLEAPIS_GEN_GITHUB_TOKEN: ${{ secrets.YOSHI_APPROVER_PRIVATE_TOKEN }}
+      GOOGLEAPIS_GEN_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4
-    - name: Install Ruby 3.2
+    - name: Install Ruby 3.3
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "3.2"
+        ruby-version: "3.3"
     - name: Install tools
       run: |
         gem install --no-document toys

--- a/.github/workflows/release-please-bootstrap.yml
+++ b/.github/workflows/release-please-bootstrap.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-      - name: Install Ruby 3.2
+      - name: Install Ruby 3.3
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.3"
       - name: Install tools
         run: |
           gem install --no-document toys

--- a/.github/workflows/release-please-now.yml
+++ b/.github/workflows/release-please-now.yml
@@ -19,14 +19,10 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-      - name: Install Ruby 3.2
+      - name: Install Ruby 3.3
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
-      - name: Install NodeJS 16.x
-        uses: actions/setup-node@v4
-        with:
-          node-version: "16.x"
+          ruby-version: "3.3"
       - name: Install tools
         run: |
           gem install --no-document toys

--- a/.github/workflows/update-pr.yml
+++ b/.github/workflows/update-pr.yml
@@ -15,14 +15,14 @@ jobs:
     if: ${{ github.repository == 'googleapis/google-cloud-ruby' }}
     runs-on: ubuntu-latest
     env:
-      GITHUB_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4
-    - name: Install Ruby 3.2
+    - name: Install Ruby 3.3
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "3.2"
+        ruby-version: "3.3"
     - name: Install tools
       run: |
         gem install --no-document toys

--- a/.github/workflows/update-release-levels.yml
+++ b/.github/workflows/update-release-levels.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-      - name: Install Ruby 3.2
+      - name: Install Ruby 3.3
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.3"
       - name: Install tools
         run: |
           gem install --no-document toys


### PR DESCRIPTION
Several actions config updates:

* Replace the defunct `YOSHI_APPROVER_TOKEN` with `GITHUB_TOKEN` for actions that use workflow_dispatch. This should allow these actions to work when triggered manually if the trigger-er has sufficient permissions (normally write permissions on the repo and its pull requests).
* Use `GITHUB_TOKEN` instead of `YOSHI_CODE_BOT_TOKEN` for the update-pr action because it needs to modify an existing pull request.
* Use Ruby 3.3 for all workflows that used to use Ruby 3.2.