### PR TITLE
chore: Add h1 heading to migration docs

### DIFF
--- a/google-cloud-asset/MIGRATING.md
+++ b/google-cloud-asset/MIGRATING.md
@@ -1,4 +1,4 @@
-## Migrating to google-cloud-asset 1.0
+# Migrating to google-cloud-asset 1.0
 
 The 1.0 release of the google-cloud-asset client is a significant upgrade
 based on a [next-gen code generator](https://github.com/googleapis/gapic-generator-ruby),

--- a/google-cloud-automl/MIGRATING.md
+++ b/google-cloud-automl/MIGRATING.md
@@ -1,4 +1,4 @@
-## Migrating to google-cloud-automl 1.0
+# Migrating to google-cloud-automl 1.0
 
 The 1.0 release of the google-cloud-automl client is a significant upgrade
 based on a [next-gen code generator](https://github.com/googleapis/gapic-generator-ruby),

--- a/google-cloud-bigquery-data_transfer/MIGRATING.md
+++ b/google-cloud-bigquery-data_transfer/MIGRATING.md
@@ -1,4 +1,4 @@
-## Migrating to google-cloud-bigquery-data_transfer 1.0
+# Migrating to google-cloud-bigquery-data_transfer 1.0
 
 The 1.0 release of the google-cloud-bigquery-data_transfer client is a significant upgrade
 based on a [next-gen code generator](https://github.com/googleapis/gapic-generator-ruby),

--- a/google-cloud-container/MIGRATING.md
+++ b/google-cloud-container/MIGRATING.md
@@ -1,4 +1,4 @@
-## Migrating to google-cloud-container 1.0
+# Migrating to google-cloud-container 1.0
 
 The 1.0 release of the google-cloud-container client is a significant upgrade
 based on a [next-gen code generator](https://github.com/googleapis/gapic-generator-ruby),

--- a/google-cloud-container_analysis/MIGRATING.md
+++ b/google-cloud-container_analysis/MIGRATING.md
@@ -1,4 +1,4 @@
-## Migrating to google-cloud-container_analysis 1.0
+# Migrating to google-cloud-container_analysis 1.0
 
 The 1.0 release of the Container Analysis client is a significant upgrade
 based on a [next-gen code generator](https://github.com/googleapis/gapic-generator-ruby),

--- a/google-cloud-dataproc/MIGRATING.md
+++ b/google-cloud-dataproc/MIGRATING.md
@@ -1,4 +1,4 @@
-## Migrating to google-cloud-dataproc 1.0
+# Migrating to google-cloud-dataproc 1.0
 
 The 1.0 release of the google-cloud-dataproc client is a significant upgrade
 based on a [next-gen code generator](https://github.com/googleapis/gapic-generator-ruby),

--- a/google-cloud-dialogflow/MIGRATING.md
+++ b/google-cloud-dialogflow/MIGRATING.md
@@ -1,4 +1,4 @@
-## Migrating to google-cloud-dialogflow 1.0
+# Migrating to google-cloud-dialogflow 1.0
 
 The 1.0 release of the google-cloud-dialogflow client is a significant upgrade
 based on a [next-gen code generator](https://github.com/googleapis/gapic-generator-ruby),

--- a/google-cloud-dlp/MIGRATING.md
+++ b/google-cloud-dlp/MIGRATING.md
@@ -1,4 +1,4 @@
-## Migrating to google-cloud-dlp 1.0
+# Migrating to google-cloud-dlp 1.0
 
 The 1.0 release of the google-cloud-dlp client is a significant upgrade
 based on a [next-gen code generator](https://github.com/googleapis/gapic-generator-ruby),

--- a/google-cloud-kms/MIGRATING.md
+++ b/google-cloud-kms/MIGRATING.md
@@ -1,4 +1,4 @@
-## Migrating to google-cloud-kms 2.0
+# Migrating to google-cloud-kms 2.0
 
 The 2.0 release of the google-cloud-kms client is a significant upgrade
 based on a [next-gen code generator](https://github.com/googleapis/gapic-generator-ruby),

--- a/google-cloud-language/MIGRATING.md
+++ b/google-cloud-language/MIGRATING.md
@@ -1,4 +1,4 @@
-## Migrating to google-cloud-language 1.0
+# Migrating to google-cloud-language 1.0
 
 The 1.0 release of the google-cloud-language client is a significant upgrade
 based on a [next-gen code generator](https://github.com/googleapis/gapic-generator-ruby),

--- a/google-cloud-monitoring/MIGRATING.md
+++ b/google-cloud-monitoring/MIGRATING.md
@@ -1,4 +1,4 @@
-## Migrating to google-cloud-monitoring 1.0
+# Migrating to google-cloud-monitoring 1.0
 
 The 1.0 release of the google-cloud-monitoring client is a significant upgrade
 based on a [next-gen code generator](https://github.com/googleapis/gapic-generator-ruby),

--- a/google-cloud-os_login/MIGRATING.md
+++ b/google-cloud-os_login/MIGRATING.md
@@ -1,4 +1,4 @@
-## Migrating to google-cloud-os_login 1.0
+# Migrating to google-cloud-os_login 1.0
 
 The 1.0 release of the google-cloud-os_login client is a significant upgrade
 based on a [next-gen code generator](https://github.com/googleapis/gapic-generator-ruby),

--- a/google-cloud-phishing_protection/MIGRATING.md
+++ b/google-cloud-phishing_protection/MIGRATING.md
@@ -1,4 +1,4 @@
-## Migrating to google-cloud-phishing_protection 0.10
+# Migrating to google-cloud-phishing_protection 0.10
 
 The 0.10 release of the google-cloud-phishing_protection client is a significant upgrade
 based on a [next-gen code generator](https://github.com/googleapis/gapic-generator-ruby),

--- a/google-cloud-recaptcha_enterprise/MIGRATING.md
+++ b/google-cloud-recaptcha_enterprise/MIGRATING.md
@@ -1,4 +1,4 @@
-## Migrating to google-cloud-recaptcha_enterprise 1.0
+# Migrating to google-cloud-recaptcha_enterprise 1.0
 
 The 1.0 release of the google-cloud-recaptcha_enterprise client is a significant upgrade
 based on a [next-gen code generator](https://github.com/googleapis/gapic-generator-ruby),

--- a/google-cloud-redis/MIGRATING.md
+++ b/google-cloud-redis/MIGRATING.md
@@ -1,4 +1,4 @@
-## Migrating to google-cloud-redis 1.0
+# Migrating to google-cloud-redis 1.0
 
 The 1.0 release of the google-cloud-redis client is a significant upgrade
 based on a [next-gen code generator](https://github.com/googleapis/gapic-generator-ruby),

--- a/google-cloud-resource_manager/MIGRATING.md
+++ b/google-cloud-resource_manager/MIGRATING.md
@@ -1,4 +1,4 @@
-## Migrating to google-cloud-resource_manager 1.0
+# Migrating to google-cloud-resource_manager 1.0
 
 The 1.0 release of the google-cloud-resource_manager client is a significant
 upgrade to add a number of new features in version V3 of the resource manager

--- a/google-cloud-scheduler/MIGRATING.md
+++ b/google-cloud-scheduler/MIGRATING.md
@@ -1,4 +1,4 @@
-## Migrating to google-cloud-scheduler 2.0
+# Migrating to google-cloud-scheduler 2.0
 
 The 2.0 release of the google-cloud-scheduler client is a significant upgrade
 based on a [next-gen code generator](https://github.com/googleapis/gapic-generator-ruby),

--- a/google-cloud-security_center/MIGRATING.md
+++ b/google-cloud-security_center/MIGRATING.md
@@ -1,4 +1,4 @@
-## Migrating to google-cloud-security_center 1.0
+# Migrating to google-cloud-security_center 1.0
 
 The 1.0 release of the google-cloud-security_center client is a significant upgrade
 based on a [next-gen code generator](https://github.com/googleapis/gapic-generator-ruby),

--- a/google-cloud-speech/MIGRATING.md
+++ b/google-cloud-speech/MIGRATING.md
@@ -1,4 +1,4 @@
-## Migrating to google-cloud-speech 1.0
+# Migrating to google-cloud-speech 1.0
 
 The 1.0 release of the google-cloud-speech client is a significant upgrade
 based on a [next-gen code generator](https://github.com/googleapis/gapic-generator-ruby),

--- a/google-cloud-talent/MIGRATING.md
+++ b/google-cloud-talent/MIGRATING.md
@@ -1,4 +1,4 @@
-## Migrating to google-cloud-talent 0.20
+# Migrating to google-cloud-talent 0.20
 
 The 0.20 release of the google-cloud-talent client is a significant upgrade
 based on a [next-gen code generator](https://github.com/googleapis/gapic-generator-ruby),

--- a/google-cloud-tasks/MIGRATING.md
+++ b/google-cloud-tasks/MIGRATING.md
@@ -1,4 +1,4 @@
-## Migrating to google-cloud-tasks 2.0
+# Migrating to google-cloud-tasks 2.0
 
 The 2.0 release of the google-cloud-tasks client is a significant upgrade
 based on a [next-gen code generator](https://github.com/googleapis/gapic-generator-ruby),

--- a/google-cloud-text_to_speech/MIGRATING.md
+++ b/google-cloud-text_to_speech/MIGRATING.md
@@ -1,4 +1,4 @@
-## Migrating to google-cloud-text_to_speech 1.0
+# Migrating to google-cloud-text_to_speech 1.0
 
 The 1.0 release of the google-cloud-text_to_speech client is a significant upgrade
 based on a [next-gen code generator](https://github.com/googleapis/gapic-generator-ruby),

--- a/google-cloud-translate/MIGRATING.md
+++ b/google-cloud-translate/MIGRATING.md
@@ -1,4 +1,4 @@
-## Migrating to google-cloud-translate 3.0
+# Migrating to google-cloud-translate 3.0
 
 The 3.0 release of the google-cloud-translate client is a significant upgrade
 based on a [next-gen code generator](https://github.com/googleapis/gapic-generator-ruby),

--- a/google-cloud-video_intelligence/MIGRATING.md
+++ b/google-cloud-video_intelligence/MIGRATING.md
@@ -1,4 +1,4 @@
-## Migrating to google-cloud-video_intelligence 3.0
+# Migrating to google-cloud-video_intelligence 3.0
 
 The 3.0 release of the google-cloud-video_intelligence client is a significant upgrade
 based on a [next-gen code generator](https://github.com/googleapis/gapic-generator-ruby),

--- a/google-cloud-vision/MIGRATING.md
+++ b/google-cloud-vision/MIGRATING.md
@@ -1,4 +1,4 @@
-## Migrating to google-cloud-vision 1.0
+# Migrating to google-cloud-vision 1.0
 
 The 1.0 release of the google-cloud-vision client is a significant upgrade
 based on a [next-gen code generator](https://github.com/googleapis/gapic-generator-ruby),

--- a/google-cloud-web_risk/MIGRATING.md
+++ b/google-cloud-web_risk/MIGRATING.md
@@ -1,4 +1,4 @@
-## Migrating to google-cloud-web_risk 1.0
+# Migrating to google-cloud-web_risk 1.0
 
 The `google-cloud-web_risk` gem is a significant upgrade over the older and now
 deprecated `google-cloud-webrisk` gem. It is based on a

--- a/grafeas/MIGRATING.md
+++ b/grafeas/MIGRATING.md
@@ -1,4 +1,4 @@
-## Migrating to grafeas 1.0
+# Migrating to grafeas 1.0
 
 The 1.0 release of the grafeas client is a significant upgrade
 based on a [next-gen code generator](https://github.com/googleapis/gapic-generator-ruby),


### PR DESCRIPTION
Fixes internal issue b/376068354. It is related to doc pages missing a title, such as in https://cloud.google.com/ruby/docs/reference/google-cloud-automl/latest/MIGRATING

Changes generated via `grep -lR "## Migrating to" | xargs sed -i 's/## Migrating/# Migrating/g'`




