### PR TITLE
test: Several test fixes

### DIFF
--- a/google-cloud-bigquery/Gemfile
+++ b/google-cloud-bigquery/Gemfile
@@ -20,6 +20,7 @@ local_dependencies.each do |name|
 end
 
 gem "autotest-suffix", "~> 1.1"
+gem "csv"
 gem "google-cloud-data_catalog", path: "../google-cloud-data_catalog"
 gem "google-cloud-storage", path: "../google-cloud-storage"
 gem "google-style", "~> 1.30.1"

--- a/google-cloud-bigquery/acceptance/bigquery/dataset_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/dataset_test.rb
@@ -185,7 +185,7 @@ describe Google::Cloud::Bigquery::Dataset, :bigquery do
     fresh.description = "Description 1"
     _(stale.etag).wont_equal fresh.etag
     err = expect { stale.description = "Description 2" }.must_raise Google::Cloud::FailedPreconditionError
-    _(err.message).must_equal "failedPrecondition: Precondition check failed."
+    _(err.message).must_match(/^(failedPrecondition|FAILED_PRECONDITION): Precondition check failed\.$/)
   end
 
   it "create dataset returns valid etag equal to get dataset" do

--- a/google-cloud-bigquery/acceptance/bigquery/table_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/table_test.rb
@@ -215,7 +215,7 @@ describe Google::Cloud::Bigquery::Table, :bigquery do
     fresh.description = "Description 1"
     _(stale.etag).wont_equal fresh.etag
     err = expect { stale.description = "Description 2" }.must_raise Google::Cloud::FailedPreconditionError
-    _(err.message).must_equal "failedPrecondition: Precondition check failed."
+    _(err.message).must_match(/^(failedPrecondition|FAILED_PRECONDITION): Precondition check failed\.$/)
   end
 
   it "create table returns valid etag equal to get table" do

--- a/google-cloud-bigquery/acceptance/bigquery/view_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/view_test.rb
@@ -82,6 +82,6 @@ describe Google::Cloud::Bigquery::Table, :view, :bigquery do
     fresh.description = "Description 1"
     _(stale.etag).wont_equal fresh.etag
     err = expect { stale.description = "Description 2" }.must_raise Google::Cloud::FailedPreconditionError
-    _(err.message).must_equal "failedPrecondition: Precondition check failed."
+    _(err.message).must_match(/^(failedPrecondition|FAILED_PRECONDITION): Precondition check failed\.$/)
   end
 end

--- a/google-cloud-storage/acceptance/storage/bucket_uniform_bucket_level_access_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_uniform_bucket_level_access_test.rb
@@ -30,7 +30,7 @@ describe Google::Cloud::Storage::Bucket, :uniform_bucket_level_access, :storage 
   let(:user_val) { "user-test@example.com" }
 
   before do
-    sleep 1
+    sleep 2
   end
 
   after do
@@ -69,6 +69,8 @@ describe Google::Cloud::Storage::Bucket, :uniform_bucket_level_access, :storage 
     _(err.message).must_match /does not have storage.objects.get access to/
 
     bucket.uniform_bucket_level_access = false
+    refute bucket.uniform_bucket_level_access?
+    sleep 1
     file.reload!
   end
 
@@ -150,6 +152,7 @@ describe Google::Cloud::Storage::Bucket, :uniform_bucket_level_access, :storage 
     _(err.message).must_match /does not have storage.objects.get access to/
 
     bucket.policy_only = false
+    sleep 1
     file.reload!
   end
 
@@ -200,6 +203,7 @@ describe Google::Cloud::Storage::Bucket, :uniform_bucket_level_access, :storage 
     refute bucket.policy_only?
     _(bucket.policy_only_locked_at).must_be :nil?
 
+    sleep 1
     file_default_acl.reload!
     _(file_default_acl.acl.readers).must_equal ["allUsers"]
   end

--- a/google-cloud-storage/acceptance/storage/universe_domain_test.rb
+++ b/google-cloud-storage/acceptance/storage/universe_domain_test.rb
@@ -15,61 +15,62 @@
 require "storage_helper"
 
 describe Google::Cloud::Storage, :universe_domain do
