### PR TITLE
feat: add Query explanation features for Ruby Firestore

### DIFF
--- a/google-cloud-firestore/acceptance/firestore/query_explain_test.rb
+++ b/google-cloud-firestore/acceptance/firestore/query_explain_test.rb
@@ -1,0 +1,185 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "firestore_helper"
+
+describe "Query Explain", :firestore_acceptance do
+  # Basic explain feature tests
+  it "runs a query with explain (analyze: false) - returns only metrics, no results" do
+    rand_query_col = firestore.col "#{root_path}/query/#{SecureRandom.hex(4)}"
+    # Add some documents
+    rand_query_col.add({name: "Alice", population: 100})
+    rand_query_col.add({name: "Bob", population: 200})
+    rand_query_col.add({name: "Charlie", population: 300})
+
+    # Run a query with explain(analyze: false)
+    results = rand_query_col.explain
+    
+    # Should have no actual document results
+    _(results.to_a).must_be :empty?
+    
+    # But should have explain_metrics
+    _(results.explain_metrics).wont_be_nil
+    _(results.explain_metrics).must_be_kind_of Google::Cloud::Firestore::V1::ExplainMetrics
+    _(results.explain_metrics.plan_summary).wont_be_nil
+  end
+
+  it "runs a query with explain (analyze: true) - returns both results and metrics" do
+    rand_query_col = firestore.col "#{root_path}/query/#{SecureRandom.hex(4)}"
+    # Add some documents
+    rand_query_col.add({name: "Alice", population: 100})
+    rand_query_col.add({name: "Bob", population: 200})
+    rand_query_col.add({name: "Charlie", population: 300})
+
+    # Run a query with explain(analyze: true)
+    results = rand_query_col.explain analyze: true
+    
+    # Should have actual document results
+    _(results.count).must_equal 3
+    
+    # And should have explain_metrics with both planning and execution data
+    _(results.explain_metrics).wont_be_nil
+    _(results.explain_metrics).must_be_kind_of Google::Cloud::Firestore::V1::ExplainMetrics
+    
+    # Verify metrics have proper structure (specific fields may vary based on implementation)
+    # This verifies that execution metrics are present (when analyze is true)
+    _(results.explain_metrics.plan_summary).wont_be_nil
+    _(results.explain_metrics.execution_stats).wont_be_nil
+  end
+
+  it "returns explain_metrics only after full enumeration" do
+    rand_query_col = firestore.col "#{root_path}/query/#{SecureRandom.hex(4)}"
+    # Add some documents
+    rand_query_col.add({name: "Alice", population: 100})
+    rand_query_col.add({name: "Bob", population: 200})
+    rand_query_col.add({name: "Charlie", population: 300})
+
+    # Run a query with explain(analyze: true)
+    results = rand_query_col.explain analyze: true
+    
+    # Before iteration, explain_metrics should be nil
+    _(results.explain_metrics).must_be_nil
+    
+    # Get just the first element
+    first = results.first
+    _(first).wont_be_nil
+    
+    # explain_metrics should still be nil since we didn't fully enumerate
+    _(results.explain_metrics).must_be_nil
+    
+    # Force complete enumeration
+    all_results = results.to_a
+    
+    # Now explain_metrics should be populated
+    _(results.explain_metrics).wont_be_nil
+    _(results.explain_metrics).must_be_kind_of Google::Cloud::Firestore::V1::ExplainMetrics
+  end
+
+  # Limit test - standard limit
+  it "works with limit and analyze: true" do
+    rand_query_col = firestore.col "#{root_path}/query/#{SecureRandom.hex(4)}"
+    # Add some documents
+    rand_query_col.add({name: "Alice", population: 100})
+    rand_query_col.add({name: "Bob", population: 200})
+    rand_query_col.add({name: "Charlie", population: 300})
+
+    # Run a query with limit and explain(analyze: true)
+    results = rand_query_col.order(:population).limit(2).explain analyze: true
+    
+    # Should respect the limit
+    _(results.count).must_equal 2
+    
+    # Verify correct ordering and limit
+    names = results.map { |doc| doc[:name] }
+    _(names).must_equal ["Alice", "Bob"]
+    
+    # And should have explain_metrics
+    _(results.explain_metrics).wont_be_nil
+  end
+
+  # Limit_to_last test - special case because of reversing
+  it "works with limit_to_last and analyze: true" do
+    rand_query_col = firestore.col "#{root_path}/query/#{SecureRandom.hex(4)}"
+    # Add some documents
+    rand_query_col.add({name: "Alice", population: 100})
+    rand_query_col.add({name: "Bob", population: 200})
+    rand_query_col.add({name: "Charlie", population: 300})
+
+    # Run a query with limit_to_last and explain(analyze: true)
+    results = rand_query_col.order(:population).limit_to_last(2).explain analyze: true
+    
+    # Should respect the limit_to_last
+    _(results.count).must_equal 2
+    
+    # Verify correct ordering - should be the last 2 items
+    names = results.map { |doc| doc[:name] }
+    _(names).must_equal ["Bob", "Charlie"]
+    
+    # And should have explain_metrics
+    _(results.explain_metrics).wont_be_nil
+  end
+
+  # Compatibility and edge cases
+  it "handles empty result sets with analyze: true" do
+    rand_query_col = firestore.col "#{root_path}/query/#{SecureRandom.hex(4)}"
+    # Add some documents that won't match our filter
+    rand_query_col.add({name: "Alice", population: 100})
+    rand_query_col.add({name: "Bob", population: 200})
+
+    # Run a query with filter that returns no results
+    results = rand_query_col.where(:population, :>, 1000).explain analyze: true
+    
+    # Should have no results
+    _(results.to_a).must_be :empty?
+    
+    # But should still have explain_metrics
+    _(results.explain_metrics).wont_be_nil
+  end
+
+  it "works with order and limit" do
+    rand_query_col = firestore.col "#{root_path}/query/#{SecureRandom.hex(4)}"
+    # Add some documents
+    rand_query_col.add({name: "Alice", population: 100})
+    rand_query_col.add({name: "Bob", population: 200})
+    rand_query_col.add({name: "Charlie", population: 300})
+
+    results = rand_query_col.order(:population).limit(2).explain analyze: true
+    _(results.count).must_equal 2
+    _(results.explain_metrics).wont_be_nil
+  end
+
+  it "doesn't produce different results from queries without explain" do
+    rand_query_col = firestore.col "#{root_path}/query/#{SecureRandom.hex(4)}"
+    # Add some documents
+    rand_query_col.add({name: "Alice", population: 100})
+    rand_query_col.add({name: "Bob", population: 200})
+    rand_query_col.add({name: "Charlie", population: 300})
+
+    # Run identical queries with and without explain(analyze: true)
+    results_with_explain = rand_query_col.order(:population).explain analyze: true
+    results_without_explain = rand_query_col.order(:population).get
+    
+    # Both should return the same document count
+    _(results_with_explain.count).must_equal results_without_explain.count
+    
+    # Both should return the same document content in the same order
+    names_with_explain = results_with_explain.map { |doc| doc[:name] }
+    names_without_explain = results_without_explain.map { |doc| doc[:name] }
+    _(names_with_explain).must_equal names_without_explain
+    
+    # Only the explain query should have metrics
+    _(results_with_explain.explain_metrics).wont_be_nil
+    _(results_without_explain).wont_respond_to :explain_metrics
+  end
+end

