### PR TITLE
feat(storage): restore soft deleted object using restore token for HNS buckets

### DIFF
--- a/google-cloud-storage/acceptance/storage/bucket_soft_delete_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_soft_delete_test.rb
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 require "storage_helper"
-require "pry"
 
 describe Google::Cloud::Storage::Bucket, :soft_delete, :storage do
   let(:bucket_name) { $bucket_names[0] }
@@ -88,14 +87,13 @@ describe Google::Cloud::Storage::Bucket, :soft_delete, :storage do
       }
     }
     let(:random_restore_token) {"random_string"}
-
+    
     before do
       hns_bucket.create_file file_path, file_name
     end
 
-
     it "restores a deleted file from bucket when correct restore token is provided"  do
-
+       binding.pry
       file = hns_bucket.file file_name
       file.delete
 

--- a/google-cloud-storage/acceptance/storage/bucket_soft_delete_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_soft_delete_test.rb
@@ -107,7 +107,7 @@ describe Google::Cloud::Storage::Bucket, :soft_delete, :storage do
       _(file.exists?).must_equal true
     end
 
-    it "can not restore a deleted file from bucket using incorrect restore token" do
+    it "can't restore a deleted file from bucket using incorrect restore token" do
       file = hns_bucket.file file_name
       file.delete
       deleted_file = hns_bucket.file file_name, soft_deleted: true, generation: file.generation

--- a/google-cloud-storage/acceptance/storage/bucket_soft_delete_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_soft_delete_test.rb
@@ -18,9 +18,9 @@ describe Google::Cloud::Storage::Bucket, :soft_delete, :storage do
   let(:bucket_name) { $bucket_names[0] }
   let :bucket do
     storage.bucket(bucket_name) ||
-    safe_gcs_execute { storage.create_bucket(bucket_name) }
+      safe_gcs_execute { storage.create_bucket(bucket_name) }
   end
-  let(:soft_delete_policy) { { retention_duration_seconds: 10*24*60*60 } } # 10 days
+  let(:soft_delete_policy) { { retention_duration_seconds: 10 * 24 * 60 * 60 } } # 10 days
   let(:file_path) { "acceptance/data/CloudPlatform_128px_Retina.png" }
   let(:file_name) { "CloudLogo1" }
 
@@ -29,12 +29,13 @@ describe Google::Cloud::Storage::Bucket, :soft_delete, :storage do
     file = bucket.create_file file_path, file_name
   end
 
+
   describe "Soft delete policy" do
     it "sets the soft delete policy" do
       _(bucket.soft_delete_policy).wont_be_nil
 
       bucket.soft_delete_policy = soft_delete_policy
-      _(bucket.soft_delete_policy.retention_duration_seconds).must_equal 10*24*60*60
+      _(bucket.soft_delete_policy.retention_duration_seconds).must_equal 10 * 24 * 60 * 60
     end
 
     it "fetches soft deleted file" do
@@ -67,8 +68,7 @@ describe Google::Cloud::Storage::Bucket, :soft_delete, :storage do
       generation = file.generation
       file.delete
 
-      restored_file = bucket.restore_file file_name, generation
-
+      bucket.restore_file file_name, generation
       file = bucket.file file_name
       _(file).wont_be_nil
       _(file.exists?).must_equal true
@@ -76,36 +76,38 @@ describe Google::Cloud::Storage::Bucket, :soft_delete, :storage do
   end
 
   describe "soft delete policy for hierarchical namespace enabled bucket" do
-    let(:hns_bucket_name) {"gcloud-ruby-acceptance-#{SecureRandom.hex(4)}"}
-    let(:hns_bucket) {
-      hierarchical_namespace = Google::Apis::StorageV1::Bucket::HierarchicalNamespace.new(enabled: true)
-      safe_gcs_execute {
+    let(:hns_bucket_name) { "gcloud-ruby-acceptance-#{SecureRandom.hex 4}" }
+    let :hns_bucket do
+      hierarchical_namespace = Google::Apis::StorageV1::Bucket::HierarchicalNamespace.new enabled: true
+      safe_gcs_execute do
         storage.create_bucket hns_bucket_name do |b|
           b.uniform_bucket_level_access = true
           b.hierarchical_namespace = hierarchical_namespace
         end
-      }
-    }
-    let(:random_restore_token) {"random_string"}
-    
+      end
+    end
+    let(:random_restore_token) { "random_string" }
+
     before do
       hns_bucket.create_file file_path, file_name
     end
 
-    it "restores a deleted file from bucket when correct restore token is provided"  do
-       binding.pry
+    it "restores a deleted file from bucket when correct restore token is provided" do
       file = hns_bucket.file file_name
       file.delete
 
       deleted_file = hns_bucket.file file_name, soft_deleted: true, generation: file.generation
