### PR TITLE
chore: Remove duplicate changelog entries

### DIFF
--- a/google-analytics-admin/CHANGELOG.md
+++ b/google-analytics-admin/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-### 0.5.1 (2024-08-09)
-
-#### Documentation
-
-* Formatting updates ([#26623](https://github.com/googleapis/google-cloud-ruby/issues/26623)) 
-
 ### 0.5.1 (2024-08-08)
 
 #### Documentation

--- a/google-analytics-data/CHANGELOG.md
+++ b/google-analytics-data/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-### 0.6.1 (2024-08-09)
-
-#### Documentation
-
-* Formatting updates ([#26623](https://github.com/googleapis/google-cloud-ruby/issues/26623)) 
-
 ### 0.6.1 (2024-08-08)
 
 #### Documentation

--- a/google-apps-chat/CHANGELOG.md
+++ b/google-apps-chat/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-### 1.0.1 (2024-08-09)
-
-#### Documentation
-
-* Formatting updates ([#26623](https://github.com/googleapis/google-cloud-ruby/issues/26623)) 
-
 ### 1.0.1 (2024-08-08)
 
 #### Documentation

--- a/google-apps-events-subscriptions/CHANGELOG.md
+++ b/google-apps-events-subscriptions/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-### 1.0.1 (2024-08-09)
-
-#### Documentation
-
-* Formatting updates ([#26623](https://github.com/googleapis/google-cloud-ruby/issues/26623)) 
-
 ### 1.0.1 (2024-08-08)
 
 #### Documentation

--- a/google-apps-meet-v2/CHANGELOG.md
+++ b/google-apps-meet-v2/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-### 0.2.1 (2024-08-09)
-
-#### Documentation
-
-* Formatting updates ([#26623](https://github.com/googleapis/google-cloud-ruby/issues/26623)) 
-
 ### 0.2.1 (2024-08-08)
 
 #### Documentation

--- a/google-apps-meet/CHANGELOG.md
+++ b/google-apps-meet/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-### 1.0.1 (2024-08-09)
-
-#### Documentation
-
-* Formatting updates ([#26623](https://github.com/googleapis/google-cloud-ruby/issues/26623)) 
-
 ### 1.0.1 (2024-08-08)
 
 #### Documentation

--- a/google-area120-tables/CHANGELOG.md
+++ b/google-area120-tables/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Release History
 
-### 0.6.1 (2024-08-09)
-
-#### Documentation
-
-* Formatting updates ([#26623](https://github.com/googleapis/google-cloud-ruby/issues/26623)) 
-
 ### 0.6.1 (2024-08-08)
 
 #### Documentation

--- a/google-cloud-access_approval/CHANGELOG.md
+++ b/google-cloud-access_approval/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Release History
 
-### 1.5.1 (2024-08-09)
-
-#### Documentation
-
-* Formatting updates ([#26623](https://github.com/googleapis/google-cloud-ruby/issues/26623)) 
-
 ### 1.5.1 (2024-08-08)
 
 #### Documentation

--- a/google-cloud-data_catalog-lineage/CHANGELOG.md
+++ b/google-cloud-data_catalog-lineage/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-### 1.0.1 (2024-08-09)
-
-#### Documentation
-
-* Formatting updates to README.md ([#26626](https://github.com/googleapis/google-cloud-ruby/issues/26626)) 
-
 ### 1.0.1 (2024-08-08)
 
 #### Documentation

--- a/google-cloud-data_catalog/CHANGELOG.md
+++ b/google-cloud-data_catalog/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Release History
 
-### 1.6.1 (2024-08-09)
-
-#### Documentation
-
-* Formatting updates to README.md ([#26626](https://github.com/googleapis/google-cloud-ruby/issues/26626)) 
-
 ### 1.6.1 (2024-08-08)
 
 #### Documentation

--- a/google-cloud-data_fusion/CHANGELOG.md
+++ b/google-cloud-data_fusion/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-### 1.4.1 (2024-08-09)
-
-#### Documentation
-
-* Formatting updates to README.md ([#26626](https://github.com/googleapis/google-cloud-ruby/issues/26626)) 
-
 ### 1.4.1 (2024-08-08)
 
 #### Documentation

--- a/google-cloud-data_labeling/CHANGELOG.md
+++ b/google-cloud-data_labeling/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Release History
 
-### 0.5.1 (2024-08-09)
-
-#### Documentation
-
-* Formatting updates to README.md ([#26626](https://github.com/googleapis/google-cloud-ruby/issues/26626)) 
-
 ### 0.5.1 (2024-08-08)
 
 #### Documentation

--- a/google-cloud-dataflow/CHANGELOG.md
+++ b/google-cloud-dataflow/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-### 0.5.1 (2024-08-09)
-
-#### Documentation
-
-* Formatting updates to README.md ([#26626](https://github.com/googleapis/google-cloud-ruby/issues/26626)) 
-
 ### 0.5.1 (2024-08-08)
 
 #### Documentation

--- a/google-cloud-dataform/CHANGELOG.md
+++ b/google-cloud-dataform/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-### 0.4.1 (2024-08-09)
-
-#### Documentation
-
-* Formatting updates to README.md ([#26626](https://github.com/googleapis/google-cloud-ruby/issues/26626)) 
-
 ### 0.4.1 (2024-08-08)
 
 #### Documentation

--- a/google-cloud-dataplex/CHANGELOG.md
+++ b/google-cloud-dataplex/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-### 1.4.1 (2024-08-09)
-
-#### Documentation
-
-* Formatting updates to README.md ([#26626](https://github.com/googleapis/google-cloud-ruby/issues/26626)) 
-
 ### 1.4.1 (2024-08-08)
 
 #### Documentation

--- a/google-cloud-dataproc-v1/CHANGELOG.md
+++ b/google-cloud-dataproc-v1/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Release History
 
-### 1.0.1 (2024-08-09)
-
-#### Documentation
-
-* Formatting updates to README.md ([#26626](https://github.com/googleapis/google-cloud-ruby/issues/26626)) 
-
 ### 1.0.1 (2024-08-08)
 
 #### Documentation

--- a/google-cloud-dataproc/CHANGELOG.md
+++ b/google-cloud-dataproc/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Release History
 
-### 2.6.1 (2024-08-09)
-
-#### Documentation
-
-* Formatting updates to README.md ([#26626](https://github.com/googleapis/google-cloud-ruby/issues/26626)) 
-
 ### 2.6.1 (2024-08-08)
 
 #### Documentation

--- a/google-cloud-dataqna-v1alpha/CHANGELOG.md
+++ b/google-cloud-dataqna-v1alpha/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Release History
 
-### 0.7.1 (2024-08-09)
-
-#### Documentation
-
-* Formatting updates to README.md ([#26626](https://github.com/googleapis/google-cloud-ruby/issues/26626)) 
-
 ### 0.7.1 (2024-08-08)
 
 #### Documentation

--- a/google-cloud-dataqna/CHANGELOG.md
+++ b/google-cloud-dataqna/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Release History
 
-### 0.5.1 (2024-08-09)
-
-#### Documentation
-
-* Formatting updates to README.md ([#26626](https://github.com/googleapis/google-cloud-ruby/issues/26626)) 
-
 ### 0.5.1 (2024-08-08)
 
 #### Documentation

--- a/google-cloud-datastore-admin/CHANGELOG.md
+++ b/google-cloud-datastore-admin/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-### 0.4.1 (2024-08-09)
-
-#### Documentation
-
-* Formatting updates to README.md ([#26626](https://github.com/googleapis/google-cloud-ruby/issues/26626)) 
-
 ### 0.4.1 (2024-08-08)
 
 #### Documentation

--- a/google-cloud-datastream/CHANGELOG.md
+++ b/google-cloud-datastream/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-### 1.4.1 (2024-08-09)
-
-#### Documentation
-
-* Formatting updates to README.md ([#26626](https://github.com/googleapis/google-cloud-ruby/issues/26626)) 
-
 ### 1.4.1 (2024-08-08)
 
 #### Documentation

--- a/google-cloud-deploy/CHANGELOG.md
+++ b/google-cloud-deploy/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-### 1.2.1 (2024-08-09)
-
-#### Documentation
-
-* Formatting updates to README.md ([#26626](https://github.com/googleapis/google-cloud-ruby/issues/26626)) 
-
 ### 1.2.1 (2024-08-08)
 
 #### Documentation


### PR DESCRIPTION
A couple of duplicate changelog entries were added by release-please as a result of a race condition. This likely happened when also performing Owlbot manual runs.

These versions were already released, but the release-please-manifest config ended up being reverted for some entries, causing it to re-run.

Related issue #26936