### PR TITLE
feat(parametermanager): Add samples for kms_key field in global & regional parameter

### DIFF
--- a/google-cloud-parameter_manager/samples/Gemfile
+++ b/google-cloud-parameter_manager/samples/Gemfile
@@ -19,6 +19,8 @@ master = ENV["GOOGLE_CLOUD_SAMPLES_TEST"] == "master"
 gem "google-cloud-parameter_manager", path: master ? "../../google-cloud-parameter_manager" : nil
 # Required for rendering the test case.
 gem "google-cloud-secret_manager", path: master ? "../../google-cloud-secret_manager" : nil
+# Required for kms_key test case.
+gem "google-cloud-kms", path: master ? "../../google-cloud-kms" : nil
 
 group :test do
   gem "google-style", "~> 1.30.1"

--- a/google-cloud-parameter_manager/samples/README.md
+++ b/google-cloud-parameter_manager/samples/README.md
@@ -103,6 +103,9 @@ authentication:
 | enable_param_version.rb             | `parameter_id`, `version_id`                 | Enables a global parameter version.                                                |
 | delete_param.rb                     | `parameter_id`                               | Deletes a global parameter.                                                        |
 | delete_param_version.rb             | `parameter_id`, `version_id`                 | Deletes a global parameter version.                                                |
+| create_param_with_kms_key.rb        | `parameter_id`, `kms_key`                    | Creates a global parameter with kms_key.                                           |
+| update_param_kms_key.rb             | `parameter_id`, `kms_key`                    | Updates a global parameter kms_key.                                           |
+| remove_param_kms_key.rb             | `parameter_id`                               | Removes a kms_key for global parameter.                                       |
 | quickstart.rb                       | `parameter_id`, `version_id`                 | Creates a global parameter, parameter version and retrieves the parameter version. |
 
 ### Run regional samples
@@ -125,4 +128,7 @@ authentication:
 | enable_regional_param_version.rb             | `parameter_id`, `version_id`                 | Enables a regional parameter version.                                                |
 | delete_regional_param.rb                     | `parameter_id`                               | Deletes a regional parameter.                                                        |
 | delete_regional_param_version.rb             | `parameter_id`, `version_id`                 | Deletes a regional parameter version.                                                |
+| create_regional_param_with_kms_key.rb        | `parameter_id`, `kms_key`                    | Creates a regional parameter with kms_key.                                           |
+| update_regional_param_kms_key.rb             | `parameter_id`, `kms_key`                    | Updates a regional parameter kms_key.                                           |
+| remove_regional_param_kms_key.rb             | `parameter_id`                               | Removes a kms_key for regional parameter.                                       |
 | regional_quickstart.rb                       | `parameter_id`, `version_id`                 | Creates a regional parameter, parameter version and retrieves the parameter version. |

--- a/google-cloud-parameter_manager/samples/acceptance/create_param_with_kms_key_test.rb
+++ b/google-cloud-parameter_manager/samples/acceptance/create_param_with_kms_key_test.rb
@@ -1,0 +1,55 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "helper"
+
+describe "#create_param_with_kms_key", :parameter_manager_snippet do
+  before do
+    setup_create_param_with_kms_keys
+  end
+
+  it "creates a parameter with kms_key" do
+    sample = SampleLoader.load "create_param_with_kms_key.rb"
+
+    out, _err = capture_io do
+      sample.run project_id: project_id, parameter_id: parameter_id, kms_key: crypt_key_id1_name
+    end
+
+    assert_equal "Created parameter projects/#{project_id}/locations/global/parameters/#{parameter_id} " \
+                 "with kms_key projects/#{project_id}/locations/global/keyRings/#{key_ring_id}/" \
+                 "cryptoKeys/#{crypt_key_id1}\n",
+                 out
+  end
+end
+
+def setup_create_param_with_kms_keys
+  key = {
+    purpose:          :ENCRYPT_DECRYPT,
+    version_template: {
+      algorithm:        :GOOGLE_SYMMETRIC_ENCRYPTION,
+      protection_level: :HSM
+    }
+  }
+  begin
+    kms_client.get_key_ring name: key_ring_name
+  rescue Google::Cloud::NotFoundError
+    kms_client.create_key_ring parent: location_name, key_ring_id: key_ring_id, key_ring: {}
+  end
+
+  begin
+    kms_client.get_crypto_key name: crypt_key_id1_name
+  rescue Google::Cloud::NotFoundError
+    kms_client.create_crypto_key parent: key_ring_name, crypto_key_id: crypt_key_id1, crypto_key: key
+  end
+end

