### PR TITLE
feat(secretmanager): add annotation and label samples

### DIFF
--- a/google-cloud-secret_manager/samples/acceptance/create_regional_secret_with_annotations_test.rb
+++ b/google-cloud-secret_manager/samples/acceptance/create_regional_secret_with_annotations_test.rb
@@ -1,0 +1,29 @@
+# Copyright 2025 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "uri"
+
+require_relative "regional_helper"
+
+describe "#create_regional_secret_with_annotations", :regional_secret_manager_snippet do
+  it "creates a regional secret with annotations" do
+    sample = SampleLoader.load "create_regional_secret_with_annotations.rb"
+
+    out, _err = capture_io do
+      sample.run project_id: project_id, location_id: location_id, secret_id: secret_id, annotation_key: annotation_key, annotation_value: annotation_value
+    end
+    secret_id_regex = Regexp.escape secret_id
+    assert_match %r{Created regional secret with annotations: projects/\S+locations/\S+/secrets/#{secret_id_regex}}, out
+  end
+end

--- a/google-cloud-secret_manager/samples/acceptance/create_regional_secret_with_labels_test.rb
+++ b/google-cloud-secret_manager/samples/acceptance/create_regional_secret_with_labels_test.rb
@@ -1,0 +1,29 @@
+# Copyright 2025 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "uri"
+
+require_relative "regional_helper"
+
+describe "#create_regional_secret_with_labels", :regional_secret_manager_snippet do
+  it "creates a regional secret with labels" do
+    sample = SampleLoader.load "create_regional_secret_with_labels.rb"
+
+    out, _err = capture_io do
+      sample.run project_id: project_id, location_id: location_id, secret_id: secret_id, label_key: label_key, label_value: label_value
+    end
+    secret_id_regex = Regexp.escape secret_id
+    assert_match %r{Created regional secret with labels: projects/\S+locations/\S+/secrets/#{secret_id_regex}}, out
+  end
+end

--- a/google-cloud-secret_manager/samples/acceptance/create_secret_with_annotations_test.rb
+++ b/google-cloud-secret_manager/samples/acceptance/create_secret_with_annotations_test.rb
@@ -1,0 +1,29 @@
+# Copyright 2025 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "uri"
+
+require_relative "helper"
+
+describe "#create_secret_with_annotations", :secret_manager_snippet do
+  it "creates a secret with annotations" do
+    sample = SampleLoader.load "create_secret_with_annotations.rb"
+
+    out, _err = capture_io do
+      sample.run project_id: project_id, secret_id: secret_id, annotation_key: annotation_key, annotation_value: annotation_value
+    end
+    secret_id_regex = Regexp.escape secret_id
+    assert_match %r{Created secret: projects/\S+/secrets/#{secret_id_regex}}, out
+  end
+end

--- a/google-cloud-secret_manager/samples/acceptance/create_secret_with_labels_test.rb
+++ b/google-cloud-secret_manager/samples/acceptance/create_secret_with_labels_test.rb
@@ -1,0 +1,29 @@
+# Copyright 2025 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "uri"
+
+require_relative "helper"
+
+describe "#create_secret_with_labels", :secret_manager_snippet do
+  it "creates a secret with labels" do
+    sample = SampleLoader.load "create_secret_with_labels.rb"
+
+    out, _err = capture_io do
+      sample.run project_id: project_id, secret_id: secret_id, label_key: label_key, label_value: label_value
+    end
+    secret_id_regex = Regexp.escape secret_id
+    assert_match %r{Created secret with label: projects/\S+/secrets/#{secret_id_regex}}, out
+  end
+end

--- a/google-cloud-secret_manager/samples/acceptance/edit_regional_secret_annotations_test.rb
+++ b/google-cloud-secret_manager/samples/acceptance/edit_regional_secret_annotations_test.rb
@@ -1,0 +1,32 @@
+# Copyright 2025 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "uri"
+
+require_relative "regional_helper"
+
+describe "#edit_regional_secret_annotations", :regional_secret_manager_snippet do
+  it "edits a regional secret annotations" do
+    sample = SampleLoader.load "edit_regional_secret_annotations.rb"
+
+    refute_nil secret
+
+    out, _err = capture_io do
+      sample.run project_id: project_id, location_id: location_id, secret_id: secret_id, annotation_key: updated_annotation_key, annotation_value: updated_annotation_value
+    end
+
+    assert_match(/Updated regional secret/, out)
+    assert_match(/New updated annotations/, out)
+  end
+end

--- a/google-cloud-secret_manager/samples/acceptance/edit_secret_annotations_test.rb
+++ b/google-cloud-secret_manager/samples/acceptance/edit_secret_annotations_test.rb
@@ -1,0 +1,32 @@
+# Copyright 2025 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "uri"
+
+require_relative "helper"
+
+describe "#edit_secret_annotations", :secret_manager_snippet do
+  it "edits the secret annotations" do
+    sample = SampleLoader.load "edit_secret_annotations.rb"
+
+    refute_nil secret
+
+    out, _err = capture_io do
+      sample.run project_id: project_id, secret_id: secret_id, annotation_key: updated_annotation_key, annotation_value: updated_annotation_value
+    end
+
+    assert_match(/Updated secret/, out)
+    assert_match(/New updated annotations/, out)
+  end
+end

--- a/google-cloud-secret_manager/samples/acceptance/helper.rb
+++ b/google-cloud-secret_manager/samples/acceptance/helper.rb
@@ -29,6 +29,15 @@ class SecretManagerSnippetSpec < Minitest::Spec
 
   let(:iam_user) { "user:sethvargo@google.com" }
 
+  let(:annotation_key) { "annotation-key" }
+  let(:annotation_value) { "annotation-value" }
+
+  let(:updated_annotation_key) { "updated-annotation-key" }
+  let(:updated_annotation_value) { "updated-annotation-value" }
+
+  let(:label_key) { "label-key" }
+  let(:label_value) { "label-value" }
+
   let :secret do
     client.create_secret(
       parent:    "projects/#{project_id}",
@@ -36,6 +45,12 @@ class SecretManagerSnippetSpec < Minitest::Spec
       secret:    {
         replication: {
           automatic: {}
+        },
+        annotations: {
+          annotation_key => annotation_value
+        },
+        labels: {
+          label_key => label_value
         }
       }
     )

--- a/google-cloud-secret_manager/samples/acceptance/regional_helper.rb
+++ b/google-cloud-secret_manager/samples/acceptance/regional_helper.rb
@@ -27,6 +27,15 @@ class RegionalSecretManagerSnippetSpec < Minitest::Spec
   let(:api_endpoint) { "secretmanager.#{location_id}.rep.googleapis.com" }
   let(:filter) { "name : ruby-quickstart-" }
 
+  let(:annotation_key) { "annotation-key" }
+  let(:annotation_value) { "annotation-value" }
+
+  let(:updated_annotation_key) { "updated-annotation-key" }
+  let(:updated_annotation_value) { "updated-annotation-value" }
+
+  let(:label_key) { "label-key" }
+  let(:label_value) { "label-value" }
+
   let :client do
     Google::Cloud::SecretManager.secret_manager_service do |config|
       config.endpoint = api_endpoint
@@ -41,7 +50,14 @@ class RegionalSecretManagerSnippetSpec < Minitest::Spec
     client.create_secret(
       parent:    "projects/#{project_id}/locations/#{location_id}",
       secret_id: secret_id,
-      secret:    {}
+      secret:    {
+        annotations: {
+          annotation_key => annotation_value
+        },
+        labels: {
+          label_key => label_value
+        }
+      }
     )
   end
 

--- a/google-cloud-secret_manager/samples/acceptance/regional_snippets_test.rb
+++ b/google-cloud-secret_manager/samples/acceptance/regional_snippets_test.rb
@@ -33,11 +33,27 @@ describe "Secret Manager Regional Snippets" do
   let(:secret_name) { "projects/#{project_id}/locations/#{location_id}/secrets/#{secret_id}" }
   let(:iam_user) { "user:sarafy@google.com" }
 
+  let(:annotation_key) { "annotation-key" }
+  let(:annotation_value) { "annotation-value" }
+
+  let(:updated_annotation_key) { "updated-annotation-key" }
+  let(:updated_annotation_value) { "updated-annotation-value" }
+
+  let(:label_key) { "label-key" }
+  let(:label_value) { "label-value" }
+
   let :secret do
     client.create_secret(
       parent:    "projects/#{project_id}/locations/#{location_id}",
       secret_id: secret_id,
-      secret:    {}
+      secret:    {
+        annotations: {
+          annotation_key => annotation_value
+        },
+        labels: {
+          label_key => label_value
+        }
+      }
     )
   end
 
@@ -464,6 +480,96 @@ describe "Secret Manager Regional Snippets" do
         expect(n_secret).wont_be_nil
         expect(n_secret.version_aliases["test"]).must_equal(1)
       }.must_output(/Updated regional secret/)
+    end
+  end
+
+  describe "#create_regional_secret_with_annotations" do
+    it "create regional secret with annotations" do
+      expect {
+        secret = create_regional_secret_with_annotations(
+          project_id: project_id,
+          location_id: location_id,
+          secret_id:  secret_id,
+          annotation_key: annotation_key,
+          annotation_value: annotation_value
+        )
+
+        expect(secret).wont_be_nil
+        expect(secret.name).must_include(secret_id)
+        expect(secret.annotations[annotation_key]).must_equal(annotation_value)
+      }.must_output(/Created regional secret/)
+    end
+  end
+
+  describe "#create_regional_secret_with_labels" do
+    it "create regional secret with labels" do
+      expect {
+        secret = create_regional_secret_with_labels(
+          project_id: project_id,
+          location_id: location_id,
+          secret_id:  secret_id,
+          label_key: label_key,
+          label_value: label_value
+        )
+
+        expect(secret).wont_be_nil
+        expect(secret.name).must_include(secret_id)
+        expect(secret.labels[label_key]).must_equal(label_value)
+      }.must_output(/Created regional secret with label/)
+    end
+  end
+
+  describe "#edit_regional_secret_annotations" do
+    it "edit regional secret annotations" do
+      expect(secret).wont_be_nil
+
+      expect {
+        n_secret = edit_regional_secret_annotations(
+          project_id: project_id,
+          location_id: location_id,
+          secret_id:  secret_id,
+          annotation_key: updated_annotation_key,
+          annotation_value: updated_annotation_value
+        )
+
+        expect(n_secret).wont_be_nil
+        expect(n_secret.name).must_include(secret_id)
+        expect(n_secret.annotations[updated_annotation_key]).must_equal(updated_annotation_value)
+      }.must_output(/Updated regional secret/)
+    end
+  end
+
+  describe "#view_regional_secret_annotations" do
+    it "view regional secret annotations" do
+      expect(secret).wont_be_nil
+
+      expect {
+        secret_annotations = view_regional_secret_annotations(
+          project_id: project_id,
+          location_id: location_id,
+          secret_id:  secret_id
+        )
+
+        expect(secret_annotations).wont_be_nil
+        expect(secret_annotations[annotation_key]).must_equal(annotation_value)
+      }.must_output(/Annotation Key: #{annotation_key}, Annotation Value: #{annotation_value}/)
+    end
+  end
+
+  describe "#view_regional_secret_labels" do
+    it "view regional secret labels" do
+      expect(secret).wont_be_nil
+
+      expect {
+        secret_labels = view_regional_secret_labels(
+          project_id: project_id,
+          location_id: location_id,
+          secret_id:  secret_id
+        )
+
+        expect(secret_labels).wont_be_nil
+        expect(secret_labels[label_key]).must_equal(label_value)
+      }.must_output(/Label Key: #{label_key}, Label Value: #{label_value}/)
     end
   end
 end

--- a/google-cloud-secret_manager/samples/acceptance/snippets_test.rb
+++ b/google-cloud-secret_manager/samples/acceptance/snippets_test.rb
@@ -26,6 +26,15 @@ describe "Secret Manager Snippets" do
 
   let(:iam_user) { "user:sethvargo@google.com" }
 
+  let(:annotation_key) { "annotation-key" }
+  let(:annotation_value) { "annotation-value" }
+
+  let(:updated_annotation_key) { "updated-annotation-key" }
+  let(:updated_annotation_value) { "updated-annotation-value" }
+
+  let(:label_key) { "label-key" }
+  let(:label_value) { "label-value" }
+
   let :secret do
     client.create_secret(
       parent:    "projects/#{project_id}",
@@ -33,6 +42,12 @@ describe "Secret Manager Snippets" do
       secret:    {
         replication: {
           automatic: {}
+        },
+        annotations: {
+          annotation_key => annotation_value
+        },
+        labels: {
+          label_key => label_value
         }
       }
     )
@@ -328,6 +343,91 @@ describe "Secret Manager Snippets" do
         expect(n_secret).wont_be_nil
         expect(n_secret.version_aliases["test"]).must_equal(1)
       }.must_output(/Updated secret/)
+    end
+  end
+
+  describe "#create_secret_with_annotations" do
+    it "create secret with annotations" do
+      expect {
+        secret = create_secret_with_annotations(
+          project_id:       project_id,
+          secret_id:        secret_id,
+          annotation_key:   annotation_key,
+          annotation_value: annotation_value
+        )
+
+        expect(secret).wont_be_nil
+        expect(secret.name).must_include(secret_id)
+        expect(secret.annotations[annotation_key]).must_equal(annotation_value)
+      }.must_output(/Created secret/)
+    end
+  end
+
+  describe "#create_secret_with_labels" do
+    it "create secret with labels" do
+      expect {
+        secret = create_secret_with_labels(
+          project_id:  project_id,
+          secret_id:   secret_id,
+          label_key:   label_key,
+          label_value: label_value
+        )
+
+        expect(secret).wont_be_nil
+        expect(secret.name).must_include(secret_id)
+        expect(secret.labels[label_key]).must_equal(label_value)
+      }.must_output(/Created secret with labels/)
+    end
+  end
+
+  describe "#edit_secret_annotations" do
+    it "edit secret annotations" do
+      expect(secret).wont_be_nil
+
+      expect {
+        n_secret = edit_secret_annotations(
+          project_id:       project_id,
+          secret_id:        secret_id,
+          annotation_key:   updated_annotation_key,
+          annotation_value: updated_annotation_value
+        )
+
+        expect(n_secret).wont_be_nil
+        expect(n_secret.name).must_include(secret_id)
+        expect(n_secret.annotations[updated_annotation_key]).must_equal(updated_annotation_value)
+      }.must_output(/Updated secret/)
+    end
+  end
+
+  describe "#view_secret_annotations" do
+    it "view secret annotations" do
+      expect(secret).wont_be_nil
+
+      expect {
+        secret_annotations = view_secret_annotations(
+          project_id: project_id,
+          secret_id:  secret_id
+        )
+
+        expect(secret_annotations).wont_be_nil
+        expect(secret_annotations[annotation_key]).must_equal(annotation_value)
+      }.must_output(/Annotation Key: #{annotation_key}, Annotation Value: #{annotation_value}/)
+    end
+  end
+
+  describe "#view_secret_labels" do
+    it "view secret labels" do
+      expect(secret).wont_be_nil
+
+      expect {
+        secret_labels = view_secret_labels(
+          project_id: project_id,
+          secret_id:  secret_id
+        )
+
+        expect(secret_labels).wont_be_nil
+        expect(secret_labels[label_key]).must_equal(label_value)
+      }.must_output(/Label Key: #{label_key}, Label Value: #{label_value}/)
     end
   end
 end

--- a/google-cloud-secret_manager/samples/acceptance/view_regional_secret_annotations_test.rb
+++ b/google-cloud-secret_manager/samples/acceptance/view_regional_secret_annotations_test.rb
@@ -1,0 +1,32 @@
+# Copyright 2025 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "uri"
+
+require_relative "regional_helper"
+
+describe "#view_regional_secret_annotations", :regional_secret_manager_snippet do
+  it "views a regional secret annotations" do
+    sample = SampleLoader.load "view_regional_secret_annotations.rb"
+
+    refute_nil secret
+
+    out, _err = capture_io do
+      sample.run project_id: project_id, location_id: location_id, secret_id: secret_id
+    end
+
+    assert_match(/Regional Secret/, out)
+    assert_match(/Annotation Key: #{Regexp.escape annotation_key}, Annotation Value: #{Regexp.escape annotation_value}/, out)
+  end
+end

--- a/google-cloud-secret_manager/samples/acceptance/view_regional_secret_labels_test.rb
+++ b/google-cloud-secret_manager/samples/acceptance/view_regional_secret_labels_test.rb
@@ -1,0 +1,32 @@
+# Copyright 2025 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "uri"
+
+require_relative "regional_helper"
+
+describe "#view_regional_secret_labels", :regional_secret_manager_snippet do
+  it "views a regional secret labels" do
+    sample = SampleLoader.load "view_regional_secret_labels.rb"
+
+    refute_nil secret
+
+    out, _err = capture_io do
+      sample.run project_id: project_id, location_id: location_id, secret_id: secret_id
+    end
+
+    assert_match(/Regional Secret/, out)
+    assert_match(/Label Key: #{Regexp.escape label_key}, Label Value: #{Regexp.escape label_value}/, out)
+  end
+end

--- a/google-cloud-secret_manager/samples/acceptance/view_secret_annotations_test.rb
+++ b/google-cloud-secret_manager/samples/acceptance/view_secret_annotations_test.rb
@@ -1,0 +1,32 @@
+# Copyright 2025 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "uri"
+
+require_relative "helper"
+
+describe "#view_secret_annotations", :secret_manager_snippet do
+  it "view the secret annotations" do
+    sample = SampleLoader.load "view_secret_annotations.rb"
+
+    refute_nil secret
+
+    out, _err = capture_io do
+      sample.run project_id: project_id, secret_id: secret_id
+    end
+
+    assert_match(/Secret/, out)
+    assert_match(/Annotation Key: #{Regexp.escape annotation_key}, Annotation Value: #{Regexp.escape annotation_value}/, out)
+  end
+end

--- a/google-cloud-secret_manager/samples/acceptance/view_secret_labels_test.rb
+++ b/google-cloud-secret_manager/samples/acceptance/view_secret_labels_test.rb
@@ -1,0 +1,32 @@
+# Copyright 2025 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "uri"
+
+require_relative "helper"
+
+describe "#view_secret_labels", :secret_manager_snippet do
+  it "view the secret labels" do
+    sample = SampleLoader.load "view_secret_labels.rb"
+
+    refute_nil secret
+
+    out, _err = capture_io do
+      sample.run project_id: project_id, secret_id: secret_id
+    end
+
+    assert_match(/Secret/, out)
+    assert_match(/Label Key: #{Regexp.escape label_key}, Label Value: #{Regexp.escape label_value}/, out)
+  end
+end

--- a/google-cloud-secret_manager/samples/create_regional_secret_with_annotations.rb
+++ b/google-cloud-secret_manager/samples/create_regional_secret_with_annotations.rb
@@ -1,0 +1,53 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START secretmanager_create_regional_secret_with_annotations]
+require "google/cloud/secret_manager"
+
+##
+# Create a regional secret with annotations
+#
+# @param project_id [String] Your Google Cloud project (e.g. "my-project")
+# @param location_id [String] Your Google Cloud location (e.g. "us-west1")
+# @param secret_id [String] Your secret name (e.g. "my-secret")
+# @param annotation_key [String] Your annotation key (e.g. "my-annotation-key")
+# @param annotation_value [String] Your annotation value (e.g "my-annotation-value")
+#
+def create_regional_secret_with_annotations project_id:, location_id:, secret_id:, annotation_key:, annotation_value:
+  # Endpoint for the regional secret manager service.
+  api_endpoint = "secretmanager.#{location_id}.rep.googleapis.com"
+
+  # Create the Secret Manager client.
+  client = Google::Cloud::SecretManager.secret_manager_service do |config|
+    config.endpoint = api_endpoint
+  end
+
+  # Build the resource name of the parent project.
+  parent = client.location_path project: project_id, location: location_id
+
+  # Create the secret.
+  secret = client.create_secret(
+    parent:    parent,
+    secret_id: secret_id,
+    secret: {
+      annotations: {
+        annotation_key => annotation_value
+      }
+    }
+  )
+
+  # Print the new secret name.
+  puts "Created regional secret with annotations: #{secret.name}"
+end
+# [END secretmanager_create_regional_secret_with_annotations]

--- a/google-cloud-secret_manager/samples/create_regional_secret_with_labels.rb
+++ b/google-cloud-secret_manager/samples/create_regional_secret_with_labels.rb
@@ -1,0 +1,53 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START secretmanager_create_regional_secret_with_labels]
+require "google/cloud/secret_manager"
+
+##
+# Create a regional secret with labels
+#
+# @param project_id [String] Your Google Cloud project (e.g. "my-project")
+# @param location_id [String] Your Google Cloud location (e.g. "us-west1")
+# @param secret_id [String] Your secret name (e.g. "my-secret")
+# @param label_key [String] Your label key (e.g. "my-label-key")
+# @param label_value [String] Your label value (e.g "my-label-value")
+#
+def create_regional_secret_with_labels project_id:, location_id:, secret_id:, label_key:, label_value:
+  # Endpoint for the regional secret manager service.
+  api_endpoint = "secretmanager.#{location_id}.rep.googleapis.com"
+
+  # Create the Secret Manager client.
+  client = Google::Cloud::SecretManager.secret_manager_service do |config|
+    config.endpoint = api_endpoint
+  end
+
+  # Build the resource name of the parent project.
+  parent = client.location_path project: project_id, location: location_id
+
+  # Create the secret.
+  secret = client.create_secret(
+    parent:    parent,
+    secret_id: secret_id,
+    secret: {
+      labels: {
+        label_key => label_value
+      }
+    }
+  )
+
+  # Print the new secret name.
+  puts "Created regional secret with labels: #{secret.name}"
+end
+# [END secretmanager_create_regional_secret_with_labels]

--- a/google-cloud-secret_manager/samples/create_secret_with_annotations.rb
+++ b/google-cloud-secret_manager/samples/create_secret_with_annotations.rb
@@ -1,0 +1,50 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START secretmanager_create_secret_with_annotations]
+require "google/cloud/secret_manager"
+
+##
+# Create a secret with annotation.
+#
+# @param project_id [String] Your Google Cloud project (e.g. "my-project")
+# @param secret_id [String] Your secret name (e.g. "my-secret")
+# @param annotation_key [String] Your annotation key (e.g. "my-annotation-key")
+# @param annotation_value [String] Your annotation value (e.g. "my-annotation-value")
+#
+def create_secret_with_annotations project_id:, secret_id:, annotation_key:, annotation_value:
+  # Create a Secret Manager client.
+  client = Google::Cloud::SecretManager.secret_manager_service
+
+  # Build the resource name of the parent project.
+  parent = client.project_path project: project_id
+
+  # Create the secret.
+  secret = client.create_secret(
+    parent:    parent,
+    secret_id: secret_id,
+    secret:    {
+      replication: {
+        automatic: {}
+      },
+      annotations: {
+        annotation_key => annotation_value
+      }
+    }
+  )
+
+  # Print the new secret name.
+  puts "Created secret: #{secret.name}"
+end
+# [END secretmanager_create_secret_with_annotations]

--- a/google-cloud-secret_manager/samples/create_secret_with_labels.rb
+++ b/google-cloud-secret_manager/samples/create_secret_with_labels.rb
@@ -1,0 +1,50 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START secretmanager_create_secret_with_labels]
+require "google/cloud/secret_manager"
+
+##
+# Create a secret with labels.
+#
+# @param project_id [String] Your Google Cloud project (e.g. "my-project")
+# @param secret_id [String] Your secret name (e.g. "my-secret")
+# @param label_key [String] Your label key (e.g. "my-label-key")
+# @param label_value [String] Your label value (e.g. "my-label-value")
+#
+def create_secret_with_labels project_id:, secret_id:, label_key:, label_value:
+  # Create a Secret Manager client.
+  client = Google::Cloud::SecretManager.secret_manager_service
+
+  # Build the resource name of the parent project.
+  parent = client.project_path project: project_id
+
+  # Create the secret.
+  secret = client.create_secret(
+    parent:    parent,
+    secret_id: secret_id,
+    secret:    {
+      replication: {
+        automatic: {}
+      },
+      labels: {
+        label_key => label_value
+      }
+    }
+  )
+
+  # Print the new secret name.
+  puts "Created secret with label: #{secret.name}"
+end
+# [END secretmanager_create_secret_with_labels]

--- a/google-cloud-secret_manager/samples/edit_regional_secret_annotations.rb
+++ b/google-cloud-secret_manager/samples/edit_regional_secret_annotations.rb
@@ -1,0 +1,63 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START secretmanager_edit_regional_secret_annotations]
+require "google/cloud/secret_manager"
+
+##
+# Edit a regional secret annotations
+#
+# @param project_id [String] Your Google Cloud project (e.g. "my-project")
+# @param location_id [String] Your Google Cloud location (e.g. "us-west11")
+# @param secret_id [String] Your secret name (e.g. "my-secret")
+# @param annotation_key [String] Your annotation key (e.g. "my-annotation-key")
+# @param annotation_value [String] Your annotation value (e.g. "my-annotation-value")
+#
+def edit_regional_secret_annotations project_id:, location_id:, secret_id:, annotation_key:, annotation_value:
+  # Endpoint for the regional secret manager service.
+  api_endpoint = "secretmanager.#{location_id}.rep.googleapis.com"
+
+  # Create the Secret Manager client.
+  client = Google::Cloud::SecretManager.secret_manager_service do |config|
+    config.endpoint = api_endpoint
+  end
+
+  # Build the resource name of the secret.
+  name = client.secret_path project: project_id, location: location_id, secret: secret_id
+
+  # Get the existing secret.
+  existing_secret = client.get_secret name: name
+
+  # Get the existing secret's annotations.
+  existing_secret_annotations = existing_secret.annotations.to_h
+
+  # Add a new annotation key and value.
+  existing_secret_annotations[annotation_key] = annotation_value
+
+  # Updates the secret.
+  secret = client.update_secret(
+    secret: {
+      name: name,
+      annotations: existing_secret_annotations
+    },
+    update_mask: {
+      paths: ["annotations"]
+    }
+  )
+
+  # Print the updated secret name and annotations.
+  puts "Updated regional secret: #{secret.name}"
+  puts "New updated annotations: #{secret.annotations}"
+end
+# [END secretmanager_edit_regional_secret_annotations]

--- a/google-cloud-secret_manager/samples/edit_secret_annotations.rb
+++ b/google-cloud-secret_manager/samples/edit_secret_annotations.rb
@@ -1,0 +1,57 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START secretmanager_edit_secret_annotations]
+require "google/cloud/secret_manager"
+
+##
+# Edits a secret annotations.
+#
+# @param project_id [String] Your Google Cloud project (e.g. "my-project")
+# @param secret_id [String] Your secret name (e.g. "my-secret")
+# @param annotation_key [String] Your annotation key (e.g. "my-annotation-key")
+# @param annotation_value [String] Your annotation value (e.g. "my-annotation-value")
+#
+def edit_secret_annotations project_id:, secret_id:, annotation_key:, annotation_value:
+  # Create a Secret Manager client.
+  client = Google::Cloud::SecretManager.secret_manager_service
+
+  # Build the resource name of the secret.
+  name = client.secret_path project: project_id, secret: secret_id
+
+  # Get the existing secret.
+  existing_secret = client.get_secret name: name
+
+  # Get the existing secret's annotations.
+  existing_secret_annotations = existing_secret.annotations.to_h
+
+  # Add a new annotation key and value.
+  existing_secret_annotations[annotation_key] = annotation_value
+
+  # Updates the secret.
+  secret = client.update_secret(
+    secret: {
+      name: name,
+      annotations: existing_secret_annotations
+    },
+    update_mask: {
+      paths: ["annotations"]
+    }
+  )
+
+  # Print the updated secret name and annotations.
+  puts "Updated secret: #{secret.name}"
+  puts "New updated annotations: #{secret.annotations}"
+end
+# [END secretmanager_edit_secret_annotations]

--- a/google-cloud-secret_manager/samples/regional_snippets.rb
+++ b/google-cloud-secret_manager/samples/regional_snippets.rb
@@ -121,6 +121,86 @@ def create_regional_secret project_id:, location_id:, secret_id:
   secret
 end
 
+def create_regional_secret_with_annotations project_id:, location_id:, secret_id:, annotation_key:, annotation_value:
+  # [START secretmanager_create_regional_secret_with_annotations]
+  # project_id       = "YOUR-GOOGLE-CLOUD-PROJECT"  # (e.g. "my-project")
+  # location_id      = "YOUR-GOOGLE-CLOUD-LOCATION" # (e.g. "us-west1")
+  # secret_id        = "YOUR-SECRET-ID"             # (e.g. "my-secret")
+  # annotation_key   = "YOUR-ANNOTATION-KEY"        # (e.g. "my-annotation-key")
+  # annotation_value = "YOUR-ANNOTATION-VALUE"      # (e.g. "my-annotation-value")
+
+  # Require the Secret Manager client library.
+  require "google/cloud/secret_manager"
+
+  # Endpoint for the regional secret manager service.
+  api_endpoint = "secretmanager.#{location_id}.rep.googleapis.com"
+
+  # Create the Secret Manager client.
+  client = Google::Cloud::SecretManager.secret_manager_service do |config|
+    config.endpoint = api_endpoint
+  end
+
+  # Build the resource name of the parent project.
+  parent = client.location_path project: project_id, location: location_id
+
+  # Create the secret.
+  secret = client.create_secret(
+    parent:    parent,
+    secret_id: secret_id,
+    secret: {
+      annotations: {
+        annotation_key => annotation_value
+      }
+    }
+  )
+
+  # Print the new secret name.
+  puts "Created regional secret with annotations: #{secret.name}"
+  # [END secretmanager_create_regional_secret_with_annotations]
+
+  secret
+end
+
+def create_regional_secret_with_labels project_id:, location_id:, secret_id:, label_key:, label_value:
+  # [START secretmanager_create_regional_secret_with_labels]
+  # project_id  = "YOUR-GOOGLE-CLOUD-PROJECT"  # (e.g. "my-project")
+  # location_id = "YOUR-GOOGLE-CLOUD-LOCATION" # (e.g. "us-west1")
+  # secret_id   = "YOUR-SECRET-ID"             # (e.g. "my-secret")
+  # label_key   = "YOUR-LABEL-KEY"             # (e.g. "my-label-key")
+  # label_value = "YOUR-LABEL-VALUE"           # (e.g. "my-label-value")
+
+  # Require the Secret Manager client library.
+  require "google/cloud/secret_manager"
+
+  # Endpoint for the regional secret manager service.
+  api_endpoint = "secretmanager.#{location_id}.rep.googleapis.com"
+
+  # Create the Secret Manager client.
+  client = Google::Cloud::SecretManager.secret_manager_service do |config|
+    config.endpoint = api_endpoint
+  end
+
+  # Build the resource name of the parent project.
+  parent = client.location_path project: project_id, location: location_id
+
+  # Create the secret.
+  secret = client.create_secret(
+    parent:    parent,
+    secret_id: secret_id,
+    secret: {
+      labels: {
+        label_key => label_value
+      }
+    }
+  )
+
+  # Print the new secret name.
+  puts "Created regional secret with label: #{secret.name}"
+  # [END secretmanager_create_regional_secret_with_labels]
+
+  secret
+end
+
 def delete_regional_secret_with_etag project_id:, location_id:, secret_id:, etag:
   # [START secretmanager_delete_regional_secret_with_etag]
   # project_id  = "YOUR-GOOGLE-CLOUD-PROJECT"  # (e.g. "my-project")
@@ -397,6 +477,56 @@ def enable_regional_secret_version project_id:, location_id:, secret_id:, versio
   # [END secretmanager_enable_regional_secret_version]
 
   response
+end
+
+def edit_regional_secret_annotations project_id:, location_id:, secret_id:, annotation_key:, annotation_value:
+  # [START secretmanager_edit_regional_secret_annotations]
+  # project_id       = "YOUR-GOOGLE-CLOUD-PROJECT"  # (e.g. "my-project")
+  # location_id      = "YOUR-GOOGLE-CLOUD-LOCATION" # (e.g. "us-west1")
+  # secret_id        = "YOUR-SECRET-ID"             # (e.g. "my-secret")
+  # annotation_key   = "YOUR-ANNOTATION-KEY"        # (e.g. "my-annotation-key")
+  # annotation_value = "YOUR-ANNOTATION-VALUE"      # (e.g. "my-annotation-value")
+
+  # Require the Secret Manager client library.
+  require "google/cloud/secret_manager"
+
+  # Endpoint for the regional secret manager service.
+  api_endpoint = "secretmanager.#{location_id}.rep.googleapis.com"
+
+  # Create the Secret Manager client.
+  client = Google::Cloud::SecretManager.secret_manager_service do |config|
+    config.endpoint = api_endpoint
+  end
+
+  # Build the resource name of the secret.
+  name = client.secret_path project: project_id, location: location_id, secret: secret_id
+
+  # Get the existing secret.
+  existing_secret = client.get_secret name: name
+
+  # Get the existing secret's annotations.
+  existing_secret_annotations = existing_secret.annotations.to_h
+
+  # Add a new annotation key and value.
+  existing_secret_annotations[annotation_key] = annotation_value
+
+  # Updates the secret.
+  secret = client.update_secret(
+    secret: {
+      name: name,
+      annotations: existing_secret_annotations
+    },
+    update_mask: {
+      paths: ["annotations"]
+    }
+  )
+
+  # Print the updated secret name and annotations.
+  puts "Updated regional secret: #{secret.name}"
+  puts "New updated annotations: #{secret.annotations}"
+  # [END secretmanager_edit_regional_secret_annotations]
+
+  secret
 end
 
 def get_regional_secret project_id:, location_id:, secret_id:
@@ -795,6 +925,76 @@ def update_regional_secret_with_etag project_id:, location_id:, secret_id:, etag
   secret
 end
 
+def view_regional_secret_annotations project_id:, location_id:, secret_id:
+  # [START secretmanager_view_regional_secret_annotations]
+  # project_id  = "YOUR-GOOGLE-CLOUD-PROJECT"  # (e.g. "my-project")
+  # location_id = "YOUR-GOOGLE-CLOUD-LOCATION" # (e.g. "us-west1")
+  # secret_id   = "YOUR-SECRET-ID"             # (e.g. "my-secret")
+
+  # Require the Secret Manager client library.
+  require "google/cloud/secret_manager"
+
+  # Endpoint for the regional secret manager service.
+  api_endpoint = "secretmanager.#{location_id}.rep.googleapis.com"
+
+  # Create the Secret Manager client.
+  client = Google::Cloud::SecretManager.secret_manager_service do |config|
+    config.endpoint = api_endpoint
+  end
+
+  # Build the resource name of the secret.
+  name = client.secret_path project: project_id, location: location_id, secret: secret_id
+
+  # Get the existing secret.
+  existing_secret = client.get_secret name: name
+
+  # Get the existing secret's annotations.
+  existing_secret_annotations = existing_secret.annotations.to_h
+
+  # Print the secret annotations.
+  existing_secret_annotations.each do |key, value|
+    puts "Annotation Key: #{key}, Annotation Value: #{value}"
+  end
+  # [END secretmanager_view_regional_secret_annotations]
+
+  existing_secret_annotations
+end
+
+def view_regional_secret_labels project_id:, location_id:, secret_id:
+  # [START secretmanager_view_regional_secret_labels]
+  # project_id  = "YOUR-GOOGLE-CLOUD-PROJECT"  # (e.g. "my-project")
+  # location_id = "YOUR-GOOGLE-CLOUD-LOCATION" # (e.g. "us-west1")
+  # secret_id   = "YOUR-SECRET-ID"             # (e.g. "my-secret")
+
+  # Require the Secret Manager client library.
+  require "google/cloud/secret_manager"
+
+  # Endpoint for the regional secret manager service.
+  api_endpoint = "secretmanager.#{location_id}.rep.googleapis.com"
+
+  # Create the Secret Manager client.
+  client = Google::Cloud::SecretManager.secret_manager_service do |config|
+    config.endpoint = api_endpoint
+  end
+
+  # Build the resource name of the secret.
+  name = client.secret_path project: project_id, location: location_id, secret: secret_id
+
+  # Get the existing secret.
+  existing_secret = client.get_secret name: name
+
+  # Get the existing secret's labels.
+  existing_secret_labels = existing_secret.labels.to_h
+
+  # Print the secret labels.
+  existing_secret_labels.each do |key, value|
+    puts "Label Key: #{key}, Label Value: #{value}"
+  end
+  # [END secretmanager_view_regional_secret_labels]
+
+  existing_secret_labels
+end
+
 if $PROGRAM_NAME == __FILE__
   args    = ARGV.dup
   command = args.shift
@@ -818,6 +1018,22 @@ if $PROGRAM_NAME == __FILE__
       project_id: ENV["GOOGLE_CLOUD_PROJECT"],
       location_id: ENV["GOOGLE_CLOUD_LOCATION"],
       secret_id:  args.shift
+    )
+  when "create_regional_secret_with_annotations"
+    create_regional_secret_with_annotations(
+      project_id: ENV["GOOGLE_CLOUD_PROJECT"],
+      location_id: ENV["GOOGLE_CLOUD_LOCATION"],
+      secret_id:  args.shift,
+      annotation_key: args.shift,
+      annotation_value: args.shift
+    )
+  when "create_regional_secret_with_labels"
+    create_regional_secret_with_labels(
+      project_id: ENV["GOOGLE_CLOUD_PROJECT"],
+      location_id: ENV["GOOGLE_CLOUD_LOCATION"],
+      secret_id:  args.shift,
+      label_key: args.shift,
+      label_value: args.shift
     )
   when "delete_regional_secret_with_etag"
     delete_regional_secret_with_etag(
@@ -846,6 +1062,14 @@ if $PROGRAM_NAME == __FILE__
       location_id: ENV["GOOGLE_CLOUD_LOCATION"],
       secret_id:  args.shift,
       version_id: args.shift
+    )
+  when "edit_regional_secret_annotations"
+    edit_regional_secret_annotations(
+      project_id: ENV["GOOGLE_CLOUD_PROJECT"],
+      location_id: ENV["GOOGLE_CLOUD_LOCATION"],
+      secret_id:  args.shift,
+      annotation_key: args.shift,
+      annotation_value: args.shift
     )
   when "enable_regional_secret_version_with_etag"
     enable_regional_secret_version_with_etag(
@@ -947,33 +1171,50 @@ if $PROGRAM_NAME == __FILE__
       location_id: ENV["GOOGLE_CLOUD_LOCATION"],
       secret_id:  args.shift
     )
+  when "view_regional_secret_anotations"
+    view_regional_secret_annotations(
+      project_id: ENV["GOOGLE_CLOUD_PROJECT"],
+      location_id: ENV["GOOGLE_CLOUD_LOCATION"],
+      secret_id:  args.shift
+    )
+  when "view_regional_secret_lanbels"
+    view_regional_secret_labels(
+      project_id: ENV["GOOGLE_CLOUD_PROJECT"],
+      location_id: ENV["GOOGLE_CLOUD_LOCATION"],
+      secret_id:  args.shift
+    )
   else
     puts <<~USAGE
       Usage: bundle exec ruby #{__FILE__} [command] [arguments]
 
       Commands:
-        access_regional_secret_version <secret> <version>                       Access a regional secret version
-        add_regional_secret_version <secret>                                    Add a new regional secret version
-        create_regional_secret <secret>                                         Create a new regional secret
-        delete_regional_secret_with_etag <secret> <etag>                        Delete an existing regional secret with associated etag
-        delete_regional_secret <secret>                                         Delete an existing regional secret
-        destroy_regional_secret_version_with_etag <secret> <version> <etag>     Destroy a regional secret version
-        destroy_regional_secret_version <secret> <version> <etag>               Destroy a regional secret version
-        disable_regional_secret_version_with_etag <secret> <version> <etag>     Disable a regional secret version
-        disable_regional_secret_version <secret> <version>                      Disable a regional secret version
-        enable_regional_secret_version_with_etag <secret> <version> <etag>      Enable a regional secret version
-        enable_regional_secret_version <secret> <version>                       Enable a regional secret version
-        get_regional_secret <secret>                                            Get a regional secret
-        get_regional_secret_version <secret> <version>                          Get a regional secret version
-        iam_grant_access_regional <secret> <version> <member>                   Grant the member access to the regional secret
-        iam_revoke_access_regional <secret> <version> <member>                  Revoke the member access to the regional secret
-        list_regional_secret_versions_with_filter <secret> <filter>             List all versions for a regional secret
-        list_regional_secret_versions <secret>                                  List all versions for a regional secret
-        list_regional_secrets_with_filter <filter>                              List all  regional secrets
-        list_regional_secrets                                                   List all  regional secrets
-        update_regional_secret_with_alias <secret>                              Update a regional secret
-        update_regional_secret_with_etag <secret> <etag>                        Update a regional secret
-        update_regional_secret <secret>                                         Update a regional secret
+        access_regional_secret_version <secret> <version>                                                    Access a regional secret version
+        add_regional_secret_version <secret>                                                                 Add a new regional secret version
+        create_regional_secret <secret>                                                                      Create a new regional secret
+        create_regional_secret_with_annotations <secret> <key> <value>                                       Create a new regional secret with annotations
+        create_regional_secret_with_labels <secret> <key> <value>                                            Create a new regional secret with labels
+        delete_regional_secret_with_etag <secret> <etag>                                                     Delete an existing regional secret with associated etag
+        delete_regional_secret <secret>                                                                      Delete an existing regional secret
+        destroy_regional_secret_version_with_etag <secret> <version> <etag>                                  Destroy a regional secret version
+        destroy_regional_secret_version <secret> <version> <etag>                                            Destroy a regional secret version
+        disable_regional_secret_version_with_etag <secret> <version> <etag>                                  Disable a regional secret version
+        disable_regional_secret_version <secret> <version>                                                   Disable a regional secret version
+        edit_regional_secret_annotations <secret> <key> <value>                                              Edit a regional secret annotations
+        enable_regional_secret_version_with_etag <secret> <version> <etag>                                   Enable a regional secret version
+        enable_regional_secret_version <secret> <version>                                                    Enable a regional secret version
+        get_regional_secret <secret>                                                                         Get a regional secret
+        get_regional_secret_version <secret> <version>                                                       Get a regional secret version
+        iam_grant_access_regional <secret> <version> <member>                                                Grant the member access to the regional secret
+        iam_revoke_access_regional <secret> <version> <member>                                               Revoke the member access to the regional secret
+        list_regional_secret_versions_with_filter <secret> <filter>                                          List all versions for a regional secret
+        list_regional_secret_versions <secret>                                                               List all versions for a regional secret
+        list_regional_secrets_with_filter <filter>                                                           List all  regional secrets
+        list_regional_secrets                                                                                List all  regional secrets
+        update_regional_secret_with_alias <secret>                                                           Update a regional secret
+        update_regional_secret_with_etag <secret> <etag>                                                     Update a regional secret
+        update_regional_secret <secret>                                                                      Update a regional secret
+        view_regional_secret_annotations <secret>                                                            View a regional secret annotations
+        view_regional_secret_labels <secret>                                                                 View a regional secret labels
 
       Environment variables:
         GOOGLE_CLOUD_PROJECT    ID of the Google Cloud project to run the regional snippets

--- a/google-cloud-secret_manager/samples/snippets.rb
+++ b/google-cloud-secret_manager/samples/snippets.rb
@@ -106,6 +106,80 @@ def create_secret project_id:, secret_id:
   secret
 end
 
+def create_secret_with_annotations project_id:, secret_id:, annotation_key:, annotation_value:
+  # [START secretmanager_create_secret_with_annotations]
+  # project_id       = "YOUR-GOOGLE-CLOUD-PROJECT" # (e.g. "my-project")
+  # secret_id        = "YOUR-SECRET-ID"            # (e.g. "my-secret")
+  # annotation_key   = "YOUR-ANNOTATION-KEY"       # (e.g. "my-annotation-key")
+  # annotation_value = "YOUR-ANNOTATION-VALUE"     # (e.g. "my-annotation-value")
+
+  # Require the Secret Manager client library.
+  require "google/cloud/secret_manager"
+
+  # Create a Secret Manager client.
+  client = Google::Cloud::SecretManager.secret_manager_service
+
+  # Build the resource name of the parent project.
+  parent = client.project_path project: project_id
+
+  # Create the secret.
+  secret = client.create_secret(
+    parent:    parent,
+    secret_id: secret_id,
+    secret:    {
+      replication: {
+        automatic: {}
+      },
+      annotations: {
+        annotation_key => annotation_value
+      }
+    }
+  )
+
+  # Print the new secret name.
+  puts "Created secret: #{secret.name}"
+  # [END secretmanager_create_secret_with_annotations]
+
+  secret
+end
+
+def create_secret_with_labels project_id:, secret_id:, label_key:, label_value:
+  # [START secretmanager_create_secret_with_labels]
+  # project_id  = "YOUR-GOOGLE-CLOUD-PROJECT" # (e.g. "my-project")
+  # secret_id   = "YOUR-SECRET-ID"            # (e.g. "my-secret")
+  # label_key   = "YOUR-LABEL-KEY"       # (e.g. "my-label-key")
+  # label_value = "YOUR-LABEL-VALUE"     # (e.g. "my-label-value")
+
+  # Require the Secret Manager client library.
+  require "google/cloud/secret_manager"
+
+  # Create a Secret Manager client.
+  client = Google::Cloud::SecretManager.secret_manager_service
+
+  # Build the resource name of the parent project.
+  parent = client.project_path project: project_id
+
+  # Create the secret.
+  secret = client.create_secret(
+    parent:    parent,
+    secret_id: secret_id,
+    secret:    {
+      replication: {
+        automatic: {}
+      },
+      labels: {
+        label_key => label_value
+      }
+    }
+  )
+
+  # Print the new secret name.
+  puts "Created secret with labels: #{secret.name}"
+  # [END secretmanager_create_secret_with_labels]
+
+  secret
+end
+
 def create_ummr_secret project_id:, secret_id:, locations:
   # project_id = "YOUR-GOOGLE-CLOUD-PROJECT"  # (e.g. "my-project")
   # secret_id  = "YOUR-SECRET-ID"             # (e.g. "my-secret")
@@ -246,6 +320,50 @@ def enable_secret_version project_id:, secret_id:, version_id:
   # [END secretmanager_enable_secret_version]
 
   response
+end
+
+def edit_secret_annotations project_id:, secret_id:, annotation_key:, annotation_value:
+  # [START secretmanager_edit_secret_annotations]
+  # project_id       = "YOUR-GOOGLE-CLOUD-PROJECT" # (e.g. "my-project")
+  # secret_id        = "YOUR-SECRET-ID"            # (e.g. "my-secret")
+  # annotation_key   = "YOUR-ANNOTATION-KEY"       # (e.g. "my-annotation-key")
+  # annotation_value = "YOUR-ANNOTATION-VALUE"     # (e.g. "my-annotation-value")
+
+  # Require the Secret Manager client library.
+  require "google/cloud/secret_manager"
+
+  # Create a Secret Manager client.
+  client = Google::Cloud::SecretManager.secret_manager_service
+
+  # Build the resource name of the secret.
+  name = client.secret_path project: project_id, secret: secret_id
+
+  # Get the existing secret.
+  existing_secret = client.get_secret name: name
+
+  # Get the existing secret's annotations.
+  existing_secret_annotations = existing_secret.annotations.to_h
+
+  # Add a new annotation key and value.
+  existing_secret_annotations[annotation_key] = annotation_value
+
+  # Updates the secret.
+  secret = client.update_secret(
+    secret: {
+      name: name,
+      annotations: existing_secret_annotations
+    },
+    update_mask: {
+      paths: ["annotations"]
+    }
+  )
+
+  # Print the updated secret name and annotations.
+  puts "Updated secret: #{secret.name}"
+  puts "New updated annotations: #{secret.annotations}"
+  # [END secretmanager_edit_secret_annotations]
+
+  secret
 end
 
 def get_secret project_id:, secret_id:
@@ -497,6 +615,64 @@ def update_secret_with_alias project_id:, secret_id:
   secret
 end
 
+def view_secret_annotations project_id:, secret_id:
+  # [START secretmanager_view_secret_annotations]
+  # project_id = "YOUR-GOOGLE-CLOUD-PROJECT" # (e.g. "my-project")
+  # secret_id  = "YOUR-SECRET-ID"            # (e.g. "my-secret")
+
+  # Require the Secret Manager client library.
+  require "google/cloud/secret_manager"
+
+  # Create a Secret Manager client.
+  client = Google::Cloud::SecretManager.secret_manager_service
+
+  # Build the resource name of the secret.
+  name = client.secret_path project: project_id, secret: secret_id
+
+  # Get the existing secret.
+  existing_secret = client.get_secret name: name
+
+  # Get the existing secret's annotations.
+  existing_secret_annotations = existing_secret.annotations.to_h
+
+  # Print the secret annotations.
+  existing_secret_annotations.each do |key, value|
+    puts "Annotation Key: #{key}, Annotation Value: #{value}"
+  end
+  # [END secretmanager_view_secret_annotations]
+
+  existing_secret_annotations
+end
+
+def view_secret_labels project_id:, secret_id:
+  # [START secretmanager_view_secret_labels]
+  # project_id = "YOUR-GOOGLE-CLOUD-PROJECT" # (e.g. "my-project")
+  # secret_id  = "YOUR-SECRET-ID"            # (e.g. "my-secret")
+
+  # Require the Secret Manager client library.
+  require "google/cloud/secret_manager"
+
+  # Create a Secret Manager client.
+  client = Google::Cloud::SecretManager.secret_manager_service
+
+  # Build the resource name of the secret.
+  name = client.secret_path project: project_id, secret: secret_id
+
+  # Get the existing secret.
+  existing_secret = client.get_secret name: name
+
+  # Get the existing secret's labels.
+  existing_secret_labels = existing_secret.labels.to_h
+
+  # Print the secret labels.
+  existing_secret_labels.each do |key, value|
+    puts "Label Key: #{key}, Label Value: #{value}"
+  end
+  # [END secretmanager_view_secret_labels]
+
+  existing_secret_labels
+end
+
 if $PROGRAM_NAME == __FILE__
   args    = ARGV.dup
   command = args.shift
@@ -518,6 +694,20 @@ if $PROGRAM_NAME == __FILE__
       project_id: ENV["GOOGLE_CLOUD_PROJECT"],
       secret_id:  args.shift
     )
+  when "create_secret_with_annotations"
+    create_secret_with_annotations(
+      project_id: ENV["GOOGLE_CLOUD_PROJECT"],
+      secret_id:  args.shift,
+      annotation_key: args.shift,
+      annotation_value: args.shift
+    )
+  when "create_secret_with_labels"
+    create_secret_with_annotations(
+      project_id: ENV["GOOGLE_CLOUD_PROJECT"],
+      secret_id:  args.shift,
+      label_key: args.shift,
+      label_value: args.shift
+    )
   when "create_ummr_secret"
     create_ummr_secret(
       project_id: ENV["GOOGLE_CLOUD_PROJECT"],
@@ -534,6 +724,13 @@ if $PROGRAM_NAME == __FILE__
       project_id: ENV["GOOGLE_CLOUD_PROJECT"],
       secret_id:  args.shift,
       version_id: args.shift
+    )
+  when "edit_secret_annotations"
+    edit_secret_annotations(
+      project_id: ENV["GOOGLE_CLOUD_PROJECT"],
+      secret_id:  args.shift,
+      annotation_key: args.shift,
+      annotation_value: args.shift
     )
   when "enable_secret_version"
     enable_secret_version(
@@ -584,26 +781,42 @@ if $PROGRAM_NAME == __FILE__
       project_id: ENV["GOOGLE_CLOUD_PROJECT"],
       secret_id:  args.shift
     )
+  when "view_secret_annotations"
+    view_secret_annotations(
+      project_id: ENV["GOOGLE_CLOUD_PROJECT"],
+      secret_id:  args.shift
+    )
+  when "view_secret_labels"
+    view_secret_labels(
+      project_id: ENV["GOOGLE_CLOUD_PROJECT"],
+      secret_id:  args.shift
+    )
   else
     puts <<~USAGE
       Usage: bundle exec ruby #{__FILE__} [command] [arguments]
 
       Commands:
-        access_secret_version <secret> <version>           Access a secret version
-        add_secret_version <secret>                        Add a new secret version
-        create_secret <secret>                             Create a new secret
-        create_ummr_secret <secret> <locations>            Create a new secret with user managed replication
-        delete_secret <secret>                             Delete an existing secret
-        destroy_secret_version <secret> <version>          Destroy a secret version
-        disable_secret_version <secret> <version>          Disable a secret version
-        enable_secret_version <secret> <version>           Enable a secret version
-        get_secret <secret>                                Get a secret
-        get_secret_version <secret> <version>              Get a secret version
-        iam_grant_access <secret> <version> <member>       Grant the member access to the secret
-        iam_revoke_access <secret> <version> <member>      Revoke the member access to the secret
-        list_secret_versions <secret>                      List all versions for a secret
-        list_secrets                                       List all secrets
-        update_secret <secret>                             Update a secret
+        access_secret_version <secret> <version>                Access a secret version
+        add_secret_version <secret>                             Add a new secret version
+        create_secret <secret>                                  Create a new secret
+        create_secret_with_annotations <secret> <key> <value>   Create a new secret with annotations
+        create_secret_with_labels <secret> <key> <value>        Create a new secret with labels
+        create_ummr_secret <secret> <locations>                 Create a new secret with user managed replication
+        delete_secret <secret>                                  Delete an existing secret
+        destroy_secret_version <secret> <version>               Destroy a secret version
+        disable_secret_version <secret> <version>               Disable a secret version
+        edit_secret_annotations <secret> <key> <value>          Edit existing secret annotations
+        enable_secret_version <secret> <version>                Enable a secret version
+        get_secret <secret>                                     Get a secret
+        get_secret_version <secret> <version>                   Get a secret version
+        iam_grant_access <secret> <version> <member>            Grant the member access to the secret
+        iam_revoke_access <secret> <version> <member>           Revoke the member access to the secret
+        list_secret_versions <secret>                           List all versions for a secret
+        list_secrets                                            List all secrets
+        update_secret <secret>                                  Update a secret
+        view_secret_annotations <secret>                        View a secret annotations
+        view_secret_labels <secret>                             View a secret labels
+
 
       Environment variables:
         GOOGLE_CLOUD_PROJECT    ID of the Google Cloud project to run snippets

--- a/google-cloud-secret_manager/samples/view_regional_secret_annotations.rb
+++ b/google-cloud-secret_manager/samples/view_regional_secret_annotations.rb
@@ -1,0 +1,49 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START secretmanager_view_regional_secret_annotations]
+require "google/cloud/secret_manager"
+
+##
+# Edit a regional secret annotations
+#
+# @param project_id [String] Your Google Cloud project (e.g. "my-project")
+# @param location_id [String] Your Google Cloud location (e.g. "us-west11")
+# @param secret_id [String] Your secret name (e.g. "my-secret")
+#
+def view_regional_secret_annotations project_id:, location_id:, secret_id:
+  # Endpoint for the regional secret manager service.
+  api_endpoint = "secretmanager.#{location_id}.rep.googleapis.com"
+
+  # Create the Secret Manager client.
+  client = Google::Cloud::SecretManager.secret_manager_service do |config|
+    config.endpoint = api_endpoint
+  end
+
+  # Build the resource name of the secret.
+  name = client.secret_path project: project_id, location: location_id, secret: secret_id
+
+  # Get the existing secret.
+  existing_secret = client.get_secret name: name
+
+  # Get the existing secret's annotations.
+  existing_secret_annotations = existing_secret.annotations.to_h
+
+  # Print the secret name and the annotations.
+  puts "Regional Secret: #{existing_secret.name}"
+  existing_secret_annotations.each do |key, value|
+    puts "Annotation Key: #{key}, Annotation Value: #{value}"
+  end
+end
+# [END secretmanager_view_regional_secret_annotations]

--- a/google-cloud-secret_manager/samples/view_regional_secret_labels.rb
+++ b/google-cloud-secret_manager/samples/view_regional_secret_labels.rb
@@ -1,0 +1,49 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START secretmanager_view_regional_secret_labels]
+require "google/cloud/secret_manager"
+
+##
+# Edit a regional secret labels
+#
+# @param project_id [String] Your Google Cloud project (e.g. "my-project")
+# @param location_id [String] Your Google Cloud location (e.g. "us-west11")
+# @param secret_id [String] Your secret name (e.g. "my-secret")
+#
+def view_regional_secret_labels project_id:, location_id:, secret_id:
+  # Endpoint for the regional secret manager service.
+  api_endpoint = "secretmanager.#{location_id}.rep.googleapis.com"
+
+  # Create the Secret Manager client.
+  client = Google::Cloud::SecretManager.secret_manager_service do |config|
+    config.endpoint = api_endpoint
+  end
+
+  # Build the resource name of the secret.
+  name = client.secret_path project: project_id, location: location_id, secret: secret_id
+
+  # Get the existing secret.
+  existing_secret = client.get_secret name: name
+
+  # Get the existing secret's labels.
+  existing_secret_labels = existing_secret.labels.to_h
+
+  # Print the secret name and the labels.
+  puts "Regional Secret: #{existing_secret.name}"
+  existing_secret_labels.each do |key, value|
+    puts "Label Key: #{key}, Label Value: #{value}"
+  end
+end
+# [END secretmanager_view_regional_secret_labels]

