### PR TITLE
feat(storage): move_object within hns bucket

### DIFF
--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -3146,6 +3146,13 @@ module Google
         ##
         # Moves object from source to destination path within bucket
         # This Operation is being performed at server side
+        # @param [String] source_object The file name existing on bucket
+        # @param [String] destination_object The new file name to be created on bucket
+        # @example
+        #   require "google/cloud/storage"
+        #   storage = Google::Cloud::Storage.new
+        #   bucket  = storage.bucket bucket_name, skip_lookup: true
+        #   bucket.move_file source_file_name, destination_file_name
         def move_file source_object,
                       destination_object,
                       if_generation_match: nil,

--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -3144,10 +3144,11 @@ module Google
         alias refresh! reload!
 
         ##
-        # Moves File from source to destination path within bucket
+        # Moves File from source to destination path within the same HNS-enabled bucket
         # This Operation is being performed at server side
         # @param [String] source_file The file name in existing bucket
         # @param [String] destination_file The new filename to be created on bucket
+        # If the destination path includes non-existent parent folders, they will be created.
         # @example
         #   require "google/cloud/storage"
         #   storage = Google::Cloud::Storage.new

--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -3144,6 +3144,43 @@ module Google
         alias refresh! reload!
 
         ##
+        # Moves object from source to destination path within bucket
+        # This Operation is being performed at server side
+        def move_file source_object,
+                      destination_object,
+                      if_generation_match: nil,
+                      if_generation_not_match: nil,
+                      if_metageneration_match: nil,
+                      if_metageneration_not_match: nil,
+                      if_source_generation_match: nil,
+                      if_source_generation_not_match: nil,
+                      if_source_metageneration_match: nil,
+                      if_source_metageneration_not_match: nil,
+                      user_project: nil,
+                      fields: nil,
+                      quota_user: nil,
+                      user_ip: nil,
+                      options: {}
+          ensure_service!
+          gapi = service.move_file name,
+                                   source_object,
+                                   destination_object,
+                                   if_generation_match: if_generation_match,
+                                   if_generation_not_match: if_generation_not_match,
+                                   if_metageneration_match: if_metageneration_match,
+                                   if_metageneration_not_match: if_metageneration_not_match,
+                                   if_source_generation_match: if_source_generation_match,
+                                   if_source_generation_not_match: if_source_generation_not_match,
+                                   if_source_metageneration_match: if_source_metageneration_match,
+                                   if_source_metageneration_not_match: if_source_metageneration_not_match,
+                                   user_project: user_project,
+                                   fields: fields,
+                                   quota_user: quota_user,
+                                   user_ip: user_ip,
+                                   options: options
+        end
+
+        ##
         # Determines whether the bucket exists in the Storage service.
         #
         # @return [Boolean] true if the bucket exists in the Storage service.

--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -3144,7 +3144,7 @@ module Google
         alias refresh! reload!
 
         ##
-        # Moves object from source to destination path within bucket
+        # Moves File from source to destination path within bucket
         # This Operation is being performed at server side
         # @param [String] source_file The file name in existing bucket
         # @param [String] destination_file The new filename to be created on bucket

--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -3146,15 +3146,15 @@ module Google
         ##
         # Moves object from source to destination path within bucket
         # This Operation is being performed at server side
-        # @param [String] source_object The file name in existing bucket
-        # @param [String] destination_object The new filename to be created on bucket
+        # @param [String] source_file The file name in existing bucket
+        # @param [String] destination_file The new filename to be created on bucket
         # @example
         #   require "google/cloud/storage"
         #   storage = Google::Cloud::Storage.new
         #   bucket  = storage.bucket bucket_name, skip_lookup: true
         #   bucket.move_file source_file_name, destination_file_name
-        def move_file source_object,
-                      destination_object,
+        def move_file source_file,
+                      destination_file,
                       if_generation_match: nil,
                       if_generation_not_match: nil,
                       if_metageneration_match: nil,
@@ -3170,8 +3170,8 @@ module Google
                       options: {}
           ensure_service!
           service.move_file name,
