### PR TITLE
Only load from `cgi` what is required for Ruby 3.5

### DIFF
--- a/google-cloud-storage/lib/google/cloud/storage/file/signer_v2.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/signer_v2.rb
@@ -15,7 +15,7 @@
 
 require "addressable/uri"
 require "base64"
-require "cgi"
+require "cgi/escape"
 require "openssl"
 require "google/cloud/storage/errors"
 

--- a/google-cloud-storage/lib/google/cloud/storage/file/signer_v4.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/signer_v4.rb
@@ -14,7 +14,7 @@
 
 
 require "addressable/uri"
-require "cgi"
+require "cgi/escape"
 require "openssl"
 require "google/cloud/storage/errors"
 

--- a/google-cloud-storage/test/google/cloud/storage/bucket_signed_url_v2_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_signed_url_v2_test.rb
@@ -35,9 +35,9 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :mock_storage do
 
       signed_uri = URI(signed_url)
       _(signed_uri.path).must_equal "/bucket/"
-      signed_url_params = CGI::parse(signed_uri.query)
-      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
-      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+      signed_url_params = URI.decode_www_form(signed_uri.query).to_h
+      _(signed_url_params["GoogleAccessId"]).must_equal "native_client_email"
+      _(signed_url_params["Signature"]).must_equal Base64.strict_encode64("native-signature").delete("\n")
 
       signing_key_mock.verify
     end
@@ -53,9 +53,9 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :mock_storage do
 
       signed_url = bucket.signed_url file_path
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
-      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["GoogleAccessId"]).must_equal "native_client_email"
+      _(signed_url_params["Signature"]).must_equal Base64.strict_encode64("native-signature").delete("\n")
 
       signing_key_mock.verify
     end
@@ -73,9 +73,9 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :mock_storage do
       signed_url = bucket.signed_url file_path, issuer: "option_issuer",
                                                 signing_key: signing_key_mock
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["GoogleAccessId"]).must_equal ["option_issuer"]
-      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("option-signature").delete("\n")]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["GoogleAccessId"]).must_equal "option_issuer"
+      _(signed_url_params["Signature"]).must_equal Base64.strict_encode64("option-signature").delete("\n")
 
       signing_key_mock.verify
     end
@@ -94,9 +94,9 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :mock_storage do
         signed_url = bucket.signed_url file_path, client_email: "option_client_email",
                                                   private_key: "option_private_key"
 
-        signed_url_params = CGI::parse(URI(signed_url).query)
-        _(signed_url_params["GoogleAccessId"]).must_equal ["option_client_email"]
-        _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("option-signature").delete("\n")]
+        signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+        _(signed_url_params["GoogleAccessId"]).must_equal "option_client_email"
+        _(signed_url_params["Signature"]).must_equal Base64.strict_encode64("option-signature").delete("\n")
 
       end
 
@@ -116,9 +116,9 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :mock_storage do
       signed_url = bucket.signed_url file_path, issuer: "option_client_email",
                                                 signer: signer_mock
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["GoogleAccessId"]).must_equal ["option_client_email"]
-      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("option-signature").delete("\n")]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["GoogleAccessId"]).must_equal "option_client_email"
+      _(signed_url_params["Signature"]).must_equal Base64.strict_encode64("option-signature").delete("\n")
 
       signer_mock.verify
     end
@@ -135,9 +135,9 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :mock_storage do
       signed_url = bucket.signed_url file_path, headers: { "X-Goog-Meta-FOO" => "bar,baz",
                                                            "X-Goog-ACL" => "public-read" }
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
-      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["GoogleAccessId"]).must_equal "native_client_email"
+      _(signed_url_params["Signature"]).must_equal Base64.strict_encode64("native-signature").delete("\n")
 
       signing_key_mock.verify
     end
@@ -188,9 +188,9 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :mock_storage do
         signed_uri = URI signed_url
         _(signed_uri.path).must_equal "/bucket/hello%20world.txt"
 
-        signed_url_params = CGI::parse signed_uri.query
-        _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
-        _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+        signed_url_params = URI.decode_www_form(signed_uri.query).to_h
+        _(signed_url_params["GoogleAccessId"]).must_equal "native_client_email"
+        _(signed_url_params["Signature"]).must_equal Base64.strict_encode64("native-signature").delete("\n")
 
         signing_key_mock.verify
       end
@@ -208,10 +208,10 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :mock_storage do
       signed_url = bucket.signed_url file_path,
                                      query: { "response-content-disposition" => "attachment; filename=\"google-cloud.png\"" }
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
-      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
-      _(signed_url_params["response-content-disposition"]).must_equal ["attachment; filename=\"google-cloud.png\""]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["GoogleAccessId"]).must_equal "native_client_email"
+      _(signed_url_params["Signature"]).must_equal Base64.strict_encode64("native-signature").delete("\n")
+      _(signed_url_params["response-content-disposition"]).must_equal "attachment; filename=\"google-cloud.png\""
 
       signing_key_mock.verify
     end
@@ -228,10 +228,10 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :mock_storage do
       signed_url = bucket.signed_url file_path,
                                       query: { disposition: :inline }
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
-      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
-      _(signed_url_params["disposition"]).must_equal ["inline"]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["GoogleAccessId"]).must_equal "native_client_email"
+      _(signed_url_params["Signature"]).must_equal Base64.strict_encode64("native-signature").delete("\n")
+      _(signed_url_params["disposition"]).must_equal "inline"
 
       signing_key_mock.verify
     end

--- a/google-cloud-storage/test/google/cloud/storage/bucket_signed_url_v4_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/bucket_signed_url_v4_test.rb
@@ -34,13 +34,13 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :mock_storage do
 
       signed_uri = URI(signed_url)
       _(signed_uri.path).must_equal "/bucket"
-      signed_url_params = CGI::parse(signed_uri.query)
-      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
-      _(signed_url_params["X-Goog-Credential"]).must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
-      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
-      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
-      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
-      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6e61746976652d7369676e6174757265"]
+      signed_url_params = URI.decode_www_form(signed_uri.query).to_h
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  "GOOG4-RSA-SHA256"
+      _(signed_url_params["X-Goog-Credential"]).must_equal  "native_client_email/20120101/auto/storage/goog4_request"
+      _(signed_url_params["X-Goog-Date"]).must_equal  "20120101T000000Z"
+      _(signed_url_params["X-Goog-Expires"]).must_equal  "604800"
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  "host"
+      _(signed_url_params["X-Goog-Signature"]).must_equal  "6e61746976652d7369676e6174757265"
 
       signing_key_mock.verify
     end
@@ -56,13 +56,13 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :mock_storage do
 
       signed_url = bucket.signed_url file_path, version: :v4
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
-      _(signed_url_params["X-Goog-Credential"]).must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
-      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
-      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
-      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
-      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6e61746976652d7369676e6174757265"]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  "GOOG4-RSA-SHA256"
+      _(signed_url_params["X-Goog-Credential"]).must_equal  "native_client_email/20120101/auto/storage/goog4_request"
+      _(signed_url_params["X-Goog-Date"]).must_equal  "20120101T000000Z"
+      _(signed_url_params["X-Goog-Expires"]).must_equal  "604800"
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  "host"
+      _(signed_url_params["X-Goog-Signature"]).must_equal  "6e61746976652d7369676e6174757265"
 
       signing_key_mock.verify
     end
