### PR TITLE
Fix google-cloud-translate README Authentication link

### DIFF
--- a/google-cloud-translate/README.md
+++ b/google-cloud-translate/README.md
@@ -33,7 +33,7 @@ In order to use this library, you first need to go through the following steps:
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 1. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
 1. [Enable the API.](https://console.cloud.google.com/apis/library/translate.googleapis.com)
-1. {file:AUTHENTICATION.md Set up authentication.}
+1. [Set up authentication.](AUTHENTICATION.md)
 
 ## Migrating from 2.x versions
 


### PR DESCRIPTION
Just a README update, so hopefully this isn't a big deal