--- a/google-cloud-firestore/lib/google/cloud/firestore/query.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/query.rb
@@ -135,7 +135,7 @@ module Google
             new_query.select.fields << field_ref
           end
 
-          Query.start new_query, parent_path, client, limit_type: limit_type
+          start_new_query new_query
         end
 
         ##
@@ -171,7 +171,7 @@ module Google
 
           new_query.from.last.all_descendants = true
 
-          Query.start new_query, parent_path, client, limit_type: limit_type
+          start_new_query new_query
         end
 
         ##
@@ -207,7 +207,7 @@ module Google
 
           new_query.from.last.all_descendants = false
 
-          Query.start new_query, parent_path, client, limit_type: limit_type
+          start_new_query new_query
         end
 
         ##
@@ -373,7 +373,7 @@ module Google
             direction: order_direction(direction)
           )
 
-          Query.start new_query, parent_path, client, limit_type: limit_type
+          start_new_query new_query
         end
         alias order_by order
 
@@ -406,7 +406,7 @@ module Google
 
           new_query.offset = num
 
-          Query.start new_query, parent_path, client, limit_type: limit_type
+          start_new_query new_query
         end
 
         ##
@@ -443,7 +443,7 @@ module Google
 
           new_query.limit = Google::Protobuf::Int32Value.new value: num
 
-          Query.start new_query, parent_path, client, limit_type: :first
+          start_new_query new_query, limit_type_override: :first
         end
 
         ##
@@ -503,7 +503,7 @@ module Google
 
           new_query.limit = Google::Protobuf::Int32Value.new value: num
 
-          Query.start new_query, parent_path, client, limit_type: :last
+          start_new_query new_query, limit_type_override: :last
         end
 
         ##
@@ -611,7 +611,7 @@ module Google
           cursor.before = true
           new_query.start_at = cursor
 
-          Query.start new_query, parent_path, client, limit_type: limit_type
+          start_new_query new_query
         end
 
         ##
@@ -720,7 +720,7 @@ module Google
           cursor.before = false
           new_query.start_at = cursor
 
-          Query.start new_query, parent_path, client, limit_type: limit_type
+          start_new_query new_query
         end
 
         ##
@@ -829,7 +829,7 @@ module Google
           cursor.before = true
           new_query.end_at = cursor
 
-          Query.start new_query, parent_path, client, limit_type: limit_type
+          start_new_query new_query
         end
 
         ##
@@ -938,7 +938,7 @@ module Google
           cursor.before = false
           new_query.end_at = cursor
 
-          Query.start new_query, parent_path, client, limit_type: limit_type
+          start_new_query new_query
         end
 
         ##
@@ -1117,11 +1117,46 @@ module Google
 
         ##
         # @private Start a new Query.
-        def self.start query, parent_path, client, limit_type: nil
-          new query, parent_path, client, limit_type: limit_type
+        #
+        # This method creates and returns a new `Query` instance, initializing it with the provided parameters.
+        #
+        # @param [Google::Cloud::Firestore::V1::StructuredQuery] query
+        #   The structured query object representing the query to be executed.
+        # @param [String] parent_path
+        #   The parent path of the collection or document the query is operating on.
+        # @param [Google::Cloud::Firestore::Client] client
+        #   The Firestore client instance.
+        # @param [Symbol, nil] limit_type
+        #   (Optional) The type of limit to apply to the query results, either `:first` or `:last`.
+        #   Defaults to `nil` if no limit is applied.
+        # @param [Google::Cloud::Firestore::V1::ExplainOptions, nil] explain_options
+        #   (Optional) The options for explaining the query plan. Defaults to `nil` if not provided.
+        #
+        # @return [Google::Cloud::Firestore::Query]
+        #   A new `Query` instance initialized with the given parameters.
+        def self.start query, parent_path, client, limit_type: nil, explain_options: nil
+          new query, parent_path, client, limit_type: limit_type, explain_options: explain_options
         end
 
         protected
