### PR TITLE
fix(pubsub): Remove get_topic lookup when publishing via lazy loading

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub/publisher.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/publisher.rb
@@ -213,7 +213,7 @@ module Google
         #
         def publish data = nil, attributes = nil, ordering_key: nil, compress: nil, compression_bytes_threshold: nil,
                     **extra_attrs, &block
-          ensure_grpc!
+          ensure_service!
           batch = BatchPublisher.new data,
                                      attributes,
                                      ordering_key,
@@ -337,7 +337,7 @@ module Google
         #   publisher.async_publisher.stop!
         #
         def publish_async data = nil, attributes = nil, ordering_key: nil, **extra_attrs, &callback
-          ensure_grpc!
+          ensure_service!
           @async_publisher ||= AsyncPublisher.new name, service, **@async_opts
           @async_publisher.publish data, attributes, ordering_key: ordering_key, **extra_attrs, &callback
         end
@@ -414,13 +414,6 @@ module Google
         # available.
         def ensure_service!
           raise "Must have active connection to service" unless service
-        end
-
-        ##
-        # Ensures a Google::Cloud::PubSub::V1::Topic object exists.
-        def ensure_grpc!
-          ensure_service!
-          reload! if reference?
         end
       end
     end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/publisher_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/publisher_test.rb
@@ -154,17 +154,13 @@ describe Google::Cloud::PubSub::Publisher, :mock_pubsub do
     mock.verify
   end
 
-  it "reloads the resource when publishing if created with skip_lookup: true" do
+  it "does not reload the resource when publishing if created with skip_lookup: true" do
     mock = Minitest::Mock.new
     pubsub.service.mocked_topic_admin = mock
 
     publisher = pubsub.publisher topic_name, skip_lookup: true
 
     _(publisher).must_be :reference?
-
-    mock.expect :get_topic, Google::Cloud::PubSub::V1::Topic.new(topic_hash(topic_name)) do |actual_topic|
-      actual_topic == {topic: topic_path(topic_name)}
-    end
 
     # Expect publish to be called
     message = "new-message-here"
@@ -181,7 +177,7 @@ describe Google::Cloud::PubSub::Publisher, :mock_pubsub do
 
     msg = publisher.publish message
 
-    _(publisher).wont_be :reference?
+    _(publisher).must_be :reference?
     _(msg.message_id).must_equal "msg1"
 
     mock.verify


### PR DESCRIPTION
This removes the `ensure_grpc!` call from `publish` and `publish_async`, allowing messages to be published using only the topic name reference. The regression was recently added in v3.1.0.

This prevents unnecessary get_topic Admin API calls during application startup, which can lead to quota exhaustion.

Fixes #32247
