### PR TITLE
fix: Update google-cloud-pubsub-v1 dependency to latest version

### DIFF
--- a/google-cloud-pubsub/google-cloud-pubsub.gemspec
+++ b/google-cloud-pubsub/google-cloud-pubsub.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "concurrent-ruby", "~> 1.3"
   gem.add_dependency "google-cloud-core", "~> 1.8"
-  gem.add_dependency "google-cloud-pubsub-v1", "~> 1.10"
+  gem.add_dependency "google-cloud-pubsub-v1", "~> 1.11"
   gem.add_dependency "retriable", "~> 3.1"
 end


### PR DESCRIPTION
I realized we actually want `v1.11` instead of `1.10` as done in #30587

[v1.11](https://github.com/googleapis/google-cloud-ruby/pull/30570)