### PR TITLE
chore: Switch to using Ruby-based release reporter

### DIFF
--- a/.kokoro/release.sh
+++ b/.kokoro/release.sh
@@ -8,6 +8,4 @@ export GEM_HOME=$HOME/.gem
 export PATH=$GEM_HOME/bin:$PATH
 
 gem install --no-document toys
-toys release install-python-tools -v
-python3 -m releasetool publish-reporter-script > /tmp/publisher-script; source /tmp/publisher-script
-toys release perform -v --force-republish --enable-docs --enable-rad < /dev/null
+toys release perform -v --reporter-org=googleapis --force-republish --enable-docs --enable-rad < /dev/null


### PR DESCRIPTION
Depends on https://github.com/googleapis/ruby-common-tools/pull/353