-                            source_object,
-                            destination_object,
+                            source_file,
+                            destination_file,
                             if_generation_match: if_generation_match,
                             if_generation_not_match: if_generation_not_match,
                             if_metageneration_match: if_metageneration_match,

--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -3146,7 +3146,7 @@ module Google
         ##
         # Moves object from source to destination path within bucket
         # This Operation is being performed at server side
-        # @param [String] source_object The file name existing on bucket
+        # @param [String] source_object The file name in existing bucket
         # @param [String] destination_object The new filename to be created on bucket
         # @example
         #   require "google/cloud/storage"

--- a/google-cloud-storage/lib/google/cloud/storage/bucket.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket.rb
@@ -3147,7 +3147,7 @@ module Google
         # Moves object from source to destination path within bucket
         # This Operation is being performed at server side
         # @param [String] source_object The file name existing on bucket
-        # @param [String] destination_object The new file name to be created on bucket
+        # @param [String] destination_object The new filename to be created on bucket
         # @example
         #   require "google/cloud/storage"
         #   storage = Google::Cloud::Storage.new
@@ -3169,22 +3169,22 @@ module Google
                       user_ip: nil,
                       options: {}
           ensure_service!
-          gapi = service.move_file name,
-                                   source_object,
-                                   destination_object,
-                                   if_generation_match: if_generation_match,
-                                   if_generation_not_match: if_generation_not_match,
-                                   if_metageneration_match: if_metageneration_match,
-                                   if_metageneration_not_match: if_metageneration_not_match,
-                                   if_source_generation_match: if_source_generation_match,
-                                   if_source_generation_not_match: if_source_generation_not_match,
-                                   if_source_metageneration_match: if_source_metageneration_match,
-                                   if_source_metageneration_not_match: if_source_metageneration_not_match,
-                                   user_project: user_project,
-                                   fields: fields,
-                                   quota_user: quota_user,
-                                   user_ip: user_ip,
-                                   options: options
+          service.move_file name,
+                            source_object,
+                            destination_object,
+                            if_generation_match: if_generation_match,
+                            if_generation_not_match: if_generation_not_match,
+                            if_metageneration_match: if_metageneration_match,
+                            if_metageneration_not_match: if_metageneration_not_match,
+                            if_source_generation_match: if_source_generation_match,
+                            if_source_generation_not_match: if_source_generation_not_match,
+                            if_source_metageneration_match: if_source_metageneration_match,
+                            if_source_metageneration_not_match: if_source_metageneration_not_match,
+                            user_project: user_project,
+                            fields: fields,
+                            quota_user: quota_user,
+                            user_ip: user_ip,
+                            options: options
         end
 
         ##

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -633,8 +633,8 @@ module Google
         ##
         # Moves object from source to destination path within bucket
         def move_file name,
-                      source_object,
-                      destination_object,
+                      source_file,
+                      destination_file,
                       if_generation_match: nil,
                       if_generation_not_match: nil,
                       if_metageneration_match: nil,
@@ -650,8 +650,8 @@ module Google
                       options: {}
           execute do
             service.move_object name,
-                                source_object,
-                                destination_object,
+                                source_file,
+                                destination_file,
                                 if_generation_match: if_generation_match,
                                 if_generation_not_match: if_generation_not_match,
                                 if_metageneration_match: if_metageneration_match,

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -631,6 +631,44 @@ module Google
         end
 
         ##
+        # Moves object from source to destination path within bucket
+        def move_file name,
+                      source_object,
+                      destination_object,
+                      if_generation_match: nil,
+                      if_generation_not_match: nil,
+                      if_metageneration_match: nil,
+                      if_metageneration_not_match: nil,
+                      if_source_generation_match: nil,
+                      if_source_generation_not_match: nil,
+                      if_source_metageneration_match: nil,
+                      if_source_metageneration_not_match: nil,
+                      user_project: nil,
+                      fields: nil,
+                      quota_user: nil,
+                      user_ip: nil,
+                      options: {}
+          execute do
+            service.move_object name,
+                                source_object,
+                                destination_object,
+                                if_generation_match: if_generation_match,
+                                if_generation_not_match: if_generation_not_match,
+                                if_metageneration_match: if_metageneration_match,
+                                if_metageneration_not_match: if_metageneration_not_match,
+                                if_source_generation_match: if_source_generation_match,
+                                if_source_generation_not_match: if_source_generation_not_match,
+                                if_source_metageneration_match: if_source_metageneration_match,
+                                if_source_metageneration_not_match: if_source_metageneration_not_match,
+                                user_project: user_project(user_project),
+                                fields: fields,
+                                quota_user: quota_user,
+                                user_ip: user_ip,
+                                options: options
+          end
+        end
+
+        ##
         # Permanently deletes a file.
         def delete_file bucket_name,
                         file_path,

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -631,7 +631,7 @@ module Google
         end
 
         ##
