### PR TITLE
chore: Add current directory to toys toplevel context

### DIFF
--- a/.toys/ci.rb
+++ b/.toys/ci.rb
@@ -309,7 +309,7 @@ def run_toplevel
     puts "toplevel: bundle ...", :bold, :cyan
     result = exec ["bundle", @bundle_task, "--retry=#{bundle_retry}"]
     unless result.success?
-      @errors << [dir, "bundle"]
+      @errors << [@cur_dir, "bundle"]
       return
     end
   end

--- a/.toys/ci.rb
+++ b/.toys/ci.rb
@@ -309,7 +309,7 @@ def run_toplevel
     puts "toplevel: bundle ...", :bold, :cyan
     result = exec ["bundle", @bundle_task, "--retry=#{bundle_retry}"]
     unless result.success?
-      @errors << [@cur_dir, "bundle"]
+      @errors << ["toplevel", "bundle"]
       return
     end
   end


### PR DESCRIPTION
We are getting a couple of failures due to `dir` not being defined in our script:
```
Error during tool execution!
    NameError: undefined local variable or method `dir' for #
    in config file: /workspace/.toys/ci.rb:312
```

![Screenshot 2024-08-05 at 2 15 22 PM](https://github.com/user-attachments/assets/b8d07b46-491a-42e3-b7a4-c386eb15229d)

Example commit id: `09e63988dcb2ec9ec11c272e5c08659007400b99`