### PR TITLE
chore(storage): Skipping test cases with pap issue

### DIFF
--- a/google-cloud-storage/acceptance/storage/bucket_acl_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_acl_test.rb
@@ -58,12 +58,7 @@ describe Google::Cloud::Storage::Bucket, :acl, :storage do
   end
 
   it "updates predefined rules" do
-    skip(
-      "Skipping this test due to a change in GCS behavior that disallows copying " \
-      "files with ACLs that include allUsers or allAuthenticatedUsers when public " \
-      "access prevention is enforced. See " \
-      "https://cloud.google.com/storage/docs/public-access-prevention for more details."
-    )
+    skip PAP_SKIP_MESSAGE
     _(bucket.acl.readers).wont_include "allAuthenticatedUsers"
     bucket.acl.auth!
     _(bucket.acl.readers).must_include "allAuthenticatedUsers"
@@ -74,12 +69,7 @@ describe Google::Cloud::Storage::Bucket, :acl, :storage do
   end
 
   it "deletes rules" do
-    skip(
-      "Skipping this test due to a change in GCS behavior that disallows copying " \
-      "files with ACLs that include allUsers or allAuthenticatedUsers when public " \
-      "access prevention is enforced. See " \
-      "https://cloud.google.com/storage/docs/public-access-prevention for more details."
-    )
+    skip PAP_SKIP_MESSAGE
     bucket.acl.auth!
     _(bucket.acl.readers).must_include "allAuthenticatedUsers"
     bucket.acl.delete "allAuthenticatedUsers"
@@ -129,12 +119,7 @@ describe Google::Cloud::Storage::Bucket, :acl, :storage do
   end
 
   it "sets predefined ACL rules" do
-    skip(
-      "Skipping this test due to a change in GCS behavior that disallows copying " \
-      "files with ACLs that include allUsers or allAuthenticatedUsers when public " \
-      "access prevention is enforced. See " \
-      "https://cloud.google.com/storage/docs/public-access-prevention for more details."
-    )
+    skip PAP_SKIP_MESSAGE
     safe_gcs_execute { bucket.acl.authenticatedRead! }
     safe_gcs_execute { bucket.acl.auth! }
     safe_gcs_execute { bucket.acl.auth_read! }

--- a/google-cloud-storage/acceptance/storage/bucket_default_acl_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_default_acl_test.rb
@@ -50,12 +50,7 @@ describe Google::Cloud::Storage::Bucket, :default_acl, :storage do
   end
 
   it "updates predefined rules" do
-    skip(
-      "Skipping this test due to a change in GCS behavior that disallows copying " \
-      "files with ACLs that include allUsers or allAuthenticatedUsers when public " \
-      "access prevention is enforced. See " \
-      "https://cloud.google.com/storage/docs/public-access-prevention for more details."
-    )
+    skip PAP_SKIP_MESSAGE
     _(bucket.default_acl.readers).wont_include "allAuthenticatedUsers"
     bucket.default_acl.auth!
     _(bucket.default_acl.readers).must_include "allAuthenticatedUsers"
@@ -66,12 +61,7 @@ describe Google::Cloud::Storage::Bucket, :default_acl, :storage do
   end
 
   it "deletes rules" do
-    skip(
-      "Skipping this test due to a change in GCS behavior that disallows copying " \
-      "files with ACLs that include allUsers or allAuthenticatedUsers when public " \
-      "access prevention is enforced. See " \
-      "https://cloud.google.com/storage/docs/public-access-prevention for more details."
-    )
+    skip PAP_SKIP_MESSAGE
     bucket.default_acl.auth!
     _(bucket.default_acl.readers).must_include "allAuthenticatedUsers"
     bucket.default_acl.delete "allAuthenticatedUsers"
@@ -118,12 +108,7 @@ describe Google::Cloud::Storage::Bucket, :default_acl, :storage do
   end
 
   it "sets predefined ACL rules" do
-    skip(
-      "Skipping this test due to a change in GCS behavior that disallows copying " \
-      "files with ACLs that include allUsers or allAuthenticatedUsers when public " \
-      "access prevention is enforced. See " \
-      "https://cloud.google.com/storage/docs/public-access-prevention for more details."
-    ) 
+    skip PAP_SKIP_MESSAGE
     safe_gcs_execute { bucket.default_acl.authenticatedRead! }
     safe_gcs_execute { bucket.default_acl.auth! }
     safe_gcs_execute { bucket.default_acl.auth_read! }

