### PR TITLE
feat(BigQuery): Exposing reservation field in JobConfiguration

### DIFF
--- a/google-cloud-bigquery/lib/google/cloud/bigquery/copy_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/copy_job.rb
@@ -194,7 +194,8 @@ module Google
               job_reference: job_ref,
               configuration: Google::Apis::BigqueryV2::JobConfiguration.new(
                 copy:    copy_cfg,
-                dry_run: options[:dryrun]
+                dry_run: options[:dryrun],
+                reservation: options[:reservation]
               )
             )
 
@@ -323,6 +324,18 @@ module Google
           # @!group Attributes
           def labels= value
             @gapi.configuration.update! labels: value
+          end
+
+          ##
+          # Sets the reservation that job would use. User can specify a reservation
+          # to execute the job. If reservation is not set, reservation is determined
+          # based on the rules defined by the reservation assignments. The expected
+          # format is `projects/`project`/locations/`location`/reservations/`reservation``.
+          # @param [String] value The reservation name.
+          #
+          # @!group Attributes
+          def reservation= value
+            @gapi.configuration.update! reservation: value
           end
 
           def cancel

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/dataset.rb
@@ -1424,6 +1424,12 @@ module Google
         #   The default value is false.
         # @param [String] session_id The ID of an existing session. See also the
         #   `create_session` param and {Job#session_id}.
+        # @param [String] reservation The reservation that job would use. User
+        #    can specify a reservation to execute the job. If reservation is not
+        #    set, reservation is determined based on the rules defined by the
+        #    reservation assignments. The expected format is
+        #    `projects/`project`/locations/`location`/reservations/`reservation``.
+        #
         # @yield [job] a job configuration object
         # @yieldparam [Google::Cloud::Bigquery::QueryJob::Updater] job a job
         #   configuration object for setting additional options for the query.
@@ -1596,7 +1602,8 @@ module Google
                       labels: nil,
                       udfs: nil,
                       create_session: nil,
-                      session_id: nil
+                      session_id: nil,
+                      reservation: nil
           ensure_service!
           options = {
             params: params,
@@ -1619,7 +1626,8 @@ module Google
             labels: labels,
             udfs: udfs,
             create_session: create_session,
-            session_id: session_id
+            session_id: session_id,
+            reservation: reservation
           }
 
           updater = QueryJob::Updater.from_options service, query, options
@@ -1748,6 +1756,12 @@ module Google
         #   `create_session` param in {#query_job} and {Job#session_id}.
         # @param [Boolean] format_options_use_int64_timestamp Output timestamp
         #   as usec int64. Default is true.
+        # @param [String] reservation The reservation that job would use. User
+        #    can specify a reservation to execute the job. If reservation is not
+        #    set, reservation is determined based on the rules defined by the
+        #    reservation assignments. The expected format is
+        #    `projects/`project`/locations/`location`/reservations/`reservation``.
+        #
         # @yield [job] a job configuration object
         # @yieldparam [Google::Cloud::Bigquery::QueryJob::Updater] job a job
         #   configuration object for setting additional options for the query.
@@ -1903,6 +1917,7 @@ module Google
                   legacy_sql: nil,
                   session_id: nil,
                   format_options_use_int64_timestamp: true,
+                  reservation: nil,
                   &block
           job = query_job query,
                           params: params,
@@ -1912,6 +1927,7 @@ module Google
                           standard_sql: standard_sql,
                           legacy_sql: legacy_sql,
                           session_id: session_id,
+                          reservation: reservation,
                           &block
           job.wait_until_done!
           ensure_job_succeeded! job
@@ -2172,6 +2188,11 @@ module Google
         #   (the first 32 characters in the ASCII-table, from `\x00` to `\x1F`)
         #   are preserved. By default, ASCII control characters are not
         #   preserved.
+        # @param [String] reservation The reservation that job would use. User
+        #    can specify a reservation to execute the job. If reservation is not
+        #    set, reservation is determined based on the rules defined by the
+        #    reservation assignments. The expected format is
+        #    `projects/`project`/locations/`location`/reservations/`reservation``.
         #
         # @yield [updater] A block for setting the schema and other
         #   options for the destination table. The schema can be omitted if the
@@ -2269,7 +2290,7 @@ module Google
                      null_marker: nil, dryrun: nil, create_session: nil, session_id: nil, date_format: nil,
                      datetime_format: nil, time_format: nil, timestamp_format: nil, null_markers: nil,
                      source_column_match: nil, time_zone: nil, reference_file_schema_uri: nil,
-                     preserve_ascii_control_characters: nil
+                     preserve_ascii_control_characters: nil, reservation: nil
           ensure_service!
 
           updater = load_job_updater table_id,
@@ -2283,7 +2304,8 @@ module Google
                                      time_format: time_format, timestamp_format: timestamp_format,
                                      null_markers: null_markers, source_column_match: source_column_match,
                                      time_zone: time_zone, reference_file_schema_uri: reference_file_schema_uri,
-                                     preserve_ascii_control_characters: preserve_ascii_control_characters
+                                     preserve_ascii_control_characters: preserve_ascii_control_characters,
+                                     reservation: reservation
 
 
           yield updater if block_given?
@@ -2453,6 +2475,11 @@ module Google
         #   (the first 32 characters in the ASCII-table, from `\x00` to `\x1F`)
         #   are preserved. By default, ASCII control characters are not
         #   preserved.