+
+        ##
+        # @private Helper for starting a new query copying existing parameters.
+        #
+        # @param [Google::Cloud::Firestore::V1::StructuredQuery] new_query
+        #    The new structured query object.
+        # @param [Symbol] limit_type_override The limit type override for the new query
+        # @param [Google::Cloud::Firestore::V1::ExplainOptions] explain_options_override
+        #   The explain options override for the new query.
+        #
+        # @return [Query] A new query
+        def start_new_query new_query, limit_type_override: nil, explain_options_override: nil
+          Query.start(new_query,
+                      parent_path,
+                      client,
+                      limit_type: limit_type_override || limit_type,
+                      explain_options: explain_options_override || explain_options)
+        end
 
         ##
         # @private

--- a/google-cloud-firestore/lib/google/cloud/firestore/query.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/query.rb
@@ -1052,8 +1052,8 @@ module Google
         #
         #   # Get the execution plan without running the query
         #   explain_result = query.explain
-        #   explain_result.fetch_metrics
-        #   pp explain_result.metrics
+        #   metrics = explain_result.explain_metrics
+        #   puts "Plan summary: #{metrics.plan_summary}" if metrics&.plan_summary
         #
         # @example Getting planning and execution stage metrics, as well as query results
         #   require "google/cloud/firestore"
@@ -1063,8 +1063,9 @@ module Google
         #
         #   # Run the query and return metrics from the planning and execution stages
         #   explain_result = query.explain analyze: true
-        #   explain_result.fetch_metrics
-        #   pp explain_result.metrics
+        #   metrics = explain_result.explain_metrics
+        #   puts "Plan summary: #{metrics.plan_summary}" if metrics&.plan_summary
+        #   puts "Results returned: #{metrics.execution_stats.results_returned}" if metrics&.execution_stats
         #   results = explain_result.to_a
         #
         def explain read_time: false, analyze: false

--- a/google-cloud-firestore/lib/google/cloud/firestore/query.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/query.rb
@@ -1014,6 +1014,12 @@ module Google
         # planning stages. If `analyze` is set to `true` the query will be planned and executed,
         # returning the full query results alongside both planning and execution stage metrics.
         #
+        # Unlike the Enumerator object that is returned from the `Query#get`,
+        # iterating over QueryExplainResult multiple times will not result in
+        # multiple requests to the server. The first set of results will be saved
+        # and re-used instead.
+        # This is to avoid the situations where the metrics change unpredictably when results are looked at.
+        #
         # @param [Time] read_time Reads documents as they were at the given time.
         #   This may not be older than 270 seconds. Optional
         #
@@ -1026,11 +1032,6 @@ module Google
         #     planning stage metrics, and execution stage metrics.
         #   Defaults to `false`.
         #
-        # Unlike the Enumerator object that is returned from the `Query#get`,
-        # iterating over QueryExplainResult multiple times will not result in
-        # multiple requests to the server. The first set of results will be saved
-        # and re-used instead.
-        #
         # @example Iterating over results multiple times
         #   require "google/cloud/firestore"
         #
@@ -1039,8 +1040,6 @@ module Google
         #   explanation_result = query.explain analyze: true
         #   results = explanation_result.to_a
         #   results_2 = explanation_result.to_a # same results, no re-query
-        #
-        # This is to avoid the situations where the metrics change unpredictably when results are looked at.
         #
         # @return [QueryExplainResult]
         #

--- a/google-cloud-firestore/lib/google/cloud/firestore/query.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/query.rb
@@ -1026,9 +1026,25 @@ module Google
         #     planning stage metrics, and execution stage metrics.
         #   Defaults to `false`.
         #
+        # Unlike the Enumerator object that is returned from the `Query#get`,
+        # iterating over QueryExplainResult multiple times will not result in
+        # multiple requests to the server. The first set of results will be saved
+        # and re-used instead.
+        #
+        # @example Iterating over results multiple times
+        #   require "google/cloud/firestore"
+        #
+        #   firestore = Google::Cloud::Firestore.new
+        #   query = firestore.col(:cities).where(:population, :>, 100000)
+        #   explanation_result = query.explain analyze: true
+        #   results = explanation_result.to_a
+        #   results_2 = explanation_result.to_a # same results, no re-query
+        #
+        # This is to avoid the situations where the metrics change unpredictably when results are looked at.
+        #
         # @return [QueryExplainResult]
         #
-        # @example
+        # @example Getting only the planning stage metrics for the query
         #   require "google/cloud/firestore"
         #
         #   firestore = Google::Cloud::Firestore.new
@@ -1039,7 +1055,7 @@ module Google
         #   explain_result.fetch_metrics
         #   pp explain_result.metrics
         #
-        # @example
+        # @example Getting planning and execution stage metrics, as well as query results
         #   require "google/cloud/firestore"
         #
         #   firestore = Google::Cloud::Firestore.new

