### PR TITLE
Add Cloud Secrets Team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,3 +23,4 @@
 /google-cloud-translate*/.           @googleapis/ruby-team yoshi-approver @googleapis/ml-apis
 /google-cloud-video_intelligence*/.  @googleapis/ruby-team yoshi-approver @googleapis/ml-apis
 /google-cloud-vision*/.              @googleapis/ruby-team yoshi-approver @googleapis/ml-apis
+/google-cloud-secret_manager*/.      @googleapis/ruby-team @yoshi-approver @GoogleCloudPlatform/cloud-secrets-team

--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -3,6 +3,10 @@ assign_issues_by:
     - 'api: storage'
     to:
     - bajajneha27
+  - labels:
+    - 'api: secretmanager'
+    to:
+    - GoogleCloudPlatform/cloud-secrets-team
 
 assign_issues:
  - dazuma


### PR DESCRIPTION
### Changes
* Add cloud secrets team to the _CODEOWNERS_ file.
* Add cloud secrets team to the _blunderbuss.yml_ file.

### Prerequisite
- [X] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-ruby/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea. - (Done)
- [X] Follow the instructions in [CONTRIBUTING](CONTRIBUTING.md). Most importantly, ensure the tests and linter pass by running `bundle exec rake ci` in the gem subdirectory. - (N/A)
- [X] Update code documentation if necessary.  - (N/A)

closes: #28094