### PR TITLE
chore: update release jobs to use new release images and not reference any cloud-devrel-kokoro-resources

### DIFF
--- a/.kokoro/reserve-gem.cfg
+++ b/.kokoro/reserve-gem.cfg
@@ -7,19 +7,13 @@ action {
   }
 }
 
-# Download resources for system tests (service account key, etc.)
-gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/google-cloud-ruby"
-
-# Download trampoline resources.
-gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
-
 # Use the trampoline script to run in docker.
 build_file: "google-cloud-ruby/.kokoro/trampoline_v2.sh"
 
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/release"
+  value: "us-central1-docker.pkg.dev/cloud-sdk-release-custom-pool/release-images/ruby-multi"
 }
 
 env_vars: {
@@ -30,6 +24,11 @@ env_vars: {
 env_vars: {
   key: "SECRET_MANAGER_KEYS"
   value: "releasetool-publish-reporter-app,releasetool-publish-reporter-googleapis-installation,releasetool-publish-reporter-pem,docuploader_service_account"
+}
+
+env_vars: {
+  key: "SECRET_MANAGER_PROJECT_ID"
+  value: "cloud-sdk-release-custom-pool"
 }
 
 # Store the packages uploaded to rubygems.org, which

--- a/.kokoro/tombstone-gem.cfg
+++ b/.kokoro/tombstone-gem.cfg
@@ -7,19 +7,13 @@ action {
   }
 }
 
-# Download resources for system tests (service account key, etc.)
-gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/google-cloud-ruby"
-
-# Download trampoline resources.
-gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
-
 # Use the trampoline script to run in docker.
 build_file: "google-cloud-ruby/.kokoro/trampoline_v2.sh"
 
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/release"
+  value: "us-central1-docker.pkg.dev/cloud-sdk-release-custom-pool/release-images/ruby-multi"
 }
 
 env_vars: {
@@ -30,6 +24,11 @@ env_vars: {
 env_vars: {
   key: "SECRET_MANAGER_KEYS"
   value: "releasetool-publish-reporter-app,releasetool-publish-reporter-googleapis-installation,releasetool-publish-reporter-pem,docuploader_service_account"
+}
+
+env_vars: {
+  key: "SECRET_MANAGER_PROJECT_ID"
+  value: "cloud-sdk-release-custom-pool"
 }
 
 # Store the packages uploaded to rubygems.org, which


### PR DESCRIPTION
cloud-devrel-kokoro-resources will be accessed via new release kokoro pool/project.
