### PR TITLE
feat(bigquery): Add table resource tags support

### DIFF
--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -1018,6 +1018,77 @@ module Google
         end
 
         ##
+        # The resource tags associated with this table. Tag keys are globally unique.
+        #
+        # @see https://cloud.google.com/iam/docs/tags-access-control#definitions
+        #   For additional information on tags.
+        #
+        # The returned hash is frozen and changes are not allowed. Use
+        # {#resource_tags=} to replace the entire hash.
+        #
+        # @return [Hash<String, String>, nil] A hash containing key/value pairs.
+        #
+        #   * The key is the namespaced friendly name of the tag key, e.g.
+        #     "12345/environment" where 12345 is the ID of the parent organization
+        #     or project resource for this tag key.
+        #   * The value is the friendly short name of the tag value, e.g. "production".
+        #
+        # @example
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #   table = dataset.table "my_table"
+        #
+        #   resource_tags = table.resource_tags
+        #   resource_tags["12345/environment"] #=> "production"
+        #
+        # @!group Attributes
+        #
+        def resource_tags
+          return nil if reference?
+          m = @gapi.resource_tags
+          m = m.to_h if m.respond_to? :to_h
+          m.dup.freeze
+        end
+
+        ##
+        # Updates the resource tags associated with this table. Tag keys are globally
+        # unique.
+        #
+        # @see https://cloud.google.com/iam/docs/tags-access-control#definitions
+        #   For additional information on tags.
+        #
+        # If the table is not a full resource representation (see
+        # {#resource_full?}), the full representation will be retrieved before
+        # the update to comply with ETag-based optimistic concurrency control.
+        #
+        # @param [Hash<String, String>] resource_tags A hash containing key/value
+        #   pairs.
+        #
+        #   * The key is the namespaced friendly name of the tag key, e.g.
+        #     "12345/environment" where 12345 is the ID of the parent organization
+        #     or project resource for this tag key.
+        #   * The value is the friendly short name of the tag value, e.g. "production".
+        #
+        # @example
+        #   require "google/cloud/bigquery"
+        #
+        #   bigquery = Google::Cloud::Bigquery.new
+        #   dataset = bigquery.dataset "my_dataset"
+        #   table = dataset.table "my_table"
+        #
+        #   table.resource_tags = { "12345/environment" => "production" }
+        #
+        # @!group Attributes
+        #
+        def resource_tags= resource_tags
+          reload! unless resource_full?
+          @gapi.resource_tags = resource_tags
+          patch_gapi! :resource_tags
+        end
+
+        ##
         # Returns the table's schema. If the table is not a view (See {#view?}),
         # this method can also be used to set, replace, or add to the schema by
         # passing a block. See {Schema} for available methods.

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_reference_update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_reference_update_test.rb
@@ -218,6 +218,27 @@ describe Google::Cloud::Bigquery::Table, :reference, :update, :mock_bigquery do
     mock.verify
   end
 
+  it "updates its resource_tags" do
+    new_resource_tags = { "bar" => "baz" }
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    table_hash = random_table_hash dataset_id, table_id, table_name, description
+    table_hash["resourceTags"] = new_resource_tags
+    request_table_gapi = Google::Apis::BigqueryV2::Table.new resource_tags: new_resource_tags, etag: etag
+    mock.expect :get_table, return_table(table_hash), [project, dataset_id, table_id], **patch_table_args
+    mock.expect :patch_table, return_table(table_hash),
+      [project, dataset_id, table_id, request_table_gapi], options: {header: {"If-Match" => etag}}
+    table.service.mocked_service = mock
+
+    _(table.resource_tags).must_be_nil
+
+    table.resource_tags = new_resource_tags
+
+    _(table.resource_tags).must_equal new_resource_tags
+    mock.verify
+  end
+
   def return_table table_hash
     Google::Apis::BigqueryV2::Table.from_json(table_hash.to_json)
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_test.rb
@@ -25,11 +25,15 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
   let(:location_code) { "US" }
   let(:labels) { { "foo" => "bar" } }
   let(:kms_key) { "path/to/encryption_key_name" }
+  let(:resource_tags) { { "bar" => "baz" } }
   let(:gapi_encrypt_config) { Google::Apis::BigqueryV2::EncryptionConfiguration.new kms_key_name: kms_key }
   let(:gapi_encrypt_config) { Google::Apis::BigqueryV2::EncryptionConfiguration.new kms_key_name: kms_key }
   let(:api_url) { "http://googleapi/bigquery/v2/projects/#{project}/datasets/#{dataset}/tables/#{table_id}" }
   let(:table_hash) { random_table_hash dataset, table_id, table_name, description }
-  let(:table_gapi) { Google::Apis::BigqueryV2::Table.from_json(table_hash.to_json).tap { |t| t.encryption_configuration = gapi_encrypt_config } }
+  let(:table_gapi) { Google::Apis::BigqueryV2::Table.from_json(table_hash.to_json).tap do |t|
+    t.encryption_configuration = gapi_encrypt_config
+    t.resource_tags = resource_tags
+  end }
   let(:table) { Google::Cloud::Bigquery::Table.from_gapi table_gapi, bigquery.service }
   let(:clone_table) { Google::Cloud::Bigquery::Table.from_gapi random_clone_gapi(dataset), bigquery.service }
   let(:snapshot_table) { Google::Cloud::Bigquery::Table.from_gapi random_snapshot_gapi(dataset), bigquery.service }
@@ -65,6 +69,8 @@ describe Google::Cloud::Bigquery::Table, :mock_bigquery do
     _(table.encryption).must_be_kind_of Google::Cloud::Bigquery::EncryptionConfiguration
     _(table.encryption.kms_key).must_equal kms_key
     _(table.encryption).must_be :frozen?
+    _(table.resource_tags).must_equal resource_tags
+    _(table.resource_tags).must_be :frozen?
   end
 
   it "knows its fully-qualified ID" do

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_update_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_update_test.rb
@@ -370,6 +370,26 @@ describe Google::Cloud::Bigquery::Table, :update, :mock_bigquery do
     mock.verify
   end
 
+  it "updates its resource_tags" do
+    new_resource_tags = { "bar" => "baz" }
+
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+    table_hash = random_table_hash dataset_id, table_id, table_name, description
+    table_hash["resourceTags"] = new_resource_tags
+    request_table_gapi = Google::Apis::BigqueryV2::Table.new resource_tags: new_resource_tags, etag: etag
+    mock.expect :patch_table, return_table(table_hash),
+      [project, dataset_id, table_id, request_table_gapi], options: {header: {"If-Match" => etag}}
+    table.service.mocked_service = mock
+
+    assert_empty table.resource_tags
+
+    table.resource_tags = new_resource_tags
+
+    _(table.resource_tags).must_equal new_resource_tags
+    mock.verify
+  end
+
   def return_table table_hash
     Google::Apis::BigqueryV2::Table.from_json(table_hash.to_json)
   end


### PR DESCRIPTION
b/319169930. Please note this FR applies to `Table` only (i.e. `Dataset` not included).

Implementations for reference:
- https://github.com/googleapis/google-cloud-go/pull/9084
- https://github.com/googleapis/java-bigquery/pull/3046