### PR TITLE
chore: Remove python deps from Cloud RAD backfill

### DIFF
--- a/.kokoro/backfill-rad.sh
+++ b/.kokoro/backfill-rad.sh
@@ -8,5 +8,4 @@ export GEM_HOME=$HOME/.gem
 export PATH=$GEM_HOME/bin:$PATH
 
 gem install --no-document toys
-toys release install-python-tools -v
-toys rad backfill -v $LIBRARIES_VERSIONS < /dev/null
+toys release perform -v --reporter-org=googleapis --gems=$LIBRARIES_VERSIONS --enable-rad --force-republish < /dev/null


### PR DESCRIPTION
`install-python-tools` doesn't exist anymore as shown in [this change](https://github.com/googleapis/ruby-common-tools/pull/356) in `ruby-common-tools`.

This was already done for other files, e.g. [`release.sh`](https://github.com/googleapis/google-cloud-ruby/blob/7298c5c38b97c232346838f3a837427449cc039c/.kokoro/release.sh#L10).

