### PR TITLE
ci: remove cloud-devrel-kokoro-resources reference

### DIFF
--- a/.kokoro/release.cfg
+++ b/.kokoro/release.cfg
@@ -7,12 +7,6 @@ action {
   }
 }
 
-# Download resources for system tests (service account key, etc.)
-gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/google-cloud-ruby"
-
-# Download trampoline resources.
-gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
-
 # Use the trampoline script to run in docker.
 build_file: "google-cloud-ruby/.kokoro/trampoline_v2.sh"
 


### PR DESCRIPTION
The GCS bucket is not used any more.

b/376072399