@@ -81,13 +81,13 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :mock_storage do
                                      issuer: "option_issuer",
                                      signing_key: signing_key_mock, version: :v4
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
-      _(signed_url_params["X-Goog-Credential"]).must_equal  ["option_issuer/20120101/auto/storage/goog4_request"]
-      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
-      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
-      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
-      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6f7074696f6e2d7369676e6174757265"]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  "GOOG4-RSA-SHA256"
+      _(signed_url_params["X-Goog-Credential"]).must_equal  "option_issuer/20120101/auto/storage/goog4_request"
+      _(signed_url_params["X-Goog-Date"]).must_equal  "20120101T000000Z"
+      _(signed_url_params["X-Goog-Expires"]).must_equal  "604800"
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  "host"
+      _(signed_url_params["X-Goog-Signature"]).must_equal  "6f7074696f6e2d7369676e6174757265"
 
       signing_key_mock.verify
     end
@@ -105,13 +105,13 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :mock_storage do
       signed_url = bucket.signed_url file_path, issuer: "option_issuer",
                                                 signer: signer_mock, version: :v4
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
-      _(signed_url_params["X-Goog-Credential"]).must_equal  ["option_issuer/20120101/auto/storage/goog4_request"]
-      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
-      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
-      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
-      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6f7074696f6e2d7369676e6174757265"]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  "GOOG4-RSA-SHA256"
+      _(signed_url_params["X-Goog-Credential"]).must_equal  "option_issuer/20120101/auto/storage/goog4_request"
+      _(signed_url_params["X-Goog-Date"]).must_equal  "20120101T000000Z"
+      _(signed_url_params["X-Goog-Expires"]).must_equal  "604800"
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  "host"
+      _(signed_url_params["X-Goog-Signature"]).must_equal  "6f7074696f6e2d7369676e6174757265"
 
       signer_mock.verify
     end
@@ -131,13 +131,13 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :mock_storage do
                                        client_email: "option_client_email",
                                        private_key: "option_private_key", version: :v4
 
-        signed_url_params = CGI::parse(URI(signed_url).query)
-        _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
-        _(signed_url_params["X-Goog-Credential"]).must_equal  ["option_client_email/20120101/auto/storage/goog4_request"]
-        _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
-        _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
-        _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
-        _(signed_url_params["X-Goog-Signature"]).must_equal  ["6f7074696f6e2d7369676e6174757265"]
+        signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+        _(signed_url_params["X-Goog-Algorithm"]).must_equal  "GOOG4-RSA-SHA256"
+        _(signed_url_params["X-Goog-Credential"]).must_equal  "option_client_email/20120101/auto/storage/goog4_request"
+        _(signed_url_params["X-Goog-Date"]).must_equal  "20120101T000000Z"
+        _(signed_url_params["X-Goog-Expires"]).must_equal  "604800"
+        _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  "host"
+        _(signed_url_params["X-Goog-Signature"]).must_equal  "6f7074696f6e2d7369676e6174757265"
 
       end
 
@@ -157,13 +157,13 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :mock_storage do
                                      headers: { "X-Goog-Meta-FOO" => "bar,baz",
                                                 "X-Goog-ACL" => "public-read" }, version: :v4
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
-      _(signed_url_params["X-Goog-Credential"]).must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
-      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
-      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
-      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host;x-goog-acl;x-goog-meta-foo"]
-      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6e61746976652d7369676e6174757265"]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  "GOOG4-RSA-SHA256"
+      _(signed_url_params["X-Goog-Credential"]).must_equal  "native_client_email/20120101/auto/storage/goog4_request"
+      _(signed_url_params["X-Goog-Date"]).must_equal  "20120101T000000Z"
+      _(signed_url_params["X-Goog-Expires"]).must_equal  "604800"
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  "host;x-goog-acl;x-goog-meta-foo"
+      _(signed_url_params["X-Goog-Signature"]).must_equal  "6e61746976652d7369676e6174757265"
 
       signing_key_mock.verify
     end
@@ -210,13 +210,13 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :mock_storage do
       signed_url = bucket.signed_url file_path,
                                      query: { "response-content-disposition" => "attachment; filename=\"google-cloud.png\"" }, version: :v4
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
-      _(signed_url_params["X-Goog-Credential"]).must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
-      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
-      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
-      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
-      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6e61746976652d7369676e6174757265"]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  "GOOG4-RSA-SHA256"
+      _(signed_url_params["X-Goog-Credential"]).must_equal  "native_client_email/20120101/auto/storage/goog4_request"
+      _(signed_url_params["X-Goog-Date"]).must_equal  "20120101T000000Z"
+      _(signed_url_params["X-Goog-Expires"]).must_equal  "604800"
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  "host"
+      _(signed_url_params["X-Goog-Signature"]).must_equal  "6e61746976652d7369676e6174757265"
       signing_key_mock.verify
     end
   end
@@ -232,13 +232,13 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :mock_storage do
       signed_url = bucket.signed_url file_path,
                                      query: { disposition: :inline }, version: :v4
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
-      _(signed_url_params["X-Goog-Credential"]).must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
-      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
-      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
-      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
-      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6e61746976652d7369676e6174757265"]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  "GOOG4-RSA-SHA256"
+      _(signed_url_params["X-Goog-Credential"]).must_equal  "native_client_email/20120101/auto/storage/goog4_request"
+      _(signed_url_params["X-Goog-Date"]).must_equal  "20120101T000000Z"
+      _(signed_url_params["X-Goog-Expires"]).must_equal  "604800"
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  "host"
+      _(signed_url_params["X-Goog-Signature"]).must_equal  "6e61746976652d7369676e6174757265"
 
       signing_key_mock.verify
     end

--- a/google-cloud-storage/test/google/cloud/storage/file_signed_url_v2_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_signed_url_v2_test.rb
@@ -35,9 +35,9 @@ describe Google::Cloud::Storage::File, :signed_url, :mock_storage do
 
       signed_url = file.signed_url
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
-      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["GoogleAccessId"]).must_equal "native_client_email"
+      _(signed_url_params["Signature"]).must_equal Base64.strict_encode64("native-signature").delete("\n")
 
       signing_key_mock.verify
     end
@@ -55,9 +55,9 @@ describe Google::Cloud::Storage::File, :signed_url, :mock_storage do
       signed_url = file.signed_url issuer: "option_issuer",
                                    signing_key: signing_key_mock
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["GoogleAccessId"]).must_equal ["option_issuer"]
-      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("option-signature").delete("\n")]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["GoogleAccessId"]).must_equal "option_issuer"
+      _(signed_url_params["Signature"]).must_equal Base64.strict_encode64("option-signature").delete("\n")
 
       signing_key_mock.verify
     end
@@ -75,9 +75,9 @@ describe Google::Cloud::Storage::File, :signed_url, :mock_storage do
       signed_url = file.signed_url issuer: "option_client_email",
                                    signer: signer_mock
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["GoogleAccessId"]).must_equal ["option_client_email"]
-      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("option-signature").delete("\n")]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["GoogleAccessId"]).must_equal "option_client_email"
+      _(signed_url_params["Signature"]).must_equal Base64.strict_encode64("option-signature").delete("\n")
 
       signer_mock.verify
     end