--- a/google-cloud-storage/acceptance/storage/bucket_uniform_bucket_level_access_test.rb
+++ b/google-cloud-storage/acceptance/storage/bucket_uniform_bucket_level_access_test.rb
@@ -75,12 +75,7 @@ describe Google::Cloud::Storage::Bucket, :uniform_bucket_level_access, :storage 
   end
 
   it "sets uniform_bucket_level_access true and is unable to modify bucket ACL rules" do
-    skip(
-      "Skipping this test due to a change in GCS behavior that disallows copying " \
-      "files with ACLs that include allUsers or allAuthenticatedUsers when public " \
-      "access prevention is enforced. See " \
-      "https://cloud.google.com/storage/docs/public-access-prevention for more details."
-    )
+    skip PAP_SKIP_MESSAGE
     refute bucket.uniform_bucket_level_access?
     bucket.uniform_bucket_level_access = true
     assert bucket.uniform_bucket_level_access?
@@ -90,12 +85,7 @@ describe Google::Cloud::Storage::Bucket, :uniform_bucket_level_access, :storage 
   end
 
   it "sets uniform_bucket_level_access true and is unable to modify default ACL rules" do
-    skip(
-      "Skipping this test due to a change in GCS behavior that disallows copying " \
-      "files with ACLs that include allUsers or allAuthenticatedUsers when public " \
-      "access prevention is enforced. See " \
-      "https://cloud.google.com/storage/docs/public-access-prevention for more details."
-    )
+    skip PAP_SKIP_MESSAGE
     refute bucket.uniform_bucket_level_access?
     bucket.uniform_bucket_level_access = true
     assert bucket.uniform_bucket_level_access?
@@ -119,12 +109,7 @@ describe Google::Cloud::Storage::Bucket, :uniform_bucket_level_access, :storage 
   end
 
   it "sets uniform_bucket_level_access true and default object acl and object acls are preserved" do
-    skip(
-      "Skipping this test due to a change in GCS behavior that disallows copying " \
-      "files with ACLs that include allUsers or allAuthenticatedUsers when public " \
-      "access prevention is enforced. See " \
-      "https://cloud.google.com/storage/docs/public-access-prevention for more details."
-    )
+    skip PAP_SKIP_MESSAGE
     bucket.default_acl.public!
     _(bucket.default_acl.readers).must_equal ["allUsers"]
     file_default_acl = bucket.create_file StringIO.new("default_acl"), "default_acl.txt"
@@ -159,12 +144,7 @@ describe Google::Cloud::Storage::Bucket, :uniform_bucket_level_access, :storage 
   end
 
   it "sets DEPRECATED policy_only true and is unable to get the file" do
-    skip(
-      "Skipping this test due to a change in GCS behavior that disallows copying " \
-      "files with ACLs that include allUsers or allAuthenticatedUsers when public " \
-      "access prevention is enforced. See " \
-      "https://cloud.google.com/storage/docs/public-access-prevention for more details."
-    )
+    skip PAP_SKIP_MESSAGE
     refute bucket.policy_only?
     file = bucket.create_file local_file, "ReaderTest.png"
 
@@ -181,12 +161,7 @@ describe Google::Cloud::Storage::Bucket, :uniform_bucket_level_access, :storage 
   end
 
   it "sets DEPRECATED policy_only true and is unable to modify bucket ACL rules" do
-    skip(
-      "Skipping this test due to a change in GCS behavior that disallows copying " \
-      "files with ACLs that include allUsers or allAuthenticatedUsers when public " \
-      "access prevention is enforced. See " \
-      "https://cloud.google.com/storage/docs/public-access-prevention for more details."
-    )
+    skip PAP_SKIP_MESSAGE
     refute bucket.policy_only?
     bucket.policy_only = true
     assert bucket.policy_only?
@@ -196,12 +171,7 @@ describe Google::Cloud::Storage::Bucket, :uniform_bucket_level_access, :storage 
   end
 
   it "sets DEPRECATED policy_only true and is unable to modify default ACL rules" do
