### PR TITLE
chore(api_hub-v1): Remove paths tests

### DIFF
--- a/google-cloud-api_hub-v1/.owlbot.rb
+++ b/google-cloud-api_hub-v1/.owlbot.rb
@@ -1,0 +1,21 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Remove path tests due to
+# https://github.com/googleapis/gapic-generator-ruby/issues/1115
+OwlBot.modifier path: %r{google/cloud/api_hub/v1/\w+_paths_test\.rb$} do
+  nil
+end
+
+OwlBot.move_files


### PR DESCRIPTION
Add a temporary owlbot postprocessor script to remove paths tests. Due to https://github.com/googleapis/gapic-generator-ruby/issues/1115, the paths tests fail if a gapic doesn't include a gRPC client. This should be removed when https://github.com/googleapis/gapic-generator-ruby/issues/1115 is fixed, or when the api_hub-v1 client gains gRPC support, whichever comes first.