### PR TITLE
fix(bigquery): remove reload! call on patch_table

### DIFF
--- a/google-cloud-bigquery/acceptance/bigquery/materialized_view_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/materialized_view_test.rb
@@ -105,7 +105,9 @@ describe Google::Cloud::Bigquery::Table, :materialized_view, :bigquery do
     # update
 
     materialized_view.enable_refresh = true
+    materialized_view.etag = ""
     materialized_view.refresh_interval_ms = 1_800_000
+    materialized_view.etag = ""
 
     materialized_view.reload!
     _(materialized_view.table_id).must_equal materialized_view_id

--- a/google-cloud-bigquery/acceptance/bigquery/materialized_view_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/materialized_view_test.rb
@@ -64,7 +64,6 @@ describe Google::Cloud::Bigquery::Table, :materialized_view, :bigquery do
   end
   let(:materialized_view_id) { "materialized_view_#{SecureRandom.hex(16)}" }
 
-  focus
   it "creates, gets, updates and deletes a materialized view" do
     create_job = dataset.query_job create_table_query
     create_job.wait_until_done!

--- a/google-cloud-bigquery/acceptance/bigquery/materialized_view_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/materialized_view_test.rb
@@ -64,6 +64,7 @@ describe Google::Cloud::Bigquery::Table, :materialized_view, :bigquery do
   end
   let(:materialized_view_id) { "materialized_view_#{SecureRandom.hex(16)}" }
 
+  focus
   it "creates, gets, updates and deletes a materialized view" do
     create_job = dataset.query_job create_table_query
     create_job.wait_until_done!

--- a/google-cloud-bigquery/acceptance/bigquery/materialized_view_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/materialized_view_test.rb
@@ -105,9 +105,7 @@ describe Google::Cloud::Bigquery::Table, :materialized_view, :bigquery do
     # update
 
     materialized_view.enable_refresh = true
-    materialized_view.etag = ""
     materialized_view.refresh_interval_ms = 1_800_000
-    materialized_view.etag = ""
 
     materialized_view.reload!
     _(materialized_view.table_id).must_equal materialized_view_id

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -3061,10 +3061,6 @@ module Google
           patch_gapi = Google::Apis::BigqueryV2::Table.new(**patch_args)
           patch_gapi.etag = etag if etag
           @gapi = service.patch_table dataset_id, table_id, patch_gapi
-
-          # TODO: restore original impl after acceptance test indicates that
-          # service etag bug is fixed
-          reload!
         end
 
         def ensure_job_succeeded! job

--- a/google-cloud-bigquery/samples/snippets/extract_table.rb
+++ b/google-cloud-bigquery/samples/snippets/extract_table.rb
@@ -17,7 +17,6 @@ require "google/cloud/bigquery"
 def extract_table bucket_name = "my-bucket",
                   dataset_id  = "my_dataset_id",
                   table_id    = "my_table_id"
-
   bigquery = Google::Cloud::Bigquery.new
   dataset  = bigquery.dataset dataset_id
   table    = dataset.table    table_id

--- a/google-cloud-bigquery/samples/snippets/load_from_file.rb
+++ b/google-cloud-bigquery/samples/snippets/load_from_file.rb
@@ -16,7 +16,6 @@ require "google/cloud/bigquery"
 
 def load_from_file dataset_id = "your_dataset_id",
                    file_path  = "path/to/file.csv"
-
   bigquery = Google::Cloud::Bigquery.new
   dataset  = bigquery.dataset dataset_id
   table_id = "new_table_id"

--- a/google-cloud-bigquery/samples/snippets/load_table_gcs_json_truncate.rb
+++ b/google-cloud-bigquery/samples/snippets/load_table_gcs_json_truncate.rb
@@ -16,7 +16,6 @@ require "google/cloud/bigquery"
 
 def load_table_gcs_json_truncate dataset_id = "your_dataset_id",
                                  table_id   = "your_table_id"
-
   bigquery = Google::Cloud::Bigquery.new
   dataset  = bigquery.dataset dataset_id
   gcs_uri  = "gs://cloud-samples-data/bigquery/us-states/us-states.json"

--- a/google-cloud-bigquery/samples/snippets/load_table_gcs_orc_truncate.rb
+++ b/google-cloud-bigquery/samples/snippets/load_table_gcs_orc_truncate.rb
@@ -16,7 +16,6 @@ require "google/cloud/bigquery"
 
 def load_table_gcs_orc_truncate dataset_id = "your_dataset_id",
                                 table_id   = "your_table_id"
