### PR TITLE
chore: Fix CODEOWNERS syntax

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,20 +7,11 @@
 
 # @googleapis/ruby-team is the default owner for anything not
 # explicitly taken by someone else.
-*                                    @googleapis/ruby-team yoshi-approver
+*                                    @googleapis/ruby-team @yoshi-approver
 
-/google-cloud-automl*/.              @googleapis/ruby-team yoshi-approver @googleapis/ml-apis
-/google-cloud-bigquery*/.            @googleapis/ruby-team yoshi-approver @googleapis/api-bigquery
-/google-cloud-bigtable*/.            @googleapis/ruby-team yoshi-approver @googleapis/api-bigtable
-/google-cloud-datastore*/.           @googleapis/ruby-team yoshi-approver @googleapis/api-datastore-sdk
-/google-cloud-firestore*/.           @googleapis/ruby-team yoshi-approver @googleapis/firestore-dpe
-/google-cloud-language*/.            @googleapis/ruby-team yoshi-approver @googleapis/ml-apis
-/google-cloud-pubsub*/.              @googleapis/ruby-team yoshi-approver @googleapis/api-pubsub
-/google-cloud-speech*/.              @googleapis/ruby-team yoshi-approver @googleapis/ml-apis
-/google-cloud-storage/               @googleapis/ruby-team yoshi-approver @googleapis/cloud-storage-dpe
-/google-cloud-talent*/.              @googleapis/ruby-team yoshi-approver @googleapis/ml-apis
-/google-cloud-text_to_speech*/.      @googleapis/ruby-team yoshi-approver @googleapis/ml-apis
-/google-cloud-translate*/.           @googleapis/ruby-team yoshi-approver @googleapis/ml-apis
-/google-cloud-video_intelligence*/.  @googleapis/ruby-team yoshi-approver @googleapis/ml-apis
-/google-cloud-vision*/.              @googleapis/ruby-team yoshi-approver @googleapis/ml-apis
-/google-cloud-secret_manager*/.      @googleapis/ruby-team @yoshi-approver @GoogleCloudPlatform/cloud-secrets-team
+/google-cloud-bigquery*/.            @googleapis/ruby-team @yoshi-approver @googleapis/api-bigquery
+/google-cloud-bigtable*/.            @googleapis/ruby-team @yoshi-approver @googleapis/api-bigtable-sdk
+/google-cloud-datastore*/.           @googleapis/ruby-team @yoshi-approver @googleapis/api-datastore-sdk
+/google-cloud-firestore*/.           @googleapis/ruby-team @yoshi-approver @googleapis/api-firestore-sdk
+/google-cloud-pubsub*/.              @googleapis/ruby-team @yoshi-approver @googleapis/api-pubsub
+/google-cloud-storage/               @googleapis/ruby-team @yoshi-approver @googleapis/cloud-storage-dpe


### PR DESCRIPTION
Fixed some issues with CODEOWNERS:

* Syntax error specifying the yoshi-approver user.
* Removed a bunch of lines referencing defunct teams or teams outside the org.
* Switched some teams to the current (mostly teamsync-ed) versions.