+        # @param [String] reservation The reservation that job would use. User
+        #    can specify a reservation to execute the job. If reservation is not
+        #    set, reservation is determined based on the rules defined by the
+        #    reservation assignments. The expected format is
+        #    `projects/`project`/locations/`location`/reservations/`reservation``.
         #
         # @yield [updater] A block for setting the schema of the destination
         #   table and other options for the load job. The schema can be omitted
@@ -2548,7 +2575,8 @@ module Google
                  quote: nil, skip_leading: nil, schema: nil, autodetect: nil, null_marker: nil, session_id: nil,
                  date_format: nil, datetime_format: nil, time_format: nil, timestamp_format: nil,
                  null_markers: nil, source_column_match: nil, time_zone: nil, reference_file_schema_uri: nil,
-                 preserve_ascii_control_characters: nil, &block
+                 preserve_ascii_control_characters: nil,
+                 reservation: nil, &block
           job = load_job table_id, files,
                          format: format, create: create, write: write, projection_fields: projection_fields,
                          jagged_rows: jagged_rows, quoted_newlines: quoted_newlines, encoding: encoding,
@@ -2559,7 +2587,7 @@ module Google
                          null_markers: null_markers, source_column_match: source_column_match, time_zone: time_zone,
                          reference_file_schema_uri: reference_file_schema_uri,
                          preserve_ascii_control_characters: preserve_ascii_control_characters,
-                         &block
+                         reservation: reservation, &block
 
           job.wait_until_done!
           ensure_job_succeeded! job
@@ -3060,7 +3088,7 @@ module Google
           end
         end
 
-        def load_job_gapi table_id, dryrun, job_id: nil, prefix: nil
+        def load_job_gapi table_id, dryrun, job_id: nil, prefix: nil, reservation: nil
           job_ref = service.job_ref_from job_id, prefix
           Google::Apis::BigqueryV2::Job.new(
             job_reference: job_ref,
@@ -3072,7 +3100,8 @@ module Google
                   table_id:   table_id
                 )
               ),
-              dry_run: dryrun
+              dry_run: dryrun,
+              reservation: reservation
             )
           )
         end
@@ -3126,8 +3155,8 @@ module Google
                              prefix: nil, labels: nil, autodetect: nil, null_marker: nil, create_session: nil,
                              session_id: nil, date_format: nil, datetime_format: nil, time_format: nil,
                              timestamp_format: nil, null_markers: nil, source_column_match: nil, time_zone: nil,
-                             reference_file_schema_uri: nil, preserve_ascii_control_characters: nil
-          new_job = load_job_gapi table_id, dryrun, job_id: job_id, prefix: prefix
+                             reference_file_schema_uri: nil, preserve_ascii_control_characters: nil, reservation: nil
+          new_job = load_job_gapi table_id, dryrun, job_id: job_id, prefix: prefix, reservation: reservation
           LoadJob::Updater.new(new_job).tap do |job|
             job.location = location if location # may be dataset reference
             job.create = create unless create.nil?

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/extract_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/extract_job.rb
@@ -280,7 +280,8 @@ module Google
               job_reference: job_ref,
               configuration: Google::Apis::BigqueryV2::JobConfiguration.new(
                 extract: extract_config,
-                dry_run: options[:dryrun]
+                dry_run: options[:dryrun],
+                reservation: options[:reservation]
               )
             )
 
@@ -436,6 +437,18 @@ module Google
           # @!group Attributes
           def use_avro_logical_types= value
             @gapi.configuration.extract.use_avro_logical_types = value
+          end
+
+          ##
+          # Sets the reservation that job would use. User can specify a reservation
+          # to execute the job. If reservation is not set, reservation is determined
+          # based on the rules defined by the reservation assignments. The expected
+          # format is `projects/`project`/locations/`location`/reservations/`reservation``.
+          # @param [String] value The reservation name.
+          #
+          # @!group Attributes
+          def reservation= value
+            @gapi.configuration.update! reservation: value
           end
 
           def cancel

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/load_job.rb
@@ -2800,6 +2800,18 @@ module Google
             @gapi.configuration.load.update! preserve_ascii_control_characters: val
           end
 
+          ##
+          # Sets the reservation that job would use. User can specify a reservation
+          # to execute the job. If reservation is not set, reservation is determined
+          # based on the rules defined by the reservation assignments. The expected
+          # format is `projects/`project`/locations/`location`/reservations/`reservation``.
+          # @param [String] value The reservation name.
+          #
+          # @!group Attributes
+          def reservation= value
+            @gapi.configuration.update! reservation: value
+          end
+
           def cancel
             raise "not implemented in #{self.class}"
           end

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/model.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/model.rb
@@ -545,6 +545,11 @@ module Google
         #   * The key portion of a label must be unique. However, you can use the
         #     same key with multiple resources.
         #   * Keys must start with a lowercase letter or international character.
+        # @param [String] reservation The reservation that job would use. User
+        #    can specify a reservation to execute the job. If reservation is not
+        #    set, reservation is determined based on the rules defined by the
+        #    reservation assignments. The expected format is
+        #    `projects/`project`/locations/`location`/reservations/`reservation``.
         #
         # @yield [job] a job configuration object
         # @yieldparam [Google::Cloud::Bigquery::ExtractJob::Updater] job a job
@@ -566,9 +571,9 @@ module Google
         #
         # @!group Data
         #
-        def extract_job extract_url, format: nil, job_id: nil, prefix: nil, labels: nil
+        def extract_job extract_url, format: nil, job_id: nil, prefix: nil, labels: nil, reservation: nil
           ensure_service!
-          options = { format: format, job_id: job_id, prefix: prefix, labels: labels }
+          options = { format: format, job_id: job_id, prefix: prefix, labels: labels, reservation: reservation }
           updater = ExtractJob::Updater.from_options service, model_ref, extract_url, options
           updater.location = location if location # may be model reference
 
