### PR TITLE
chore(secretmanager): Add regional samples for delayed destroy

### DIFF
--- a/google-cloud-secret_manager/samples/acceptance/create_regional_secret_with_delayed_destroy_test.rb
+++ b/google-cloud-secret_manager/samples/acceptance/create_regional_secret_with_delayed_destroy_test.rb
@@ -1,0 +1,29 @@
+# Copyright 2025 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "uri"
+
+require_relative "regional_helper"
+
+describe "#create_regional_secret_with_delayed_destroy", :regional_secret_manager_snippet do
+  it "creates a regional secret with delayed destroy enabled" do
+    sample = SampleLoader.load "create_regional_secret_with_delayed_destroy.rb"
+
+    out, _err = capture_io do
+      sample.run project_id: project_id, location_id: location_id, secret_id: secret_id, time_to_live: time_to_live
+    end
+    secret_id_regex = Regexp.escape secret_id
+    assert_match %r{Created regional secret: projects/\S+locations/\S+/secrets/#{secret_id_regex}}, out
+  end
+end

--- a/google-cloud-secret_manager/samples/acceptance/destroy_regional_secret_version_test.rb
+++ b/google-cloud-secret_manager/samples/acceptance/destroy_regional_secret_version_test.rb
@@ -30,4 +30,31 @@ describe "#destroy_regional_secret_version", :regional_secret_manager_snippet do
     refute_nil n_version
     assert_equal "destroyed", n_version.state.to_s.downcase
   end
+
+  it "disables the secret version when delayed destroy is enabled" do
+    sample = SampleLoader.load "destroy_regional_secret_version.rb"
+
+    refute_nil secret_version
+
+    # enables the delayed destroy on the secret.
+    client.update_secret(
+      secret: {
+        name: secret_name,
+        version_destroy_ttl: {
+          seconds: time_to_live
+        }
+      },
+      update_mask: {
+        paths: ["version_destroy_ttl"]
+      }
+    )
+
+    assert_output(/Destroyed regional secret version/) do
+      sample.run project_id: project_id, location_id: location_id, secret_id: secret_id, version_id: version_id
+    end
+
+    n_version = client.get_secret_version name: version_name
+    refute_nil n_version
+    assert_equal "disabled", n_version.state.to_s.downcase
+  end
 end

--- a/google-cloud-secret_manager/samples/acceptance/disable_regional_secret_delayed_destroy_test.rb
+++ b/google-cloud-secret_manager/samples/acceptance/disable_regional_secret_delayed_destroy_test.rb
@@ -1,0 +1,33 @@
+# Copyright 2025 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "uri"
+
+require_relative "regional_helper"
+
+describe "#disable_regional_secret_delayed_destroy", :regional_secret_manager_snippet do
+  it "disables the regional secret delayed destroy" do
+    sample = SampleLoader.load "disable_regional_secret_delayed_destroy.rb"
+
+    refute_nil secret_version
+
+    assert_output(/Disabled secret delayed destroy/) do
+      sample.run project_id: project_id, location_id: location_id, secret_id: secret_id
+    end
+
+    n_version = client.get_secret name: secret_name
+    refute_nil n_version
+    assert_nil n_version.version_destroy_ttl, "Expected versionDestroyTtl to be nil"
+  end
+end

--- a/google-cloud-secret_manager/samples/acceptance/enable_regional_secret_version_test.rb
+++ b/google-cloud-secret_manager/samples/acceptance/enable_regional_secret_version_test.rb
@@ -31,4 +31,32 @@ describe "#enable_regional_secret_version", :regional_secret_manager_snippet do
     refute_nil n_version
     assert_equal "enabled", n_version.state.to_s.downcase
   end
+
+  it "enables the secret version scheduled for destruction" do
+    sample = SampleLoader.load "enable_regional_secret_version.rb"
+
+    refute_nil secret_version
+
+    # enables the delayed destroy on the secret.
+    client.update_secret(
+      secret: {
+        name: secret_name,
+        version_destroy_ttl: {
+          seconds: time_to_live
+        }
+      },
+      update_mask: {
+        paths: ["version_destroy_ttl"]
+      }
+    )
+    client.destroy_secret_version name: version_name
+
+    assert_output(/Enabled regional secret version/) do
+      sample.run project_id: project_id, location_id: location_id, secret_id: secret_id, version_id: version_id
+    end
+
+    n_version = client.get_secret_version name: version_name
+    refute_nil n_version
+    assert_equal "enabled", n_version.state.to_s.downcase
+  end
 end

--- a/google-cloud-secret_manager/samples/acceptance/regional_helper.rb
+++ b/google-cloud-secret_manager/samples/acceptance/regional_helper.rb
@@ -36,6 +36,8 @@ class RegionalSecretManagerSnippetSpec < Minitest::Spec
   let(:label_key) { "label-key" }
   let(:label_value) { "label-value" }
 
+  let(:time_to_live) { 86_400 }
+
   let :client do
     Google::Cloud::SecretManager.secret_manager_service do |config|
       config.endpoint = api_endpoint

--- a/google-cloud-secret_manager/samples/acceptance/regional_snippets_test.rb
+++ b/google-cloud-secret_manager/samples/acceptance/regional_snippets_test.rb
@@ -42,6 +42,8 @@ describe "Secret Manager Regional Snippets" do
   let(:label_key) { "label-key" }
   let(:label_value) { "label-value" }
 
+  let(:time_to_live) { 86_400 }
+
   let :secret do
     client.create_secret(
       parent:    "projects/#{project_id}/locations/#{location_id}",
@@ -570,6 +572,75 @@ describe "Secret Manager Regional Snippets" do
         expect(secret_labels).wont_be_nil
         expect(secret_labels[label_key]).must_equal(label_value)
       }.must_output(/Label Key: #{label_key}, Label Value: #{label_value}/)
+    end
+  end
+
+  describe "#create_regional_secret_with_delayed_destroy" do
+    it "create regional secret with delayed destroy enabled" do
+      expect {
+        secret = create_regional_secret_with_delayed_destroy(
+          project_id: project_id,
+          location_id: location_id,
+          secret_id: secret_id,
+          time_to_live: time_to_live
+        )
+
+        expect(secret).wont_be_nil
+        expect(secret.name).must_include(secret_id)
+        expect(secret.version_destroy_ttl.seconds).must_equal(time_to_live)
+      }.must_output(/Created regional secret/)
+    end
+  end
+
+  describe "#disable_regional_secret_delayed_destroy" do
+    it "disables the regional secret's delayed destroy" do
+      expect(secret_version).wont_be_nil
+
+      # enables the delayed destroy on the secret.
+      client.update_secret(
+        secret: {
+          name: secret_name,
+          version_destroy_ttl: {
+            seconds: time_to_live
+          }
+        },
+        update_mask: {
+          paths: ["version_destroy_ttl"]
+        }
+      )
+      client.destroy_secret_version name: version_name
+
+      expect {
+        disable_regional_secret_delayed_destroy(
+          project_id: project_id,
+          location_id: location_id,
+          secret_id:  secret_id
+        )
+      }.must_output(/Disabled regional secret delayed destroy/)
+
+      n_version = client.get_secret name: secret_name
+      expect(n_version).wont_be_nil
+      expect(n_version.version_destroy_ttl).must_be_nil
+    end
+  end
+
+  describe "#update_regional_secret_with_delayed_destroy" do
+    it "updates the regional secret delayed destroy ttl" do
+      expect(secret).wont_be_nil
+
+      updated_time_to_live = 172_800
+
+      expect {
+        n_secret = update_regional_secret_with_delayed_destroy(
+          project_id: project_id,
+          location_id: location_id,
+          secret_id:  secret_id,
+          updated_time_to_live: updated_time_to_live
+        )
+
+        expect(n_secret).wont_be_nil
+        expect(n_secret.version_destroy_ttl.seconds).must_equal(updated_time_to_live)
+      }.must_output(/Updated regional secret/)
     end
   end
 end

--- a/google-cloud-secret_manager/samples/acceptance/update_regional_secret_with_delayed_destroy_test.rb
+++ b/google-cloud-secret_manager/samples/acceptance/update_regional_secret_with_delayed_destroy_test.rb
@@ -1,0 +1,34 @@
+# Copyright 2025 Google, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "uri"
+
+require_relative "regional_helper"
+
+describe "#update_regional_secret_with_delayed_destroy", :regional_secret_manager_snippet do
+  it "updates the secret's delayed destroy ttl value" do
+    sample = SampleLoader.load "update_regional_secret_with_delayed_destroy.rb"
+
+    refute_nil secret
+
+    updated_time_to_live = 172_800
+
+    out, _err = capture_io do
+      sample.run project_id: project_id, location_id: location_id, secret_id: secret_id, updated_time_to_live: updated_time_to_live
+    end
+
+    assert_match(/Updated regional secret/, out)
+    assert_match(/New updated regional secret ttl/, out)
+  end
+end

--- a/google-cloud-secret_manager/samples/create_regional_secret_with_delayed_destroy.rb
+++ b/google-cloud-secret_manager/samples/create_regional_secret_with_delayed_destroy.rb
@@ -1,0 +1,52 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START secretmanager_create_regional_secret_with_delayed_destroy]
+require "google/cloud/secret_manager"
+
+##
+# Create a regional secret with delayed destroy
+#
+# @param project_id [String] Your Google Cloud project (e.g. "my-project")
+# @param location_id [String] Your Google Cloud location (e.g. "us-west1")
+# @param secret_id [String] Your secret name (e.g. "my-secret")
+# @param time_to_live [Integer] Your delayed destroy ttl in seconds for secret versions (e.g. 86400)
+#
+def create_regional_secret_with_delayed_destroy project_id:, location_id:, secret_id:, time_to_live:
+  # Endpoint for the regional secret manager service.
+  api_endpoint = "secretmanager.#{location_id}.rep.googleapis.com"
+
+  # Create the Secret Manager client.
+  client = Google::Cloud::SecretManager.secret_manager_service do |config|
+    config.endpoint = api_endpoint
+  end
+
+  # Build the resource name of the parent project.
+  parent = client.location_path project: project_id, location: location_id
+
+  # Create the secret.
+  secret = client.create_secret(
+    parent:    parent,
+    secret_id: secret_id,
+    secret: {
+      version_destroy_ttl: {
+        seconds: time_to_live
+      }
+    }
+  )
+
+  # Print the new secret name.
+  puts "Created regional secret: #{secret.name}"
+end
+# [END secretmanager_create_regional_secret_with_delayed_destroy]

--- a/google-cloud-secret_manager/samples/disable_regional_secret_delayed_destroy.rb
+++ b/google-cloud-secret_manager/samples/disable_regional_secret_delayed_destroy.rb
@@ -1,0 +1,50 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START secretmanager_disable_regional_secret_delayed_destroy]
+require "google/cloud/secret_manager"
+
+##
+# Disables a regional secret delayed destroy
+#
+# @param project_id [String] Your Google Cloud project (e.g. "my-project")
+# @param location_id [String] Your Google Cloud location (e.g. "us-west1")
+# @param secret_id [String] Your secret name (e.g. "my-secret")
+#
+def disable_regional_secret_delayed_destroy project_id:, location_id:, secret_id:
+  # Endpoint for the regional secret manager service.
+  api_endpoint = "secretmanager.#{location_id}.rep.googleapis.com"
+
+  # Create the Secret Manager client.
+  client = Google::Cloud::SecretManager.secret_manager_service do |config|
+    config.endpoint = api_endpoint
+  end
+
+  # Build the resource name of the secret.
+  name = client.secret_path project: project_id, location: location_id, secret: secret_id
+
+  # Create the secret.
+  secret = client.update_secret(
+    secret: {
+      name: name
+    },
+    update_mask: {
+      paths: ["version_destroy_ttl"]
+    }
+  )
+
+  # Print a success message.
+  puts "Disabled secret delayed destroy: #{secret.name}"
+end
+# [END secretmanager_disable_regional_secret_delayed_destroy]