--- a/google-cloud-parameter_manager/samples/acceptance/create_regional_param_with_kms_key_test.rb
+++ b/google-cloud-parameter_manager/samples/acceptance/create_regional_param_with_kms_key_test.rb
@@ -1,0 +1,56 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "regional_helper"
+
+describe "#create_regional_param_with_kms_key", :regional_parameter_manager_snippet do
+  before do
+    setup_create_regional_param_with_kms_keys
+  end
+
+  it "creates a regional parameter with kms_key" do
+    sample = SampleLoader.load "create_regional_param_with_kms_key.rb"
+
+    out, _err = capture_io do
+      sample.run project_id: project_id, location_id: location_id, parameter_id: parameter_id,
+                 kms_key: crypt_key_id1_name
+    end
+
+    assert_equal "Created regional parameter projects/#{project_id}/locations/#{location_id}/" \
+                 "parameters/#{parameter_id} with kms_key projects/#{project_id}/locations/" \
+                 "#{location_id}/keyRings/#{key_ring_id}/cryptoKeys/#{crypt_key_id1}\n",
+                 out
+  end
+end
+
+def setup_create_regional_param_with_kms_keys
+  key = {
+    purpose:          :ENCRYPT_DECRYPT,
+    version_template: {
+      algorithm:        :GOOGLE_SYMMETRIC_ENCRYPTION,
+      protection_level: :HSM
+    }
+  }
+  begin
+    kms_client.get_key_ring name: key_ring_name
+  rescue Google::Cloud::NotFoundError
+    kms_client.create_key_ring parent: location_name, key_ring_id: key_ring_id, key_ring: {}
+  end
+
+  begin
+    kms_client.get_crypto_key name: crypt_key_id1_name
+  rescue Google::Cloud::NotFoundError
+    kms_client.create_crypto_key parent: key_ring_name, crypto_key_id: crypt_key_id1, crypto_key: key
+  end
+end

--- a/google-cloud-parameter_manager/samples/acceptance/remove_param_kms_key_test.rb
+++ b/google-cloud-parameter_manager/samples/acceptance/remove_param_kms_key_test.rb
@@ -1,0 +1,61 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "helper"
+
+describe "#remove_param_kms_key", :parameter_manager_snippet do
+  before do
+    setup_remove_param_kms_keys
+  end
+
+  it "Removes a parameter kms_key" do
+    sample = SampleLoader.load "remove_param_kms_key.rb"
+
+    out, _err = capture_io do
+      sample.run project_id: project_id, parameter_id: parameter_id
+    end
+
+    assert_equal "Removed kms_key for parameter projects/#{project_id}/locations/global/" \
+                 "parameters/#{parameter_id}\n",
+                 out
+  end
+end
+
+def setup_remove_param_kms_keys
+  key = {
+    purpose:          :ENCRYPT_DECRYPT,
+    version_template: {
+      algorithm:        :GOOGLE_SYMMETRIC_ENCRYPTION,
+      protection_level: :HSM
+    }
+  }
+
+  begin
+    kms_client.get_key_ring name: key_ring_name
+  rescue Google::Cloud::NotFoundError
+    kms_client.create_key_ring parent: location_name, key_ring_id: key_ring_id, key_ring: {}
+  end
+
+  begin
+    kms_client.get_crypto_key name: crypt_key_id1_name
+  rescue Google::Cloud::NotFoundError
+    kms_client.create_crypto_key parent: key_ring_name, crypto_key_id: crypt_key_id1, crypto_key: key
+  end
+
+  parameter = {
+    kms_key: crypt_key_id1_name
+  }
+
+  client.create_parameter parent: location_name, parameter_id: parameter_id, parameter: parameter
+end

