### PR TITLE
feat(bigtable): Provide access to the admin clients from the main Bigtable client

### DIFF
--- a/google-cloud-bigtable/Gemfile
+++ b/google-cloud-bigtable/Gemfile
@@ -24,7 +24,7 @@ local_dependencies.each do |name|
   gem name, path: "../#{name}"
 end
 
-gem "google-style", "~> 1.27.1"
+gem "google-style", "~> 1.30.1"
 gem "minitest", "~> 5.16"
 gem "minitest-focus", "~> 1.1"
 gem "minitest-reporters", "~> 1.5.0", require: false

--- a/google-cloud-bigtable/README.md
+++ b/google-cloud-bigtable/README.md
@@ -48,37 +48,40 @@ entry.set_cell(
   "cf1",
   "field1",
   "XYZ",
-  timestamp: Time.now.to_i * 1000 # Time stamp in milli seconds.
+  timestamp: Time.now.to_i * 1000 # Time stamp in milliseconds.
 ).delete_cells("cf2", "field02")
 
 table.mutate_row(entry)
 ```
 
-## Enabling Logging
+## Debug Logging
 
-To enable logging for this library, set the logger for the underlying [gRPC](https://github.com/grpc/grpc/tree/master/src/ruby) library. The logger that you set may be a Ruby stdlib [`Logger`](https://ruby-doc.org/current/stdlibs/logger/Logger.html) as shown below, or a [`Google::Cloud::Logging::Logger`](https://googleapis.dev/ruby/google-cloud-logging/latest) that will write logs to [Stackdriver Logging](https://cloud.google.com/logging/). See [grpc/logconfig.rb](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/logconfig.rb) and the gRPC [spec_helper.rb](https://github.com/grpc/grpc/blob/master/src/ruby/spec/spec_helper.rb) for additional information.
+This library comes with opt-in Debug Logging that can help you troubleshoot
+your application's integration with the API. When logging is activated, key
+events such as requests and responses, along with data payloads and metadata
+such as headers and client configuration, are logged to the standard error
+stream.
 
-Configuring a Ruby stdlib logger:
+**WARNING:** Client Library Debug Logging includes your data payloads in
+plaintext, which could include sensitive data such as PII for yourself or your
+customers, private keys, or other security data that could be compromising if
+leaked. Always practice good data hygiene with your application logs, and follow
+the principle of least access. Google also recommends that Client Library Debug
+Logging be enabled only temporarily during active debugging, and not used
+permanently in production.
 
-```ruby
-require "logger"
-
-module MyLogger
-  LOGGER = Logger.new $stderr, level: Logger::WARN
-  def logger
-    LOGGER
-  end
-end
-
-# Define a gRPC module-level logger method before grpc/logconfig.rb loads.
-module GRPC
-  extend MyLogger
-end
-```
+To enable logging, set the environment variable `GOOGLE_SDK_RUBY_LOGGING_GEMS`
+to the value `all`. Alternatively, you can set the value to a comma-delimited
+list of client library gem names. This will select the default logging behavior,
+which writes logs to the standard error stream. On a local workstation, this may
+result in logs appearing on the console. When running on a Google Cloud hosting
+service such as [Google Cloud Run](https://cloud.google.com/run), this generally
+results in logs appearing alongside your application logs in the
+[Google Cloud Logging](https://cloud.google.com/logging/) service.
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 2.6+.
+This library is supported on Ruby 3.0+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or

--- a/google-cloud-bigtable/google-cloud-bigtable.gemspec
+++ b/google-cloud-bigtable/google-cloud-bigtable.gemspec
@@ -21,10 +21,10 @@ Gem::Specification.new do |gem|
                        "TROUBLESHOOTING.md", "CHANGELOG.md", "CODE_OF_CONDUCT.md", "LICENSE", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.7"
+  gem.required_ruby_version = ">= 3.0"
 
   gem.add_dependency "concurrent-ruby", "~> 1.0"
-  gem.add_dependency "google-cloud-bigtable-admin-v2", ">= 0.0", "< 2.a"
-  gem.add_dependency "google-cloud-bigtable-v2", ">= 0.14", "< 2.a"
+  gem.add_dependency "google-cloud-bigtable-admin-v2", "~> 1.7"
+  gem.add_dependency "google-cloud-bigtable-v2", "~> 1.5"
   gem.add_dependency "google-cloud-core", "~> 1.5"
 end

--- a/google-cloud-bigtable/lib/google/cloud/bigtable.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable.rb
@@ -27,6 +27,9 @@ module Google
     # See {file:OVERVIEW.md Bigtable Overview}.
     #
     module Bigtable
+      # rubocop:disable Metrics/CyclomaticComplexity
+      # rubocop:disable Metrics/AbcSize
+
       ##
       # Service for managing Cloud Bigtable instances and tables and for reading from and
       # writing to Bigtable tables.
@@ -74,8 +77,6 @@ module Google
       #
       #   client = Google::Cloud::Bigtable.new
       #
-      # rubocop:disable Metrics/CyclomaticComplexity
-      # rubocop:disable Metrics/AbcSize
       def self.new project_id: nil,
                    credentials: nil,
                    emulator_host: nil,
@@ -108,7 +109,6 @@ module Google
       end
       # rubocop:enable Metrics/CyclomaticComplexity
       # rubocop:enable Metrics/AbcSize
-
 
       ##
       # Configure the Google Cloud Bigtable library.

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/project.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/project.rb
@@ -62,6 +62,32 @@ module Google
         end
 
         ##
+        # Retrieve a client for instance administration. This client should be
+        # used for instance administration operations such as managing
+        # clusters, instances, and app profiles. See
+        # https://cloud.google.com/ruby/docs/reference/google-cloud-bigtable-admin-v2/latest/Google-Cloud-Bigtable-Admin-V2-BigtableInstanceAdmin-Client
+        # for documentation on this class.
+        #
+        # @return [Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdmin::Client]
+        #
+        def instance_admin_client
+          service.instances
+        end
+
+        ##
+        # Retrieve a client for table administration. This client should be
+        # used for table administration operations such as managing tables,
+        # backups, snapshots, and authorized views. See
+        # https://cloud.google.com/ruby/docs/reference/google-cloud-bigtable-admin-v2/latest/Google-Cloud-Bigtable-Admin-V2-BigtableTableAdmin-Client
+        # for documentation on this class.
+        #
+        # @return [Google::Cloud::Bigtable::Admin::V2::BigtableTableAdmin::Client]
+        #
+        def table_admin_client
+          service.tables
+        end
+
+        ##
         # The identifier for the Cloud Bigtable project.
         #
         # @return [String] Project ID.


### PR DESCRIPTION
Includes the following:

* Updates the minimum Ruby version to 3.0
* Updates the dependencies on the underlying GAPICs to the latest version
* Adds convenience methods for getting the admin GAPICs from the main Bigtable client
* Updates the readme to reflect the new way of enabling logging
* Updates the samples in OVERVIEW.md to reflect the new way of doing admin tasks