### PR TITLE
WIP

### DIFF
--- a/google-cloud-storage/lib/google/cloud/storage/bucket/list.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/bucket/list.rb
@@ -27,6 +27,7 @@ module Google
           # that match the request and this value should be passed to
           # the next {Google::Cloud::Storage::Project#buckets} to continue.
           attr_accessor :token
+          attr_reader :unreachable
 
           ##
           # @private Create a new Bucket::List with an array of values.
@@ -147,7 +148,7 @@ module Google
           # @private New Bucket::List from a Google API Client
           # Google::Apis::StorageV1::Buckets object.
           def self.from_gapi gapi_list, service, prefix = nil, max = nil,
-                             user_project: nil, soft_deleted: nil
+                             user_project: nil, soft_deleted: nil, return_partial_success: false
             buckets = new(Array(gapi_list.items).map do |gapi_object|
               Bucket.from_gapi gapi_object, service, user_project: user_project
             end)
@@ -157,6 +158,7 @@ module Google
             buckets.instance_variable_set :@max, max
             buckets.instance_variable_set :@user_project, user_project
             buckets.instance_variable_set :@soft_deleted, soft_deleted
+            buckets.instance_variable_set :@unreachable, Array(gapi_list.unreachable) if return_partial_success
             buckets
           end
 

--- a/google-cloud-storage/lib/google/cloud/storage/project.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/project.rb
@@ -158,6 +158,8 @@ module Google
         #   bucket instances and their files.
         #
         #   See also {Bucket#requester_pays=} and {Bucket#requester_pays}.
+        # @param [Boolean] return_partial_success If true, retrieves the list of
+        #   buckets that could not be reached.
         #
         # @return [Array<Google::Cloud::Storage::Bucket>] (See
         #   {Google::Cloud::Storage::Bucket::List})
@@ -201,11 +203,22 @@ module Google
         #   soft_deleted_buckets.each do |bucket|
         #     puts bucket.name
         #   end
-        def buckets prefix: nil, token: nil, max: nil, user_project: nil, soft_deleted: nil
-          gapi = service.list_buckets \
-            prefix: prefix, token: token, max: max, user_project: user_project, soft_deleted: soft_deleted
-          Bucket::List.from_gapi \
-            gapi, service, prefix, max, user_project: user_project, soft_deleted: soft_deleted
+        # @example Retrieve list of unreachable buckets
+        #   require "google/cloud/storage"
+        #
+        #   storage = Google::Cloud::Storage.new
+        #
+        #   buckets = storage.buckets return_partial_success: true
+        #   buckets.unreachable.each do |bucket|
+        #     puts bucket
+        #   end
+        #  
+        def buckets prefix: nil, token: nil, max: nil, user_project: nil, soft_deleted: nil, return_partial_success: false
+            gapi = service.list_buckets \
+              prefix: prefix, token: token, max: max, user_project: user_project, soft_deleted: soft_deleted, return_partial_success: return_partial_success
+            Bucket::List.from_gapi \
+              gapi, service, prefix, max, user_project: user_project, soft_deleted: soft_deleted, return_partial_success: return_partial_success
+          
         end
         alias find_buckets buckets
 

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -96,12 +96,13 @@ module Google
 
         ##
         # Retrieves a list of buckets for the given project.
-        def list_buckets prefix: nil, token: nil, max: nil, user_project: nil, soft_deleted: nil, options: {}
+        def list_buckets prefix: nil, token: nil, max: nil, user_project: nil, soft_deleted: nil, return_partial_success: false, options: {}
           execute do
             service.list_buckets \
               @project, prefix: prefix, page_token: token, max_results: max,
                         user_project: user_project(user_project),
-                        soft_deleted: soft_deleted, options: options
+                        soft_deleted: soft_deleted,
+                        return_partial_success: return_partial_success, options: options
           end
         end
 

--- a/google-cloud-storage/samples/storage_list_unreachable_buckets.rb
+++ b/google-cloud-storage/samples/storage_list_unreachable_buckets.rb
@@ -1,0 +1,27 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START storage_list_unreachable_buckets]
+def list_unreachable_buckets
+  require "google/cloud/storage"
+
+  storage = Google::Cloud::Storage.new  
+  bucket_list = storage.buckets(return_partial_success: true)
+  bucket_list.unreachable.each do |bucket|
+    puts bucket
+  end
+end
+# [END storage_list_unreachable_buckets]
+
+list_unreachable_buckets if $PROGRAM_NAME == __FILE__


### PR DESCRIPTION
This pull request enhances the Google Cloud Storage client library by adding support for partial success scenarios when listing buckets. Previously, listing operations only returned the list of successfully created bucket. With this change, users can now opt to receive a list of successfully retrieved buckets along with a separate collection of bucket names that were unreachable, providing morevisibility into listing operations.

### Highlights

* **Partial Success for Bucket Listing**: Introduced a new `return_partial_success` parameter to the `buckets` method, allowing the API to return a list of unreachable buckets.
* **Access to Unreachable Buckets**: The `Bucket::List` object now includes an `unreachable` attribute, which will contain the names of buckets that could not be reached when `return_partial_success` is enabled.
* **New Sample Code**: A new sample `storage_list_unreachable_buckets.rb` has been added to demonstrate how to use this new feature and retrieve unreachable buckets.