--- a/google-cloud-parameter_manager/samples/acceptance/remove_regional_param_kms_key_test.rb
+++ b/google-cloud-parameter_manager/samples/acceptance/remove_regional_param_kms_key_test.rb
@@ -1,0 +1,61 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "regional_helper"
+
+describe "#remove_regional_param_kms_key", :regional_parameter_manager_snippet do
+  before do
+    setup_remove_regional_param_kms_keys
+  end
+
+  it "Removes a regional parameter kms_key" do
+    sample = SampleLoader.load "remove_regional_param_kms_key.rb"
+
+    out, _err = capture_io do
+      sample.run project_id: project_id, location_id: location_id, parameter_id: parameter_id
+    end
+
+    assert_equal "Removed kms_key for regional parameter projects/#{project_id}/locations/" \
+                 "#{location_id}/parameters/#{parameter_id}\n",
+                 out
+  end
+end
+
+def setup_remove_regional_param_kms_keys
+  key = {
+    purpose:          :ENCRYPT_DECRYPT,
+    version_template: {
+      algorithm:        :GOOGLE_SYMMETRIC_ENCRYPTION,
+      protection_level: :HSM
+    }
+  }
+
+  begin
+    kms_client.get_key_ring name: key_ring_name
+  rescue Google::Cloud::NotFoundError
+    kms_client.create_key_ring parent: location_name, key_ring_id: key_ring_id, key_ring: {}
+  end
+
+  begin
+    kms_client.get_crypto_key name: crypt_key_id1_name
+  rescue Google::Cloud::NotFoundError
+    kms_client.create_crypto_key parent: key_ring_name, crypto_key_id: crypt_key_id1, crypto_key: key
+  end
+
+  parameter = {
+    kms_key: crypt_key_id1_name
+  }
+
+  client.create_parameter parent: location_name, parameter_id: parameter_id, parameter: parameter
+end

--- a/google-cloud-parameter_manager/samples/acceptance/update_param_kms_key_test.rb
+++ b/google-cloud-parameter_manager/samples/acceptance/update_param_kms_key_test.rb
@@ -1,0 +1,68 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "helper"
+
+describe "#update_param_kms_key", :parameter_manager_snippet do
+  before do
+    setup_update_param_kms_keys
+  end
+
+  it "Updates a parameter kms_key" do
+    sample = SampleLoader.load "update_param_kms_key.rb"
+
+    out, _err = capture_io do
+      sample.run project_id: project_id, parameter_id: parameter_id, kms_key: crypt_key_id2_name
+    end
+
+    assert_equal "Updated parameter projects/#{project_id}/locations/global/parameters/" \
+                 "#{parameter_id} with kms_key projects/#{project_id}/locations/global/" \
+                 "keyRings/#{key_ring_id}/cryptoKeys/#{crypt_key_id2}\n",
+                 out
+  end
+end
+
+def setup_update_param_kms_keys
+  key = {
+    purpose:          :ENCRYPT_DECRYPT,
+    version_template: {
+      algorithm:        :GOOGLE_SYMMETRIC_ENCRYPTION,
+      protection_level: :HSM
+    }
+  }
+
+  begin
+    kms_client.get_key_ring name: key_ring_name
+  rescue Google::Cloud::NotFoundError
+    kms_client.create_key_ring parent: location_name, key_ring_id: key_ring_id, key_ring: {}
+  end
+
+  begin
+    kms_client.get_crypto_key name: crypt_key_id1_name
+  rescue Google::Cloud::NotFoundError
+    kms_client.create_crypto_key parent: key_ring_name, crypto_key_id: crypt_key_id1, crypto_key: key
+  end
+
+  begin
+    kms_client.get_crypto_key name: crypt_key_id2_name
+  rescue Google::Cloud::NotFoundError
+    kms_client.create_crypto_key parent: key_ring_name, crypto_key_id: crypt_key_id2, crypto_key: key
+  end
+
+  parameter = {
+    kms_key: crypt_key_id1_name
+  }
+
+  client.create_parameter parent: location_name, parameter_id: parameter_id, parameter: parameter
+end