--- a/google-cloud-firestore/lib/google/cloud/firestore/query_explain_result.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/query_explain_result.rb
@@ -1,0 +1,116 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+module Google
+  module Cloud
+    module Firestore
+      ##
+      # # QueryExplainResult
+      #
+      # Represents the result of a Firestore query explanation. This class
+      # provides an enumerable interface to iterate over the {DocumentSnapshot}
+      # results (if the explanation was run with `analyze: true`) and allows
+      # access to the {Google::Cloud::Firestore::V1::ExplainMetrics} which
+      # contain details about the query plan and execution statistics.
+      #
+      # @see Query#explain
+      #
+      # @example Iterating over results and accessing metrics
+      #   require "google/cloud/firestore"
+      #
+      #   firestore = Google::Cloud::Firestore.new
+      #   query = firestore.col(:cities).where(:population, :>, 100000)
+      #
+      #   # Run the query and return metrics from the planning and execution stages
+      #   explanation_result = query.explain analyze: true
+      #
+      #   explanation_result.each do |city_snapshot|
+      #     puts "City: #{city_snapshot.document_id}, Population: #{city_snapshot[:population]}"
+      #   end
+      #
+      #   # Metrics are populated after iterating or calling fetch_metrics
+      #   metrics = explanation_result.explain_metrics
+      #   puts "Results returned: #{metrics.execution_stats.results_returned}" if metrics&.execution_stats
+      #
+      # @example Fetching metrics directly (which also iterates internally if needed)
+      #   require "google/cloud/firestore"
+      #
+      #   firestore = Google::Cloud::Firestore.new
+      #   query = firestore.col(:cities).where(:population, :>, 100000)
+      #
+      #   # Get the execution plan without running the query (or with analyze: true)
+      #   explanation_result = query.explain analyze: false # or true
+      #
+      #   metrics = explanation_result.fetch_metrics
+      #   if metrics
+      #     puts "Plan summary: #{metrics.plan_summary}"
+      #     if metrics.execution_stats
+      #       puts "Execution stats: #{metrics.execution_stats.results_returned} results"
+      #     end
+      #   end
+      ##
+      class QueryExplainResult
+        include Enumerable
+
+        # The metrics from planning and execution stages of the query.
+        # This attribute is populated after iterating through the results (e.g., via {#each})
+        # or by explicitly calling {#fetch_metrics}.
+        # It will be `nil` if the query explanation did not produce metrics or if
+        # iteration has not yet occurred.
+        #
+        # @return [Google::Cloud::Firestore::V1::ExplainMetrics, nil] The query explanation metrics,
+        #   or `nil` if not yet populated or not available.
+        attr_reader :explain_metrics
+
+        # @private Creates a new QueryRunResult.
+        def initialize results_enum, client
+          @results_enum = results_enum
+          @client = client
+        end
+
+        # Iterates over the document snapshots returned by the query explanation
+        # if `analyze: true` was used. If `analyze: false` was used, this
+        # method will still iterate but will not yield any documents, though it
+        # will populate the query explanation metrics.
+        #
+        # @yieldparam [DocumentSnapshot] snapshot A document snapshot from the query results.
+        # @return [Enumerator] If no block is given.
+        def each
+          return enum_for :each unless block_given?
+          @results ||= @results_enum.to_a
+          @results.each do |result|
+            @explain_metrics ||= result.explain_metrics if result.explain_metrics
+            next if result.document.nil?
+
+            yield DocumentSnapshot.from_query_result(result, @client)
+          end
+        end
+
+        # Ensures that all results from the underlying enumerator have been seen
+        # and the metrics are populated.
+        # This method will iterate through any remaining results if they haven't been
+        # fully processed yet.
+        #
+        # @return [Google::Cloud::Firestore::V1::ExplainMetrics, nil] The query explanation metrics.
+        def fetch_metrics
+          # rubocop:disable Lint/EmptyBlock
+          each {} if explain_metrics.nil?
+          # rubocop:enable Lint/EmptyBlock
+          explain_metrics
+        end
+      end
+    end
+  end
+end

--- a/google-cloud-firestore/lib/google/cloud/firestore/query_explain_result.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/query_explain_result.rb
@@ -30,16 +30,8 @@ module Google
       # multiple requests to the server. The first set of results will be saved
       # and re-used instead.
       #
-      # @example Iterating over results multiple times
-      #   require "google/cloud/firestore"
-      #
-      #   firestore = Google::Cloud::Firestore.new
-      #   query = firestore.col(:cities).where(:population, :>, 100000)
-      #   explanation_result = query.explain analyze: true
-      #   results = explanation_result.to_a
-      #   results_2 = explanation_result.to_a # same results, no re-query
-      #
-      # This is to avoid the situations where the metrics change unpredictably when results are looked at.
+      # This is to avoid the situations where the metrics do not correspond to the results
+      # if results are partially re-enumerated
       #
       # @see Query#explain
       #
@@ -56,7 +48,6 @@ module Google
       #     puts "City: #{city_snapshot.document_id}, Population: #{city_snapshot[:population]}"
       #   end
       #
-      #   # Metrics are populated after iterating or calling fetch_metrics
       #   metrics = explanation_result.explain_metrics
       #   puts "Results returned: #{metrics.execution_stats.results_returned}" if metrics&.execution_stats
       #
@@ -69,13 +60,19 @@ module Google
       #   # Get the execution plan without running the query (or with analyze: true)
       #   explanation_result = query.explain analyze: false # or true
       #
-      #   metrics = explanation_result.fetch_metrics
-      #   if metrics
-      #     puts "Plan summary: #{metrics.plan_summary}"
-      #     if metrics.execution_stats
-      #       puts "Execution stats: #{metrics.execution_stats.results_returned} results"
-      #     end
-      #   end
+      #   metrics = explanation_result.explain_metrics
+      #   puts "Plan summary: #{metrics.plan_summary}" if metrics&.plan_summary
+      #   puts "Results returned: #{metrics.execution_stats.results_returned}" if metrics&.execution_stats
+      #
+      # @example Iterating over results multiple times
+      #   require "google/cloud/firestore"
+      #
+      #   firestore = Google::Cloud::Firestore.new
+      #   query = firestore.col(:cities).where(:population, :>, 100000)
+      #   explanation_result = query.explain analyze: true
+      #   results = explanation_result.to_a
+      #   results_2 = explanation_result.to_a # same results, no re-query
+      #
       ##
       class QueryExplainResult
         include Enumerable