@@ -603,6 +608,12 @@ module Google
         #
         #   * `ml_tf_saved_model` - TensorFlow SavedModel
         #   * `ml_xgboost_booster` - XGBoost Booster
+        # @param [String] reservation The reservation that job would use. User
+        #    can specify a reservation to execute the job. If reservation is not
+        #    set, reservation is determined based on the rules defined by the
+        #    reservation assignments. The expected format is
+        #    `projects/`project`/locations/`location`/reservations/`reservation``.
+        #
         # @yield [job] a job configuration object
         # @yieldparam [Google::Cloud::Bigquery::ExtractJob::Updater] job a job
         #   configuration object for setting additional options.
@@ -620,8 +631,8 @@ module Google
         #
         # @!group Data
         #
-        def extract extract_url, format: nil, &block
-          job = extract_job extract_url, format: format, &block
+        def extract extract_url, format: nil, reservation: nil, &block
+          job = extract_job extract_url, format: format, reservation: reservation, &block
           job.wait_until_done!
           ensure_job_succeeded! job
           true

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb
@@ -178,6 +178,12 @@ module Google
         #   * The key portion of a label must be unique. However, you can use the
         #     same key with multiple resources.
         #   * Keys must start with a lowercase letter or international character.
+        # @param [String] reservation The reservation that job would use. User
+        #    can specify a reservation to execute the job. If reservation is not
+        #    set, reservation is determined based on the rules defined by the
+        #    reservation assignments. The expected format is
+        #    `projects/`project`/locations/`location`/reservations/`reservation``.
+        #
         # @yield [job] a job configuration object
         # @yieldparam [Google::Cloud::Bigquery::CopyJob::Updater] job a job
         #   configuration object for setting additional options.
@@ -199,9 +205,11 @@ module Google
         #
         # @!group Data
         #
-        def copy_job source_table, destination_table, create: nil, write: nil, job_id: nil, prefix: nil, labels: nil
+        def copy_job source_table, destination_table, create: nil, write: nil, job_id: nil, prefix: nil, labels: nil,
+                     reservation: nil
           ensure_service!