-      restored_file = hns_bucket.restore_file file_name, deleted_file.generation, restore_token: deleted_file.restore_token
+      hns_bucket.restore_file(
+        file_name,
+        deleted_file.generation,
+        restore_token: deleted_file.restore_token
+      )
       file = hns_bucket.file file_name
       _(file).wont_be_nil
       _(file.exists?).must_equal true
-
     end
 
-    it "can not restore a deleted file from bucket using incorrect restore token"  do
+    it "can not restore a deleted file from bucket using incorrect restore token" do
       file = hns_bucket.file file_name
       file.delete
       deleted_file = hns_bucket.file file_name, soft_deleted: true, generation: file.generation

--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -1843,6 +1843,8 @@ module Google
         #   Name of the file.
         # @param [Fixnum] generation
         #   Selects a specific revision of this object.
+        # @param [String] restore_token
+        #   UUID generated specificly for softdeleted objects of HNS bucket
         # @param [Boolean] copy_source_acl
         #   If true, copies the source file's ACL; otherwise, uses the
         #   bucket's default file ACL. The default is false.

--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -1882,6 +1882,7 @@ module Google
         #
         def restore_file file_path,
                          generation,
+                         restore_token: nil,
                          copy_source_acl: nil,
                          if_generation_match: nil,
                          if_generation_not_match: nil,
@@ -1895,6 +1896,7 @@ module Google
           gapi = service.restore_file name,
                                       file_path,
                                       generation,
+                                      restore_token: restore_token,
                                       copy_source_acl: File::Acl.predefined_rule_for(copy_source_acl),
                                       if_generation_match: if_generation_match,
                                       if_generation_not_match: if_generation_not_match,

--- a/google-cloud-storage/lib/google/cloud/storage/file.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file.rb
@@ -1589,6 +1589,10 @@ module Google
           true
         end
 
+        def restore_token
+          @gapi.restore_token
+        end
+
         # Mode of object level retention configuration.
         # Valid values are 'Locked' or 'Unlocked'
         #

--- a/google-cloud-storage/lib/google/cloud/storage/file.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file.rb
@@ -1589,6 +1589,11 @@ module Google
           true
         end
 
+        # A universally unique identifier (UUID), along with the object's name and generation value
+        # required to restore a soft-deleted object only if its name and generation value do not uniquely identify it
+        #
+        # @return [String]
+
         def restore_token
           @gapi.restore_token
         end

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -661,6 +661,7 @@ module Google
         def restore_file bucket_name,
                          file_path,
                          generation,
+                         restore_token: nil,
                          copy_source_acl: nil,
                          if_generation_match: nil,
                          if_generation_not_match: nil,
@@ -678,6 +679,7 @@ module Google
 
           execute do
             service.restore_object bucket_name, file_path, generation,
+                                   restore_token: restore_token,
                                    copy_source_acl: copy_source_acl,
                                    if_generation_match: if_generation_match,
                                    if_generation_not_match: if_generation_not_match,

--- a/google-cloud-storage/test/helper.rb
+++ b/google-cloud-storage/test/helper.rb
@@ -514,6 +514,7 @@ class MockStorage < Minitest::Spec
       projection: projection,
       user_project: user_project,
       fields: fields,
+      restore_token: restore_token,
       options: options
     }
   end

--- a/google-cloud-storage/test/helper.rb
+++ b/google-cloud-storage/test/helper.rb
@@ -144,6 +144,7 @@ class MockStorage < Minitest::Spec
                        name=random_file_path,
                        generation="1234567890",
                        kms_key_name="path/to/encryption_key_name",
+                       restore_token: nil,
                        custom_time: nil,
                        retention_params: nil,
                        override_unlocked_retention: nil,
@@ -175,6 +176,7 @@ class MockStorage < Minitest::Spec
       "kmsKeyName" => kms_key_name,
       "temporaryHold" => true,
       "eventBasedHold" => true,
+      "restore_token" => restore_token,
       "retentionExpirationTime" => Time.now,
       "retention" => file_retention_hash(retention_params),
       "overrideUnlockedRetention" => override_unlocked_retention,
@@ -494,6 +496,7 @@ class MockStorage < Minitest::Spec
   end
 
   def restore_object_args copy_source_acl: nil,
+                          restore_token: nil,
                           if_generation_match: nil,
                           if_generation_not_match: nil,
                           if_metageneration_match: nil,


### PR DESCRIPTION
Add support for restore token to soft deleted from HNS bucket.

Operation Supported:

- If a restore token is provided as an input to restore_file method along with flename and generation token, it will restore seamlessly.
- If restore token is provided, the method calls works as earlier filename and generation token.
- Invalid restore tokens will result in a 404 Not Found error from the Storage Transfer API.

```ruby
 @example
require "google/cloud/storage"
storage = Google::Cloud::Storage.new
bucket = storage.bucket "my-hns-bucket"
bucket.restore_file "path/of/file", <generation-of-the-file>, "<restore_token>"
```