-        # Moves object from source to destination path within bucket
+        # Moves file from source to destination path within bucket
         def move_file name,
                       source_file,
                       destination_file,

--- a/google-cloud-storage/samples/acceptance/buckets_test.rb
+++ b/google-cloud-storage/samples/acceptance/buckets_test.rb
@@ -593,13 +593,13 @@ describe "Buckets Snippets" do
         b.hierarchical_namespace = hierarchical_namespace
       end
     end
-    let :create_file_hns do
+    let :create_source_file do
       file_content = "A" * (3 * 1024 * 1024) # 3 MB of 'A' characters
       file = StringIO.new file_content
       hns_bucket.create_file file, file_1_name
     end
     it "object is moved and old object is deleted" do
-      create_file_hns
+      create_source_file
       out, _err = capture_io do
         move_object bucket_name: hns_bucket.name, source_file_name: file_1_name, destination_file_name: file_2_name
       end
@@ -609,7 +609,7 @@ describe "Buckets Snippets" do
     end
 
     it "raises error if source and destination are having same filename" do
-      create_file_hns
+      create_source_file
       exception = assert_raises Google::Cloud::InvalidArgumentError do
         move_object bucket_name: hns_bucket.name, source_file_name: file_1_name, destination_file_name: file_1_name
       end

--- a/google-cloud-storage/samples/acceptance/buckets_test.rb
+++ b/google-cloud-storage/samples/acceptance/buckets_test.rb
@@ -584,8 +584,8 @@ describe "Buckets Snippets" do
   end
 
   describe "storage move object" do
-    let(:file_1_name) { "file_1_name_#{SecureRandom.hex}.txt" }
-    let(:file_2_name) { "file_2_name_#{SecureRandom.hex}.txt" }
+    let(:source_file) { "file_1_name_#{SecureRandom.hex}.txt" }
+    let(:destination_file) { "file_2_name_#{SecureRandom.hex}.txt" }
     let :hns_bucket do
       hierarchical_namespace = Google::Apis::StorageV1::Bucket::HierarchicalNamespace.new enabled: true
       storage_client.create_bucket random_bucket_name do |b|
@@ -596,22 +596,22 @@ describe "Buckets Snippets" do
     let :create_source_file do
       file_content = "A" * (3 * 1024 * 1024) # 3 MB of 'A' characters
       file = StringIO.new file_content
-      hns_bucket.create_file file, file_1_name
+      hns_bucket.create_file file, source_file
     end
     it "object is moved and old object is deleted" do
       create_source_file
       out, _err = capture_io do
-        move_object bucket_name: hns_bucket.name, source_file_name: file_1_name, destination_file_name: file_2_name
+        move_object bucket_name: hns_bucket.name, source_file_name: source_file, destination_file_name: destination_file
       end
-      assert_includes out, "New File #{file_2_name} created\n"
-      refute_nil(hns_bucket.file(file_2_name))
-      assert_nil(hns_bucket.file(file_1_name))
+      assert_includes out, "New File #{destination_file} created\n"
+      refute_nil(hns_bucket.file(destination_file))
+      assert_nil(hns_bucket.file(source_file))
     end
 
     it "raises error if source and destination are having same filename" do
       create_source_file
       exception = assert_raises Google::Cloud::InvalidArgumentError do
