### PR TITLE
fix(translate-v2): Ensure access token is fetched with recent googleauth versions in the non-api-key case

### DIFF
--- a/google-cloud-translate-v2/lib/google/cloud/translate/v2/service.rb
+++ b/google-cloud-translate-v2/lib/google/cloud/translate/v2/service.rb
@@ -140,7 +140,7 @@ module Google
             client = credentials.client
             return if client.nil?
 
-            client.fetch_access_token! if client.expires_within? 30
+            client.fetch_access_token! if client.access_token.nil? || client.expires_within?(30)
             client.generate_authenticated_request request: request
             request
           end

--- a/google-cloud-translate-v2/test/google/cloud/translate/v2/service_test.rb
+++ b/google-cloud-translate-v2/test/google/cloud/translate/v2/service_test.rb
@@ -20,6 +20,10 @@ class FakeClient
     false
   end
 
+  def access_token
+    :token
+  end
+
   def generate_authenticated_request request:
   end
 end


### PR DESCRIPTION
This may address https://github.com/googleapis/google-auth-library-ruby/issues/504. It also addresses some integration test failures related to the translate-v2 client.

Older versions of googleauth (prior to 0.11 or 0.12) eagerly fetched access tokens for some credential types. This could cause issues in environments where the service providing the tokens were slow to initialize. It also did extra work by fetching a token prematurely if the credential was never used or was delayed in its use, and would cause confusion when troubleshooting auth via logs use because the token fetch would be significantly separated from its use.

This eager pre-fetching was removed in more recent versions of googleauth, but it looks like the translate-v2 client was depending on the old behavior: its logic failed ever to fetch a token if no previous token (and thus no expiration date) was already present. This PR updates the translate-v2 client logic to ensure a token is fetched if not present at all.