--- a/google-cloud-firestore/lib/google/cloud/firestore/query_explain_result.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/query_explain_result.rb
@@ -115,6 +115,7 @@ module Google
         def each
           return enum_for :each unless block_given?
           @results ||= @results_enum.to_a
+
           @results.each do |result|
             @explain_metrics ||= result.explain_metrics if result.explain_metrics
             @metrics_fetched = !@explain_metrics.nil?

--- a/google-cloud-firestore/lib/google/cloud/firestore/query_explain_result.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/query_explain_result.rb
@@ -25,6 +25,22 @@ module Google
       # access to the {Google::Cloud::Firestore::V1::ExplainMetrics} which
       # contain details about the query plan and execution statistics.
       #
+      # Unlike the Enumerator object that is returned from the `Query#get`,
+      # iterating over QueryExplainResult multiple times will not result in
+      # multiple requests to the server. The first set of results will be saved
+      # and re-used instead.
+      #
+      # @example Iterating over results multiple times
+      #   require "google/cloud/firestore"
+      #
+      #   firestore = Google::Cloud::Firestore.new
+      #   query = firestore.col(:cities).where(:population, :>, 100000)
+      #   explanation_result = query.explain analyze: true
+      #   results = explanation_result.to_a
+      #   results_2 = explanation_result.to_a # same results, no re-query
+      #
+      # This is to avoid the situations where the metrics change unpredictably when results are looked at.
+      #
       # @see Query#explain
       #
       # @example Iterating over results and accessing metrics

--- a/google-cloud-firestore/lib/google/cloud/firestore/service.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/service.rb
@@ -120,18 +120,24 @@ module Google
           paged_enum.response
         end
 
-        def run_query path, query_grpc, transaction: nil, read_time: nil
+        def run_query path, query_grpc, transaction: nil, read_time: nil, explain_options: nil
           run_query_req = {
             parent:           path,
             structured_query: query_grpc
           }
+
           if transaction.is_a? String
             run_query_req[:transaction] = transaction
           elsif transaction
             run_query_req[:new_transaction] = transaction
           end
+
           if read_time
             run_query_req[:read_time] = read_time_to_timestamp(read_time)
+          end
+
+          if explain_options
+            run_query_req[:explain_options] = explain_options
           end
 
           firestore.run_query run_query_req, call_options(parent: database_path)