-        move_object bucket_name: hns_bucket.name, source_file_name: file_1_name, destination_file_name: file_1_name
+        move_object bucket_name: hns_bucket.name, source_file_name: source_file, destination_file_name: source_file
       end
       assert_equal "invalid: Source and destination object names must be different.", exception.message
     end

--- a/google-cloud-storage/samples/acceptance/buckets_test.rb
+++ b/google-cloud-storage/samples/acceptance/buckets_test.rb
@@ -598,7 +598,7 @@ describe "Buckets Snippets" do
       file = StringIO.new file_content
       hns_bucket.create_file file, source_file
     end
-    it "file is moved and old object is deleted" do
+    it "file is moved and old file is deleted" do
       create_source_file
       out, _err = capture_io do
         move_object bucket_name: hns_bucket.name, source_file_name: source_file, destination_file_name: destination_file

--- a/google-cloud-storage/samples/acceptance/buckets_test.rb
+++ b/google-cloud-storage/samples/acceptance/buckets_test.rb
@@ -608,15 +608,6 @@ describe "Buckets Snippets" do
       assert_nil(hns_bucket.file(file_1_name))
     end
 
-    it "raises error for non hns bucket" do
-      file_content = "A" * (3 * 1024 * 1024) # 3 MB of 'A' characters
-      file = StringIO.new file_content
-      bucket.create_file file, file_1_name
-      assert_raises Google::Cloud::AlreadyExistsError do
-        move_object bucket_name: bucket.name, source_file_name: file_1_name, destination_file_name: file_2_name
-      end
-    end
-
     it "raises error if source and destination are having same filename" do
       create_file_hns
       exception = assert_raises Google::Cloud::InvalidArgumentError do

--- a/google-cloud-storage/samples/acceptance/buckets_test.rb
+++ b/google-cloud-storage/samples/acceptance/buckets_test.rb
@@ -586,19 +586,18 @@ describe "Buckets Snippets" do
   describe "storage move object" do
     let(:file_1_name) { "file_1_name_#{SecureRandom.hex}.txt" }
     let(:file_2_name) { "file_2_name_#{SecureRandom.hex}.txt" }
-    let(:hns_bucket) {
+    let :hns_bucket do
       hierarchical_namespace = Google::Apis::StorageV1::Bucket::HierarchicalNamespace.new enabled: true
-
       storage_client.create_bucket random_bucket_name do |b|
         b.uniform_bucket_level_access = true
         b.hierarchical_namespace = hierarchical_namespace
       end
-    }
-    let(:create_file_hns) {
-        file_content = "A" * (3 * 1024 * 1024) # 3 MB of 'A' characters
-        file = StringIO.new file_content
-      hns_bucket.create_file file,file_1_name
-    }
+    end
+    let :create_file_hns do
+      file_content = "A" * (3 * 1024 * 1024) # 3 MB of 'A' characters
+      file = StringIO.new file_content
+      hns_bucket.create_file file, file_1_name
+    end
     it "obejct is moved and old object is deleted" do
       create_file_hns
       out, _err = capture_io do
@@ -612,16 +611,15 @@ describe "Buckets Snippets" do
     it "raises error for non hns bucket" do
       file_content = "A" * (3 * 1024 * 1024) # 3 MB of 'A' characters
       file = StringIO.new file_content
-      bucket.create_file file,file_1_name
-      exception = assert_raises(Google::Cloud::AlreadyExistsError) do
+      bucket.create_file file, file_1_name
+      assert_raises Google::Cloud::AlreadyExistsError do
         move_object bucket_name: bucket.name, source_file_name: file_1_name, destination_file_name: file_2_name
       end
-      assert_equal "conflict: The bucket does not support hierarchical namespace.", exception.message
     end
 
     it "raises error if source and destination are having same filename" do
       create_file_hns
-      exception = assert_raises(Google::Cloud::InvalidArgumentError) do
+      exception = assert_raises Google::Cloud::InvalidArgumentError do
         move_object bucket_name: hns_bucket.name, source_file_name: file_1_name, destination_file_name: file_1_name
       end
       assert_equal "invalid: Source and destination object names must be different.", exception.message

