### PR TITLE
feat(BigQuery): Add support for preserve_ascii_control_characters in CSVOptions

### DIFF
--- a/google-cloud-bigquery/acceptance/bigquery/query_external_test.rb
+++ b/google-cloud-bigquery/acceptance/bigquery/query_external_test.rb
@@ -36,6 +36,15 @@ describe Google::Cloud::Bigquery::External, :bigquery do
   let(:data_io) { StringIO.new data_csv }
   let(:storage) { Google::Cloud.storage }
   let(:file) { bucket.file("pets.csv") || bucket.create_file(data_io, "pets.csv") }
+  let(:control_char_data) do
+    [
+      ["id", "name", "breed"],
+      [1, "foo\x01bar", "baz\x1Fqux"]
+    ]
+  end
+  let(:control_char_data_csv) { CSV.generate { |csv| control_char_data.each { |row| csv << row } } }
+  let(:control_char_data_io) { StringIO.new control_char_data_csv }
+  let(:control_char_file) { bucket.file("pets_control_chars.csv") || bucket.create_file(control_char_data_io, "pets_control_chars.csv") }
 
   it "queries an external table (with autodetect)" do
     ext_table = dataset.external file.to_gs_url
@@ -68,5 +77,41 @@ describe Google::Cloud::Bigquery::External, :bigquery do
       { id: 5, name: "ryan", breed: "golden retriever?" },
       { id: 6, name: "stephen", breed: "idkanycatbreeds" }
     ]
+  end
+  
+  it "queries an external table with preserve_ascii_control_characters" do
+    # First, test with preserve_ascii_control_characters = true
+    ext_table_preserved = dataset.external control_char_file.to_gs_url do |t|
+      t.skip_leading_rows = 1
+      t.preserve_ascii_control_characters = true
+      t.schema do |s|
+        s.integer "id", mode: :required
+        s.string "name", mode: :required
+        s.string "breed", mode: :required
+      end
+    end
+
+    data_preserved = dataset.query "SELECT id, name, breed FROM pets_control", external: { pets_control: ext_table_preserved }
+    _(data_preserved.count).must_equal 1
+    _(data_preserved.first[:id]).must_equal 1
+    _(data_preserved.first[:name]).must_equal "foo\x01bar"
+    _(data_preserved.first[:breed]).must_equal "baz\x1Fqux"
+
+    # Second, test with preserve_ascii_control_characters = false
+    ext_table_stripped = dataset.external control_char_file.to_gs_url do |t|
+      t.skip_leading_rows = 1
+      t.preserve_ascii_control_characters = false
+      t.schema do |s|
+        s.integer "id", mode: :required
+        s.string "name", mode: :required
+        s.string "breed", mode: :required
+      end
+    end
+
+    data_stripped = dataset.query "SELECT id, name, breed FROM pets_control", external: { pets_control: ext_table_stripped }
+    _(data_stripped.count).must_equal 1
+    _(data_stripped.first[:id]).must_equal 1
+    _(data_stripped.first[:name]).must_equal "foo bar" # each control char should be replaced with a space
+    _(data_stripped.first[:breed]).must_equal "baz qux"
   end
 end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/external/csv_source.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/external/csv_source.rb
@@ -538,6 +538,53 @@ module Google
             @gapi.csv_options.source_column_match = source_column_match
           end
 
+          # Indicates if the embedded ASCII control characters (the first 32
+          # characters in the ASCII-table, from `\x00` to `\x1F`) are preserved.
+          # By default, ASCII control characters are not preserved.
+          #
+          # @return [Boolean, nil] whether or not ASCII control characters are
+          #   preserved. `nil` if not set.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   csv_url = "gs://bucket/path/to/data.csv"
+          #   csv_table = bigquery.external csv_url do |csv|
+          #     csv.preserve_ascii_control_characters = true
+          #   end
+          #
+          #   csv_table.preserve_ascii_control_characters #=> true
+          #
+          def preserve_ascii_control_characters
+            @gapi.csv_options.preserve_ascii_control_characters
+          end
+
+          # Sets whether the embedded ASCII control characters (the first 32
+          # characters in the ASCII-table, from `\x00` to `\x1F`) are preserved.
+          # By default, ASCII control characters are not preserved.
+          #
+          # @param [Boolean, nil] val whether or not ASCII control characters
+          #    are preserved. `nil` to unset.
+          #
+          # @example
+          #   require "google/cloud/bigquery"
+          #
+          #   bigquery = Google::Cloud::Bigquery.new
+          #
+          #   csv_url = "gs://bucket/path/to/data.csv"
+          #   csv_table = bigquery.external csv_url do |csv|
+          #     csv.preserve_ascii_control_characters = true
+          #   end
+          #
+          #   csv_table.preserve_ascii_control_characters #=> true
+          #
+          def preserve_ascii_control_characters= val
+            frozen_check!
+            @gapi.csv_options.preserve_ascii_control_characters = val
+          end
+
           ##
           # The schema for the data.
           #

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
@@ -737,6 +737,18 @@ module Google
         end
 
         ##