--- a/google-cloud-firestore/test/google/cloud/firestore/query/explain_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/query/explain_test.rb
@@ -1,0 +1,256 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Firestore::Query, :explain_options, :mock_firestore do
+  let(:query) { Google::Cloud::Firestore::Query.start nil, "#{firestore.path}/documents", firestore }
+  let(:read_time) { Time.now }
+  let :query_results_enum do
+    [
+      Google::Cloud::Firestore::V1::RunQueryResponse.new(
+        read_time: Google::Cloud::Firestore::Convert.time_to_timestamp(read_time),
+        document: Google::Cloud::Firestore::V1::Document.new(
+          name: "projects/#{project}/databases/(default)/documents/users/alice",
+          fields: { "name" => Google::Cloud::Firestore::V1::Value.new(string_value: "Alice") },
+          create_time: Google::Cloud::Firestore::Convert.time_to_timestamp(read_time),
+          update_time: Google::Cloud::Firestore::Convert.time_to_timestamp(read_time)
+        )),
+      Google::Cloud::Firestore::V1::RunQueryResponse.new(
+        read_time: Google::Cloud::Firestore::Convert.time_to_timestamp(read_time),
+        document: Google::Cloud::Firestore::V1::Document.new(
+          name: "projects/#{project}/databases/(default)/documents/users/carol",
+          fields: { "name" => Google::Cloud::Firestore::V1::Value.new(string_value: "Bob") },
+          create_time: Google::Cloud::Firestore::Convert.time_to_timestamp(read_time),
+          update_time: Google::Cloud::Firestore::Convert.time_to_timestamp(read_time)
+        ),
+        explain_metrics: Google::Cloud::Firestore::V1::ExplainMetrics.new()
+      )
+    ].to_enum
+  end
+
+  it "runs query with explain options (analyze: false)" do
+    expected_query = Google::Cloud::Firestore::V1::StructuredQuery.new(
+      select: Google::Cloud::Firestore::V1::StructuredQuery::Projection.new(
+        fields: [Google::Cloud::Firestore::V1::StructuredQuery::FieldReference.new(field_path: "name")])
+    )
+    explain_options = Google::Cloud::Firestore::V1::ExplainOptions.new(analyze: false)
+
+    firestore_mock.expect :run_query, query_results_enum, run_query_args(expected_query, explain_options: explain_options)
+
+    results_enum = query.select(:name).explain.to_enum
+    assert_results_enum results_enum
+  end
+
+  it "runs query with explain options (analyze: true)" do
+    expected_query = Google::Cloud::Firestore::V1::StructuredQuery.new(
+      select: Google::Cloud::Firestore::V1::StructuredQuery::Projection.new(
+        fields: [Google::Cloud::Firestore::V1::StructuredQuery::FieldReference.new(field_path: "name")])
+    )
+    explain_options = Google::Cloud::Firestore::V1::ExplainOptions.new(analyze: true)
+
+    firestore_mock.expect :run_query, query_results_enum, run_query_args(expected_query, explain_options: explain_options)
+
+    results_enum = query.select(:name).explain(analyze: true).to_enum
+    assert_results_enum results_enum
+  end
+
+  it "runs query with explain and order_by" do
+    expected_query = Google::Cloud::Firestore::V1::StructuredQuery.new(
+      order_by: [
+        Google::Cloud::Firestore::V1::StructuredQuery::Order.new(
+          field: Google::Cloud::Firestore::V1::StructuredQuery::FieldReference.new(field_path: "age"),
+          direction: :ASCENDING
+        )
+      ]
+    )
+    explain_options = Google::Cloud::Firestore::V1::ExplainOptions.new(analyze: false)
+
+    firestore_mock.expect :run_query, query_results_enum, run_query_args(expected_query, explain_options: explain_options)
+
+    results_enum = query.order(:age).explain.to_enum
+    assert_results_enum results_enum
+  end
+
+  # Test explain with limit
+  it "runs query with explain and limit" do
+    expected_query = Google::Cloud::Firestore::V1::StructuredQuery.new(
+      limit: Google::Protobuf::Int32Value.new(value: 5)
+    )
+    explain_options = Google::Cloud::Firestore::V1::ExplainOptions.new(analyze: false)
+
+    firestore_mock.expect :run_query, query_results_enum, run_query_args(expected_query, explain_options: explain_options)
+
+    results_enum = query.limit(5).explain.to_enum
+    assert_results_enum results_enum
+  end
+
+  # Test explain with limit_to_last
+  it "runs query with explain and limit_to_last" do
+    expected_query = Google::Cloud::Firestore::V1::StructuredQuery.new(
+      limit: Google::Protobuf::Int32Value.new(value: 5),
+      order_by: [
+        Google::Cloud::Firestore::V1::StructuredQuery::Order.new(
+          field: Google::Cloud::Firestore::V1::StructuredQuery::FieldReference.new(field_path: "__name__"),
+          direction: :DESCENDING
+        )
+      ]
+    )
+    explain_options = Google::Cloud::Firestore::V1::ExplainOptions.new(analyze: false)
+
+    firestore_mock.expect :run_query, query_results_enum, run_query_args(expected_query, explain_options: explain_options)
+
+    # Need to start with an order for limit_to_last to work
+    results_enum = query.order("__name__").limit_to_last(5).explain.to_enum
+    
+    # The query enumerator will reverse the results for limit_to_last so we have to undo that for verification
+    reversed_results_enum = results_enum.to_a.reverse.to_enum
+    assert_results_enum reversed_results_enum
+  end
+
+  it "runs query with explain and start_at field value" do
+    expected_query = Google::Cloud::Firestore::V1::StructuredQuery.new(
+      start_at: Google::Cloud::Firestore::V1::Cursor.new(
+        values: [Google::Cloud::Firestore::Convert.raw_to_value("Alice")], 
+        before: true
+      ),
+      order_by: [
+        Google::Cloud::Firestore::V1::StructuredQuery::Order.new(
+          field: Google::Cloud::Firestore::V1::StructuredQuery::FieldReference.new(field_path: "name"),
+          direction: :ASCENDING
+        )
+      ]
+    )
+    explain_options = Google::Cloud::Firestore::V1::ExplainOptions.new(analyze: false)
+
+    firestore_mock.expect :run_query, query_results_enum, run_query_args(expected_query, explain_options: explain_options)
+
+    results_enum = query.order("name").start_at("Alice").explain.to_enum
+    assert_results_enum results_enum
+  end
+
+  # Test explain with end_at cursor using field values instead of document snapshot
+  it "runs query with explain and end_at field value" do
+    expected_query = Google::Cloud::Firestore::V1::StructuredQuery.new(
+      end_at: Google::Cloud::Firestore::V1::Cursor.new(
+        values: [Google::Cloud::Firestore::Convert.raw_to_value("Bob")], 
+        before: false
+      ),
+      order_by: [
+        Google::Cloud::Firestore::V1::StructuredQuery::Order.new(
+          field: Google::Cloud::Firestore::V1::StructuredQuery::FieldReference.new(field_path: "name"),
+          direction: :ASCENDING
+        )
+      ]
+    )
+    explain_options = Google::Cloud::Firestore::V1::ExplainOptions.new(analyze: false)
+
+    firestore_mock.expect :run_query, query_results_enum, run_query_args(expected_query, explain_options: explain_options)
+
+    results_enum = query.order("name").end_at("Bob").explain.to_enum
+    assert_results_enum results_enum
+  end
+
+
+  it "raises an error when explain is called with invalid analyze parameter" do
+    # Test with a non-boolean parameter
+    error = assert_raises ArgumentError do
+      query.select(:name).explain(analyze: "true")
+    end
+    _(error.message).must_match(/analyze must be a boolean/)
+    
+    # Test with nil parameter
+    error = assert_raises ArgumentError do
+      query.select(:name).explain(analyze: nil)
+    end
+    _(error.message).must_match(/analyze must be a boolean/)
+    
+    # Test with something other than analyze parameter
+    error = assert_raises ArgumentError do
+      query.select(:name).explain(invalid_param: true)
+    end
+    _(error.message).must_match(/unknown keyword/)
+  end
+
+  it "does not eagerly read all documents when analyze: true and taking one" do
+    exploding_enum = ExplodingEnum.new query_results_enum
+
+    expected_query = Google::Cloud::Firestore::V1::StructuredQuery.new(
+      select: Google::Cloud::Firestore::V1::StructuredQuery::Projection.new(
+        fields: [Google::Cloud::Firestore::V1::StructuredQuery::FieldReference.new(field_path: "name")])
+    )
+    explain_options = Google::Cloud::Firestore::V1::ExplainOptions.new(analyze: true)
+
+    firestore_mock.expect :run_query, exploding_enum, run_query_args(expected_query, explain_options: explain_options)
+
+    # nothing is raised when getting the first document
+    results_enum = query.select(:name).explain(analyze: true).to_enum
+    first_doc = results_enum.first
+    refute_nil first_doc, "First document should be present"
+  end
+
+  it "does eagerly read all documents when analyze: true and taking one with limit_to_last" do
+    exploding_enum = ExplodingEnum.new query_results_enum
+
+    expected_query = Google::Cloud::Firestore::V1::StructuredQuery.new(
+      limit: Google::Protobuf::Int32Value.new(value: 5),
+      order_by: [
+        Google::Cloud::Firestore::V1::StructuredQuery::Order.new(
+          field: Google::Cloud::Firestore::V1::StructuredQuery::FieldReference.new(field_path: "__name__"),
+          direction: :DESCENDING
+        )
+      ]
+    )
+    explain_options = Google::Cloud::Firestore::V1::ExplainOptions.new(analyze: true)
+
+    firestore_mock.expect :run_query, exploding_enum, run_query_args(expected_query, explain_options: explain_options)
+
+    # Need to start with an order for limit_to_last to work
+    assert_raises RuntimeError do 
+      results_enum = query.order("__name__").limit_to_last(5).explain(analyze: true).to_enum
+      first_doc = results_enum.first
+    end
+  end
+
+  def assert_results_enum enum
+    _(enum).must_be_kind_of Enumerator
+
+    results = enum.to_a
+    _(results.count).must_equal 2
+
+    results.each do |result|
+      _(result).must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
+
+      _(result.ref).must_be_kind_of Google::Cloud::Firestore::DocumentReference
+      _(result.ref.client).must_equal firestore
+
+      _(result.parent).must_be_kind_of Google::Cloud::Firestore::CollectionReference
+      _(result.parent.collection_id).must_equal "users"
+      _(result.parent.collection_path).must_equal "users"
+      _(result.parent.client).must_equal firestore
+    end
+
+    _(results.first.data).must_be_kind_of Hash
+    _(results.first.data).must_equal({ name: "Alice" })
+    _(results.first.created_at).must_equal read_time
+    _(results.first.updated_at).must_equal read_time
+    _(results.first.read_at).must_equal read_time
+
+    _(results.last.data).must_be_kind_of Hash
+    _(results.last.data).must_equal({ name: "Bob" })
+    _(results.last.created_at).must_equal read_time
+    _(results.last.updated_at).must_equal read_time
+    _(results.last.read_at).must_equal read_time
+  end
+end

