### PR TITLE
fix(bigquery): allow insert to target dataset/table in another project

### DIFF
--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -2810,7 +2810,7 @@ module Google
           ensure_service!
 
           # Get table, don't use Dataset#table which handles NotFoundError
-          gapi = service.get_table dataset_id, table_id, metadata_view: view
+          gapi = service.get_project_table project_id, dataset_id, table_id, metadata_view: view
           table = Table.from_gapi gapi, service, metadata_view: view
           # Get the AsyncInserter from the table
           table.insert_async skip_invalid: skip_invalid,
@@ -2865,7 +2865,8 @@ module Google
           ensure_service!
           gapi = service.insert_tabledata dataset_id, table_id, rows, skip_invalid:   skip_invalid,
                                                                       ignore_unknown: ignore_unknown,
-                                                                      insert_ids:     insert_ids
+                                                                      insert_ids:     insert_ids,
+                                                                      project_id:     project_id
           InsertResponse.from_gapi rows, gapi
         end
 

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -257,15 +257,17 @@ module Google
           end
         end
 
-        def insert_tabledata dataset_id, table_id, rows, insert_ids: nil, ignore_unknown: nil, skip_invalid: nil
+        def insert_tabledata dataset_id, table_id, rows, insert_ids: nil, ignore_unknown: nil,
+                             skip_invalid: nil, project_id: nil
           json_rows = Array(rows).map { |row| Convert.to_json_row row }
           insert_tabledata_json_rows dataset_id, table_id, json_rows, insert_ids:     insert_ids,
                                                                       ignore_unknown: ignore_unknown,
-                                                                      skip_invalid:   skip_invalid
+                                                                      skip_invalid:   skip_invalid,
+                                                                      project_id:     project_id
         end
 
         def insert_tabledata_json_rows dataset_id, table_id, json_rows, insert_ids: nil, ignore_unknown: nil,
-                                       skip_invalid: nil
+                                       skip_invalid: nil, project_id: nil
           rows_and_ids = Array(json_rows).zip Array(insert_ids)
           insert_rows = rows_and_ids.map do |json_row, insert_id|
             if insert_id == :skip
@@ -286,9 +288,10 @@ module Google
           }.to_json
 
           # The insertAll with insertId operation is considered idempotent
+          project_id ||= @project
           execute backoff: true do
             service.insert_all_table_data(
-              @project, dataset_id, table_id, insert_req,
+              project_id, dataset_id, table_id, insert_req,
               options: { skip_serialization: true }
             )
           end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -2747,7 +2747,8 @@ module Google
                                           rows,
                                           skip_invalid: skip_invalid,
                                           ignore_unknown: ignore_unknown,
-                                          insert_ids: insert_ids
+                                          insert_ids: insert_ids,
+                                          project_id: project_id
           InsertResponse.from_gapi rows, gapi
         end
 

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table/async_inserter.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table/async_inserter.rb
@@ -294,7 +294,8 @@ module Google
                                                                       json_rows,
                                                                       skip_invalid: @skip_invalid,
                                                                       ignore_unknown: @ignore_unknown,
-                                                                      insert_ids: insert_ids
+                                                                      insert_ids: insert_ids,
+                                                                      project_id: @table.project_id
 
               result = Result.new InsertResponse.from_gapi(orig_rows, insert_resp)
             rescue StandardError => e

--- a/google-cloud-bigquery/test/google/cloud/bigquery/dataset_insert_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/dataset_insert_test.rb
@@ -69,6 +69,29 @@ describe Google::Cloud::Bigquery::Dataset, :insert, :mock_bigquery do
     _(result.error_count).must_equal 0
   end
 
+  it "can insert rows into another project" do
+    mock = Minitest::Mock.new
+    insert_req = {
+      rows: [insert_rows.first], ignoreUnknownValues: nil, skipInvalidRows: nil
+    }.to_json
+    another_project_id = "another-project"
+    mock.expect :insert_all_table_data, success_table_insert_gapi,
+                [another_project_id, dataset_id, table_id, insert_req], options: { skip_serialization: true }
+    dataset.service.mocked_service = mock
+    dataset.gapi.dataset_reference.project_id = another_project_id
+
+    result = nil
+    SecureRandom.stub :uuid, insert_id do
+      result = dataset.insert table_id, rows.first
+    end
+
+    mock.verify
+
+    _(result).must_be :success?
+    _(result.insert_count).must_equal 1
+    _(result.error_count).must_equal 0
+  end
+
   describe "dataset reference" do
     let(:dataset) {Google::Cloud::Bigquery::Dataset.new_reference project, dataset_id, bigquery.service }
 


### PR DESCRIPTION
Allow `insertAll` API to target tables in a dataset that lives in a separated project, other than the project usage on the main client and which is used for billing.

I haven't added integration tests, since we would not have write access to two different projects in our CI pipelines. But I tested locally with this given code:
```
$ export GOOGLE_CLOUD_PROJECT=projectA
$ bq mk --table test_dataset.ruby-test-001 name:STRING,value:NUMERIC
```
```
bigquery = Google::Cloud::Bigquery.new
project_id = "projectB"
dataset_id = "test_dataset"
table_id = "ruby-test-001"
dataset  = bigquery.dataset dataset_id, project_id: project_id
table    = dataset.table table_id

row_data = [
  { name: "Alice", value: 5  },
  { name: "Bob",   value: 10 }
]
response = table.insert row_data

if response.success?
  puts "Inserted rows successfully"
else
  puts "Failed to insert #{response.error_rows.count} rows"
end

inserter = table.insert_async do |result|
  if result.error?
    puts result.error
  else
    puts "inserted #{result.insert_count} rows with #{result.error_count} errors"
  end
end

inserter.insert row_data

inserter.stop.wait!
```

Follow up on #27681 and https://github.com/googleapis/google-cloud-ruby/issues/27368