--- a/google-cloud-parameter_manager/samples/acceptance/update_regional_param_kms_key_test.rb
+++ b/google-cloud-parameter_manager/samples/acceptance/update_regional_param_kms_key_test.rb
@@ -1,0 +1,69 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "regional_helper"
+
+describe "#update_regional_param_kms_key", :regional_parameter_manager_snippet do
+  before do
+    setup_update_regional_param_kms_keys
+  end
+
+  it "Updates a regional parameter kms_key" do
+    sample = SampleLoader.load "update_regional_param_kms_key.rb"
+
+    out, _err = capture_io do
+      sample.run project_id: project_id, location_id: location_id, parameter_id: parameter_id,
+                 kms_key: crypt_key_id2_name
+    end
+
+    assert_equal "Updated regional parameter projects/#{project_id}/locations/#{location_id}/parameters/" \
+                 "#{parameter_id} with kms_key projects/#{project_id}/locations/#{location_id}/keyRings/" \
+                 "#{key_ring_id}/cryptoKeys/#{crypt_key_id2}\n",
+                 out
+  end
+end
+
+def setup_update_regional_param_kms_keys
+  key = {
+    purpose:          :ENCRYPT_DECRYPT,
+    version_template: {
+      algorithm:        :GOOGLE_SYMMETRIC_ENCRYPTION,
+      protection_level: :HSM
+    }
+  }
+
+  begin
+    kms_client.get_key_ring name: key_ring_name
+  rescue Google::Cloud::NotFoundError
+    kms_client.create_key_ring parent: location_name, key_ring_id: key_ring_id, key_ring: {}
+  end
+
+  begin
+    kms_client.get_crypto_key name: crypt_key_id1_name
+  rescue Google::Cloud::NotFoundError
+    kms_client.create_crypto_key parent: key_ring_name, crypto_key_id: crypt_key_id1, crypto_key: key
+  end
+
+  begin
+    kms_client.get_crypto_key name: crypt_key_id2_name
+  rescue Google::Cloud::NotFoundError
+    kms_client.create_crypto_key parent: key_ring_name, crypto_key_id: crypt_key_id2, crypto_key: key
+  end
+
+  parameter = {
+    kms_key: crypt_key_id1_name
+  }
+
+  client.create_parameter parent: location_name, parameter_id: parameter_id, parameter: parameter
+end

--- a/google-cloud-parameter_manager/samples/create_param_with_kms_key.rb
+++ b/google-cloud-parameter_manager/samples/create_param_with_kms_key.rb
@@ -1,0 +1,51 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START parametermanager_create_param_with_kms_key]
+require "google/cloud/parameter_manager"
+
+##
+# Create a parameter with a KMS key
+#
+# @param project_id [String] The Google Cloud project (e.g. "my-project")
+# @param parameter_id [String] The parameter name (e.g. "my-parameter")
+# @param kms_key [String] The KMS key name
+# (e.g. "projects/my-project/locations/global/keyRings/my-keyring/cryptoKeys/my-key")
+#
+def create_param_with_kms_key project_id:, parameter_id:, kms_key:
+  # Create a Parameter Manager client.
+  client = Google::Cloud::ParameterManager.parameter_manager
+
+  # Build the resource name of the parent project.
+  parent = client.location_path project: project_id, location: "global"
+
+  parameter = {
+    kms_key: kms_key
+  }
+
+  # Create the parameter.
+  param = client.create_parameter parent: parent, parameter_id: parameter_id, parameter: parameter
+
+  # Print the new parameter name.
+  puts "Created parameter #{param.name} with kms_key #{param.kms_key}"
+end
+# [END parametermanager_create_param_with_kms_key]
+
+if $PROGRAM_NAME == __FILE__
+  create_param_with_kms_key(
+    project_id: ENV["GOOGLE_CLOUD_PROJECT"] || raise("missing GOOGLE_CLOUD_PROJECT"),
+    parameter_id: ARGV.shift,
+    kms_key: ARGV.shift
+  )
+end

