### PR TITLE
feat(parametermanager): Added cloud-parameters-team for issues for parameter-manager

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,3 +15,4 @@
 /google-cloud-firestore*/.           @googleapis/ruby-team @yoshi-approver @googleapis/api-firestore-sdk
 /google-cloud-pubsub*/.              @googleapis/ruby-team @yoshi-approver @googleapis/api-pubsub
 /google-cloud-storage/               @googleapis/ruby-team @yoshi-approver @googleapis/gcs-sdk-team
+/google-cloud-parameter_manager*/.   @googleapis/ruby-team @yoshi-approver @googleapis/cloud-parameters-team

--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -7,6 +7,10 @@ assign_issues_by:
     - 'api: secretmanager'
     to:
     - GoogleCloudPlatform/cloud-secrets-team
+  - labels:
+    - 'api: parametermanager'
+    to:
+    - GoogleCloudPlatform/cloud-parameters-team
 
 assign_issues:
  - dazuma


### PR DESCRIPTION
Added cloud-parameters-team to b e assigned issues for parameter-manager (Client has been created at https://github.com/googleapis/google-cloud-ruby/tree/main/google-cloud-parameter_manager)

https://github.com/googleapis/google-cloud-ruby/pull/29196 was closed due to client not being created yet

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-ruby/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea.
- [ ] Follow the instructions in [CONTRIBUTING](CONTRIBUTING.md). Most importantly, ensure the tests and linter pass by running `bundle exec rake ci` in the gem subdirectory.
- [ ] Update code documentation if necessary.

closes: #29370