### PR TITLE
chore: Fix rubygems key acquisition in reserve-gem and tombstone-gem scripts

### DIFF
--- a/.kokoro/reserve-gem.cfg
+++ b/.kokoro/reserve-gem.cfg
@@ -31,6 +31,17 @@ env_vars: {
   value: "cloud-sdk-release-custom-pool"
 }
 
+# Pick up Rubygems key from internal keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "rubygems-publish-key"
+      backend: "blade:keystore-fastconfigpush"
+    }
+  }
+}
+
 # Store the packages uploaded to rubygems.org, which
 # we can later use to generate SBOMs and attestations.
 action {

--- a/.kokoro/tombstone-gem.cfg
+++ b/.kokoro/tombstone-gem.cfg
@@ -31,6 +31,17 @@ env_vars: {
   value: "cloud-sdk-release-custom-pool"
 }
 
+# Pick up Rubygems key from internal keystore
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "rubygems-publish-key"
+      backend: "blade:keystore-fastconfigpush"
+    }
+  }
+}
+
 # Store the packages uploaded to rubygems.org, which
 # we can later use to generate SBOMs and attestations.
 action {


### PR DESCRIPTION
This info needs to come from keystore now. It no longer lives in GCS.