@@ -96,9 +96,9 @@ describe Google::Cloud::Storage::File, :signed_url, :mock_storage do
         signed_url = file.signed_url client_email: "option_client_email",
                                      private_key: "option_private_key"
 
-        signed_url_params = CGI::parse(URI(signed_url).query)
-        _(signed_url_params["GoogleAccessId"]).must_equal ["option_client_email"]
-        _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("option-signature").delete("\n")]
+        signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+        _(signed_url_params["GoogleAccessId"]).must_equal "option_client_email"
+        _(signed_url_params["Signature"]).must_equal Base64.strict_encode64("option-signature").delete("\n")
 
       end
 
@@ -117,9 +117,9 @@ describe Google::Cloud::Storage::File, :signed_url, :mock_storage do
       signed_url = file.signed_url headers: { "X-Goog-Meta-FOO" => "bar,baz",
                                               "X-Goog-ACL" => "public-read" }
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
-      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["GoogleAccessId"]).must_equal "native_client_email"
+      _(signed_url_params["Signature"]).must_equal Base64.strict_encode64("native-signature").delete("\n")
 
       signing_key_mock.verify
     end
@@ -135,10 +135,10 @@ describe Google::Cloud::Storage::File, :signed_url, :mock_storage do
 
       signed_url = file.signed_url query: { "response-content-disposition" => "attachment; filename=\"test.png\"" }
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
-      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
-      _(signed_url_params["response-content-disposition"]).must_equal ["attachment; filename=\"test.png\""]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["GoogleAccessId"]).must_equal "native_client_email"
+      _(signed_url_params["Signature"]).must_equal Base64.strict_encode64("native-signature").delete("\n")
+      _(signed_url_params["response-content-disposition"]).must_equal "attachment; filename=\"test.png\""
 
       signing_key_mock.verify
     end
@@ -190,9 +190,9 @@ describe Google::Cloud::Storage::File, :signed_url, :mock_storage do
         signed_uri = URI signed_url
         _(signed_uri.path).must_equal "/bucket/hello%20world%20%231.txt"
 
-        signed_url_params = CGI::parse signed_uri.query
-        _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
-        _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+        signed_url_params = URI.decode_www_form(signed_uri.query).to_h
+        _(signed_url_params["GoogleAccessId"]).must_equal "native_client_email"
+        _(signed_url_params["Signature"]).must_equal Base64.strict_encode64("native-signature").delete("\n")
 
         signing_key_mock.verify
       end
@@ -209,10 +209,10 @@ describe Google::Cloud::Storage::File, :signed_url, :mock_storage do
 
       signed_url = file.signed_url query: { "response-content-disposition" => "attachment; filename=\"google-cloud.png\"" }
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
-      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
-      _(signed_url_params["response-content-disposition"]).must_equal ["attachment; filename=\"google-cloud.png\""]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["GoogleAccessId"]).must_equal "native_client_email"
+      _(signed_url_params["Signature"]).must_equal Base64.strict_encode64("native-signature").delete("\n")
+      _(signed_url_params["response-content-disposition"]).must_equal "attachment; filename=\"google-cloud.png\""
 
       signing_key_mock.verify
     end
@@ -227,10 +227,10 @@ describe Google::Cloud::Storage::File, :signed_url, :mock_storage do
       credentials.signing_key = signing_key_mock
 
       signed_url = file.signed_url query: { disposition: :inline }
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
-      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
-      _(signed_url_params["disposition"]).must_equal ["inline"]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["GoogleAccessId"]).must_equal "native_client_email"
+      _(signed_url_params["Signature"]).must_equal Base64.strict_encode64("native-signature").delete("\n")
+      _(signed_url_params["disposition"]).must_equal "inline"
 
       signing_key_mock.verify
     end

--- a/google-cloud-storage/test/google/cloud/storage/file_signed_url_v4_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/file_signed_url_v4_test.rb
@@ -36,13 +36,13 @@ describe Google::Cloud::Storage::File, :signed_url, :v4, :mock_storage do
 
       signed_url = file.signed_url version: :v4
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
-      _(signed_url_params["X-Goog-Credential"]).must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
-      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
-      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
-      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
-      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6e61746976652d7369676e6174757265"]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  "GOOG4-RSA-SHA256"
+      _(signed_url_params["X-Goog-Credential"]).must_equal  "native_client_email/20120101/auto/storage/goog4_request"
+      _(signed_url_params["X-Goog-Date"]).must_equal  "20120101T000000Z"
+      _(signed_url_params["X-Goog-Expires"]).must_equal  "604800"
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  "host"
+      _(signed_url_params["X-Goog-Signature"]).must_equal  "6e61746976652d7369676e6174757265"
 
       signing_key_mock.verify
     end
@@ -59,13 +59,13 @@ describe Google::Cloud::Storage::File, :signed_url, :v4, :mock_storage do
       signed_url = file.signed_url issuer: "option_issuer",
                                    signing_key: signing_key_mock, version: :v4
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
-      _(signed_url_params["X-Goog-Credential"]).must_equal  ["option_issuer/20120101/auto/storage/goog4_request"]
-      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
-      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
-      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
-      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6f7074696f6e2d7369676e6174757265"]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  "GOOG4-RSA-SHA256"
+      _(signed_url_params["X-Goog-Credential"]).must_equal  "option_issuer/20120101/auto/storage/goog4_request"
+      _(signed_url_params["X-Goog-Date"]).must_equal  "20120101T000000Z"
+      _(signed_url_params["X-Goog-Expires"]).must_equal  "604800"
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  "host"
+      _(signed_url_params["X-Goog-Signature"]).must_equal  "6f7074696f6e2d7369676e6174757265"
 
       signing_key_mock.verify
     end
@@ -83,13 +83,13 @@ describe Google::Cloud::Storage::File, :signed_url, :v4, :mock_storage do
       signed_url = file.signed_url issuer: "option_issuer",
                                    signer: signer_mock, version: :v4
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
-      _(signed_url_params["X-Goog-Credential"]).must_equal  ["option_issuer/20120101/auto/storage/goog4_request"]
-      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
-      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
-      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
-      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6f7074696f6e2d7369676e6174757265"]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  "GOOG4-RSA-SHA256"
+      _(signed_url_params["X-Goog-Credential"]).must_equal  "option_issuer/20120101/auto/storage/goog4_request"
+      _(signed_url_params["X-Goog-Date"]).must_equal  "20120101T000000Z"
+      _(signed_url_params["X-Goog-Expires"]).must_equal  "604800"
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  "host"
+      _(signed_url_params["X-Goog-Signature"]).must_equal  "6f7074696f6e2d7369676e6174757265"
 
       signer_mock.verify
     end
@@ -108,13 +108,13 @@ describe Google::Cloud::Storage::File, :signed_url, :v4, :mock_storage do
         signed_url = file.signed_url client_email: "option_client_email",
                                      private_key: "option_private_key", version: :v4
 