--- a/google-cloud-secret_manager/samples/view_secret_annotations.rb
+++ b/google-cloud-secret_manager/samples/view_secret_annotations.rb
@@ -1,0 +1,43 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START secretmanager_view_secret_annotations]
+require "google/cloud/secret_manager"
+
+##
+# View annotations of a secret.
+#
+# @param project_id [String] Your Google Cloud project (e.g. "my-project")
+# @param secret_id [String] Your secret name (e.g. "my-secret")
+#
+def view_secret_annotations project_id:, secret_id:
+  # Create a Secret Manager client.
+  client = Google::Cloud::SecretManager.secret_manager_service
+
+  # Build the resource name of the secret.
+  name = client.secret_path project: project_id, secret: secret_id
+
+  # Get the existing secret.
+  existing_secret = client.get_secret name: name
+
+  # Get the existing secret's annotations.
+  existing_secret_annotations = existing_secret.annotations.to_h
+
+  # Print the secret name and the annotations.
+  puts "Secret: #{existing_secret.name}"
+  existing_secret_annotations.each do |key, value|
+    puts "Annotation Key: #{key}, Annotation Value: #{value}"
+  end
+end
+# [END secretmanager_view_secret_annotations]

--- a/google-cloud-secret_manager/samples/view_secret_labels.rb
+++ b/google-cloud-secret_manager/samples/view_secret_labels.rb
@@ -1,0 +1,43 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START secretmanager_view_secret_labels]
+require "google/cloud/secret_manager"
+
+##
+# View labels of a secret.
+#
+# @param project_id [String] Your Google Cloud project (e.g. "my-project")
+# @param secret_id [String] Your secret name (e.g. "my-secret")
+#
+def view_secret_labels project_id:, secret_id:
+  # Create a Secret Manager client.
+  client = Google::Cloud::SecretManager.secret_manager_service
+
+  # Build the resource name of the secret.
+  name = client.secret_path project: project_id, secret: secret_id
+
+  # Get the existing secret.
+  existing_secret = client.get_secret name: name
+
+  # Get the existing secret's labels.
+  existing_secret_labels = existing_secret.labels.to_h
+
+  # Print the secret name and the labels.
+  puts "Secret: #{existing_secret.name}"
+  existing_secret_labels.each do |key, value|
+    puts "Label Key: #{key}, Label Value: #{value}"
+  end
+end
+# [END secretmanager_view_secret_labels]


### PR DESCRIPTION
### Changes
* Add annotation samples for global apis
* Add annotation samples for regional apis
* Add label samples for global apis
* Add label samples for regional apis
* Add test files for added samples
* Update the snippets for added samples
* Update the required helper class and file
## Prerequisite
- [X] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-ruby/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea.
   - https://github.com/googleapis/google-cloud-ruby/issues/28816
- [X] Follow the instructions in [CONTRIBUTING](CONTRIBUTING.md). Most importantly, ensure the tests and linter pass by running `bundle exec rake ci` in the gem subdirectory.
   - Followed all the instructions in adding the samples.
- [X] Update code documentation if necessary.
   - No code documentation changes are required.
   - Updated the necessary files.

closes: #<28816>