--- a/google-cloud-parameter_manager/samples/create_regional_param_with_kms_key.rb
+++ b/google-cloud-parameter_manager/samples/create_regional_param_with_kms_key.rb
@@ -1,0 +1,58 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START parametermanager_create_regional_param_with_kms_key]
+require "google/cloud/parameter_manager"
+
+##
+# Create a regional parameter with a KMS key
+#
+# @param project_id [String] The Google Cloud project (e.g. "my-project")
+# @param location_id [String] The location name (e.g. "us-central1")
+# @param parameter_id [String] The parameter name (e.g. "my-parameter")
+# @param kms_key [String] The KMS key name
+# (e.g. "projects/my-project/locations/us-central1/keyRings/my-keyring/cryptoKeys/my-key")
+#
+def create_regional_param_with_kms_key project_id:, location_id:, parameter_id:, kms_key:
+  # Endpoint for the regional parameter manager service.
+  api_endpoint = "parametermanager.#{location_id}.rep.googleapis.com"
+
+  # Create the Parameter Manager client.
+  client = Google::Cloud::ParameterManager.parameter_manager do |config|
+    config.endpoint = api_endpoint
+  end
+
+  # Build the resource name of the parent project.
+  parent = client.location_path project: project_id, location: location_id
+
+  parameter = {
+    kms_key: kms_key
+  }
+
+  # Create the parameter.
+  param = client.create_parameter parent: parent, parameter_id: parameter_id, parameter: parameter
+
+  # Print the new parameter name.
+  puts "Created regional parameter #{param.name} with kms_key #{param.kms_key}"
+end
+# [END parametermanager_create_regional_param_with_kms_key]
+
+if $PROGRAM_NAME == __FILE__
+  create_regional_param_with_kms_key(
+    project_id: ENV["GOOGLE_CLOUD_PROJECT"] || raise("missing GOOGLE_CLOUD_PROJECT"),
+    location_id: ENV["GOOGLE_CLOUD_LOCATION"] || "us-central1",
+    parameter_id: ARGV.shift,
+    kms_key: ARGV.shift
+  )
+end

--- a/google-cloud-parameter_manager/samples/remove_param_kms_key.rb
+++ b/google-cloud-parameter_manager/samples/remove_param_kms_key.rb
@@ -1,0 +1,52 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START parametermanager_remove_param_kms_key]
+require "google/cloud/parameter_manager"
+
+##
+# Remove the KMS key from a parameter
+#
+# @param project_id [String] The Google Cloud project (e.g. "my-project")
+# @param parameter_id [String] The parameter name (e.g. "my-parameter")
+#
+def remove_param_kms_key project_id:, parameter_id:
+  # Create a Parameter Manager client.
+  client = Google::Cloud::ParameterManager.parameter_manager
+
+  # Build the resource name of the parent project.
+  name = client.parameter_path project: project_id, location: "global", parameter: parameter_id
+
+  parameter = {
+    name: name
+  }
+
+  update_mask = {
+    paths: ["kms_key"]
+  }
+
+  # Update the parameter.
+  param = client.update_parameter parameter: parameter, update_mask: update_mask
+
+  # Print the parameter name.
+  puts "Removed kms_key for parameter #{param.name}"
+end
+# [END parametermanager_remove_param_kms_key]
+
+if $PROGRAM_NAME == __FILE__
+  remove_param_kms_key(
+    project_id: ENV["GOOGLE_CLOUD_PROJECT"] || raise("missing GOOGLE_CLOUD_PROJECT"),
+    parameter_id: ARGV.shift
+  )
+end

--- a/google-cloud-parameter_manager/samples/remove_regional_param_kms_key.rb
+++ b/google-cloud-parameter_manager/samples/remove_regional_param_kms_key.rb
@@ -1,0 +1,59 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START parametermanager_remove_regional_param_kms_key]
+require "google/cloud/parameter_manager"
+
+##
+# Remove the KMS key from a regional parameter
+#
+# @param project_id [String] The Google Cloud project (e.g. "my-project")
+# @param location_id [String] The location name (e.g. "us-central1")
+# @param parameter_id [String] The parameter name (e.g. "my-parameter")
+#
+def remove_regional_param_kms_key project_id:, location_id:, parameter_id:
+  # Endpoint for the regional parameter manager service.
+  api_endpoint = "parametermanager.#{location_id}.rep.googleapis.com"
+
+  # Create the Parameter Manager client.
+  client = Google::Cloud::ParameterManager.parameter_manager do |config|
+    config.endpoint = api_endpoint
+  end
+
+  # Build the resource name of the parent project.
+  name = client.parameter_path project: project_id, location: location_id, parameter: parameter_id
+
+  parameter = {
+    name: name
+  }
+
+  update_mask = {
+    paths: ["kms_key"]
+  }
+
+  # Update the parameter.
+  param = client.update_parameter parameter: parameter, update_mask: update_mask
+
+  # Print the parameter name.
+  puts "Removed kms_key for regional parameter #{param.name}"
+end
+# [END parametermanager_remove_regional_param_kms_key]
+
+if $PROGRAM_NAME == __FILE__
+  remove_regional_param_kms_key(
+    project_id: ENV["GOOGLE_CLOUD_PROJECT"] || raise("missing GOOGLE_CLOUD_PROJECT"),
+    location_id: ENV["GOOGLE_CLOUD_LOCATION"] || "us-central1",
+    parameter_id: ARGV.shift
+  )
+end