-        signed_url_params = CGI::parse(URI(signed_url).query)
-        _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
-        _(signed_url_params["X-Goog-Credential"]).must_equal  ["option_client_email/20120101/auto/storage/goog4_request"]
-        _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
-        _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
-        _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
-        _(signed_url_params["X-Goog-Signature"]).must_equal  ["6f7074696f6e2d7369676e6174757265"]
+        signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+        _(signed_url_params["X-Goog-Algorithm"]).must_equal  "GOOG4-RSA-SHA256"
+        _(signed_url_params["X-Goog-Credential"]).must_equal  "option_client_email/20120101/auto/storage/goog4_request"
+        _(signed_url_params["X-Goog-Date"]).must_equal  "20120101T000000Z"
+        _(signed_url_params["X-Goog-Expires"]).must_equal  "604800"
+        _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  "host"
+        _(signed_url_params["X-Goog-Signature"]).must_equal  "6f7074696f6e2d7369676e6174757265"
 
       end
 
@@ -133,13 +133,13 @@ describe Google::Cloud::Storage::File, :signed_url, :v4, :mock_storage do
       signed_url = file.signed_url headers: { "X-Goog-Meta-FOO" => "bar,baz",
                                               "X-Goog-ACL" => "public-read" }, version: :v4
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
-      _(signed_url_params["X-Goog-Credential"]).must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
-      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
-      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
-      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host;x-goog-acl;x-goog-meta-foo"]
-      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6e61746976652d7369676e6174757265"]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  "GOOG4-RSA-SHA256"
+      _(signed_url_params["X-Goog-Credential"]).must_equal  "native_client_email/20120101/auto/storage/goog4_request"
+      _(signed_url_params["X-Goog-Date"]).must_equal  "20120101T000000Z"
+      _(signed_url_params["X-Goog-Expires"]).must_equal  "604800"
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  "host;x-goog-acl;x-goog-meta-foo"
+      _(signed_url_params["X-Goog-Signature"]).must_equal  "6e61746976652d7369676e6174757265"
 
       signing_key_mock.verify
     end
@@ -185,13 +185,13 @@ describe Google::Cloud::Storage::File, :signed_url, :v4, :mock_storage do
 
       signed_url = file.signed_url query: { "response-content-disposition" => "attachment; filename=\"google-cloud.png\"" }, version: :v4
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
-      _(signed_url_params["X-Goog-Credential"]).must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
-      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
-      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
-      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
-      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6e61746976652d7369676e6174757265"]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  "GOOG4-RSA-SHA256"
+      _(signed_url_params["X-Goog-Credential"]).must_equal  "native_client_email/20120101/auto/storage/goog4_request"
+      _(signed_url_params["X-Goog-Date"]).must_equal  "20120101T000000Z"
+      _(signed_url_params["X-Goog-Expires"]).must_equal  "604800"
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  "host"
+      _(signed_url_params["X-Goog-Signature"]).must_equal  "6e61746976652d7369676e6174757265"
       signing_key_mock.verify
     end
   end
@@ -206,13 +206,13 @@ describe Google::Cloud::Storage::File, :signed_url, :v4, :mock_storage do
 
       signed_url = file.signed_url query: { disposition: :inline }, version: :v4
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
-      _(signed_url_params["X-Goog-Credential"]).must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
-      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
-      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
-      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
-      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6e61746976652d7369676e6174757265"]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  "GOOG4-RSA-SHA256"
+      _(signed_url_params["X-Goog-Credential"]).must_equal  "native_client_email/20120101/auto/storage/goog4_request"
+      _(signed_url_params["X-Goog-Date"]).must_equal  "20120101T000000Z"
+      _(signed_url_params["X-Goog-Expires"]).must_equal  "604800"
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  "host"
+      _(signed_url_params["X-Goog-Signature"]).must_equal  "6e61746976652d7369676e6174757265"
 
       signing_key_mock.verify
     end

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_signed_url_v2_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_signed_url_v2_test.rb
@@ -31,9 +31,9 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v2, :lazy, :mock_storage 
 
       signed_url = bucket.signed_url file_path
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
-      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["GoogleAccessId"]).must_equal "native_client_email"
+      _(signed_url_params["Signature"]).must_equal Base64.strict_encode64("native-signature").delete("\n")
 
       signing_key_mock.verify
     end
@@ -51,9 +51,9 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v2, :lazy, :mock_storage 
       signed_url = bucket.signed_url file_path, issuer: "option_issuer",
                                                 signing_key: signing_key_mock
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["GoogleAccessId"]).must_equal ["option_issuer"]
-      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("option-signature").delete("\n")]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["GoogleAccessId"]).must_equal "option_issuer"
+      _(signed_url_params["Signature"]).must_equal Base64.strict_encode64("option-signature").delete("\n")
 
       signing_key_mock.verify
     end
@@ -72,9 +72,9 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v2, :lazy, :mock_storage 
         signed_url = bucket.signed_url file_path, client_email: "option_client_email",
                                                   private_key: "option_private_key"
 
-        signed_url_params = CGI::parse(URI(signed_url).query)
-        _(signed_url_params["GoogleAccessId"]).must_equal ["option_client_email"]
-        _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("option-signature").delete("\n")]
+        signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+        _(signed_url_params["GoogleAccessId"]).must_equal "option_client_email"
+        _(signed_url_params["Signature"]).must_equal Base64.strict_encode64("option-signature").delete("\n")
 
       end
 
@@ -93,9 +93,9 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v2, :lazy, :mock_storage 
       signed_url = bucket.signed_url file_path, headers: { "X-Goog-Meta-FOO" => "bar,baz",
                                                            "X-Goog-ACL" => "public-read" }
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
-      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["GoogleAccessId"]).must_equal "native_client_email"
+      _(signed_url_params["Signature"]).must_equal Base64.strict_encode64("native-signature").delete("\n")
 
       signing_key_mock.verify
     end
@@ -135,9 +135,9 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v2, :lazy, :mock_storage 
         signed_uri = URI signed_url
         _(signed_uri.path).must_equal "/bucket/hello%20world.txt"
 
-        signed_url_params = CGI::parse signed_uri.query
-        _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
-        _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+        signed_url_params = URI.decode_www_form(signed_uri.query).to_h
+        _(signed_url_params["GoogleAccessId"]).must_equal "native_client_email"
+        _(signed_url_params["Signature"]).must_equal Base64.strict_encode64("native-signature").delete("\n")
 
         signing_key_mock.verify
       end
@@ -155,10 +155,10 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v2, :lazy, :mock_storage 
       signed_url = bucket.signed_url file_path,
                                      query: { "response-content-disposition" => "attachment; filename=\"google-cloud.png\"" }
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
-      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
-      _(signed_url_params["response-content-disposition"]).must_equal ["attachment; filename=\"google-cloud.png\""]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["GoogleAccessId"]).must_equal "native_client_email"
+      _(signed_url_params["Signature"]).must_equal Base64.strict_encode64("native-signature").delete("\n")
+      _(signed_url_params["response-content-disposition"]).must_equal "attachment; filename=\"google-cloud.png\""
 
       signing_key_mock.verify
     end

