### PR TITLE
chore: Change release-please schedule to once a day

### DIFF
--- a/.github/workflows/release-please-now.yml
+++ b/.github/workflows/release-please-now.yml
@@ -1,8 +1,7 @@
 name: Release-Please Now
 on:
   schedule:
-    - cron: '02 0 * * *'
-    - cron: '02 13 * * *'
+    - cron: '02 10 * * *'
   workflow_dispatch:
     inputs:
       args:


### PR DESCRIPTION
This changes release-please to run once a day, at 10:02 UTC.

It should also help minimize race conditions on manifest files, as it will take place outside of our team's usual work hours.