### PR TITLE
chore: Deleting a library removes the directory altogether instead of moving it to obsolete

### DIFF
--- a/.github/workflows/delete-library.yml
+++ b/.github/workflows/delete-library.yml
@@ -1,17 +1,17 @@
-name: Mark Library Obsolete
+name: Delete a library
 
 on:
   workflow_dispatch:
     inputs:
       gem:
-        description: "gem name to obsolete"
+        description: "name of gem to remove"
         required: true
       flags:
-        description: "Extra flags to pass to toys obsolete-library"
+        description: "Extra flags to pass to toys delete-library"
         required: false
 
 jobs:
-  ObsoleteLibrary:
+  DeleteLibrary:
     if: ${{ github.repository == 'googleapis/google-cloud-ruby' }}
     runs-on: ubuntu-latest
     env:
@@ -19,13 +19,13 @@ jobs:
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4
-    - name: Install Ruby 3.3
+    - name: Install Ruby 3.4
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "3.3"
+        ruby-version: "3.4"
     - name: Install tools
       run: |
         gem install --no-document toys
-    - name: Obsolete-library
+    - name: Delete-library
       run: |
-        toys obsolete-library -v --fork ${{ github.event.inputs.flags }} ${{ github.event.inputs.gem }}
+        toys delete-library -v --fork ${{ github.event.inputs.flags }} ${{ github.event.inputs.gem }}

--- a/.toys/delete-library.rb
+++ b/.toys/delete-library.rb
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-desc "A tool that obsoletes a client library"
+desc "A tool that removes a client library from the repository"
 
 required_arg :gem_name
 
@@ -32,17 +32,16 @@ include "yoshi-pr-generator"
 def run
   setup
   branch_name = "pr/delete/#{gem_name}"
-  message = "chore: obsolete #{gem_name}"
+  message = "chore: remove #{gem_name}"
   result = yoshi_pr_generator.capture enabled: !git_remote.nil?,
                                       remote: git_remote,
                                       branch_name: branch_name,
                                       commit_message: message do
     remove_release_manifest
     remove_release_config
-    remove_owlbot_config
     remove_directory
   end
-  puts "result: #{result}"
+  puts "Pull request result: #{result}"
 end
 
 def setup
@@ -66,12 +65,6 @@ def remove_release_config
   File.write "release-please-config.json", "#{JSON.pretty_generate config_json}\n"
 end
 
-def remove_owlbot_config
-  rm_f "#{gem_name}/.OwlBot.yaml"
-  rm_f "#{gem_name}/.owlbot-manifest.json"
-  rm_f "#{gem_name}/.owlbot.rb"
-end
-
 def remove_directory
-  mv gem_name, "obsolete/#{gem_name}"
+  rm_rf gem_name
 end


### PR DESCRIPTION
The current obsolete-library action and tool moves the library code to an "obsolete" directory. This was really unnecessary, since we can always retrieve the code from the git history in the unlikely event that we need it. This change updates the tool to simply delete the directory altogether, and renames it to "delete-library".