--- a/google-cloud-storage/test/google/cloud/storage/lazy/bucket_signed_url_v4_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/bucket_signed_url_v4_test.rb
@@ -31,13 +31,13 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :lazy, :mock_storage 
 
       signed_url = bucket.signed_url file_path, version: :v4
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
-      _(signed_url_params["X-Goog-Credential"]).must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
-      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
-      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
-      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
-      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6e61746976652d7369676e6174757265"]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  "GOOG4-RSA-SHA256"
+      _(signed_url_params["X-Goog-Credential"]).must_equal  "native_client_email/20120101/auto/storage/goog4_request"
+      _(signed_url_params["X-Goog-Date"]).must_equal  "20120101T000000Z"
+      _(signed_url_params["X-Goog-Expires"]).must_equal  "604800"
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  "host"
+      _(signed_url_params["X-Goog-Signature"]).must_equal  "6e61746976652d7369676e6174757265"
 
       signing_key_mock.verify
     end
@@ -56,13 +56,13 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :lazy, :mock_storage 
                                      issuer: "option_issuer",
                                      signing_key: signing_key_mock, version: :v4
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
-      _(signed_url_params["X-Goog-Credential"]).must_equal  ["option_issuer/20120101/auto/storage/goog4_request"]
-      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
-      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
-      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
-      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6f7074696f6e2d7369676e6174757265"]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  "GOOG4-RSA-SHA256"
+      _(signed_url_params["X-Goog-Credential"]).must_equal  "option_issuer/20120101/auto/storage/goog4_request"
+      _(signed_url_params["X-Goog-Date"]).must_equal  "20120101T000000Z"
+      _(signed_url_params["X-Goog-Expires"]).must_equal  "604800"
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  "host"
+      _(signed_url_params["X-Goog-Signature"]).must_equal  "6f7074696f6e2d7369676e6174757265"
 
       signing_key_mock.verify
     end
@@ -82,13 +82,13 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :lazy, :mock_storage 
                                        client_email: "option_client_email",
                                        private_key: "option_private_key", version: :v4
 
-        signed_url_params = CGI::parse(URI(signed_url).query)
-        _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
-        _(signed_url_params["X-Goog-Credential"]).must_equal  ["option_client_email/20120101/auto/storage/goog4_request"]
-        _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
-        _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
-        _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
-        _(signed_url_params["X-Goog-Signature"]).must_equal  ["6f7074696f6e2d7369676e6174757265"]
+        signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+        _(signed_url_params["X-Goog-Algorithm"]).must_equal  "GOOG4-RSA-SHA256"
+        _(signed_url_params["X-Goog-Credential"]).must_equal  "option_client_email/20120101/auto/storage/goog4_request"
+        _(signed_url_params["X-Goog-Date"]).must_equal  "20120101T000000Z"
+        _(signed_url_params["X-Goog-Expires"]).must_equal  "604800"
+        _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  "host"
+        _(signed_url_params["X-Goog-Signature"]).must_equal  "6f7074696f6e2d7369676e6174757265"
 
       end
 
@@ -108,13 +108,13 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :lazy, :mock_storage 
                                      headers: { "X-Goog-Meta-FOO" => "bar,baz",
                                                 "X-Goog-ACL" => "public-read" }, version: :v4
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
-      _(signed_url_params["X-Goog-Credential"]).must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
-      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
-      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
-      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host;x-goog-acl;x-goog-meta-foo"]
-      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6e61746976652d7369676e6174757265"]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  "GOOG4-RSA-SHA256"
+      _(signed_url_params["X-Goog-Credential"]).must_equal  "native_client_email/20120101/auto/storage/goog4_request"
+      _(signed_url_params["X-Goog-Date"]).must_equal  "20120101T000000Z"
+      _(signed_url_params["X-Goog-Expires"]).must_equal  "604800"
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  "host;x-goog-acl;x-goog-meta-foo"
+      _(signed_url_params["X-Goog-Signature"]).must_equal  "6e61746976652d7369676e6174757265"
 
       signing_key_mock.verify
     end
@@ -149,13 +149,13 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :lazy, :mock_storage 
       signed_url = bucket.signed_url file_path,
                                      query: { "response-content-disposition" => "attachment; filename=\"google-cloud.png\"" }, version: :v4
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
-      _(signed_url_params["X-Goog-Credential"]).must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
-      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
-      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
-      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
-      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6e61746976652d7369676e6174757265"]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  "GOOG4-RSA-SHA256"
+      _(signed_url_params["X-Goog-Credential"]).must_equal  "native_client_email/20120101/auto/storage/goog4_request"
+      _(signed_url_params["X-Goog-Date"]).must_equal  "20120101T000000Z"
+      _(signed_url_params["X-Goog-Expires"]).must_equal  "604800"
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  "host"
+      _(signed_url_params["X-Goog-Signature"]).must_equal  "6e61746976652d7369676e6174757265"
       signing_key_mock.verify
     end
   end
@@ -171,13 +171,13 @@ describe Google::Cloud::Storage::Bucket, :signed_url, :v4, :lazy, :mock_storage 
       signed_url = bucket.signed_url file_path,
                                      query: { disposition: :inline }, version: :v4
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
-      _(signed_url_params["X-Goog-Credential"]).must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
-      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
-      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
-      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
-      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6e61746976652d7369676e6174757265"]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  "GOOG4-RSA-SHA256"
+      _(signed_url_params["X-Goog-Credential"]).must_equal  "native_client_email/20120101/auto/storage/goog4_request"
+      _(signed_url_params["X-Goog-Date"]).must_equal  "20120101T000000Z"
+      _(signed_url_params["X-Goog-Expires"]).must_equal  "604800"
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  "host"
+      _(signed_url_params["X-Goog-Signature"]).must_equal  "6e61746976652d7369676e6174757265"
 
       signing_key_mock.verify
     end

--- a/google-cloud-storage/test/google/cloud/storage/lazy/file_signed_url_v2_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/file_signed_url_v2_test.rb
@@ -34,9 +34,9 @@ describe Google::Cloud::Storage::File, :signed_url, :v2, :lazy, :mock_storage do
 
       signed_url = file.signed_url
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
-      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["GoogleAccessId"]).must_equal "native_client_email"
+      _(signed_url_params["Signature"]).must_equal Base64.strict_encode64("native-signature").delete("\n")
 
       signing_key_mock.verify
     end
@@ -54,9 +54,9 @@ describe Google::Cloud::Storage::File, :signed_url, :v2, :lazy, :mock_storage do
       signed_url = file.signed_url issuer: "option_issuer",
                                    signing_key: signing_key_mock
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["GoogleAccessId"]).must_equal ["option_issuer"]
-      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("option-signature").delete("\n")]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["GoogleAccessId"]).must_equal "option_issuer"
+      _(signed_url_params["Signature"]).must_equal Base64.strict_encode64("option-signature").delete("\n")
 
       signing_key_mock.verify
     end
@@ -75,9 +75,9 @@ describe Google::Cloud::Storage::File, :signed_url, :v2, :lazy, :mock_storage do
         signed_url = file.signed_url client_email: "option_client_email",
                                      private_key: "option_private_key"
 
-        signed_url_params = CGI::parse(URI(signed_url).query)
-        _(signed_url_params["GoogleAccessId"]).must_equal ["option_client_email"]
-        _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("option-signature").delete("\n")]
+        signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+        _(signed_url_params["GoogleAccessId"]).must_equal "option_client_email"
+        _(signed_url_params["Signature"]).must_equal Base64.strict_encode64("option-signature").delete("\n")
 
       end
 