-    skip(
-      "Skipping this test due to a change in GCS behavior that disallows copying " \
-      "files with ACLs that include allUsers or allAuthenticatedUsers when public " \
-      "access prevention is enforced. See " \
-      "https://cloud.google.com/storage/docs/public-access-prevention for more details."
-    )
+    skip PAP_SKIP_MESSAGE
     refute bucket.policy_only?
     safe_gcs_execute { bucket.policy_only = true }
     assert bucket.policy_only?
@@ -225,12 +195,7 @@ describe Google::Cloud::Storage::Bucket, :uniform_bucket_level_access, :storage 
   end
 
   it "sets DEPRECATED policy_only true and default object acl and object acls are preserved" do
-    skip(
-      "Skipping this test due to a change in GCS behavior that disallows copying " \
-      "files with ACLs that include allUsers or allAuthenticatedUsers when public " \
-      "access prevention is enforced. See " \
-      "https://cloud.google.com/storage/docs/public-access-prevention for more details."
-    )
+    skip PAP_SKIP_MESSAGE
     bucket.default_acl.public!
     _(bucket.default_acl.readers).must_equal ["allUsers"]
     file_default_acl = bucket.create_file StringIO.new("default_acl"), "default_acl.txt"
@@ -251,12 +216,7 @@ describe Google::Cloud::Storage::Bucket, :uniform_bucket_level_access, :storage 
   end
 
   it "creates new bucket with public_access_prevention enforced then sets public_access_prevention to enforced" do
-    skip(
-      "Skipping this test due to a change in GCS behavior that disallows copying " \
-      "files with ACLs that include allUsers or allAuthenticatedUsers when public " \
-      "access prevention is enforced. See " \
-      "https://cloud.google.com/storage/docs/public-access-prevention for more details."
-    )
+    skip PAP_SKIP_MESSAGE
     # Insert a new bucket with Public Access Prevention Enforced.
     bucket_pap = storage.create_bucket "#{$bucket_names[2]}-pap" do |b|
       b.public_access_prevention = :enforced

--- a/google-cloud-storage/acceptance/storage/file_acl_test.rb
+++ b/google-cloud-storage/acceptance/storage/file_acl_test.rb
@@ -30,12 +30,7 @@ describe Google::Cloud::Storage::File, :acl, :storage do
   let(:user_val) { "user-test@example.com" }
 
   before do
-    skip(
-      "Skipping this test due to a change in GCS behavior that disallows copying " \
-      "files with ACLs that include allUsers or allAuthenticatedUsers when public " \
-      "access prevention is enforced. See " \
-      "https://cloud.google.com/storage/docs/public-access-prevention for more details."
-    )
+    skip PAP_SKIP_MESSAGE
     # always create the bucket and set default acl to auth
     safe_gcs_execute { bucket.default_acl.auth! }
   end

--- a/google-cloud-storage/acceptance/storage/file_test.rb
+++ b/google-cloud-storage/acceptance/storage/file_test.rb
@@ -595,12 +595,7 @@ describe Google::Cloud::Storage::File, :storage do
   end
 
   it "should copy an existing file" do
-    skip(
-      "Skipping this test due to a change in GCS behavior that disallows copying " \
-      "files with ACLs that include allUsers or allAuthenticatedUsers when public " \
-      "access prevention is enforced. See " \
-      "https://cloud.google.com/storage/docs/public-access-prevention for more details."
-    )
+    skip PAP_SKIP_MESSAGE
     
     uploaded = bucket.create_file files[:logo][:path], "CloudLogo", acl: "public_read", content_language: "en"
     _(uploaded.acl.readers).must_include "allUsers" # has "public_read"
@@ -634,12 +629,7 @@ describe Google::Cloud::Storage::File, :storage do
   end
 
   it "should copy an existing file, with updates" do
-    skip(
-      "Skipping this test due to a change in GCS behavior that disallows copying " \
-      "files with ACLs that include allUsers or allAuthenticatedUsers when public " \
-      "access prevention is enforced. See " \
-      "https://cloud.google.com/storage/docs/public-access-prevention for more details."
-    )
+    skip PAP_SKIP_MESSAGE
     uploaded = bucket.create_file files[:logo][:path], "CloudLogo", acl: "public_read", content_language: "en", content_type: "image/png"
     _(uploaded.acl.readers).must_include "allUsers" # has "public_read"
     _(uploaded.content_language).must_equal "en"
