### PR TITLE
chore: Stop using rake for the remaining workflows

### DIFF
--- a/.toys/new-library.rb
+++ b/.toys/new-library.rb
@@ -175,7 +175,7 @@ end
 def test_library
   Dir.chdir gem_name do
     exec ["bundle", "install"]
-    exec ["bundle", "exec", "rake", "ci"]
+    exec ["toys", "ci", "--rubocop", "--yard", "--test"]
   end
 end
 

--- a/.toys/owlbot.rb
+++ b/.toys/owlbot.rb
@@ -348,10 +348,7 @@ def process_single_gem name, temp_staging_dir
   return unless enable_tests
   cd name do
     exec ["bundle", "install"]
-    # The MT_COMPAT environment variable is a temporary hack to allow
-    # minitest-rg 5.2.0 to work in minitest 5.19 or later. This should be
-    # removed if we have a better solution or decide to drop rg.
-    exec ["bundle", "exec", "rake", "ci"], env: { "MT_COMPAT" => "true" }
+    exec ["toys", "ci", "--rubocop", "--yard", "--test"]
   end
 end
 

--- a/.toys/peek-client.rb
+++ b/.toys/peek-client.rb
@@ -64,7 +64,7 @@ end
 
 def run_test dir
   exec ["bundle", "install"], chdir: dir
-  exec ["bundle", "exec", "rake", "ci"], chdir: dir
+  exec ["toys", "ci", "--rubocop", "--yard", "--test"], chdir: dir
 end
 
 def piper_client_dir


### PR DESCRIPTION
This is a step towards being able to remove the Rakefiles from client directories: stop calling rake in any of our workflows.

This also:

* Removes setting of `MT_COMPAT` which is no longer needed with recent versions of minitest and minitest-rg
* Adds the `--conformance` test to CI. This will be implemented by a small number of handwritten clients, starting with storage and bigtable.