-          options = { create: create, write: write, labels: labels, job_id: job_id, prefix: prefix }
+          options = { create: create, write: write, labels: labels, job_id: job_id, prefix: prefix,
+            reservation: reservation }
 
           updater = CopyJob::Updater.from_options(
             service,
@@ -258,6 +266,12 @@ module Google
         #   * `append` - BigQuery appends the data to the table.
         #   * `empty` - An error will be returned if the destination table
         #     already contains data.
+        # @param [String] reservation The reservation that job would use. User
+        #    can specify a reservation to execute the job. If reservation is not
+        #    set, reservation is determined based on the rules defined by the
+        #    reservation assignments. The expected format is
+        #    `projects/`project`/locations/`location`/reservations/`reservation``.
+        #
         # @yield [job] a job configuration object
         # @yieldparam [Google::Cloud::Bigquery::CopyJob::Updater] job a job
         #   configuration object for setting additional options.
@@ -276,8 +290,8 @@ module Google
         #
         # @!group Data
         #
-        def copy source_table, destination_table, create: nil, write: nil, &block
-          job = copy_job source_table, destination_table, create: create, write: write, &block
+        def copy source_table, destination_table, create: nil, write: nil, reservation: nil, &block
+          job = copy_job source_table, destination_table, create: create, write: write, reservation: reservation, &block
           job.wait_until_done!
           ensure_job_succeeded! job
           true
@@ -479,6 +493,12 @@ module Google
         #   The default value is false.
         # @param [String] session_id The ID of an existing session. See also the
         #   `create_session` param and {Job#session_id}.
+        # @param [String] reservation The reservation that job would use. User
+        #    can specify a reservation to execute the job. If reservation is not
+        #    set, reservation is determined based on the rules defined by the
+        #    reservation assignments. The expected format is
+        #    `projects/`project`/locations/`location`/reservations/`reservation``.
+        #
         # @yield [job] a job configuration object
         # @yieldparam [Google::Cloud::Bigquery::QueryJob::Updater] job a job
         #   configuration object for setting query options.
@@ -631,7 +651,8 @@ module Google
                       labels: nil,
                       udfs: nil,
                       create_session: nil,
-                      session_id: nil
+                      session_id: nil,
+                      reservation: nil
           ensure_service!
           project ||= self.project
           options = {
@@ -657,7 +678,8 @@ module Google
             labels: labels,
             udfs: udfs,
             create_session: create_session,
-            session_id: session_id
+            session_id: session_id,
+            reservation: reservation
           }
 
           updater = QueryJob::Updater.from_options service, query, options
@@ -785,6 +807,11 @@ module Google
         #   `create_session` param in {#query_job} and {Job#session_id}.
         # @param [Boolean] format_options_use_int64_timestamp Output timestamp
         #   as usec int64. Default is true.
+        # @param [String] reservation The reservation that job would use. User
+        #    can specify a reservation to execute the job. If reservation is not
+        #    set, reservation is determined based on the rules defined by the
+        #    reservation assignments. The expected format is
+        #    `projects/`project`/locations/`location`/reservations/`reservation``.
         #
         # @yield [job] a job configuration object
         # @yieldparam [Google::Cloud::Bigquery::QueryJob::Updater] job a job
@@ -933,6 +960,7 @@ module Google
                   legacy_sql: nil,
                   session_id: nil,
                   format_options_use_int64_timestamp: true,
+                  reservation: nil,
                   &block
           job = query_job query,
                           params: params,
@@ -944,6 +972,7 @@ module Google
                           standard_sql: standard_sql,
                           legacy_sql: legacy_sql,
                           session_id: session_id,
+                          reservation: reservation,
                           &block
           job.wait_until_done!
 
@@ -1161,6 +1190,11 @@ module Google
         #   (the first 32 characters in the ASCII-table, from `\x00` to `\x1F`)
         #   are preserved. By default, ASCII control characters are not
         #   preserved.
+        # @param [String] reservation The reservation that job would use. User
+        #    can specify a reservation to execute the job. If reservation is not
+        #    set, reservation is determined based on the rules defined by the
+        #    reservation assignments. The expected format is
+        #    `projects/`project`/locations/`location`/reservations/`reservation``.
         #
         # @yield [updater] A block for setting the schema and other
         #   options for the destination table. The schema can be omitted if the
@@ -1188,7 +1222,7 @@ module Google
                      null_marker: nil, dryrun: nil, create_session: nil, session_id: nil, project_id: nil,
                      date_format: nil, datetime_format: nil, time_format: nil, timestamp_format: nil,
                      null_markers: nil, source_column_match: nil, time_zone: nil, reference_file_schema_uri: nil,
-                     preserve_ascii_control_characters: nil, &block
+                     preserve_ascii_control_characters: nil, reservation: nil, &block
           ensure_service!
           dataset_id ||= "_SESSION" unless create_session.nil? && session_id.nil?
           session_dataset = dataset dataset_id, skip_lookup: true, project_id: project_id
@@ -1204,7 +1238,8 @@ module Google
                           time_format: time_format, timestamp_format: timestamp_format,
                           null_markers: null_markers, source_column_match: source_column_match,
                           time_zone: time_zone, reference_file_schema_uri: reference_file_schema_uri,
-                          preserve_ascii_control_characters: preserve_ascii_control_characters, &block
+                          preserve_ascii_control_characters: preserve_ascii_control_characters,
+                          reservation: reservation, &block
         end
 
         ##
@@ -1368,6 +1403,11 @@ module Google
         #   (the first 32 characters in the ASCII-table, from `\x00` to `\x1F`)
         #   are preserved. By default, ASCII control characters are not
         #   preserved.
+        # @param [String] reservation The reservation that job would use. User
+        #    can specify a reservation to execute the job. If reservation is not
+        #    set, reservation is determined based on the rules defined by the
+        #    reservation assignments. The expected format is
+        #    `projects/`project`/locations/`location`/reservations/`reservation``.
         #
         # @yield [updater] A block for setting the schema of the destination
         #   table and other options for the load job. The schema can be omitted
@@ -1400,7 +1440,7 @@ module Google
                  skip_leading: nil, schema: nil, autodetect: nil, null_marker: nil, session_id: nil,
                  date_format: nil, datetime_format: nil, time_format: nil, timestamp_format: nil,
                  null_markers: nil, source_column_match: nil, time_zone: nil, reference_file_schema_uri: nil,
-                 preserve_ascii_control_characters: nil, &block
+                 preserve_ascii_control_characters: nil, reservation: nil, &block
           job = load_job table_id, files, dataset_id: dataset_id,
                         format: format, create: create, write: write, projection_fields: projection_fields,
                         jagged_rows: jagged_rows, quoted_newlines: quoted_newlines, encoding: encoding,
@@ -1411,7 +1451,8 @@ module Google
                         timestamp_format: timestamp_format, null_markers: null_markers,
                         source_column_match: source_column_match, time_zone: time_zone,
                         reference_file_schema_uri: reference_file_schema_uri,
-                        preserve_ascii_control_characters: preserve_ascii_control_characters, &block
+                        preserve_ascii_control_characters: preserve_ascii_control_characters, reservation: reservation,
+                         &block
 
           job.wait_until_done!
           ensure_job_succeeded! job
@@ -2114,6 +2155,12 @@ module Google
         #   * The key portion of a label must be unique. However, you can use the
         #     same key with multiple resources.
         #   * Keys must start with a lowercase letter or international character.
+        # @param [String] reservation The reservation that job would use. User
+        #    can specify a reservation to execute the job. If reservation is not
+        #    set, reservation is determined based on the rules defined by the
+        #    reservation assignments. The expected format is
+        #    `projects/`project`/locations/`location`/reservations/`reservation``.
+        #
         # @yield [job] a job configuration object
         # @yieldparam [Google::Cloud::Bigquery::ExtractJob::Updater] job a job
         #   configuration object for setting additional options.
@@ -2142,10 +2189,10 @@ module Google
         # @!group Data
         #
         def extract_job source, extract_url, format: nil, compression: nil, delimiter: nil, header: nil, job_id: nil,
-                        prefix: nil, labels: nil
+                        prefix: nil, labels: nil, reservation: nil
           ensure_service!
           options = { format: format, compression: compression, delimiter: delimiter, header: header, job_id: job_id,
-                      prefix: prefix, labels: labels }
+                      prefix: prefix, labels: labels, reservation: reservation }
           source_ref = if source.respond_to? :model_ref
                          source.model_ref
                        else
@@ -2212,6 +2259,12 @@ module Google
         #   models.
         # @param [Boolean] header Whether to print out a header row in table
         #   exports. Default is `true`. Not applicable when extracting models.