+        # When source_format is set to `CSV`, indicates if the embedded ASCII
+        # control characters (the first 32 characters in the ASCII-table, from
+        # `\x00` to `\x1F`) are preserved. By default, ASCII control
+        # characters are not preserved.
+        #
+        # @return [Boolean, nil] whether or not ASCII control characters are
+        #   preserved. `nil` if not set.
+        def preserve_ascii_control_characters
+          @gapi.configuration.load.preserve_ascii_control_characters
+        end
+
+        ##
         # Yielded to a block to accumulate changes for a patch request.
         class Updater < LoadJob
           ##
@@ -2750,6 +2762,18 @@ module Google
           #   `America/Los_Angeles`. `nil` to unset.
           def time_zone= time_zone
             @gapi.configuration.load.update! time_zone: time_zone
+          end
+
+          ##
+          # When source_format is set to `CSV`, sets whether the embedded ASCII
+          # control characters (the first 32 characters in the ASCII-table, from
+          # `\x00` to `\x1F`) are preserved. By default, ASCII control
+          # characters are not preserved.
+          #
+          # @param [Boolean, nil] val whether or not ASCII control characters
+          #   are preserved. `nil` to unset.
+          def preserve_ascii_control_characters= val
+            @gapi.configuration.load.update! preserve_ascii_control_characters: val
           end
 
           def cancel

--- a/google-cloud-bigquery/test/google/cloud/bigquery/external_csv_source_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/external_csv_source_test.rb
@@ -245,6 +245,26 @@ describe Google::Cloud::Bigquery::External::CsvSource do
     _(table.to_gapi.to_h).must_equal table_gapi.to_h
   end
 
+  it "sets preserve_ascii_control_characters" do
+    table = Google::Cloud::Bigquery::External::CsvSource.new.tap do |e|
+      e.gapi.source_uris = ["gs://my-bucket/path/to/file.csv"]
+      e.gapi.source_format = "CSV"
+    end
+    table_gapi = Google::Apis::BigqueryV2::ExternalDataConfiguration.new(
+      source_uris: ["gs://my-bucket/path/to/file.csv"],
+      source_format: "CSV",
+      csv_options: Google::Apis::BigqueryV2::CsvOptions.new(
+        preserve_ascii_control_characters: true
+      )
+    )
+    _(table.preserve_ascii_control_characters).must_be :nil?
+
+    table.preserve_ascii_control_characters = true
+
+    _(table.preserve_ascii_control_characters).must_equal true
+
+    _(table.to_gapi.to_h).must_equal table_gapi.to_h
+  end
 
   it "sets schema using block" do
     table = Google::Cloud::Bigquery::External::CsvSource.new.tap do |e|

--- a/google-cloud-bigquery/test/google/cloud/bigquery/load_job_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/load_job_test.rb
@@ -97,6 +97,7 @@ describe Google::Cloud::Bigquery::LoadJob, :mock_bigquery do
     _(job_defaults.null_markers).must_equal []
     _(job_defaults.source_column_match).must_be :nil?
     _(job_defaults.time_zone).must_be :nil?
+    _(job_defaults.preserve_ascii_control_characters).must_be :nil?
   end
 
   it "knows its full attributes" do
@@ -121,6 +122,7 @@ describe Google::Cloud::Bigquery::LoadJob, :mock_bigquery do
     _(job.null_markers).must_equal ["NULL", "nil"]
     _(job.source_column_match).must_equal "POSITION"
     _(job.time_zone).must_equal "America/Los_Angeles"
+    _(job.preserve_ascii_control_characters).must_equal true
   end
 
   it "knows its statistics data" do
@@ -197,6 +199,7 @@ describe Google::Cloud::Bigquery::LoadJob, :mock_bigquery do
       "nullMarkers" => ["NULL", "nil"],
       "sourceColumnMatch" => "POSITION",
       "timeZone" => "America/Los_Angeles",
+      "preserveAsciiControlCharacters" => true
     }
     hash["statistics"]["load"] = {
       "inputFiles" => "3", # String per google/google-api-ruby-client#439

--- a/google-cloud-bigquery/test/google/cloud/bigquery/load_job_updater_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/load_job_updater_test.rb
@@ -186,4 +186,19 @@ describe Google::Cloud::Bigquery::LoadJob::Updater do
     job_gapi = updater.to_gapi
     _(job_gapi.configuration.load.datetime_format).must_be :nil?
   end
+  
+  it "can set preserve_ascii_control_characters" do
+    updater = new_updater
+    updater.preserve_ascii_control_characters = true
+    job_gapi = updater.to_gapi
+    _(job_gapi.configuration.load.preserve_ascii_control_characters).must_equal true
+
+    updater.preserve_ascii_control_characters = false
+    job_gapi = updater.to_gapi
+    _(job_gapi.configuration.load.preserve_ascii_control_characters).must_equal false
+
+    updater.preserve_ascii_control_characters = nil
+    job_gapi = updater.to_gapi
+    _(job_gapi.configuration.load.preserve_ascii_control_characters).must_be :nil?
+  end
 end


### PR DESCRIPTION
https://b.corp.google.com/issues/243699405