-  
-  # Fetch secret values from the secret_manager path
-  TEST_UNIVERSE_PROJECT_ID = File.read(File.realpath(File.join(ENV["KOKORO_GFILE_DIR"], "secret_manager", "client-library-test-universe-project-id")))
-  TEST_UNIVERSE_LOCATION = File.read(File.realpath(File.join(ENV["KOKORO_GFILE_DIR"], "secret_manager", "client-library-test-universe-storage-location")))
-  TEST_UNIVERSE_DOMAIN = File.read(File.realpath(File.join( ENV["KOKORO_GFILE_DIR"], "secret_manager", "client-library-test-universe-domain")))
-  TEST_UNIVERSE_DOMAIN_CREDENTIAL = File.realpath(File.join( ENV["KOKORO_GFILE_DIR"], "secret_manager", "client-library-test-universe-domain-credential"))
+  if ENV["KOKORO_GFILE_DIR"]
+    # Fetch secret values from the secret_manager path
+    TEST_UNIVERSE_PROJECT_ID = File.read(File.realpath(File.join(ENV["KOKORO_GFILE_DIR"], "secret_manager", "client-library-test-universe-project-id")))
+    TEST_UNIVERSE_LOCATION = File.read(File.realpath(File.join(ENV["KOKORO_GFILE_DIR"], "secret_manager", "client-library-test-universe-storage-location")))
+    TEST_UNIVERSE_DOMAIN = File.read(File.realpath(File.join( ENV["KOKORO_GFILE_DIR"], "secret_manager", "client-library-test-universe-domain")))
+    TEST_UNIVERSE_DOMAIN_CREDENTIAL = File.realpath(File.join( ENV["KOKORO_GFILE_DIR"], "secret_manager", "client-library-test-universe-domain-credential"))
 
-  let :ud_storage do
-    Google::Cloud::Storage.new(
-      project_id: TEST_UNIVERSE_PROJECT_ID,
-      credentials: TEST_UNIVERSE_DOMAIN_CREDENTIAL,
-      universe_domain: TEST_UNIVERSE_DOMAIN
-    )
-  end
-  let(:t) { Time.now.utc.iso8601.gsub ":", "-" }
-  let(:ud_bucket_name) { "ud-test-ruby-bucket-#{t}-#{SecureRandom.hex(4)}".downcase }
-
-  after do
-    ud_bucket = ud_storage.bucket ud_bucket_name
-    if ud_bucket
-      ud_bucket.files.all &:delete
-      safe_gcs_execute { ud_bucket.delete }
+    let :ud_storage do
+      Google::Cloud::Storage.new(
+        project_id: TEST_UNIVERSE_PROJECT_ID,
+        credentials: TEST_UNIVERSE_DOMAIN_CREDENTIAL,
+        universe_domain: TEST_UNIVERSE_DOMAIN
+      )
     end
-  end
+    let(:t) { Time.now.utc.iso8601.gsub ":", "-" }
+    let(:ud_bucket_name) { "ud-test-ruby-bucket-#{t}-#{SecureRandom.hex(4)}".downcase }
 
-  it "validates presense of test project secret values" do
-    refute_nil TEST_UNIVERSE_PROJECT_ID, "TEST_UNIVERSE_PROJECT_ID should not be nil"
-    refute_nil TEST_UNIVERSE_LOCATION, "TEST_UNIVERSE_LOCATION should not be nil"
-    refute_nil TEST_UNIVERSE_DOMAIN, "TEST_UNIVERSE_DOMAIN should not be nil"
-    refute_nil TEST_UNIVERSE_DOMAIN_CREDENTIAL, "TEST_UNIVERSE_DOMAIN_CREDENTIAL should not be nil"
-  end
+    after do
+      ud_bucket = ud_storage.bucket ud_bucket_name
+      if ud_bucket
+        ud_bucket.files.all &:delete
+        safe_gcs_execute { ud_bucket.delete }
+      end
+    end
 
