### PR TITLE
chore: Add logger methods to dummy stub classes for tests

### DIFF
--- a/google-cloud-bigtable-v2/test/google/cloud/bigtable/v2/bigtable/helpers_test.rb
+++ b/google-cloud-bigtable-v2/test/google/cloud/bigtable/v2/bigtable/helpers_test.rb
@@ -33,6 +33,10 @@ class ::Google::Cloud::Bigtable::V2::Bigtable::HelpersTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_config_channel_args

--- a/google-cloud-pubsub-v1/test/google/cloud/pubsub/v1/publisher/helpers_test.rb
+++ b/google-cloud-pubsub-v1/test/google/cloud/pubsub/v1/publisher/helpers_test.rb
@@ -35,6 +35,10 @@ class ::Google::Cloud::PubSub::V1::Publisher::HelpersTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_config_channel_args

--- a/google-cloud-pubsub-v1/test/google/cloud/pubsub/v1/subscriber/helpers_test.rb
+++ b/google-cloud-pubsub-v1/test/google/cloud/pubsub/v1/subscriber/helpers_test.rb
@@ -35,6 +35,10 @@ class ::Google::Cloud::PubSub::V1::Subscriber::HelpersTest < Minitest::Test
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   def test_config_channel_args

--- a/google-cloud-pubsub/test/google/cloud/pubsub/service_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/service_test.rb
@@ -29,6 +29,10 @@ describe Google::Cloud::PubSub::Service do
     def stub_logger
       nil
     end
+
+    def logger
+      nil
+    end
   end
 
   let(:project) { "test" }


### PR DESCRIPTION
Same issue fixed in https://github.com/googleapis/gapic-generator-ruby/pull/1136 but this is for a small number of handwritten files.

Tests will fail until the fixes in https://github.com/googleapis/gapic-generator-ruby/pull/1136 land.