+        # @param [String] reservation The reservation that job would use. User
+        #    can specify a reservation to execute the job. If reservation is not
+        #    set, reservation is determined based on the rules defined by the
+        #    reservation assignments. The expected format is
+        #    `projects/`project`/locations/`location`/reservations/`reservation``.
+        #
         # @yield [job] a job configuration object
         # @yieldparam [Google::Cloud::Bigquery::ExtractJob::Updater] job a job
         #   configuration object for setting additional options.
@@ -2237,12 +2290,14 @@ module Google
         #
         # @!group Data
         #
-        def extract source, extract_url, format: nil, compression: nil, delimiter: nil, header: nil, &block
+        def extract source, extract_url, format: nil, compression: nil, delimiter: nil, header: nil, reservation: nil,
+                    &block
           job = extract_job source, extract_url,
                             format:      format,
                             compression: compression,
                             delimiter:   delimiter,
                             header:      header,
+                            reservation: reservation,
                             &block
           job.wait_until_done!
           ensure_job_succeeded! job

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
@@ -792,7 +792,8 @@ module Google
                   query: query,
                   default_dataset: dataset_config,
                   maximum_billing_tier: options[:maximum_billing_tier]
-                )
+                ),
+                reservation: options[:reservation]
               )
             )
 
@@ -1594,6 +1595,18 @@ module Google
           def clustering_fields= fields
             @gapi.configuration.query.clustering ||= Google::Apis::BigqueryV2::Clustering.new
             @gapi.configuration.query.clustering.fields = fields
+          end
+
+          ##
+          # Sets the reservation that job would use. User can specify a reservation
+          # to execute the job. If reservation is not set, reservation is determined
+          # based on the rules defined by the reservation assignments. The expected
+          # format is `projects/`project`/locations/`location`/reservations/`reservation``.
+          # @param [String] value The reservation name.
+          #
+          # @!group Attributes
+          def reservation= value
+            @gapi.configuration.update! reservation: value
           end
 
           def cancel

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/table.rb
@@ -1848,6 +1848,12 @@ format_options_use_int64_timestamp: format_options_use_int64_timestamp
         # @param [Boolean] dryrun  If set, don't actually run this job. Behavior
         #   is undefined however for non-query jobs and may result in an error.
         #   Deprecated.
+        # @param [String] operation_type The type of operation for this job.
+        # @param [String] reservation The reservation that job would use. User
+        #    can specify a reservation to execute the job. If reservation is not
+        #    set, reservation is determined based on the rules defined by the
+        #    reservation assignments. The expected format is
+        #    `projects/`project`/locations/`location`/reservations/`reservation``.
         #
         # @yield [job] a job configuration object
         # @yieldparam [Google::Cloud::Bigquery::CopyJob::Updater] job a job
@@ -1880,7 +1886,7 @@ format_options_use_int64_timestamp: format_options_use_int64_timestamp
         # @!group Data
         #
         def copy_job destination_table, create: nil, write: nil, job_id: nil, prefix: nil, labels: nil, dryrun: nil,
