### PR TITLE
feat(storage): Restart delete resumable upload config

### DIFF
--- a/google-cloud-storage/lib/google-cloud-storage.rb
+++ b/google-cloud-storage/lib/google-cloud-storage.rb
@@ -142,7 +142,7 @@ module Google
     def self.storage project_id = nil, credentials = nil, scope: nil,
                      retries: nil, timeout: nil, open_timeout: nil, read_timeout: nil, send_timeout: nil,
                      max_elapsed_time: nil, base_interval: nil, max_interval: nil, multiplier: nil,
-                     upload_chunk_size: nil
+                     upload_chunk_size: nil, upload_url: nil, delete_upload: nil
       require "google/cloud/storage"
       Google::Cloud::Storage.new project_id: project_id,
                                  credentials: credentials,
@@ -156,7 +156,9 @@ module Google
                                  base_interval: base_interval,
                                  max_interval: max_interval,
                                  multiplier: multiplier,
-                                 upload_chunk_size: upload_chunk_size
+                                 upload_chunk_size: upload_chunk_size,
+                                 upload_url: upload_url,
+                                 delete_upload: delete_upload
     end
   end
 end
@@ -193,4 +195,6 @@ Google::Cloud.configure.add_config! :storage do |config|
   config.add_field! :upload_chunk_size, nil, match: Integer
   config.add_field! :endpoint, nil, match: String, allow_nil: true
   config.add_field! :universe_domain, nil, match: String, allow_nil: true
+  config.add_field! :upload_url, nil, match: String, allow_nil: true
+  config.add_field! :delete_upload, nil, match: Integer, allow_nil: true
 end

--- a/google-cloud-storage/lib/google/cloud/storage.rb
+++ b/google-cloud-storage/lib/google/cloud/storage.rb
@@ -94,7 +94,9 @@ module Google
                    timeout: nil, open_timeout: nil, read_timeout: nil,
                    send_timeout: nil, endpoint: nil, project: nil, keyfile: nil,
                    max_elapsed_time: nil, base_interval: nil, max_interval: nil,
-                   multiplier: nil, upload_chunk_size: nil, universe_domain: nil
+                   multiplier: nil, upload_chunk_size: nil, universe_domain: nil,
+                   upload_url: nil, delete_upload: nil
+
         scope             ||= configure.scope
         retries           ||= configure.retries
         timeout           ||= configure.timeout
@@ -109,7 +111,8 @@ module Google
         multiplier        ||= configure.multiplier
         upload_chunk_size ||= configure.upload_chunk_size
         universe_domain   ||= configure.universe_domain
-
+        upload_url        ||= configure.upload_url
+        delete_upload     ||= configure.delete_upload
         unless credentials.is_a? Google::Auth::Credentials
           credentials = Storage::Credentials.new credentials, scope: scope
         end
@@ -125,6 +128,7 @@ module Google
             host: endpoint, quota_project: configure.quota_project,
             max_elapsed_time: max_elapsed_time, base_interval: base_interval,
             max_interval: max_interval, multiplier: multiplier, upload_chunk_size: upload_chunk_size,
+            upload_url: upload_url, delete_upload: delete_upload,
             universe_domain: universe_domain
           )
         )

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -49,7 +49,9 @@ module Google
                        timeout: nil, open_timeout: nil, read_timeout: nil,
                        send_timeout: nil, host: nil, quota_project: nil,
                        max_elapsed_time: nil, base_interval: nil, max_interval: nil,
-                       multiplier: nil, upload_chunk_size: nil, universe_domain: nil
+                       multiplier: nil, upload_chunk_size: nil, universe_domain: nil,
+                       upload_url: nil, delete_upload: nil
+
           host ||= Google::Cloud::Storage.configure.endpoint
           @project = project
           @credentials = credentials
@@ -73,6 +75,8 @@ module Google
           @service.request_options.multiplier = multiplier if multiplier
           @service.request_options.add_invocation_id_header = true
           @service.request_options.upload_chunk_size = upload_chunk_size if upload_chunk_size
+          @service.request_options.upload_url = upload_url if upload_url
+          @service.request_options.delete_upload = delete_upload if delete_upload
           @service.authorization = @credentials.client if @credentials
           @service.root_url = host if host
           @service.universe_domain = universe_domain || Google::Cloud::Storage.configure.universe_domain


### PR DESCRIPTION
```Ruby
@example   

storage = Google::Cloud::Storage.new upload_chunk_size: chunk_size
#Initiating Resumable upload 
  bucket = storage.bucket bucket_name
 # Restarting  Resumable upload 
  storage = Google::Cloud::Storage.new(upload_chunk_size: chunk_size, upload_url: upload_url)
# Deleting Resumable upload 
  storage = Google::Cloud::Storage.new(upload_chunk_size: chunk_size, upload_url: upload_url, delete_upload: true)

  bucket.create_file file, file_name

```
