### PR TITLE
fix(bigquery): use destination table's project_id for queries

### DIFF
--- a/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/query_job.rb
@@ -757,6 +757,7 @@ module Google
 
           data_hash = service.list_tabledata destination_table_dataset_id,
                                              destination_table_table_id,
+                                             project_id: destination_table_project_id,
                                              token: token,
                                              max: max,
                                              start: start,
@@ -1826,6 +1827,10 @@ module Google
 
         def destination_table_table_id
           @gapi.configuration.query.destination_table.table_id
+        end
+
+        def destination_table_project_id
+          @gapi.configuration.query.destination_table.project_id
         end
 
         def destination_table_gapi

--- a/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
+++ b/google-cloud-bigquery/lib/google/cloud/bigquery/service.rb
@@ -248,11 +248,11 @@ access_policy_version: access_policy_version, update_mode: update_mode
         ##
         # Retrieves data from the table.
         def list_tabledata dataset_id, table_id, max: nil, token: nil, start: nil,
-                           format_options_use_int64_timestamp: nil
+                           format_options_use_int64_timestamp: nil, project_id: nil
           # The list operation is considered idempotent
           execute backoff: true do
             json_txt = service.list_table_data \
-              @project, dataset_id, table_id,
+              project_id || @project, dataset_id, table_id,
               max_results: max,
               page_token:  token,
               start_index: start,

--- a/google-cloud-bigquery/test/google/cloud/bigquery/query_job_data_test.rb
+++ b/google-cloud-bigquery/test/google/cloud/bigquery/query_job_data_test.rb
@@ -75,9 +75,37 @@ describe Google::Cloud::Bigquery::QueryJob, :data, :mock_bigquery do
     _(data[2][:duration]).must_be :nil?
     _(data[2][:target_end]).must_be :nil?
     _(data[2][:birthday]).must_be :nil?
-    end
+  end
+
+  it "can retrieve query results for cross-project queries" do
+    mock = Minitest::Mock.new
+    bigquery.service.mocked_service = mock
+
+    cross_project = "cross-project-id"
+    job_hash = JSON.parse(query_job_resp_json("SELECT name FROM `users`"))
+    job_hash["configuration"]["query"]["destinationTable"] = {
+      "projectId" => cross_project,
+      "datasetId" => dataset_id,
+      "tableId" => table_id
+    }
+    cross_job = Google::Cloud::Bigquery::Job.from_gapi Google::Apis::BigqueryV2::Job.from_json(job_hash.to_json), bigquery.service
+
+    mock.expect :get_job_query_results,
+                query_data_gapi,
+                [project, cross_job.job_id], location: "US", max_results: 0, page_token: nil, start_index: nil, timeout_ms: nil, format_options_use_int64_timestamp: nil
+    mock.expect :list_table_data,
+                table_data_gapi.to_json,
+                [cross_project, dataset_id, table_id], max_results: nil, page_token: nil, start_index: nil, options: {skip_deserialization: true}, format_options_use_int64_timestamp: true
+
+    _(cross_job).must_be :done?
+    data = cross_job.data
+    mock.verify
+
+    _(data.class).must_equal Google::Cloud::Bigquery::Data
+  end
 
   it "can retrieve query results when it already has destination_schema" do
+
     mock = Minitest::Mock.new
     bigquery.service.mocked_service = mock
     mock.expect :list_table_data,


### PR DESCRIPTION
* Add `destination_table_project_id` helper method.
* Update `data` method to pass `destination_table_project_id` to `service.list_tabledata`.

closes: #33810