-                     operation_type: nil
+                     operation_type: nil, reservation: nil
           ensure_service!
           options = { create: create,
                       write: write,
@@ -1888,7 +1894,8 @@ format_options_use_int64_timestamp: format_options_use_int64_timestamp
                       labels: labels,
                       job_id: job_id,
                       prefix: prefix,
-                      operation_type: operation_type }
+                      operation_type: operation_type,
+                      reservation: reservation }
           updater = CopyJob::Updater.from_options(
             service,
             table_ref,
@@ -1941,6 +1948,12 @@ format_options_use_int64_timestamp: format_options_use_int64_timestamp
         #   * `append` - BigQuery appends the data to the table.
         #   * `empty` - An error will be returned if the destination table
         #     already contains data.
+        # @param [String] reservation The reservation that job would use. User
+        #    can specify a reservation to execute the job. If reservation is not
+        #    set, reservation is determined based on the rules defined by the
+        #    reservation assignments. The expected format is
+        #    `projects/`project`/locations/`location`/reservations/`reservation``.
+        #
         # @yield [job] a job configuration object
         # @yieldparam [Google::Cloud::Bigquery::CopyJob::Updater] job a job
         #   configuration object for setting additional options.
@@ -1968,11 +1981,12 @@ format_options_use_int64_timestamp: format_options_use_int64_timestamp
         #
         # @!group Data
         #
-        def copy destination_table, create: nil, write: nil, &block
+        def copy destination_table, create: nil, write: nil, reservation: nil, &block
           copy_job_with_operation_type destination_table,
                                        create: create,
                                        write: write,
                                        operation_type: OperationType::COPY,
+                                       reservation: reservation,
                                        &block
         end
 
@@ -1998,6 +2012,11 @@ format_options_use_int64_timestamp: format_options_use_int64_timestamp
         #   Reference](https://cloud.google.com/bigquery/query-reference#from)
         #   (`project-name:dataset_id.table_id`). This is useful for referencing
         #   tables in other projects and datasets.
+        # @param [String] reservation The reservation that job would use. User
+        #    can specify a reservation to execute the job. If reservation is not
+        #    set, reservation is determined based on the rules defined by the
+        #    reservation assignments. The expected format is
+        #    `projects/`project`/locations/`location`/reservations/`reservation``.
         #
         # @yield [job] a job configuration object
         # @yieldparam [Google::Cloud::Bigquery::CopyJob::Updater] job a job
@@ -2026,9 +2045,10 @@ format_options_use_int64_timestamp: format_options_use_int64_timestamp
         #
         # @!group Data
         #
-        def clone destination_table, &block
+        def clone destination_table, reservation: nil, &block
           copy_job_with_operation_type destination_table,
                                        operation_type: OperationType::CLONE,
+                                       reservation: reservation,
                                        &block
         end
 
@@ -2053,6 +2073,11 @@ format_options_use_int64_timestamp: format_options_use_int64_timestamp
         #   Reference](https://cloud.google.com/bigquery/query-reference#from)
         #   (`project-name:dataset_id.table_id`). This is useful for referencing
         #   tables in other projects and datasets.
+        # @param [String] reservation The reservation that job would use. User
+        #    can specify a reservation to execute the job. If reservation is not
+        #    set, reservation is determined based on the rules defined by the
+        #    reservation assignments. The expected format is
+        #    `projects/`project`/locations/`location`/reservations/`reservation``.
         #
         # @yield [job] a job configuration object
         # @yieldparam [Google::Cloud::Bigquery::CopyJob::Updater] job a job
@@ -2081,9 +2106,10 @@ format_options_use_int64_timestamp: format_options_use_int64_timestamp
         #
         # @!group Data
         #
-        def snapshot destination_table, &block
+        def snapshot destination_table, reservation: nil, &block
           copy_job_with_operation_type destination_table,
                                        operation_type: OperationType::SNAPSHOT,
+                                       reservation: reservation,
                                        &block
         end
 
@@ -2125,6 +2151,12 @@ format_options_use_int64_timestamp: format_options_use_int64_timestamp
         #   * `append` - BigQuery appends the data to the table.
         #   * `empty` - An error will be returned if the destination table
         #     already contains data.
+        # @param [String] reservation The reservation that job would use. User
+        #    can specify a reservation to execute the job. If reservation is not
+        #    set, reservation is determined based on the rules defined by the
+        #    reservation assignments. The expected format is
+        #    `projects/`project`/locations/`location`/reservations/`reservation``.
+        #
         # @yield [job] a job configuration object
         # @yieldparam [Google::Cloud::Bigquery::CopyJob::Updater] job a job
         #   configuration object for setting additional options.
@@ -2152,11 +2184,12 @@ format_options_use_int64_timestamp: format_options_use_int64_timestamp
         #
         # @!group Data
         #
-        def restore destination_table, create: nil, write: nil, &block
+        def restore destination_table, create: nil, write: nil, reservation: nil, &block
           copy_job_with_operation_type destination_table,
                                        create: create,
                                        write: write,
                                        operation_type: OperationType::RESTORE,
+                                       reservation: reservation,
                                        &block
         end
 
@@ -2229,6 +2262,11 @@ format_options_use_int64_timestamp: format_options_use_int64_timestamp
         # @param [Boolean] dryrun  If set, don't actually run this job. Behavior
         #   is undefined however for non-query jobs and may result in an error.
         #   Deprecated.
+        # @param [String] reservation The reservation that job would use. User
+        #    can specify a reservation to execute the job. If reservation is not
+        #    set, reservation is determined based on the rules defined by the
+        #    reservation assignments. The expected format is
+        #    `projects/`project`/locations/`location`/reservations/`reservation``.
         #
         # @yield [job] a job configuration object
         # @yieldparam [Google::Cloud::Bigquery::ExtractJob::Updater] job a job
@@ -2251,10 +2289,10 @@ format_options_use_int64_timestamp: format_options_use_int64_timestamp
         # @!group Data
         #
         def extract_job extract_url, format: nil, compression: nil, delimiter: nil, header: nil, job_id: nil,
-                        prefix: nil, labels: nil, dryrun: nil
+                        prefix: nil, labels: nil, dryrun: nil, reservation: nil
           ensure_service!
           options = { format: format, compression: compression, delimiter: delimiter, header: header, dryrun: dryrun,
-                      job_id: job_id, prefix: prefix, labels: labels }
+                      job_id: job_id, prefix: prefix, labels: labels, reservation: reservation }
           updater = ExtractJob::Updater.from_options service, table_ref, extract_url, options
           updater.location = location if location # may be table reference
 
@@ -2298,6 +2336,12 @@ format_options_use_int64_timestamp: format_options_use_int64_timestamp
         #   exported data. Default is <code>,</code>.
         # @param [Boolean] header Whether to print out a header row in the
         #   results. Default is `true`.
+        # @param [String] reservation The reservation that job would use. User
+        #    can specify a reservation to execute the job. If reservation is not
+        #    set, reservation is determined based on the rules defined by the
+        #    reservation assignments. The expected format is
+        #    `projects/`project`/locations/`location`/reservations/`reservation``.
+        #
         # @yield [job] a job configuration object
         # @yieldparam [Google::Cloud::Bigquery::ExtractJob::Updater] job a job
         #   configuration object for setting additional options.
@@ -2326,12 +2370,13 @@ format_options_use_int64_timestamp: format_options_use_int64_timestamp
         #
         # @!group Data
         #
-        def extract extract_url, format: nil, compression: nil, delimiter: nil, header: nil, &block
+        def extract extract_url, format: nil, compression: nil, delimiter: nil, header: nil, reservation: nil, &block
           job = extract_job extract_url,
                             format:      format,
                             compression: compression,
                             delimiter:   delimiter,
                             header:      header,
+                            reservation: reservation,
                             &block
           job.wait_until_done!
           ensure_job_succeeded! job
@@ -2524,6 +2569,11 @@ format_options_use_int64_timestamp: format_options_use_int64_timestamp
         #   (the first 32 characters in the ASCII-table, from `\x00` to `\x1F`)
         #   are preserved. By default, ASCII control characters are not
         #   preserved.
