### PR TITLE
ci: new image for release job

### DIFF
--- a/.kokoro/release.cfg
+++ b/.kokoro/release.cfg
@@ -28,6 +28,11 @@ env_vars: {
 }
 
 env_vars: {
+  key: "SECRET_MANAGER_PROJECT_ID"
+  value: "cloud-sdk-release-custom-pool"
+}
+
+env_vars: {
   key: "SECRET_MANAGER_KEYS"
   value: "releasetool-publish-reporter-app,releasetool-publish-reporter-googleapis-installation,releasetool-publish-reporter-pem,docuploader_service_account"
 }

--- a/.kokoro/release.cfg
+++ b/.kokoro/release.cfg
@@ -19,7 +19,7 @@ build_file: "google-cloud-ruby/.kokoro/trampoline_v2.sh"
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/release"
+  value: "us-central1-docker.pkg.dev/cloud-sdk-release-custom-pool/release-images/ruby-multi"
 }
 
 env_vars: {


### PR DESCRIPTION
Using the new image location for Kokoro release job.

b/376072399 cl/691026116

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-ruby/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea.
- [ ] Follow the instructions in [CONTRIBUTING](CONTRIBUTING.md). Most importantly, ensure the tests and linter pass by running `bundle exec rake ci` in the gem subdirectory.
- [ ] Update code documentation if necessary.

closes: #<issue_number_goes_here>