--- a/google-cloud-storage/samples/acceptance/buckets_test.rb
+++ b/google-cloud-storage/samples/acceptance/buckets_test.rb
@@ -598,7 +598,7 @@ describe "Buckets Snippets" do
       file = StringIO.new file_content
       hns_bucket.create_file file, file_1_name
     end
-    it "obejct is moved and old object is deleted" do
+    it "object is moved and old object is deleted" do
       create_file_hns
       out, _err = capture_io do
         move_object bucket_name: hns_bucket.name, source_file_name: file_1_name, destination_file_name: file_2_name

--- a/google-cloud-storage/samples/acceptance/buckets_test.rb
+++ b/google-cloud-storage/samples/acceptance/buckets_test.rb
@@ -583,7 +583,7 @@ describe "Buckets Snippets" do
     end
   end
 
-  describe "storage move object" do
+  describe "storage move file" do
     let(:source_file) { "file_1_name_#{SecureRandom.hex}.txt" }
     let(:destination_file) { "file_2_name_#{SecureRandom.hex}.txt" }
     let :hns_bucket do
@@ -598,7 +598,7 @@ describe "Buckets Snippets" do
       file = StringIO.new file_content
       hns_bucket.create_file file, source_file
     end
-    it "object is moved and old object is deleted" do
+    it "file is moved and old object is deleted" do
       create_source_file
       out, _err = capture_io do
         move_object bucket_name: hns_bucket.name, source_file_name: source_file, destination_file_name: destination_file

--- a/google-cloud-storage/samples/storage_move_object.rb
+++ b/google-cloud-storage/samples/storage_move_object.rb
@@ -31,8 +31,10 @@ def move_object bucket_name:, source_file_name:, destination_file_name:
   bucket.move_file source_file_name, destination_file_name
   fetch_file = bucket.file destination_file_name
   puts "New File #{fetch_file.name} created\n"
-
 end
 # [END storage_move_object]
 
-move_object bucket_name: ARGV.shift, source_file_name: ARGV.shift, destination_file_name: ARGV.shift if $PROGRAM_NAME == __FILE__
+if $PROGRAM_NAME == __FILE__
+  move_object bucket_name: ARGV.shift, source_file_name: ARGV.shift,
+              destination_file_name: ARGV.shift
+end

--- a/google-cloud-storage/samples/storage_move_object.rb
+++ b/google-cloud-storage/samples/storage_move_object.rb
@@ -1,0 +1,38 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START storage_move_object]
+def move_object bucket_name:, source_file_name:, destination_file_name:
+  # The ID of your GCS bucket
+  # bucket_name = "your-unique-bucket-name"
+
+  # The name of your GCS object
+  # source_file_name = "your-file-name"
+
+  # The new object name which you want to craete
+  # destination_file_name = "your-new-file-name"
+
+  require "google/cloud/storage"
+
+  storage = Google::Cloud::Storage.new
+  bucket  = storage.bucket bucket_name, skip_lookup: true
+
+  bucket.move_file source_file_name, destination_file_name
+  fetch_file = bucket.file destination_file_name
+  puts "New File #{fetch_file.name} created\n"
+
+end
+# [END storage_move_object]
+
+move_object bucket_name: ARGV.shift, source_file_name: ARGV.shift, destination_file_name: ARGV.shift if $PROGRAM_NAME == __FILE__

--- a/google-cloud-storage/samples/storage_remove_bucket_conditional_iam_binding.rb
+++ b/google-cloud-storage/samples/storage_remove_bucket_conditional_iam_binding.rb
@@ -37,10 +37,10 @@ def remove_bucket_conditional_iam_binding bucket_name:
         description: description,
         expression:  expression
       }
-      if (b.role == role) && (b.condition &&
-        b.condition.title == title &&
-        b.condition.description == description &&
-        b.condition.expression == expression)
+      if b.role == role && b.condition &&
+         b.condition.title == title &&
+         b.condition.description == description &&
+         b.condition.expression == expression
         binding_to_remove = b
       end
     end