+        # @param [String] reservation The reservation that job would use. User
+        #    can specify a reservation to execute the job. If reservation is not
+        #    set, reservation is determined based on the rules defined by the
+        #    reservation assignments. The expected format is
+        #    `projects/`project`/locations/`location`/reservations/`reservation``.
         #
         # @yield [load_job] a block for setting the load job
         # @yieldparam [LoadJob] load_job the load job object to be updated
@@ -2583,7 +2633,7 @@ format_options_use_int64_timestamp: format_options_use_int64_timestamp
                      null_marker: nil, dryrun: nil, create_session: nil, session_id: nil, schema: self.schema,
                      date_format: nil, datetime_format: nil, time_format: nil, timestamp_format: nil,
                      null_markers: nil, source_column_match: nil, time_zone: nil, reference_file_schema_uri: nil,
-                     preserve_ascii_control_characters: nil
+                     preserve_ascii_control_characters: nil, reservation: nil
           ensure_service!
 
           updater = load_job_updater format: format, create: create, write: write, projection_fields: projection_fields,
@@ -2597,7 +2647,8 @@ format_options_use_int64_timestamp: format_options_use_int64_timestamp
                                      timestamp_format: timestamp_format, null_markers: null_markers,
                                      source_column_match: source_column_match, time_zone: time_zone,
                                      reference_file_schema_uri: reference_file_schema_uri,
-                                     preserve_ascii_control_characters: preserve_ascii_control_characters
+                                     preserve_ascii_control_characters: preserve_ascii_control_characters,
+                                     reservation: reservation
 
           yield updater if block_given?
 
@@ -2755,6 +2806,11 @@ format_options_use_int64_timestamp: format_options_use_int64_timestamp
         #   (the first 32 characters in the ASCII-table, from `\x00` to `\x1F`)
         #   are preserved. By default, ASCII control characters are not
         #   preserved.
+        # @param [String] reservation The reservation that job would use. User
+        #    can specify a reservation to execute the job. If reservation is not
+        #    set, reservation is determined based on the rules defined by the
+        #    reservation assignments. The expected format is
+        #    `projects/`project`/locations/`location`/reservations/`reservation``.
         #
         # @yield [updater] A block for setting the schema of the destination
         #   table and other options for the load job. The schema can be omitted
@@ -2819,7 +2875,7 @@ format_options_use_int64_timestamp: format_options_use_int64_timestamp
                  quote: nil, skip_leading: nil, autodetect: nil, null_marker: nil, session_id: nil,
                  schema: self.schema, date_format: nil, datetime_format: nil, time_format: nil, timestamp_format: nil,
                  null_markers: nil, source_column_match: nil, time_zone: nil, reference_file_schema_uri: nil,
-                 preserve_ascii_control_characters: nil, &block
+                 preserve_ascii_control_characters: nil, reservation: nil, &block
           job = load_job files, format: format, create: create, write: write, projection_fields: projection_fields,
                                 jagged_rows: jagged_rows, quoted_newlines: quoted_newlines, encoding: encoding,
                                 delimiter: delimiter, ignore_unknown: ignore_unknown, max_bad_records: max_bad_records,
@@ -2829,7 +2885,8 @@ format_options_use_int64_timestamp: format_options_use_int64_timestamp
                                 timestamp_format: timestamp_format, null_markers: null_markers,
                                 source_column_match: source_column_match, time_zone: time_zone,
                                 reference_file_schema_uri: reference_file_schema_uri,
-                                preserve_ascii_control_characters: preserve_ascii_control_characters, &block
+                                preserve_ascii_control_characters: preserve_ascii_control_characters,
+                                reservation: reservation, &block
 
           job.wait_until_done!
           ensure_job_succeeded! job
@@ -3223,11 +3280,13 @@ format_options_use_int64_timestamp: format_options_use_int64_timestamp
 
         protected
 
-        def copy_job_with_operation_type destination_table, create: nil, write: nil, operation_type: nil, &block
+        def copy_job_with_operation_type destination_table, create: nil, write: nil, operation_type: nil,
+                                         reservation: nil, &block
           job = copy_job destination_table,
                          create: create,
                          write: write,
                          operation_type: operation_type,
+                         reservation: reservation,
                          &block
           job.wait_until_done!
           ensure_job_succeeded! job
@@ -3278,7 +3337,7 @@ format_options_use_int64_timestamp: format_options_use_int64_timestamp
           end
         end
 
-        def load_job_gapi table_id, dryrun, job_id: nil, prefix: nil
+        def load_job_gapi table_id, dryrun, job_id: nil, prefix: nil, reservation: nil
           job_ref = service.job_ref_from job_id, prefix
           Google::Apis::BigqueryV2::Job.new(
             job_reference: job_ref,
@@ -3290,7 +3349,8 @@ format_options_use_int64_timestamp: format_options_use_int64_timestamp
                   table_id:   table_id
                 )
               ),
-              dry_run: dryrun
+              dry_run: dryrun,
+              reservation: reservation
             )
           )
         end
@@ -3344,8 +3404,9 @@ format_options_use_int64_timestamp: format_options_use_int64_timestamp
                              prefix: nil, labels: nil, autodetect: nil, null_marker: nil,
                              create_session: nil, session_id: nil, date_format: nil, datetime_format: nil,
                              time_format: nil, timestamp_format: nil, null_markers: nil, source_column_match: nil,
