### PR TITLE
samples(ai_platform): Disable broken sample test

### DIFF
--- a/google-cloud-ai_platform/samples/acceptance/predict_text_prompt_test.rb
+++ b/google-cloud-ai_platform/samples/acceptance/predict_text_prompt_test.rb
@@ -27,6 +27,10 @@ describe "Vertex AI Quickstart" do
   let(:model) { "text-bison@001" }
 
   it "generates text" do
+    # As of May 2025, this sample does not work. The text-bison model has been
+    # retired, and the replacement requires Gemini, which is not available via
+    # the PredictionService. This sample should probably be removed.
+    skip
     sample = SampleLoader.load "predict_text_prompt.rb"
 
     assert_output(/\S/) do


### PR DESCRIPTION
The sample as currently written is now broken. The referenced model (text-bison) has been retired as of a few weeks ago, and the replacement requires Gemini, which is not available via the PredictionService. This sample will need to be rewritten or retired. For now we're just going to disable the test. See internal issue b/418022526.