--- a/google-cloud-firestore/test/google/cloud/firestore/query/get_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/query/get_test.rb
@@ -426,8 +426,9 @@ describe Google::Cloud::Firestore::Query, :get, :mock_firestore do
 
     _(explain_result).must_be_kind_of Google::Cloud::Firestore::QueryExplainResult
 
-    explain_result.fetch_metrics
+    _(explain_result.metrics_fetched?).must_equal false
     _(explain_result.explain_metrics).must_equal query_result_metrics
+    _(explain_result.metrics_fetched?).must_equal true 
 
     assert_results_enum explain_result.to_enum
   end

--- a/google-cloud-firestore/test/google/cloud/firestore/query/get_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/query/get_test.rb
@@ -301,6 +301,121 @@ describe Google::Cloud::Firestore::Query, :get, :mock_firestore do
 
     assert_results_enum results_enum
   end
+ 
+  it "gets a query with limit_last" do
+    expected_query = Google::Cloud::Firestore::V1::StructuredQuery.new(
+      select: Google::Cloud::Firestore::V1::StructuredQuery::Projection.new(
+        fields: [Google::Cloud::Firestore::V1::StructuredQuery::FieldReference.new(field_path: "name")]),
+      order_by: [
+        Google::Cloud::Firestore::V1::StructuredQuery::Order.new(
+          field: Google::Cloud::Firestore::V1::StructuredQuery::FieldReference.new(field_path: "name"),
+          direction: :DESCENDING)],
+      limit: Google::Protobuf::Int32Value.new(value: 2)
+    )
+    
+    firestore_mock.expect :run_query, query_results_enum, run_query_args(expected_query)
+    # Later calls to `first` and `to_a` will result in separate firestore mock reads
+    firestore_mock.expect :run_query, query_results_enum, run_query_args(expected_query)
+
+    results_enum = query.select(:name).order_by(:name).limit_to_last(2).get
+    _(results_enum).must_be_kind_of Enumerator
+
+    # The results are reverted with limit_last, so "Bob" becomes the first result
+    first = results_enum.first
+    _(first).must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
+    _(first.data).must_equal({ name: "Bob" })
+        
+    results = results_enum.to_a
+    _(results.last).must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
+    _(results.last.data).must_equal({ name: "Alice" })
+  end
+
+  it "does not eagerly read without `limit_last`" do
+    expected_query = Google::Cloud::Firestore::V1::StructuredQuery.new(
+      select: Google::Cloud::Firestore::V1::StructuredQuery::Projection.new(
+        fields: [Google::Cloud::Firestore::V1::StructuredQuery::FieldReference.new(field_path: "name")])
+    )
+    firestore_mock.expect(:run_query, ExplodingEnum.new(query_results_enum), run_query_args(expected_query))
+    # Later calls to `first` and `to_a` will result in separate firestore mock reads
+    firestore_mock.expect(:run_query, ExplodingEnum.new(query_results_enum), run_query_args(expected_query))
+
+    results_enum = query.select(:name).get
+    _(results_enum).must_be_kind_of Enumerator
+
+    first = results_enum.first
+    _(first).must_be_kind_of Google::Cloud::Firestore::DocumentSnapshot
+
+    assert_raises(RuntimeError) { results_enum.to_a }
+  end
+
+  it "does eagerly read the whole enum with `limit_last` when first entry is read" do
+    expected_query = Google::Cloud::Firestore::V1::StructuredQuery.new(
+      select: Google::Cloud::Firestore::V1::StructuredQuery::Projection.new(
+        fields: [Google::Cloud::Firestore::V1::StructuredQuery::FieldReference.new(field_path: "name")]),
+      order_by: [
+        Google::Cloud::Firestore::V1::StructuredQuery::Order.new(
+          field: Google::Cloud::Firestore::V1::StructuredQuery::FieldReference.new(field_path: "name"),
+          direction: :DESCENDING)],
+      limit: Google::Protobuf::Int32Value.new(value: 2)
+    )
+    
+    firestore_mock.expect :run_query, ExplodingEnum.new(query_results_enum), run_query_args(expected_query)
+
+    results_enum = query.select(:name).order_by(:name).limit_to_last(2).get
+    _(results_enum).must_be_kind_of Enumerator
+    
+    assert_raises(RuntimeError) { results_enum.first }
+  end
+
+  it "gets a query with explanation" do
+    expected_query = Google::Cloud::Firestore::V1::StructuredQuery.new(
+      select: Google::Cloud::Firestore::V1::StructuredQuery::Projection.new(
+        fields: [Google::Cloud::Firestore::V1::StructuredQuery::FieldReference.new(field_path: "name")])
+    )
+    expected_explain_options = Google::Cloud::Firestore::V1::ExplainOptions.new(analyze: true)
+
+    query_result_metrics = Google::Cloud::Firestore::V1::ExplainMetrics.new(
+      plan_summary: Google::Cloud::Firestore::V1::PlanSummary.new(
+        indexes_used: [
+
+        ]
+      ),
+      execution_stats: Google::Cloud::Firestore::V1::ExecutionStats.new(
+        results_returned: 2
+      )
+    )
+
+    query_results_with_explanation = [
+      Google::Cloud::Firestore::V1::RunQueryResponse.new(
+        read_time: Google::Cloud::Firestore::Convert.time_to_timestamp(read_time),
+        document: Google::Cloud::Firestore::V1::Document.new(
+          name: "projects/#{project}/databases/(default)/documents/users/alice",
+          fields: { "name" => Google::Cloud::Firestore::V1::Value.new(string_value: "Alice") },
+          create_time: Google::Cloud::Firestore::Convert.time_to_timestamp(read_time),
+          update_time: Google::Cloud::Firestore::Convert.time_to_timestamp(read_time)
+        )),
+      Google::Cloud::Firestore::V1::RunQueryResponse.new(
+        explain_metrics: query_result_metrics,
+        read_time: Google::Cloud::Firestore::Convert.time_to_timestamp(read_time),
+        document: Google::Cloud::Firestore::V1::Document.new(
+          name: "projects/#{project}/databases/(default)/documents/users/bob",
+          fields: { "name" => Google::Cloud::Firestore::V1::Value.new(string_value: "Bob") },
+          create_time: Google::Cloud::Firestore::Convert.time_to_timestamp(read_time),
+          update_time: Google::Cloud::Firestore::Convert.time_to_timestamp(read_time)
+        ))
+    ].to_enum
+
+    firestore_mock.expect :run_query, query_results_with_explanation, run_query_args(expected_query, explain_options: expected_explain_options)
+
+    explain_result = query.select(:name).explain(analyze: true)
+
+    _(explain_result).must_be_kind_of Google::Cloud::Firestore::QueryExplainResult
+
+    explain_result.fetch_metrics
+    _(explain_result.explain_metrics).must_equal query_result_metrics
+
+    assert_results_enum explain_result.to_enum
+  end
 
   def assert_results_enum enum
     _(enum).must_be_kind_of Enumerator