@@ -96,9 +96,9 @@ describe Google::Cloud::Storage::File, :signed_url, :v2, :lazy, :mock_storage do
       signed_url = file.signed_url headers: { "X-Goog-Meta-FOO" => "bar,baz",
                                               "X-Goog-ACL" => "public-read" }
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
-      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["GoogleAccessId"]).must_equal "native_client_email"
+      _(signed_url_params["Signature"]).must_equal Base64.strict_encode64("native-signature").delete("\n")
 
       signing_key_mock.verify
     end
@@ -114,10 +114,10 @@ describe Google::Cloud::Storage::File, :signed_url, :v2, :lazy, :mock_storage do
 
       signed_url = file.signed_url query: { "response-content-disposition" => "attachment; filename=\"test.png\"" }
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
-      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
-      _(signed_url_params["response-content-disposition"]).must_equal ["attachment; filename=\"test.png\""]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["GoogleAccessId"]).must_equal "native_client_email"
+      _(signed_url_params["Signature"]).must_equal Base64.strict_encode64("native-signature").delete("\n")
+      _(signed_url_params["response-content-disposition"]).must_equal "attachment; filename=\"test.png\""
 
       signing_key_mock.verify
     end
@@ -157,9 +157,9 @@ describe Google::Cloud::Storage::File, :signed_url, :v2, :lazy, :mock_storage do
         signed_uri = URI signed_url
         _(signed_uri.path).must_equal "/bucket/hello%20world.txt"
 
-        signed_url_params = CGI::parse signed_uri.query
-        _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
-        _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+        signed_url_params = URI.decode_www_form(signed_uri.query).to_h
+        _(signed_url_params["GoogleAccessId"]).must_equal "native_client_email"
+        _(signed_url_params["Signature"]).must_equal Base64.strict_encode64("native-signature").delete("\n")
 
         signing_key_mock.verify
       end
@@ -176,10 +176,10 @@ describe Google::Cloud::Storage::File, :signed_url, :v2, :lazy, :mock_storage do
 
       signed_url = file.signed_url query: { "response-content-disposition" => "attachment; filename=\"google-cloud.png\"" }
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
-      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
-      _(signed_url_params["response-content-disposition"]).must_equal ["attachment; filename=\"google-cloud.png\""]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["GoogleAccessId"]).must_equal "native_client_email"
+      _(signed_url_params["Signature"]).must_equal Base64.strict_encode64("native-signature").delete("\n")
+      _(signed_url_params["response-content-disposition"]).must_equal "attachment; filename=\"google-cloud.png\""
 
       signing_key_mock.verify
     end

--- a/google-cloud-storage/test/google/cloud/storage/lazy/file_signed_url_v4_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/lazy/file_signed_url_v4_test.rb
@@ -32,13 +32,13 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :lazy, :mock_storage
 
       signed_url = file.signed_url version: :v4
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
-      _(signed_url_params["X-Goog-Credential"]).must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
-      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
-      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
-      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
-      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6e61746976652d7369676e6174757265"]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  "GOOG4-RSA-SHA256"
+      _(signed_url_params["X-Goog-Credential"]).must_equal  "native_client_email/20120101/auto/storage/goog4_request"
+      _(signed_url_params["X-Goog-Date"]).must_equal  "20120101T000000Z"
+      _(signed_url_params["X-Goog-Expires"]).must_equal  "604800"
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  "host"
+      _(signed_url_params["X-Goog-Signature"]).must_equal  "6e61746976652d7369676e6174757265"
 
       signing_key_mock.verify
     end
@@ -56,13 +56,13 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :lazy, :mock_storage
       signed_url = file.signed_url issuer: "option_issuer",
                                    signing_key: signing_key_mock, version: :v4
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
-      _(signed_url_params["X-Goog-Credential"]).must_equal  ["option_issuer/20120101/auto/storage/goog4_request"]
-      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
-      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
-      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
-      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6f7074696f6e2d7369676e6174757265"]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  "GOOG4-RSA-SHA256"
+      _(signed_url_params["X-Goog-Credential"]).must_equal  "option_issuer/20120101/auto/storage/goog4_request"
+      _(signed_url_params["X-Goog-Date"]).must_equal  "20120101T000000Z"
+      _(signed_url_params["X-Goog-Expires"]).must_equal  "604800"
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  "host"
+      _(signed_url_params["X-Goog-Signature"]).must_equal  "6f7074696f6e2d7369676e6174757265"
 
       signing_key_mock.verify
     end
@@ -81,13 +81,13 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :lazy, :mock_storage
         signed_url = file.signed_url client_email: "option_client_email",
                                      private_key: "option_private_key", version: :v4
 
-        signed_url_params = CGI::parse(URI(signed_url).query)
-        _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
-        _(signed_url_params["X-Goog-Credential"]).must_equal  ["option_client_email/20120101/auto/storage/goog4_request"]
-        _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
-        _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
-        _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
-        _(signed_url_params["X-Goog-Signature"]).must_equal  ["6f7074696f6e2d7369676e6174757265"]
+        signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+        _(signed_url_params["X-Goog-Algorithm"]).must_equal  "GOOG4-RSA-SHA256"
+        _(signed_url_params["X-Goog-Credential"]).must_equal  "option_client_email/20120101/auto/storage/goog4_request"
+        _(signed_url_params["X-Goog-Date"]).must_equal  "20120101T000000Z"
+        _(signed_url_params["X-Goog-Expires"]).must_equal  "604800"
+        _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  "host"
+        _(signed_url_params["X-Goog-Signature"]).must_equal  "6f7074696f6e2d7369676e6174757265"
 
       end
 
@@ -106,13 +106,13 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :lazy, :mock_storage
       signed_url = file.signed_url headers: { "X-Goog-Meta-FOO" => "bar,baz",
                                               "X-Goog-ACL" => "public-read" }, version: :v4
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
-      _(signed_url_params["X-Goog-Credential"]).must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
-      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
-      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
-      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host;x-goog-acl;x-goog-meta-foo"]
-      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6e61746976652d7369676e6174757265"]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  "GOOG4-RSA-SHA256"
+      _(signed_url_params["X-Goog-Credential"]).must_equal  "native_client_email/20120101/auto/storage/goog4_request"
+      _(signed_url_params["X-Goog-Date"]).must_equal  "20120101T000000Z"
+      _(signed_url_params["X-Goog-Expires"]).must_equal  "604800"
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  "host;x-goog-acl;x-goog-meta-foo"
+      _(signed_url_params["X-Goog-Signature"]).must_equal  "6e61746976652d7369676e6174757265"
 
       signing_key_mock.verify
     end
@@ -146,13 +146,13 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :lazy, :mock_storage
 
       signed_url = file.signed_url query: { "response-content-disposition" => "attachment; filename=\"google-cloud.png\"" }, version: :v4
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
-      _(signed_url_params["X-Goog-Credential"]).must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
-      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
-      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
-      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
-      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6e61746976652d7369676e6174757265"]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  "GOOG4-RSA-SHA256"
+      _(signed_url_params["X-Goog-Credential"]).must_equal  "native_client_email/20120101/auto/storage/goog4_request"
+      _(signed_url_params["X-Goog-Date"]).must_equal  "20120101T000000Z"
+      _(signed_url_params["X-Goog-Expires"]).must_equal  "604800"
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  "host"
+      _(signed_url_params["X-Goog-Signature"]).must_equal  "6e61746976652d7369676e6174757265"
       signing_key_mock.verify
     end
   end
