### PR TITLE
feat(google-cloud-vision_ai): Add google-cloud-vision_ai to bootstrap releases

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -773,6 +773,8 @@
   "google-cloud-vision-v1p3beta1+FILLER": "0.0.0",
   "google-cloud-vision-v1p4beta1": "0.8.0",
   "google-cloud-vision-v1p4beta1+FILLER": "0.0.0",
+  "google-cloud-vision_ai": "0.1.0",
+  "google-cloud-vision_ai+FILLER": "0.0.0",
   "google-cloud-vision_ai-v1": "0.1.0",
   "google-cloud-vision_ai-v1+FILLER": "0.0.0",
   "google-cloud-vm_migration": "1.2.0",

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -773,7 +773,7 @@
   "google-cloud-vision-v1p3beta1+FILLER": "0.0.0",
   "google-cloud-vision-v1p4beta1": "0.8.0",
   "google-cloud-vision-v1p4beta1+FILLER": "0.0.0",
-  "google-cloud-vision_ai": "0.1.0",
+  "google-cloud-vision_ai": "0.0.1",
   "google-cloud-vision_ai+FILLER": "0.0.0",
   "google-cloud-vision_ai-v1": "0.1.0",
   "google-cloud-vision_ai-v1+FILLER": "0.0.0",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1559,6 +1559,10 @@
       "component": "google-cloud-vision-v1p4beta1",
       "version_file": "lib/google/cloud/vision/v1p4beta1/version.rb"
     },
+    "google-cloud-vision_ai": {
+      "component": "google-cloud-vision_ai",
+      "version_file": "lib/google/cloud/vision_ai/version.rb"
+    },
     "google-cloud-vision_ai-v1": {
       "component": "google-cloud-vision_ai-v1",
       "version_file": "lib/google/cloud/vision_ai/v1/version.rb"


### PR DESCRIPTION
It looks like this was missing in #26487.

PLMK if it is expected.