--- a/google-cloud-storage/test/google/cloud/storage/bucket_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_test.rb
@@ -1381,6 +1381,32 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
     _(bucket.api_url).must_equal "#{new_url_root}/b/#{bucket_name}"
     mock.verify
   end
+  describe "storage move object" do
+    it "moves a file object for bucket" do
+      file_name = "file.ext"
+      file_2_name = "file1.ext"
+      mock = Minitest::Mock.new
+      mock.expect :move_object,Google::Apis::StorageV1::Object.from_json(random_file_hash(bucket.name, file_2_name).to_json),[ bucket.name, file_name,file_2_name],**move_object_args
+      bucket.service.mocked_service = mock
+      file = bucket.move_file file_name, file_2_name
+      mock.verify
+      _(file).must_be_kind_of Google::Apis::StorageV1::Object
+    end
+
+    it "raises error if source and destination are having same filename" do
+      file_name = "file.ext"
+      file_2_name = "file1.ext"
+      mock = Minitest::Mock.new
+      mock.expect :move_object, [ bucket.name, file_name,file_name] do
+        raise Google::Cloud::InvalidArgumentError, "invalid: Source and destination object names must be different."
+      end
+      bucket.service.mocked_service = mock
+      exception = assert_raises(Google::Cloud::InvalidArgumentError) do
+          bucket.move_file file_name, file_name
+      end
+      assert_equal "invalid: Source and destination object names must be different.", exception.message
+    end
+  end
 
   def create_file_gapi bucket=nil, name = nil
     Google::Apis::StorageV1::Object.from_json random_file_hash(bucket, name).to_json

--- a/google-cloud-storage/test/google/cloud/storage/bucket_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_test.rb
@@ -1382,7 +1382,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
     mock.verify
   end
   describe "storage move file" do
-    it "moves a file object for bucket" do
+    it "moves a file for bucket" do
       file_name = "file.ext"
       file_2_name = "file1.ext"
       mock = Minitest::Mock.new

--- a/google-cloud-storage/test/google/cloud/storage/bucket_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_test.rb
@@ -1381,7 +1381,7 @@ describe Google::Cloud::Storage::Bucket, :mock_storage do
     _(bucket.api_url).must_equal "#{new_url_root}/b/#{bucket_name}"
     mock.verify
   end
-  describe "storage move object" do
+  describe "storage move file" do
     it "moves a file object for bucket" do
       file_name = "file.ext"
       file_2_name = "file1.ext"

--- a/google-cloud-storage/test/helper.rb
+++ b/google-cloud-storage/test/helper.rb
@@ -457,6 +457,36 @@ class MockStorage < Minitest::Spec
     }
   end
 
+  def move_object_args if_generation_match: nil,
+                       if_generation_not_match: nil,
+                       if_metageneration_match: nil,
+                       if_metageneration_not_match: nil,
+                       if_source_generation_match: nil,
+                       if_source_generation_not_match: nil,
+                       if_source_metageneration_match: nil,
+                       if_source_metageneration_not_match: nil,
+                       user_project: nil,
+                       fields: nil,
+                       quota_user: nil,
+                       user_ip: nil,
+                       options: {}
+    {
+      if_generation_match: if_generation_match,
+      if_generation_not_match: if_generation_not_match,
+      if_metageneration_match: if_metageneration_match,
+      if_metageneration_not_match: if_metageneration_not_match,
+      if_source_generation_match: if_source_generation_match,
+      if_source_generation_not_match: if_source_generation_not_match,
+      if_source_metageneration_match: if_source_metageneration_match,
+      if_source_metageneration_not_match: if_source_metageneration_not_match,
+      user_project: user_project,
+      fields: fields,
+      quota_user: quota_user,
+      user_ip: user_ip,
+      options: options
+    }
+  end
+
   def delete_object_args generation: nil,
                          if_generation_match: nil,
                          if_generation_not_match: nil,


### PR DESCRIPTION
    Add support for MoveFile within HNS bucket
 ```ruby
    @example
           require "google/cloud/storage"
           storage = Google::Cloud::Storage.new
           bucket  = storage.bucket bucket_name, skip_lookup: true
           bucket.move_file source_file_name, destination_file_name
```