@@ -676,12 +666,7 @@ describe Google::Cloud::Storage::File, :storage do
   end
 
   it "should copy an existing file, with force_copy_metadata set to true" do
-    skip(
-      "Skipping this test due to a change in GCS behavior that disallows copying " \
-      "files with ACLs that include allUsers or allAuthenticatedUsers when public " \
-      "access prevention is enforced. See " \
-      "https://cloud.google.com/storage/docs/public-access-prevention for more details."
-    )
+    skip PAP_SKIP_MESSAGE
     uploaded = bucket.create_file files[:logo][:path], "CloudLogo", acl: "public_read", content_language: "en", content_type: "image/png"
     _(uploaded.acl.readers).must_include "allUsers" # has "public_read"
     _(uploaded.content_language).must_equal "en"

--- a/google-cloud-storage/acceptance/storage_helper.rb
+++ b/google-cloud-storage/acceptance/storage_helper.rb
@@ -22,6 +22,11 @@ require "retriable"
 require "google/cloud/storage"
 require "google/cloud/pubsub"
 
+PAP_SKIP_MESSAGE = "Skipping this test due to a change in GCS behavior that disallows copying " \
+                   "files with ACLs that include allUsers or allAuthenticatedUsers when public " \
+                   "access prevention is enforced. See " \
+                   "https://cloud.google.com/storage/docs/public-access-prevention for more details.".freeze
+
 # Generate JUnit format test reports
 if ENV["GCLOUD_TEST_GENERATE_XML_REPORT"]
   require "minitest/reporters"

--- a/google-cloud-storage/samples/acceptance/files_test.rb
+++ b/google-cloud-storage/samples/acceptance/files_test.rb
@@ -324,12 +324,7 @@ describe "Files Snippets" do
   end
 
   it "make_public" do
-    skip(
-      "Skipping this test due to a change in GCS behavior that disallows copying " \
-      "files with ACLs that include allUsers or allAuthenticatedUsers when public " \
-      "access prevention is enforced. See " \
-      "https://cloud.google.com/storage/docs/public-access-prevention for more details."
-    )
+    skip PAP_SKIP_MESSAGE
     bucket.create_file local_file, remote_file_name
     response = Net::HTTP.get URI(bucket.file(remote_file_name).public_url)
     refute_equal File.read(local_file), response

--- a/google-cloud-storage/samples/acceptance/helper.rb
+++ b/google-cloud-storage/samples/acceptance/helper.rb
@@ -24,6 +24,10 @@ require "securerandom"
 require "uri"
 require "ostruct"
 
+PAP_SKIP_MESSAGE = "Skipping this test due to a change in GCS behavior that disallows copying " \
+                   "files with ACLs that include allUsers or allAuthenticatedUsers when public " \
+                   "access prevention is enforced. See " \
+                   "https://cloud.google.com/storage/docs/public-access-prevention for more details.".freeze
 
 def fixture_bucket
   storage_client = Google::Cloud::Storage.new

--- a/google-cloud-storage/samples/acceptance/iam_test.rb
+++ b/google-cloud-storage/samples/acceptance/iam_test.rb
@@ -55,12 +55,7 @@ describe "IAM Snippets" do
   end
 
   it "set_bucket_public_iam" do
-    skip(
-      "Skipping this test due to a change in GCS behavior that disallows copying " \
-      "files with ACLs that include allUsers or allAuthenticatedUsers when public " \
-      "access prevention is enforced. See " \
-      "https://cloud.google.com/storage/docs/public-access-prevention for more details."
-    )
+    skip PAP_SKIP_MESSAGE
     # set_bucket_public_iam
     assert_output "Bucket #{bucket.name} is now publicly readable\n" do
       set_bucket_public_iam bucket_name: bucket.name


### PR DESCRIPTION
This pull request addresses failing acceptance tests in the 'google-cloud-storage' gem. Due to a recent update in Google Cloud Storage's Public Access Prevention (PAP) enforcement, certain operations involving public ACLs ('allUsers' or 'allAuthenticatedUsers') are now disallowed when PAP is active. To ensure the test suite remains stable, several tests that attempt these operations have been temporarily skipped with a clear explanation and a link to the relevant GCS documentation.