### PR TITLE
samples(monitoring): Clarify necessary gem and requires in the monitoring samples

### DIFF
--- a/google-cloud-monitoring/samples/metrics.rb
+++ b/google-cloud-monitoring/samples/metrics.rb
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "google/cloud/monitoring"
 
 def create_metric_descriptor project_id:, metric_type:
   # [START monitoring_create_metric]
+  gem "google-cloud-monitoring"
+  require "google/cloud/monitoring"
+
   # Your Google Cloud Platform project ID
   # project_id = "YOUR_PROJECT_ID"
 
@@ -41,6 +43,9 @@ end
 
 def delete_metric_descriptor project_id:, metric_type:
   # [START monitoring_delete_metric]
+  gem "google-cloud-monitoring"
+  require "google/cloud/monitoring"
+
   # Your Google Cloud Platform project ID
   # project_id = "YOUR_PROJECT_ID"
 
@@ -58,6 +63,9 @@ end
 
 def write_time_series project_id:, metric_type:
   # [START monitoring_write_timeseries]
+  gem "google-cloud-monitoring"
+  require "google/cloud/monitoring"
+
   # Your Google Cloud Platform project ID
   # project_id = "YOUR_PROJECT_ID"
 
@@ -88,6 +96,9 @@ end
 
 def list_time_series project_id:
   # [START monitoring_read_timeseries_simple]
+  gem "google-cloud-monitoring"
+  require "google/cloud/monitoring"
+
   # Your Google Cloud Platform project ID
   # project_id = "YOUR_PROJECT_ID"
 
@@ -115,6 +126,9 @@ end
 
 def list_time_series_header project_id:
   # [START monitoring_read_timeseries_fields]
+  gem "google-cloud-monitoring"
+  require "google/cloud/monitoring"
+
   # Your Google Cloud Platform project ID
   # project_id = "YOUR_PROJECT_ID"
 
@@ -142,6 +156,9 @@ end
 
 def list_time_series_aggregate project_id:
   # [START monitoring_read_timeseries_align]
+  gem "google-cloud-monitoring"
+  require "google/cloud/monitoring"
+
   # Your Google Cloud Platform project ID
   # project_id = "YOUR_PROJECT_ID"
 
@@ -175,6 +192,9 @@ end
 
 def list_time_series_reduce project_id:
   # [START monitoring_read_timeseries_reduce]
+  gem "google-cloud-monitoring"
+  require "google/cloud/monitoring"
+
   # Your Google Cloud Platform project ID
   # project_id = "YOUR_PROJECT_ID"
 
@@ -210,6 +230,9 @@ end
 
 def list_metric_descriptors project_id:
   # [START monitoring_list_descriptors]
+  gem "google-cloud-monitoring"
+  require "google/cloud/monitoring"
+
   # Your Google Cloud Platform project ID
   # project_id = "YOUR_PROJECT_ID"
 
@@ -225,6 +248,9 @@ end
 
 def list_monitored_resources project_id:
   # [START monitoring_list_resources]
+  gem "google-cloud-monitoring"
+  require "google/cloud/monitoring"
+
   # Your Google Cloud Platform project ID
   # project_id = "YOUR_PROJECT_ID"
 
@@ -259,6 +285,9 @@ end
 
 def get_metric_descriptor project_id:, metric_type:
   # [START monitoring_get_descriptor]
+  gem "google-cloud-monitoring"
+  require "google/cloud/monitoring"
+
   # Your Google Cloud Platform project ID
   # project_id = "YOUR_PROJECT_ID"
 

--- a/google-cloud-monitoring/samples/quickstart.rb
+++ b/google-cloud-monitoring/samples/quickstart.rb
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "google/cloud/monitoring"
-
 def quickstart project_id:, metric_label:
   # [START monitoring_quickstart]
+  gem "google-cloud-monitoring"
+  require "google/cloud/monitoring"
+
   # Your Google Cloud Platform project ID
   # project_id = "YOUR_PROJECT_ID"
 

--- a/google-cloud-monitoring/samples/uptime_check.rb
+++ b/google-cloud-monitoring/samples/uptime_check.rb
@@ -12,9 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# rubocop:disable Lint/DuplicateRequire
+
 # [START monitoring_uptime_check_list_ips]
+gem "google-cloud-monitoring"
+require "google/cloud/monitoring"
+
 def list_ips
-  require "google/cloud/monitoring"
   client = Google::Cloud::Monitoring.uptime_check_service
 
   # Iterate over all results.
@@ -25,9 +29,10 @@ end
 # [END monitoring_uptime_check_list_ips]
 
 # [START monitoring_uptime_check_create]
-def create_uptime_check_config project_id: nil, host_name: nil, display_name: nil
-  require "google/cloud/monitoring"
+gem "google-cloud-monitoring"
+require "google/cloud/monitoring"
 
+def create_uptime_check_config project_id: nil, host_name: nil, display_name: nil
   client = Google::Cloud::Monitoring.uptime_check_service
   project_name = client.project_path project: project_id
   config = {
@@ -49,9 +54,10 @@ end
 # [END monitoring_uptime_check_create]
 
 # [START monitoring_uptime_check_delete]
-def delete_uptime_check_config config_name
-  require "google/cloud/monitoring"
+gem "google-cloud-monitoring"
+require "google/cloud/monitoring"
 
+def delete_uptime_check_config config_name
   client = Google::Cloud::Monitoring.uptime_check_service
   client.delete_uptime_check_config name: config_name
   puts "Deleted #{config_name}"
@@ -60,9 +66,10 @@ end
 
 
 # [START monitoring_uptime_check_list_configs]
-def list_uptime_check_configs project_id
-  require "google/cloud/monitoring"
+gem "google-cloud-monitoring"
+require "google/cloud/monitoring"
 
+def list_uptime_check_configs project_id
   client = Google::Cloud::Monitoring.uptime_check_service
   project_name = client.project_path project: project_id
   configs = client.list_uptime_check_configs parent: project_name
@@ -72,9 +79,10 @@ end
 # [END monitoring_uptime_check_list_configs]
 
 # [START monitoring_uptime_check_get]
-def get_uptime_check_config config_name
-  require "google/cloud/monitoring"
+gem "google-cloud-monitoring"
+require "google/cloud/monitoring"
 
+def get_uptime_check_config config_name
   client = Google::Cloud::Monitoring.uptime_check_service
   config = client.get_uptime_check_config name: config_name
   pp config.to_h
@@ -83,11 +91,12 @@ end
 # [END monitoring_uptime_check_get]
 
 # [START monitoring_uptime_check_update]
+gem "google-cloud-monitoring"
+require "google/cloud/monitoring"
+
 def update_uptime_check_config config_name:         nil,
                                new_display_name:    nil,
                                new_http_check_path: nil
-  require "google/cloud/monitoring"
-
   client = Google::Cloud::Monitoring.uptime_check_service
   config = { name: config_name }
   field_mask = { paths: [] }
@@ -103,6 +112,8 @@ def update_uptime_check_config config_name:         nil,
                                     update_mask:         field_mask
 end
 # [END monitoring_uptime_check_update]
+
+# rubocop:enable Lint/DuplicateRequire
 
 if $PROGRAM_NAME == __FILE__
   command = ARGV.shift


### PR DESCRIPTION
We're moving `gem` and `require` statements inside the sample region tags so they appear along with the code samples. This will ensure it is clear in these samples which gem to install and what to require. (Other samples will show the Gemfile and header code including requires, in a separate region tag, but the monitoring samples do not and assume that the samples are standalone.)

Closes: #8388