### PR TITLE
chore: Support --pull-googleapis from owlbot script

### DIFF
--- a/.github/workflows/new-library.yml
+++ b/.github/workflows/new-library.yml
@@ -13,7 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
-      GOOGLEAPIS_GEN_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4
@@ -21,9 +20,11 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: "3.3"
+    - name: Install Bazel
+      uses: bazel-contrib/setup-bazel@0.8.5
     - name: Install tools
       run: |
         gem install --no-document toys
     - name: Create library
       run: |
-        toys new-library -v --pull --test --fork --bootstrap-releases ${{ github.event.inputs.protoPath }}
+        toys new-library -v --bazelisk --pull --pull-googleapis --test --fork --bootstrap-releases ${{ github.event.inputs.protoPath }}

--- a/.github/workflows/owlbot.yml
+++ b/.github/workflows/owlbot.yml
@@ -16,7 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.YOSHI_CODE_BOT_TOKEN }}
-      GOOGLEAPIS_GEN_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4
@@ -24,9 +23,11 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: "3.3"
+    - name: Install Bazel
+      uses: bazel-contrib/setup-bazel@0.8.5
     - name: Install tools
       run: |
         gem install --no-document toys
     - name: OwlBot
       run: |
-        toys owlbot -v --pull --fork ${{ github.event.inputs.flags }} ${{ github.event.inputs.gems }}
+        toys owlbot -v --pull --fork --pull-googleapis --bazelisk ${{ github.event.inputs.flags }} ${{ github.event.inputs.gems }}

--- a/.toys/new-library.rb
+++ b/.toys/new-library.rb
@@ -27,6 +27,9 @@ end
 flag :source_path, "--source-path=PATH" do
   desc "Path to the googleapis-gen source repo"
 end
+flag :pull_googleapis, "--pull-googleapis[=COMMIT]" do
+  desc "Generate by pulling googleapis/googleapis and running Bazel from the protos there"
+end
 flag :pull, "--[no-]pull" do
   desc "Pull the latest owlbot images before running"
 end
@@ -66,11 +69,6 @@ include :git_cache
 include "yoshi-pr-generator"
 
 def run
-  # Temporary hack to allow minitest-rg 5.2.0 to work in minitest 5.19 or
-  # later. This should be removed if we have a better solution or decide to
-  # drop rg.
-  ENV["MT_COMPAT"] = "true"
-
   setup
   set :branch_name, "gen/#{gem_name}" unless branch_name
   commit_message = "feat: Initial generation of #{gem_name}"
@@ -130,6 +128,11 @@ def call_owlbot
   cmd << "--protos-path" << protos_path if protos_path
   cmd << "--source-path" << source_path if source_path
   cmd << "--piper-client" << piper_client if piper_client
+  if pull_googleapis == true
+    cmd << "--pull-googleapis"
+  elsif pull_googleapis
+    cmd << "--pull-googleapis=#{pull_googleapis}"
+  end
   cmd << "--bazelisk" if enable_bazelisk
   cmd += verbosity_flags
   exec_tool cmd


### PR DESCRIPTION
By default the owlbot and new-library jobs were pulling the private googleapis-gen repo and using its version of the generated GAPICs. Unfortunately, we can no longer do that from a github action because the yoshi-approver token no longer exists, and we cannot pull that repo using the action's default token. So this PR provides a new flag `--pull-googleapis` that does a checkout of https://github.com/googleapis/googleapis and uses it as a protos path, running the codegen directly. This technique is now used by the github actions.