-                             time_zone: nil, reference_file_schema_uri: nil, preserve_ascii_control_characters: nil
-          new_job = load_job_gapi table_id, dryrun, job_id: job_id, prefix: prefix
+                             time_zone: nil, reference_file_schema_uri: nil, preserve_ascii_control_characters: nil,
+                             reservation: nil
+          new_job = load_job_gapi table_id, dryrun, job_id: job_id, prefix: prefix, reservation: reservation
           LoadJob::Updater.new(new_job).tap do |job|
             job.location = location if location # may be table reference
             job.create = create unless create.nil?

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_clone_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_clone_test.rb
@@ -121,7 +121,8 @@ describe Google::Cloud::Bigquery::Table, :copy, :mock_bigquery do
           "writeDisposition" => nil,
           "operationType" => "CLONE"
         },
-        "dryRun" => nil
+        "dryRun" => nil,
+        "reservation" => nil
       }
     }.to_json
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_copy_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_copy_test.rb
@@ -186,7 +186,8 @@ describe Google::Cloud::Bigquery::Table, :copy, :mock_bigquery do
           "writeDisposition" => nil,
           "operationType" => "COPY"
         },
-        "dryRun" => nil
+        "dryRun" => nil,
+        "reservation" => nil
       }
     }.to_json
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_extract_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_extract_test.rb
@@ -248,7 +248,8 @@ describe Google::Cloud::Bigquery::Table, :extract, :mock_bigquery do
           "fieldDelimiter" => nil,
           "destinationFormat" => nil
         },
-        "dryRun" => nil
+        "dryRun" => nil,
+        "reservation" => nil
       }
     }.to_json
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_restore_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_restore_test.rb
@@ -186,7 +186,8 @@ describe Google::Cloud::Bigquery::Table, :copy, :mock_bigquery do
           "writeDisposition" => nil,
           "operationType" => "RESTORE"
         },
-        "dryRun" => nil
+        "dryRun" => nil,
+        "reservation" => nil
       }
     }.to_json
   end

--- a/google-cloud-bigquery/test/google/cloud/bigquery/table_snapshot_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/table_snapshot_test.rb
@@ -121,7 +121,8 @@ describe Google::Cloud::Bigquery::Table, :copy, :mock_bigquery do
           "writeDisposition" => nil,
           "operationType" => "SNAPSHOT"
         },
-        "dryRun" => nil
+        "dryRun" => nil,
+        "reservation" => nil
       }
     }.to_json
   end

--- a/google-cloud-bigquery/test/helper.rb
+++ b/google-cloud-bigquery/test/helper.rb
@@ -393,7 +393,8 @@ class MockBigquery < Minitest::Spec
           "writeDisposition" => nil,
           "operationType" => nil
         },
-        "dryRun" => nil
+        "dryRun" => nil,
+        "reservation" => nil
       }
     }
     hash["jobReference"]["location"] = location if location
@@ -610,13 +611,13 @@ class MockBigquery < Minitest::Spec
       routineType: "SCALAR_FUNCTION",
       language: "SQL",
       arguments: [
-        { 
+        {
           name: "arr",
           argumentKind: "FIXED_TYPE",
           mode: "IN",
-          dataType: { 
+          dataType: {
             typeKind: "ARRAY",
-            arrayElementType: { 
+            arrayElementType: {
               typeKind: "STRUCT",
               structType: {
                 fields: [
@@ -637,7 +638,7 @@ class MockBigquery < Minitest::Spec
             }
           }
         },
-        { 
+        {
           name: "out",
           argumentKind: "ANY_TYPE",
           mode: "OUT",
@@ -659,7 +660,7 @@ class MockBigquery < Minitest::Spec
 
   def random_routine_partial_hash dataset, id
     # List representation: etag, routineReference, routineType, creationTime, lastModifiedTime and language.
-    { 
+    {
       etag: "etag123456789",
       routineReference: {
         projectId: project,
@@ -698,7 +699,8 @@ class MockBigquery < Minitest::Spec
       },
       "configuration" => {
         # config call goes here
-        "dryRun" => false
+        "dryRun" => false,
+        "reservation" => nil
       },
       "status" => {
         "state" => state
@@ -951,7 +953,8 @@ class MockBigquery < Minitest::Spec
           "maximumBytesBilled" => nil,
           "userDefinedFunctionResources" => []
         },
-        "dryRun" => dry_run
+        "dryRun" => dry_run,
+        "reservation" => nil
       }
     }
     hash["jobReference"]["location"] = location if location
@@ -978,7 +981,8 @@ class MockBigquery < Minitest::Spec
           "fieldDelimiter" => nil,
           "destinationFormat" => nil
         },
-        "dryRun" => nil
+        "dryRun" => nil,
+        "reservation" => nil
       }
     }
     hash["jobReference"]["location"] = location if location
@@ -1093,7 +1097,8 @@ class MockBigquery < Minitest::Spec
           destination_table: table_reference,
           source_format: source_format
         ),
-        dry_run: nil
+        dry_run: nil,
+        reservation: nil
       )
     )
     unless session_id.nil?
@@ -1122,7 +1127,8 @@ class MockBigquery < Minitest::Spec
           autodetect: true,
           null_marker: "\N"
         ),
-        dry_run: nil
+        dry_run: nil,
+        reservation: nil
       )
     )
   end
@@ -1143,7 +1149,8 @@ class MockBigquery < Minitest::Spec
       job_reference: job_reference_gapi(project, job_id, location: location),
       configuration: Google::Apis::BigqueryV2::JobConfiguration.new(
         load: load,
-        dry_run: nil
+        dry_run: nil,
+        reservation: nil
       )
     )
   end


### PR DESCRIPTION
Plus adding missing parameters to load_job initializers and updaters. I included it in this PR to avoid merge conflicts later.

https://buganizer.corp.google.com/issues/414633737