--- a/google-cloud-secret_manager/samples/regional_snippets.rb
+++ b/google-cloud-secret_manager/samples/regional_snippets.rb
@@ -995,6 +995,124 @@ def view_regional_secret_labels project_id:, location_id:, secret_id:
   existing_secret_labels
 end
 
+def create_regional_secret_with_delayed_destroy project_id:, location_id:, secret_id:, time_to_live:
+  # [START secretmanager_create_regional_secret_with_delayed_destroy]
+  # project_id   = "YOUR-GOOGLE-CLOUD-PROJECT"            # (e.g. "my-project")
+  # location_id  = "YOUR-GOOGLE-CLOUD-LOCATION"           # (e.g. "us-west1")
+  # secret_id    = "YOUR-SECRET-ID"                       # (e.g. "my-secret")
+  # time_to_live = "TOUR_DELAYED_DESTROY_TTL_IN_SECONDS"  # (e.g. 86400)
+
+  # Require the Secret Manager client library.
+  require "google/cloud/secret_manager"
+
+  # Endpoint for the regional secret manager service.
+  api_endpoint = "secretmanager.#{location_id}.rep.googleapis.com"
+
+  # Create the Secret Manager client.
+  client = Google::Cloud::SecretManager.secret_manager_service do |config|
+    config.endpoint = api_endpoint
+  end
+
+  # Build the resource name of the parent project.
+  parent = client.location_path project: project_id, location: location_id
+
+  # Create the secret.
+  secret = client.create_secret(
+    parent:    parent,
+    secret_id: secret_id,
+    secret: {
+      version_destroy_ttl: {
+        seconds: time_to_live
+      }
+    }
+  )
+
+  # Print the new secret name.
+  puts "Created regional secret: #{secret.name}"
+  # [END secretmanager_create_regional_secret_with_delayed_destroy]
+
+  secret
+end
+
+def disable_regional_secret_delayed_destroy project_id:, location_id:, secret_id:
+  # [START secretmanager_disable_regional_secret_delayed_destroy]
+  # project_id   = "YOUR-GOOGLE-CLOUD-PROJECT"   # (e.g. "my-project")
+  # location_id  = "YOUR-GOOGLE-CLOUD-LOCATION"  # (e.g. "us-west1")
+  # secret_id    = "YOUR-SECRET-ID"              # (e.g. "my-secret")
+
+  # Require the Secret Manager client library.
+  require "google/cloud/secret_manager"
+
+  # Endpoint for the regional secret manager service.
+  api_endpoint = "secretmanager.#{location_id}.rep.googleapis.com"
+
+  # Create the Secret Manager client.
+  client = Google::Cloud::SecretManager.secret_manager_service do |config|
+    config.endpoint = api_endpoint
+  end
+
+  # Build the resource name of the secret.
+  name = client.secret_path project: project_id, location: location_id, secret: secret_id
+
+  # Create the secret.
+  secret = client.update_secret(
+    secret: {
+      name: name
+    },
+    update_mask: {
+      paths: ["version_destroy_ttl"]
+    }
+  )
+
+  # Print a success message.
+  puts "Disabled regional secret delayed destroy: #{secret.name}"
+  # [END secretmanager_disable_regional_secret_delayed_destroy]
+
+  secret
+end
+
+def update_regional_secret_with_delayed_destroy project_id:, location_id:, secret_id:, updated_time_to_live:
+  # [START secretmanager_update_regional_secret_with_delayed_destroy]
+  # project_id   = "YOUR-GOOGLE-CLOUD-PROJECT"            # (e.g. "my-project")
+  # location_id  = "YOUR-GOOGLE-CLOUD-LOCATION"           # (e.g. "us-west1")
+  # secret_id    = "YOUR-SECRET-ID"                       # (e.g. "my-secret")
+  # time_to_live = "TOUR_DELAYED_DESTROY_TTL_IN_SECONDS"  # (e.g. 86400)
+
+  # Require the Secret Manager client library.
+  require "google/cloud/secret_manager"
+
+  # Endpoint for the regional secret manager service.
+  api_endpoint = "secretmanager.#{location_id}.rep.googleapis.com"
+
+  # Create the Secret Manager client.
+  client = Google::Cloud::SecretManager.secret_manager_service do |config|
+    config.endpoint = api_endpoint
+  end
+
+  # Build the resource name of the secret.
+  name = client.secret_path project: project_id, location: location_id, secret: secret_id
+
+  # Create the secret.
+  secret = client.update_secret(
+    secret: {
+      name: name,
+      version_destroy_ttl: {
+        seconds: updated_time_to_live
+      }
+    },
+    update_mask: {
+      paths: ["version_destroy_ttl"]
+    }
+  )
+
+  # Print the updated secret name and the new ttl value.
+  puts "Updated regional secret: #{secret.name}"
+  puts "New updated regional secret ttl: #{secret.version_destroy_ttl}"
+  # [END secretmanager_update_regional_secret_with_delayed_destroy]
+
+  secret
+end
+
 if $PROGRAM_NAME == __FILE__
   args    = ARGV.dup
   command = args.shift
