### PR TITLE
chore(perf): Make all gems load faster

### DIFF
--- a/google-cloud-core/lib/google/cloud.rb
+++ b/google-cloud-core/lib/google/cloud.rb
@@ -156,9 +156,12 @@ module Google
     # @private
     #
     def self.auto_load_files
-      return Gem.find_latest_files "google-cloud-*.rb" if Gem.respond_to? :find_latest_files
-      # Ruby 2.0 does not have Gem.find_latest_files
-      Gem.find_files "google-cloud-*.rb"
+      Gem.loaded_specs.values.filter_map do |spec|
+        next unless spec.name.start_with?("google-cloud-")
+        path = File.join(spec.lib_dirs_glob, spec.name + ".rb")
+        next unless File.exist?(path)
+        path
+      end
     end
   end
 end


### PR DESCRIPTION
`Gem.find_latest_files`'s performance scales with the amount of files contained across all gems of a project. This can quickly get out of hand, especially on projects with many gems, or large gems.

`Gem.loaded_spec` is already populated by bundler, and we can iterate over only the name of the gems to detect those matching the `google-cloud-*` pattern. We can then guess the name of the file we expect to be present.

On my machine, this makes `auto_load_files` go from ~100ms to <1ms, and requiring `bigtable` goes from ~220ms to ~110ms.

- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-ruby/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea.
- [ ] Follow the instructions in [CONTRIBUTING](CONTRIBUTING.md). Most importantly, ensure the tests and linter pass by running `bundle exec rake ci` in the gem subdirectory.
- [x] Update code documentation if necessary.