-  it "creates a new bucket and uploads an object with universe_domain" do
-    # Create a bucket
-    ud_bucket =  ud_storage.create_bucket ud_bucket_name, location: TEST_UNIVERSE_LOCATION 
-    _(ud_bucket).wont_be_nil
-    _(ud_bucket.name).must_equal ud_bucket_name
-    # Upload an object
-    ud_file_name = "ud-test-file"
-    ud_payload = StringIO.new "Hello world!"
-    ud_file = ud_bucket.create_file ud_payload, ud_file_name
-    _(ud_file.name).must_equal ud_file_name
+    it "validates presense of test project secret values" do
+      refute_nil TEST_UNIVERSE_PROJECT_ID, "TEST_UNIVERSE_PROJECT_ID should not be nil"
+      refute_nil TEST_UNIVERSE_LOCATION, "TEST_UNIVERSE_LOCATION should not be nil"
+      refute_nil TEST_UNIVERSE_DOMAIN, "TEST_UNIVERSE_DOMAIN should not be nil"
+      refute_nil TEST_UNIVERSE_DOMAIN_CREDENTIAL, "TEST_UNIVERSE_DOMAIN_CREDENTIAL should not be nil"
+    end
 
-    # Read the file uploaded
-    uploaded_ud_file = ud_bucket.file ud_file_name
-    _(uploaded_ud_file.name).must_equal ud_file_name
+    it "creates a new bucket and uploads an object with universe_domain" do
+      # Create a bucket
+      ud_bucket =  ud_storage.create_bucket ud_bucket_name, location: TEST_UNIVERSE_LOCATION 
+      _(ud_bucket).wont_be_nil
+      _(ud_bucket.name).must_equal ud_bucket_name
+      # Upload an object
+      ud_file_name = "ud-test-file"
+      ud_payload = StringIO.new "Hello world!"
+      ud_file = ud_bucket.create_file ud_payload, ud_file_name
+      _(ud_file.name).must_equal ud_file_name
 
-    # Delete the object
-    uploaded_ud_file.delete
-    _(ud_bucket.file uploaded_ud_file.name).must_be_nil
+      # Read the file uploaded
+      uploaded_ud_file = ud_bucket.file ud_file_name
+      _(uploaded_ud_file.name).must_equal ud_file_name
 
-    # Delete the bucket
-    ud_bucket.delete
-    bucket= ud_storage.bucket ud_bucket_name
-    assert_nil bucket, "Bucket #{ud_bucket_name} should not exist"
+      # Delete the object
+      uploaded_ud_file.delete
+      _(ud_bucket.file uploaded_ud_file.name).must_be_nil
 
+      # Delete the bucket
+      ud_bucket.delete
+      bucket= ud_storage.bucket ud_bucket_name
+      assert_nil bucket, "Bucket #{ud_bucket_name} should not exist"
+
+    end
   end
 end

--- a/google-cloud-storage/acceptance/storage_helper.rb
+++ b/google-cloud-storage/acceptance/storage_helper.rb
@@ -33,6 +33,7 @@ scopes = ["https://www.googleapis.com/auth/devstorage.full_control", "https://ww
 $storage = Google::Cloud.new.storage retries: 10, scope: scopes
 
 # Create second storage object for tests requiring one, such as requester pays and user project.
+$storage_2 = nil
 if (proj = ENV["GCLOUD_TEST_STORAGE_REQUESTER_PAYS_PROJECT"]) &&
   (keyfile = ENV["GCLOUD_TEST_STORAGE_REQUESTER_PAYS_KEYFILE"] ||
     (ENV["GCLOUD_TEST_STORAGE_REQUESTER_PAYS_KEYFILE_JSON"] &&


### PR DESCRIPTION
A few miscellaneous test fixes. Doesn't fix all possible flakes, but handles some of the currently common ones.

* Added csv explicitly to the bigquery test bundle because it's not a built-in gem in Ruby 3.4+
* Updated some expected message text in the bigquery acceptance tests as the backend seems to have changed.
* Added a guard around universe domain acceptance tests for storage so the acceptance tests can be run locally in the absence of the test universe credentials
* Added a few short pauses during storage acceptance tests to wait for state propagation.
* Eliminated an uninitialized global warning in the storage acceptance tests