@@ -1183,6 +1301,26 @@ if $PROGRAM_NAME == __FILE__
       location_id: ENV["GOOGLE_CLOUD_LOCATION"],
       secret_id:  args.shift
     )
+  when "create_regional_secret_with_delayed_destroy"
+    create_regional_secret_with_delayed_destroy(
+      project_id: ENV["GOOGLE_CLOUD_PROJECT"],
+      location_id: ENV["GOOGLE_CLOUD_LOCATION"],
+      secret_id:  args.shift,
+      time_to_live: args.shift
+    )
+  when "disable_regional_secret_delayed_destroy"
+    disable_regional_secret_delayed_destroy(
+      project_id: ENV["GOOGLE_CLOUD_PROJECT"],
+      location_id: ENV["GOOGLE_CLOUD_LOCATION"],
+      secret_id:  args.shift
+    )
+  when "update_regional_secret_with_delayed_destroy"
+    update_regional_secret_with_delayed_destroy(
+      project_id: ENV["GOOGLE_CLOUD_PROJECT"],
+      location_id: ENV["GOOGLE_CLOUD_LOCATION"],
+      secret_id:  args.shift,
+      updated_time_to_live: args.shift
+    )
   else
     puts <<~USAGE
       Usage: bundle exec ruby #{__FILE__} [command] [arguments]
