### PR TITLE
fix(firestore): correct cursor flipping in limit_to_last

### DIFF
--- a/google-cloud-firestore/lib/google/cloud/firestore/query.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/query.rb
@@ -493,12 +493,12 @@ module Google
             new_start_at = new_query.end_at.dup
             if new_end_at
               new_end_at.before = !new_end_at.before
-              new_query.end_at = new_end_at
             end
             if new_start_at
               new_start_at.before = !new_start_at.before
-              new_query.start_at = new_start_at
             end
+            new_query.end_at = new_end_at
+            new_query.start_at = new_start_at
           end
 
           new_query.limit = Google::Protobuf::Int32Value.new value: num


### PR DESCRIPTION
* Fix Google::Cloud::Firestore::Query#limit_to_last

Ensure that cursors are correctly flipped when using limit_to_last in Firestore queries. This change moves the assignment of new_start_at and new_end_at outside of the conditional blocks to ensure they are always set correctly. Added tests to cover scenarios with order, start_at, and end_at in combination with limit_to_last.

closes: #27527