@@ -167,13 +167,13 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :lazy, :mock_storage
 
       signed_url = file.signed_url query: { disposition: :inline }, version: :v4
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
-      _(signed_url_params["X-Goog-Credential"]).must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
-      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
-      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
-      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
-      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6e61746976652d7369676e6174757265"]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  "GOOG4-RSA-SHA256"
+      _(signed_url_params["X-Goog-Credential"]).must_equal  "native_client_email/20120101/auto/storage/goog4_request"
+      _(signed_url_params["X-Goog-Date"]).must_equal  "20120101T000000Z"
+      _(signed_url_params["X-Goog-Expires"]).must_equal  "604800"
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  "host"
+      _(signed_url_params["X-Goog-Signature"]).must_equal  "6e61746976652d7369676e6174757265"
 
       signing_key_mock.verify
     end

--- a/google-cloud-storage/test/google/cloud/storage/project_signed_url_v2_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/project_signed_url_v2_test.rb
@@ -28,9 +28,9 @@ describe Google::Cloud::Storage::Project, :signed_url, :v2, :mock_storage do
 
       signed_url = storage.signed_url bucket_name, file_path
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
-      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["GoogleAccessId"]).must_equal "native_client_email"
+      _(signed_url_params["Signature"]).must_equal Base64.strict_encode64("native-signature").delete("\n")
 
       signing_key_mock.verify
     end
@@ -49,9 +49,9 @@ describe Google::Cloud::Storage::Project, :signed_url, :v2, :mock_storage do
                                       issuer: "option_issuer",
                                       signing_key: signing_key_mock
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["GoogleAccessId"]).must_equal ["option_issuer"]
-      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("option-signature").delete("\n")]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["GoogleAccessId"]).must_equal "option_issuer"
+      _(signed_url_params["Signature"]).must_equal Base64.strict_encode64("option-signature").delete("\n")
 
       signing_key_mock.verify
     end
@@ -70,9 +70,9 @@ describe Google::Cloud::Storage::Project, :signed_url, :v2, :mock_storage do
                                       issuer: "option_client_email",
                                       signer: signer_mock
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["GoogleAccessId"]).must_equal ["option_client_email"]
-      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("option-signature").delete("\n")]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["GoogleAccessId"]).must_equal "option_client_email"
+      _(signed_url_params["Signature"]).must_equal Base64.strict_encode64("option-signature").delete("\n")
 
       signer_mock.verify
     end
@@ -92,9 +92,9 @@ describe Google::Cloud::Storage::Project, :signed_url, :v2, :mock_storage do
                                         client_email: "option_client_email",
                                         private_key: "option_private_key"
 
-        signed_url_params = CGI::parse(URI(signed_url).query)
-        _(signed_url_params["GoogleAccessId"]).must_equal ["option_client_email"]
-        _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("option-signature").delete("\n")]
+        signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+        _(signed_url_params["GoogleAccessId"]).must_equal "option_client_email"
+        _(signed_url_params["Signature"]).must_equal Base64.strict_encode64("option-signature").delete("\n")
 
       end
 
@@ -114,9 +114,9 @@ describe Google::Cloud::Storage::Project, :signed_url, :v2, :mock_storage do
                                       headers: { "X-Goog-Meta-FOO" => "bar,baz",
                                                  "X-Goog-ACL" => "public-read" }
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
-      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["GoogleAccessId"]).must_equal "native_client_email"
+      _(signed_url_params["Signature"]).must_equal Base64.strict_encode64("native-signature").delete("\n")
 
       signing_key_mock.verify
     end
@@ -132,10 +132,10 @@ describe Google::Cloud::Storage::Project, :signed_url, :v2, :mock_storage do
 
       signed_url = storage.signed_url bucket_name, file_path, query: { "response-content-disposition" => "attachment; filename=\"test.png\"" }
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
-      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
-      _(signed_url_params["response-content-disposition"]).must_equal ["attachment; filename=\"test.png\""]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["GoogleAccessId"]).must_equal "native_client_email"
+      _(signed_url_params["Signature"]).must_equal Base64.strict_encode64("native-signature").delete("\n")
+      _(signed_url_params["response-content-disposition"]).must_equal "attachment; filename=\"test.png\""
 
       signing_key_mock.verify
     end
@@ -188,9 +188,9 @@ describe Google::Cloud::Storage::Project, :signed_url, :v2, :mock_storage do
         signed_uri = URI signed_url
         _(signed_uri.path).must_equal "/bucket/hello%20world.txt"
 
-        signed_url_params = CGI::parse signed_uri.query
-        _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
-        _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
+        signed_url_params = URI.decode_www_form(signed_uri.query).to_h
+        _(signed_url_params["GoogleAccessId"]).must_equal "native_client_email"
+        _(signed_url_params["Signature"]).must_equal Base64.strict_encode64("native-signature").delete("\n")
 
         signing_key_mock.verify
       end
@@ -208,10 +208,10 @@ describe Google::Cloud::Storage::Project, :signed_url, :v2, :mock_storage do
       signed_url = storage.signed_url bucket_name, file_path,
                                       query: { "response-content-disposition" => "attachment; filename=\"google-cloud.png\"" }
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
-      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
-      _(signed_url_params["response-content-disposition"]).must_equal ["attachment; filename=\"google-cloud.png\""]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["GoogleAccessId"]).must_equal "native_client_email"
+      _(signed_url_params["Signature"]).must_equal Base64.strict_encode64("native-signature").delete("\n")
+      _(signed_url_params["response-content-disposition"]).must_equal "attachment; filename=\"google-cloud.png\""
 
       signing_key_mock.verify
     end
@@ -228,10 +228,10 @@ describe Google::Cloud::Storage::Project, :signed_url, :v2, :mock_storage do
       signed_url = storage.signed_url bucket_name, file_path,
                                       query: { disposition: :inline }
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["GoogleAccessId"]).must_equal ["native_client_email"]
-      _(signed_url_params["Signature"]).must_equal [Base64.strict_encode64("native-signature").delete("\n")]
-      _(signed_url_params["disposition"]).must_equal ["inline"]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["GoogleAccessId"]).must_equal "native_client_email"
+      _(signed_url_params["Signature"]).must_equal Base64.strict_encode64("native-signature").delete("\n")
+      _(signed_url_params["disposition"]).must_equal "inline"
 
       signing_key_mock.verify
     end

--- a/google-cloud-storage/test/google/cloud/storage/project_signed_url_v4_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/project_signed_url_v4_test.rb
@@ -28,13 +28,13 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :mock_storage do
 
       signed_url = storage.signed_url bucket_name, file_path, version: :v4
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
-      _(signed_url_params["X-Goog-Credential"]).must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
-      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
-      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
-      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
-      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6e61746976652d7369676e6174757265"]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  "GOOG4-RSA-SHA256"
+      _(signed_url_params["X-Goog-Credential"]).must_equal  "native_client_email/20120101/auto/storage/goog4_request"
+      _(signed_url_params["X-Goog-Date"]).must_equal  "20120101T000000Z"
+      _(signed_url_params["X-Goog-Expires"]).must_equal  "604800"
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  "host"
+      _(signed_url_params["X-Goog-Signature"]).must_equal  "6e61746976652d7369676e6174757265"
 
       signing_key_mock.verify
     end