@@ -1192,12 +1330,14 @@ if $PROGRAM_NAME == __FILE__
         add_regional_secret_version <secret>                                                                 Add a new regional secret version
         create_regional_secret <secret>                                                                      Create a new regional secret
         create_regional_secret_with_annotations <secret> <key> <value>                                       Create a new regional secret with annotations
+        create_regional_secret_with_delayed_destroy <secret> <ttl>                                           Create a new regional secret with delayed destroy
         create_regional_secret_with_labels <secret> <key> <value>                                            Create a new regional secret with labels
         delete_regional_secret_with_etag <secret> <etag>                                                     Delete an existing regional secret with associated etag
         delete_regional_secret <secret>                                                                      Delete an existing regional secret
         destroy_regional_secret_version_with_etag <secret> <version> <etag>                                  Destroy a regional secret version
         destroy_regional_secret_version <secret> <version> <etag>                                            Destroy a regional secret version
         disable_regional_secret_version_with_etag <secret> <version> <etag>                                  Disable a regional secret version
+        disable_regional_secret_delayed_destroy <secret>                                                     Disable a regional secret's delayed destroy
         disable_regional_secret_version <secret> <version>                                                   Disable a regional secret version
         edit_regional_secret_annotations <secret> <key> <value>                                              Edit a regional secret annotations
         enable_regional_secret_version_with_etag <secret> <version> <etag>                                   Enable a regional secret version