-
   bigquery = Google::Cloud::Bigquery.new
   dataset  = bigquery.dataset dataset_id
   gcs_uri  = "gs://cloud-samples-data/bigquery/us-states/us-states.orc"

--- a/google-cloud-bigquery/test/google/cloud/bigquery/materialized_view_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/materialized_view_test.rb
@@ -53,8 +53,7 @@ describe Google::Cloud::Bigquery::Table, :materialized_view, :mock_bigquery do
         enable_refresh: new_enable_refresh
       )
     )
-    mock.expect :patch_table, returned_table_gapi, [project, dataset_id, table_id, patch_table_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, returned_table_gapi, [project, dataset_id, table_id], **patch_table_args
+    mock.expect :patch_table, returned_table_gapi, [project, dataset_id, table_id, patch_table_gapi], options: {header: {"If-Match" => etag}}    
     materialized_view.service.mocked_service = mock
 
     materialized_view.enable_refresh = new_enable_refresh
@@ -75,8 +74,7 @@ describe Google::Cloud::Bigquery::Table, :materialized_view, :mock_bigquery do
         refresh_interval_ms: new_refresh_interval_ms
       )
     )
-    mock.expect :patch_table, returned_table_gapi, [project, dataset_id, table_id, patch_table_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, returned_table_gapi, [project, dataset_id, table_id], **patch_table_args
+    mock.expect :patch_table, returned_table_gapi, [project, dataset_id, table_id, patch_table_gapi], options: {header: {"If-Match" => etag}}    
     materialized_view.service.mocked_service = mock
 
     materialized_view.refresh_interval_ms = new_refresh_interval_ms

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_external_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_external_test.rb
@@ -69,7 +69,6 @@ describe Google::Cloud::Bigquery::Table, :external, :mock_bigquery do
     mock = Minitest::Mock.new
     mock.expect :patch_table, table_gapi,
       [project, dataset_id, table_id, request_table_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, response_table_gapi, [project, dataset_id, table_id], **patch_table_args
     table.service.mocked_service = mock
 
     table.external = bigquery.external "gs://my-bucket/path/to/file.json" do |json|

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_reference_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_reference_test.rb
@@ -123,7 +123,6 @@ describe Google::Cloud::Bigquery::Table, :reference, :mock_bigquery do
     patch_table_gapi = Google::Apis::BigqueryV2::Table.new schema: new_schema_gapi, etag: etag
     mock.expect :patch_table, returned_table_gapi,
       [table.project_id, table.dataset_id, table.table_id, patch_table_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, returned_table_gapi, [table.project_id, table.dataset_id, table.table_id], **patch_table_args
     table.service.mocked_service = mock
 
     table.schema do |schema|
@@ -145,7 +144,6 @@ describe Google::Cloud::Bigquery::Table, :reference, :mock_bigquery do
     patch_table_gapi = Google::Apis::BigqueryV2::Table.new schema: new_schema_gapi, etag: etag
     mock.expect :patch_table, returned_table_gapi,
       [table.project_id, table.dataset_id, table.table_id, patch_table_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, returned_table_gapi, [table.project_id, table.dataset_id, table.table_id], **patch_table_args
     table.service.mocked_service = mock
 
     table.schema replace: true do |schema|
@@ -179,7 +177,6 @@ describe Google::Cloud::Bigquery::Table, :reference, :mock_bigquery do
     mock.expect :get_table, table_gapi, [table.project_id, table.dataset_id, table.table_id], **patch_table_args
     mock.expect :patch_table, table_gapi,
       [project, dataset_id, table_id, request_table_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, response_table_gapi, [project, dataset_id, table_id], **patch_table_args
     table.service.mocked_service = mock
 
     table.external = bigquery.external "gs://my-bucket/path/to/file.json" do |json|

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_reference_update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_reference_update_test.rb
@@ -36,7 +36,6 @@ describe Google::Cloud::Bigquery::Table, :reference, :update, :mock_bigquery do
     mock.expect :get_table, return_table(table_hash), [project, dataset_id, table_id], **patch_table_args
     mock.expect :patch_table, return_table(table_hash),
       [project, dataset_id, table_id, request_table_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, return_table(table_hash), [project, dataset_id, table_id], **patch_table_args
 
     table.service.mocked_service = mock
 
@@ -55,7 +54,6 @@ describe Google::Cloud::Bigquery::Table, :reference, :update, :mock_bigquery do
     mock.expect :get_table, return_table(table_hash), [project, dataset_id, table_id], **patch_table_args
     mock.expect :patch_table, return_table(table_hash),
       [project, dataset_id, table_id, request_table_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, return_table(table_hash), [project, dataset_id, table_id], **patch_table_args
     table.service.mocked_service = mock
 
     table.description = new_description
@@ -77,7 +75,6 @@ describe Google::Cloud::Bigquery::Table, :reference, :update, :mock_bigquery do
     mock.expect :get_table, return_table(table_hash), [project, dataset_id, table_id], **patch_table_args
     mock.expect :patch_table, return_table(table_hash),
       [project, dataset_id, table_id, request_table_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, return_table(table_hash), [project, dataset_id, table_id], **patch_table_args
     table.service.mocked_service = mock
 
     table.time_partitioning_type = type
@@ -99,7 +96,6 @@ describe Google::Cloud::Bigquery::Table, :reference, :update, :mock_bigquery do
     mock.expect :get_table, return_table(table_hash), [project, dataset_id, table_id], **patch_table_args
     mock.expect :patch_table, return_table(table_hash),
                 [project, dataset_id, table_id, request_table_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, return_table(table_hash), [project, dataset_id, table_id], **patch_table_args
     table.service.mocked_service = mock
 
     table.time_partitioning_field = field
@@ -122,7 +118,6 @@ describe Google::Cloud::Bigquery::Table, :reference, :update, :mock_bigquery do
     mock.expect :get_table, return_table(table_hash), [project, dataset_id, table_id], **patch_table_args
     mock.expect :patch_table, return_table(table_hash),
       [project, dataset_id, table_id, request_table_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, return_table(table_hash), [project, dataset_id, table_id], **patch_table_args
     table.service.mocked_service = mock
 
     table.time_partitioning_expiration = expiration
@@ -146,7 +141,6 @@ describe Google::Cloud::Bigquery::Table, :reference, :update, :mock_bigquery do
     mock.expect :get_table, return_table(table_hash), [project, dataset_id, table_id], **patch_table_args
     mock.expect :patch_table, return_table(table_hash_clustering),
       [project, dataset_id, table_id, request_table_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, return_table(table_hash_clustering), [project, dataset_id, table_id], **patch_table_args
     table.service.mocked_service = mock
 
     table.clustering_fields = clustering_fields
@@ -174,7 +168,6 @@ describe Google::Cloud::Bigquery::Table, :reference, :update, :mock_bigquery do
     mock.expect :get_table, return_table(table_hash), [project, dataset_id, table_id], **patch_table_args
     mock.expect :patch_table, return_table(table_hash_clustering),
       [project, dataset_id, table_id, request_table_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, return_table(table_hash_clustering), [project, dataset_id, table_id], **patch_table_args
     table.service.mocked_service = mock
 
     table.clustering_fields = new_clustering_fields
@@ -198,7 +191,6 @@ describe Google::Cloud::Bigquery::Table, :reference, :update, :mock_bigquery do
     mock.expect :get_table, return_table(table_hash), [project, dataset_id, table_id], **patch_table_args
     mock.expect :patch_table, return_table(table_hash_clustering),
       [project, dataset_id, table_id, request_table_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, return_table(table_hash_clustering), [project, dataset_id, table_id], **patch_table_args
     table.service.mocked_service = mock
 
     table.clustering_fields = nil
@@ -218,7 +210,6 @@ describe Google::Cloud::Bigquery::Table, :reference, :update, :mock_bigquery do
     mock.expect :get_table, return_table(table_hash), [project, dataset_id, table_id], **patch_table_args
     mock.expect :patch_table, return_table(table_hash),
       [project, dataset_id, table_id, request_table_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, return_table(table_hash), [project, dataset_id, table_id], **patch_table_args
     table.service.mocked_service = mock
 
     table.labels = new_labels

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_schema_test.rb
@@ -194,7 +194,6 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     patch_table_gapi = Google::Apis::BigqueryV2::Table.new schema: new_schema_gapi, etag: etag
     mock.expect :patch_table, returned_table_gapi,
       [table.project_id, table.dataset_id, table.table_id, patch_table_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, returned_table_gapi, [table.project_id, table.dataset_id, table.table_id], **patch_table_args
     table.service.mocked_service = mock
 
     table.schema replace: true do |schema|
@@ -238,7 +237,6 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     patch_table_gapi = Google::Apis::BigqueryV2::Table.new schema: new_schema_gapi, etag: etag
     mock.expect :patch_table, returned_table_gapi,
       [table.project_id, table.dataset_id, table.table_id, patch_table_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, returned_table_gapi, [table.project_id, table.dataset_id, table.table_id], **patch_table_args
     table.service.mocked_service = mock
 
     table.schema do |schema|
@@ -259,7 +257,6 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     patch_table_gapi = Google::Apis::BigqueryV2::Table.new schema: new_schema_gapi, etag: etag
     mock.expect :patch_table, returned_table_gapi,
       [table.project_id, table.dataset_id, table.table_id, patch_table_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, returned_table_gapi, [table.project_id, table.dataset_id, table.table_id], **patch_table_args
     table.service.mocked_service = mock
 
     table.schema replace: true do |schema|
@@ -282,7 +279,6 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     patch_table_gapi = Google::Apis::BigqueryV2::Table.new schema: new_schema_gapi, etag: etag
     mock.expect :patch_table, returned_table_gapi,
                 [table.project_id, table.dataset_id, table.table_id, patch_table_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, returned_table_gapi, [table.project_id, table.dataset_id, table.table_id], **patch_table_args
     table.service.mocked_service = mock
     io = StringIO.new(rank_schema_json)
 
@@ -302,7 +298,6 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     patch_table_gapi = Google::Apis::BigqueryV2::Table.new schema: new_schema_gapi, etag: etag
     mock.expect :patch_table, returned_table_gapi,
       [table.project_id, table.dataset_id, table.table_id, patch_table_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, returned_table_gapi, [table.project_id, table.dataset_id, table.table_id], **patch_table_args
     table.service.mocked_service = mock
 
     table.schema replace: true do |schema|
@@ -329,7 +324,6 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     patch_table_gapi = Google::Apis::BigqueryV2::Table.new schema: new_schema_gapi, etag: etag
     mock.expect :patch_table, returned_table_gapi,
       [table.project_id, table.dataset_id, table.table_id, patch_table_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, returned_table_gapi, [table.project_id, table.dataset_id, table.table_id], **patch_table_args
     table.service.mocked_service = mock
 
     table.schema replace: true do |schema|
@@ -351,7 +345,6 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     patch_next_table_gapi = Google::Apis::BigqueryV2::Table.new schema: next_schema_gapi, etag: etag
     mock.expect :patch_table, next_table_gapi,
       [table.project_id, table.dataset_id, table.table_id, patch_next_table_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, returned_table_gapi, [table.project_id, table.dataset_id, table.table_id], **patch_table_args
     table.service.mocked_service = mock
 
     table.schema do |schema|
@@ -393,7 +386,6 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     patch_table_gapi = Google::Apis::BigqueryV2::Table.new schema: nested_schema_gapi, etag: etag
     mock.expect :patch_table, returned_table_gapi,
       [table.project_id, table.dataset_id, table.table_id, patch_table_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, returned_table_gapi, [table.project_id, table.dataset_id, table.table_id], **patch_table_args
     table.service.mocked_service = mock
 
     table.schema replace: true do |schema|
@@ -419,7 +411,6 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     patch_table_gapi = Google::Apis::BigqueryV2::Table.new schema: new_schema_gapi, etag: etag
     mock.expect :patch_table, returned_table_gapi,
                 [table.project_id, table.dataset_id, table.table_id, patch_table_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, returned_table_gapi, [table.project_id, table.dataset_id, table.table_id], **patch_table_args
     table.service.mocked_service = mock
 
     table.schema replace: true do |schema|

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_update_test.rb
@@ -35,7 +35,6 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     request_table_gapi = Google::Apis::BigqueryV2::Table.new friendly_name: "My Updated Table", etag: etag
     mock.expect :patch_table, return_table(table_hash),
       [project, dataset_id, table_id, request_table_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, return_table(table_hash), [project, dataset_id, table_id], **patch_table_args
 
     table.service.mocked_service = mock
 
@@ -70,7 +69,6 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     request_table_gapi = Google::Apis::BigqueryV2::Table.new description: "This is my updated table", etag: etag
     mock.expect :patch_table, return_table(table_hash),
       [project, dataset_id, table_id, request_table_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, return_table(table_hash), [project, dataset_id, table_id], **patch_table_args
     table.service.mocked_service = mock
 
     _(table.name).must_equal table_name
@@ -106,7 +104,6 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     request_table_gapi = Google::Apis::BigqueryV2::Table.new time_partitioning: partitioning, etag: etag
     mock.expect :patch_table, return_table(table_hash),
       [project, dataset_id, table_id, request_table_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, return_table(table_hash), [project, dataset_id, table_id], **patch_table_args
     table.service.mocked_service = mock
 
     _(table.name).must_equal table_name
@@ -141,7 +138,6 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     request_table_gapi = Google::Apis::BigqueryV2::Table.new time_partitioning: partitioning, etag: etag
     mock.expect :patch_table, return_table(table_hash),
                 [project, dataset_id, table_id, request_table_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, return_table(table_hash), [project, dataset_id, table_id], **patch_table_args
     table.service.mocked_service = mock
 
     _(table.name).must_equal table_name
@@ -178,7 +174,6 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     request_table_gapi = Google::Apis::BigqueryV2::Table.new time_partitioning: partitioning, etag: etag
     mock.expect :patch_table, return_table(table_hash),
       [project, dataset_id, table_id, request_table_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, return_table(table_hash), [project, dataset_id, table_id], **patch_table_args
     table.service.mocked_service = mock
 
     _(table.name).must_equal table_name
@@ -212,7 +207,6 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     request_table_gapi = Google::Apis::BigqueryV2::Table.new time_partitioning: partitioning, etag: etag
     mock.expect :patch_table, return_table(table_hash),
       [project, dataset_id, table_id, request_table_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, return_table(table_hash), [project, dataset_id, table_id], **patch_table_args
     table.service.mocked_service = mock
 
     table.time_partitioning_expiration = nil
@@ -229,7 +223,6 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     request_table_gapi = Google::Apis::BigqueryV2::Table.new require_partition_filter: false, etag: etag
     mock.expect :patch_table, return_table(table_hash),
       [project, dataset_id, table_id, request_table_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, return_table(table_hash), [project, dataset_id, table_id], **patch_table_args
     table.service.mocked_service = mock
 
     _(table.name).must_equal table_name
@@ -265,7 +258,6 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     request_table_gapi = Google::Apis::BigqueryV2::Table.new clustering: clustering, etag: etag
     mock.expect :patch_table, return_table(table_hash),
       [project, dataset_id, table_id, request_table_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, return_table(table_hash), [project, dataset_id, table_id], **patch_table_args
     table.service.mocked_service = mock
 
     _(table.clustering_fields).must_be :nil?
@@ -296,7 +288,6 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     request_table_gapi = Google::Apis::BigqueryV2::Table.new clustering: clustering, etag: etag
     mock.expect :patch_table, return_table(table_hash_clustering_2),
       [project, dataset_id, table_id, request_table_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, return_table(table_hash_clustering_2), [project, dataset_id, table_id], **patch_table_args
     table_clustering.service.mocked_service = mock
 
     _(table_clustering.clustering_fields).must_equal clustering_fields
@@ -323,7 +314,6 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     request_table_gapi = Google::Apis::BigqueryV2::Table.new clustering: nil, etag: etag
     mock.expect :patch_table, return_table(table_hash),
       [project, dataset_id, table_id, request_table_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, return_table(table_hash), [project, dataset_id, table_id], **patch_table_args
     table_clustering.service.mocked_service = mock
 
     _(table_clustering.clustering_fields).must_equal clustering_fields
@@ -345,7 +335,6 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     request_table_gapi = Google::Apis::BigqueryV2::Table.new labels: new_labels, etag: etag
     mock.expect :patch_table, return_table(table_hash),
       [project, dataset_id, table_id, request_table_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, return_table(table_hash), [project, dataset_id, table_id], **patch_table_args
     table.service.mocked_service = mock
 
     _(table.labels).must_equal labels
@@ -366,7 +355,6 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     request_table_gapi = Google::Apis::BigqueryV2::Table.new encryption_configuration: Google::Apis::BigqueryV2::EncryptionConfiguration.new(kms_key_name: kms_key), etag: etag
     mock.expect :patch_table, return_table(table_hash),
       [project, dataset_id, table_id, request_table_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, return_table(table_hash), [project, dataset_id, table_id], **patch_table_args
     table.service.mocked_service = mock
 
     _(table.encryption).must_be :nil?

--- a/google-cloud-bigquery/test/google/cloud/bigquery/view_update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/view_update_test.rb
@@ -36,7 +36,6 @@ describe Google::Cloud::Bigquery::Table, :view, :update, :mock_bigquery do
     request_view_gapi = Google::Apis::BigqueryV2::Table.new friendly_name: "My Updated View", etag: etag
     mock.expect :patch_table, return_view(view_hash),
       [project, dataset_id, table_id, request_view_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, return_view(view_hash), [project, dataset_id, table_id], **patch_table_args
     view.service.mocked_service = mock
 
     _(view.name).must_equal table_name
@@ -60,7 +59,6 @@ describe Google::Cloud::Bigquery::Table, :view, :update, :mock_bigquery do
     request_view_gapi = Google::Apis::BigqueryV2::Table.new description: "This is my updated view", etag: etag
     mock.expect :patch_table, return_view(view_hash),
       [project, dataset_id, table_id, request_view_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, return_view(view_hash), [project, dataset_id, table_id], **patch_table_args
     view.service.mocked_service = mock
 
     _(view.name).must_equal table_name
@@ -92,7 +90,6 @@ describe Google::Cloud::Bigquery::Table, :view, :update, :mock_bigquery do
     )
     mock.expect :patch_table, return_view(view_hash, request_view_gapi.view),
       [project, dataset_id, table_id, request_view_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, return_view(view_hash, request_view_gapi.view), [project, dataset_id, table_id], **patch_table_args
     view.service.mocked_service = mock
 
     _(view.name).must_equal table_name
@@ -128,7 +125,6 @@ describe Google::Cloud::Bigquery::Table, :view, :update, :mock_bigquery do
     )
     mock.expect :patch_table, return_view(view_hash, request_view_gapi.view),
       [project, dataset_id, table_id, request_view_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, return_view(view_hash, request_view_gapi.view), [project, dataset_id, table_id], **patch_table_args
     view.service.mocked_service = mock
 
     _(view.name).must_equal table_name
@@ -164,7 +160,6 @@ describe Google::Cloud::Bigquery::Table, :view, :update, :mock_bigquery do
     )
     mock.expect :patch_table, return_view(view_hash, request_view_gapi.view),
       [project, dataset_id, table_id, request_view_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, return_view(view_hash, request_view_gapi.view), [project, dataset_id, table_id], **patch_table_args
     view.service.mocked_service = mock
 
     _(view.name).must_equal table_name
@@ -200,7 +195,6 @@ describe Google::Cloud::Bigquery::Table, :view, :update, :mock_bigquery do
     )
     mock.expect :patch_table, return_view(view_hash, request_view_gapi.view),
       [project, dataset_id, table_id, request_view_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, return_view(view_hash, request_view_gapi.view), [project, dataset_id, table_id], **patch_table_args
     view.service.mocked_service = mock
 
     _(view.name).must_equal table_name
@@ -239,7 +233,6 @@ describe Google::Cloud::Bigquery::Table, :view, :update, :mock_bigquery do
     )
     mock.expect :patch_table, return_view(view_hash, request_view_gapi.view),
       [project, dataset_id, table_id, request_view_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, return_view(view_hash, request_view_gapi.view), [project, dataset_id, table_id], **patch_table_args
     view.service.mocked_service = mock
 
     _(view.name).must_equal table_name
@@ -277,7 +270,6 @@ describe Google::Cloud::Bigquery::Table, :view, :update, :mock_bigquery do
     )
     mock.expect :patch_table, return_view(view_hash, request_view_gapi.view),
       [project, dataset_id, table_id, request_view_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, return_view(view_hash, request_view_gapi.view), [project, dataset_id, table_id], **patch_table_args
     view.service.mocked_service = mock
 
     _(view.name).must_equal table_name
@@ -315,7 +307,6 @@ describe Google::Cloud::Bigquery::Table, :view, :update, :mock_bigquery do
     )
     mock.expect :patch_table, return_view(view_hash, request_view_gapi.view),
       [project, dataset_id, table_id, request_view_gapi], options: {header: {"If-Match" => etag}}
-    mock.expect :get_table, return_view(view_hash, request_view_gapi.view), [project, dataset_id, table_id], **patch_table_args
     view.service.mocked_service = mock
 
     _(view.name).must_equal table_name


### PR DESCRIPTION
Initially for PR https://github.com/googleapis/google-cloud-ruby/pull/27681, tests for materialized view updates where failing (mainly test `creates, gets, updates and deletes a materialized view`). 

On PR https://github.com/googleapis/google-cloud-ruby/pull/1674, support for `etag` was added, but at the time, there was a problem on etag handling where the latest version of the table was not returned, requiring to call `reload!` to re-fetch table metadata. This PR removes the extra `reload!` call and remove expectations on tests that an call to `get_table` is going to happen.