--- a/google-cloud-parameter_manager/samples/update_param_kms_key.rb
+++ b/google-cloud-parameter_manager/samples/update_param_kms_key.rb
@@ -1,0 +1,56 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START parametermanager_update_param_kms_key]
+require "google/cloud/parameter_manager"
+
+##
+# Update the KMS key of a parameter
+#
+# @param project_id [String] The Google Cloud project (e.g. "my-project")
+# @param parameter_id [String] The parameter name (e.g. "my-parameter")
+# @param kms_key [String] The KMS key name
+# (e.g. "projects/my-project/locations/global/keyRings/my-keyring/cryptoKeys/my-key")
+#
+def update_param_kms_key project_id:, parameter_id:, kms_key:
+  # Create a Parameter Manager client.
+  client = Google::Cloud::ParameterManager.parameter_manager
+
+  # Build the resource name of the parent project.
+  name = client.parameter_path project: project_id, location: "global", parameter: parameter_id
+
+  parameter = {
+    name: name,
+    kms_key: kms_key
+  }
+
+  update_mask = {
+    paths: ["kms_key"]
+  }
+
+  # Update the parameter.
+  param = client.update_parameter parameter: parameter, update_mask: update_mask
+
+  # Print the parameter name.
+  puts "Updated parameter #{param.name} with kms_key #{param.kms_key}"
+end
+# [END parametermanager_update_param_kms_key]
+
+if $PROGRAM_NAME == __FILE__
+  update_param_kms_key(
+    project_id: ENV["GOOGLE_CLOUD_PROJECT"] || raise("missing GOOGLE_CLOUD_PROJECT"),
+    parameter_id: ARGV.shift,
+    kms_key: ARGV.shift
+  )
+end

--- a/google-cloud-parameter_manager/samples/update_regional_param_kms_key.rb
+++ b/google-cloud-parameter_manager/samples/update_regional_param_kms_key.rb
@@ -1,0 +1,63 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START parametermanager_update_regional_param_kms_key]
+require "google/cloud/parameter_manager"
+
+##
+# Update the KMS key of a regional parameter
+#
+# @param project_id [String] The Google Cloud project (e.g. "my-project")
+# @param location_id [String] The location name (e.g. "us-central1")
+# @param parameter_id [String] The parameter name (e.g. "my-parameter")
+# @param kms_key [String] The KMS key name
+# (e.g. "projects/my-project/locations/us-central1/keyRings/my-keyring/cryptoKeys/my-key")
+#
+def update_regional_param_kms_key project_id:, location_id:, parameter_id:, kms_key:
+  # Endpoint for the regional parameter manager service.
+  api_endpoint = "parametermanager.#{location_id}.rep.googleapis.com"
+
+  # Create the Parameter Manager client.
+  client = Google::Cloud::ParameterManager.parameter_manager do |config|
+    config.endpoint = api_endpoint
+  end
+
+  # Build the resource name of the parent project.
+  name = client.parameter_path project: project_id, location: location_id, parameter: parameter_id
+
+  parameter = {
+    name: name,
+    kms_key: kms_key
+  }
+
+  update_mask = {
+    paths: ["kms_key"]
+  }
+
+  # Update the parameter.
+  param = client.update_parameter parameter: parameter, update_mask: update_mask
+
+  # Print the parameter name.
+  puts "Updated regional parameter #{param.name} with kms_key #{param.kms_key}"
+end
+# [END parametermanager_update_regional_param_kms_key]
+
+if $PROGRAM_NAME == __FILE__
+  update_regional_param_kms_key(
+    project_id: ENV["GOOGLE_CLOUD_PROJECT"] || raise("missing GOOGLE_CLOUD_PROJECT"),
+    location_id: ENV["GOOGLE_CLOUD_LOCATION"] || "us-central1",
+    parameter_id: ARGV.shift,
+    kms_key: ARGV.shift
+  )
+end


### PR DESCRIPTION
# Description
Created samples for the kms_key field in the global and regional Parameter Manager API.

#### Samples List:

1. create_param_with_kms_key
2. create_regional_param_with_kms_key
3. update_param_kms_key
4. update_regional_param_kms_key
5. remove_param_kms_key
6. remove_regional_param_kms_key