@@ -1211,6 +1351,7 @@ if $PROGRAM_NAME == __FILE__
         list_regional_secrets_with_filter <filter>                                                           List all  regional secrets
         list_regional_secrets                                                                                List all  regional secrets
         update_regional_secret_with_alias <secret>                                                           Update a regional secret
+        update_regional_secret_with_delayed_destroy <secret> <ttl>                                           Update a regional secret's delayed destroy ttl value
         update_regional_secret_with_etag <secret> <etag>                                                     Update a regional secret
         update_regional_secret <secret>                                                                      Update a regional secret
         view_regional_secret_annotations <secret>                                                            View a regional secret annotations

--- a/google-cloud-secret_manager/samples/update_regional_secret_with_delayed_destroy.rb
+++ b/google-cloud-secret_manager/samples/update_regional_secret_with_delayed_destroy.rb
@@ -1,0 +1,55 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START secretmanager_update_regional_secret_with_delayed_destroy]
+require "google/cloud/secret_manager"
+
+##
+# Update a regional secret's delayed destroy
+#
+# @param project_id [String] Your Google Cloud project (e.g. "my-project")
+# @param location_id [String] Your Google Cloud location (e.g. "us-west1")
+# @param secret_id [String] Your secret name (e.g. "my-secret")
+# @param updated_time_to_live [Integer] Your ttl in seconds for new secret versions (e.g., 86400)
+#
+def update_regional_secret_with_delayed_destroy project_id:, location_id:, secret_id:, updated_time_to_live:
+  # Endpoint for the regional secret manager service.
+  api_endpoint = "secretmanager.#{location_id}.rep.googleapis.com"
+
+  # Create the Secret Manager client.
+  client = Google::Cloud::SecretManager.secret_manager_service do |config|
+    config.endpoint = api_endpoint
+  end
+
+  # Build the resource name of the secret.
+  name = client.secret_path project: project_id, location: location_id, secret: secret_id
+
+  # Create the secret.
+  secret = client.update_secret(
+    secret: {
+      name: name,
+      version_destroy_ttl: {
+        seconds: updated_time_to_live
+      }
+    },
+    update_mask: {
+      paths: ["version_destroy_ttl"]
+    }
+  )
+
+  # Print the updated secret name and the new ttl value.
+  puts "Updated regional secret: #{secret.name}"
+  puts "New updated regional secret ttl: #{secret.version_destroy_ttl}"
+end
+# [END secretmanager_update_regional_secret_with_delayed_destroy]


### PR DESCRIPTION
### Changes
- Added the necessary code samples for Delayed Destroy
- Added the test files for the code samples added
- Added the samples in the snippet file
- Added the tests for the changes in snippet file

### Prerequisite

- [X] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-ruby/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea.
    - https://github.com/googleapis/google-cloud-ruby/issues/29465
- [X] Follow the instructions in [CONTRIBUTING](CONTRIBUTING.md). Most importantly, ensure the tests and linter pass by running `bundle exec rake ci` in the gem subdirectory.
- [X] Update code documentation if necessary.

closes: #<29465>