### PR TITLE
tests: Fixes for scheduler sample tests

### DIFF
--- a/google-cloud-scheduler/samples/Gemfile
+++ b/google-cloud-scheduler/samples/Gemfile
@@ -24,6 +24,7 @@ gem "sinatra"
 group :test do
   gem "google-style", "~> 1.25.1"
   gem "minitest", "~> 5.14"
+  gem "minitest-focus", "~> 1.4"
   gem "rack-test"
   gem "rake"
 end

--- a/google-cloud-scheduler/samples/acceptance/sample_server_test.rb
+++ b/google-cloud-scheduler/samples/acceptance/sample_server_test.rb
@@ -17,6 +17,7 @@
 require_relative "../app"
 
 require "minitest/autorun"
+require "minitest/focus"
 require "rack/test"
 
 # Test the Sinatra server for the Cloud Scheduler sample.

--- a/google-cloud-scheduler/samples/app.rb
+++ b/google-cloud-scheduler/samples/app.rb
@@ -19,6 +19,8 @@ $stdout.sync = true
 # [START cloudscheduler_app]
 require "sinatra"
 
+set :environment, :production
+
 # Define relative URI for job endpoint
 post "/log_payload" do
   # Log the request payload


### PR DESCRIPTION
Workaround for a change that appeared in recent versions of Sinatra. Also added minitest-focus to the Gemfile so we have that facility available when debugging.