@@ -53,13 +53,13 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :mock_storage do
                                       issuer: "option_issuer",
                                       signing_key: signing_key_mock, version: :v4
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
-      _(signed_url_params["X-Goog-Credential"]).must_equal  ["option_issuer/20120101/auto/storage/goog4_request"]
-      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
-      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
-      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
-      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6f7074696f6e2d7369676e6174757265"]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  "GOOG4-RSA-SHA256"
+      _(signed_url_params["X-Goog-Credential"]).must_equal  "option_issuer/20120101/auto/storage/goog4_request"
+      _(signed_url_params["X-Goog-Date"]).must_equal  "20120101T000000Z"
+      _(signed_url_params["X-Goog-Expires"]).must_equal  "604800"
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  "host"
+      _(signed_url_params["X-Goog-Signature"]).must_equal  "6f7074696f6e2d7369676e6174757265"
 
       signing_key_mock.verify
     end
@@ -78,13 +78,13 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :mock_storage do
                                       issuer: "option_issuer",
                                       signer: signer_mock, version: :v4
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
-      _(signed_url_params["X-Goog-Credential"]).must_equal  ["option_issuer/20120101/auto/storage/goog4_request"]
-      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
-      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
-      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
-      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6f7074696f6e2d7369676e6174757265"]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  "GOOG4-RSA-SHA256"
+      _(signed_url_params["X-Goog-Credential"]).must_equal  "option_issuer/20120101/auto/storage/goog4_request"
+      _(signed_url_params["X-Goog-Date"]).must_equal  "20120101T000000Z"
+      _(signed_url_params["X-Goog-Expires"]).must_equal  "604800"
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  "host"
+      _(signed_url_params["X-Goog-Signature"]).must_equal  "6f7074696f6e2d7369676e6174757265"
 
       signer_mock.verify
     end
@@ -104,13 +104,13 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :mock_storage do
                                         client_email: "option_client_email",
                                         private_key: "option_private_key", version: :v4
 
-        signed_url_params = CGI::parse(URI(signed_url).query)
-        _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
-        _(signed_url_params["X-Goog-Credential"]).must_equal  ["option_client_email/20120101/auto/storage/goog4_request"]
-        _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
-        _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
-        _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
-        _(signed_url_params["X-Goog-Signature"]).must_equal  ["6f7074696f6e2d7369676e6174757265"]
+        signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+        _(signed_url_params["X-Goog-Algorithm"]).must_equal  "GOOG4-RSA-SHA256"
+        _(signed_url_params["X-Goog-Credential"]).must_equal  "option_client_email/20120101/auto/storage/goog4_request"
+        _(signed_url_params["X-Goog-Date"]).must_equal  "20120101T000000Z"
+        _(signed_url_params["X-Goog-Expires"]).must_equal  "604800"
+        _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  "host"
+        _(signed_url_params["X-Goog-Signature"]).must_equal  "6f7074696f6e2d7369676e6174757265"
 
       end
 
@@ -130,13 +130,13 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :mock_storage do
                                       headers: { "X-Goog-Meta-FOO" => "bar,baz",
                                                  "X-Goog-ACL" => "public-read" }, version: :v4
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
-      _(signed_url_params["X-Goog-Credential"]).must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
-      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
-      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
-      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host;x-goog-acl;x-goog-meta-foo"]
-      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6e61746976652d7369676e6174757265"]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  "GOOG4-RSA-SHA256"
+      _(signed_url_params["X-Goog-Credential"]).must_equal  "native_client_email/20120101/auto/storage/goog4_request"
+      _(signed_url_params["X-Goog-Date"]).must_equal  "20120101T000000Z"
+      _(signed_url_params["X-Goog-Expires"]).must_equal  "604800"
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  "host;x-goog-acl;x-goog-meta-foo"
+      _(signed_url_params["X-Goog-Signature"]).must_equal  "6e61746976652d7369676e6174757265"
 
       signing_key_mock.verify
     end
@@ -184,13 +184,13 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :mock_storage do
       signed_url = storage.signed_url bucket_name, file_path,
                                       query: { "response-content-disposition" => "attachment; filename=\"google-cloud.png\"" }, version: :v4
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
-      _(signed_url_params["X-Goog-Credential"]).must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
-      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
-      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
-      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
-      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6e61746976652d7369676e6174757265"]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  "GOOG4-RSA-SHA256"
+      _(signed_url_params["X-Goog-Credential"]).must_equal  "native_client_email/20120101/auto/storage/goog4_request"
+      _(signed_url_params["X-Goog-Date"]).must_equal  "20120101T000000Z"
+      _(signed_url_params["X-Goog-Expires"]).must_equal  "604800"
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  "host"
+      _(signed_url_params["X-Goog-Signature"]).must_equal  "6e61746976652d7369676e6174757265"
       signing_key_mock.verify
     end
   end
@@ -206,13 +206,13 @@ describe Google::Cloud::Storage::Project, :signed_url, :v4, :mock_storage do
       signed_url = storage.signed_url bucket_name, file_path,
                                       query: { disposition: :inline }, version: :v4
 
-      signed_url_params = CGI::parse(URI(signed_url).query)
-      _(signed_url_params["X-Goog-Algorithm"]).must_equal  ["GOOG4-RSA-SHA256"]
-      _(signed_url_params["X-Goog-Credential"]).must_equal  ["native_client_email/20120101/auto/storage/goog4_request"]
-      _(signed_url_params["X-Goog-Date"]).must_equal  ["20120101T000000Z"]
-      _(signed_url_params["X-Goog-Expires"]).must_equal  ["604800"]
-      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  ["host"]
-      _(signed_url_params["X-Goog-Signature"]).must_equal  ["6e61746976652d7369676e6174757265"]
+      signed_url_params = URI.decode_www_form(URI(signed_url).query).to_h
+      _(signed_url_params["X-Goog-Algorithm"]).must_equal  "GOOG4-RSA-SHA256"
+      _(signed_url_params["X-Goog-Credential"]).must_equal  "native_client_email/20120101/auto/storage/goog4_request"
+      _(signed_url_params["X-Goog-Date"]).must_equal  "20120101T000000Z"
+      _(signed_url_params["X-Goog-Expires"]).must_equal  "604800"
+      _(signed_url_params["X-Goog-SignedHeaders"]).must_equal  "host"
+      _(signed_url_params["X-Goog-Signature"]).must_equal  "6e61746976652d7369676e6174757265"
 
       signing_key_mock.verify
     end


### PR DESCRIPTION
In Ruby 3.5 most of the `cgi` gem will be removed. Only the various escape/unescape methods will be retained by default.

https://bugs.ruby-lang.org/issues/21258

`CGI.parse` is used only in tests and can be replaced by `URI.decode_www_form`, which returns an array of arrays. So it just needs to be converted to a hash before.

`CGI.escape` is available by requiring `cgi/escape` and doesn't emit a warning on Ruby 3.5

------

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-ruby/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea.
- [x] Follow the instructions in [CONTRIBUTING](CONTRIBUTING.md). Most importantly, ensure the tests and linter pass by running `bundle exec rake ci` in the gem subdirectory.
- [ ] Update code documentation if necessary.

closes: None