--- a/google-cloud-firestore/test/google/cloud/firestore/query/get_test.rb
+++ b/google-cloud-firestore/test/google/cloud/firestore/query/get_test.rb
@@ -50,6 +50,21 @@ describe Google::Cloud::Firestore::Query, :get, :mock_firestore do
     assert_results_enum results_enum
   end
 
+  it "re-queries Firestore every time the get results are enumerated" do
+    expected_query = Google::Cloud::Firestore::V1::StructuredQuery.new(
+      select: Google::Cloud::Firestore::V1::StructuredQuery::Projection.new(
+        fields: [Google::Cloud::Firestore::V1::StructuredQuery::FieldReference.new(field_path: "name")])
+    )
+    firestore_mock.expect :run_query, query_results_enum, run_query_args(expected_query)
+
+    results_enum = query.select(:name).get
+    assert_results_enum results_enum
+
+    # second iteration through enum results in a second call to firestore_mock
+    firestore_mock.expect :run_query, query_results_enum, run_query_args(expected_query)
+    assert_results_enum results_enum 
+  end
+
   it "gets a query with a single select and read time set" do
     expected_query = Google::Cloud::Firestore::V1::StructuredQuery.new(
       select: Google::Cloud::Firestore::V1::StructuredQuery::Projection.new(


### PR DESCRIPTION
Server-side query explanation feature is triggered by a new parameter `explain_options` in `RunQueryRequest`. If that parameter is set, some of the `RunQueryResponse`s will have a a non-nil `explain_metrics` field. 

The goal of this PR is to facilitate setting `explain_options` and surface `explain_metrics` in a consistent user-friendly fashion on the client side. This is achieved by adding a new `explain` instance-level method to the Query class that can be invoked instead of `get`.