### PR TITLE
fix(storage): Remove accept encoding gzip for metadata

### DIFF
--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -64,7 +64,6 @@ module Google
           @service.request_options.header ||= {}
           @service.request_options.header["x-goog-api-client"] =
             "gl-ruby/#{RUBY_VERSION} gccl/#{Google::Cloud::Storage::VERSION}"
-          @service.request_options.header["Accept-Encoding"] = "gzip"
           @service.request_options.quota_project = quota_project if quota_project
           @service.request_options.max_elapsed_time = max_elapsed_time if max_elapsed_time
           @service.request_options.base_interval = base_interval if base_interval

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -64,6 +64,7 @@ module Google
           @service.request_options.header ||= {}
           @service.request_options.header["x-goog-api-client"] =
             "gl-ruby/#{RUBY_VERSION} gccl/#{Google::Cloud::Storage::VERSION}"
+            
           @service.request_options.quota_project = quota_project if quota_project
           @service.request_options.max_elapsed_time = max_elapsed_time if max_elapsed_time
           @service.request_options.base_interval = base_interval if base_interval

--- a/google-cloud-storage/lib/google/cloud/storage/service.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/service.rb
@@ -64,7 +64,6 @@ module Google
           @service.request_options.header ||= {}
           @service.request_options.header["x-goog-api-client"] =
             "gl-ruby/#{RUBY_VERSION} gccl/#{Google::Cloud::Storage::VERSION}"
-            
           @service.request_options.quota_project = quota_project if quota_project
           @service.request_options.max_elapsed_time = max_elapsed_time if max_elapsed_time
           @service.request_options.base_interval = base_interval if base_interval

--- a/google-cloud-storage/test/google/cloud/storage/project_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/project_test.rb
@@ -67,6 +67,11 @@ describe Google::Cloud::Storage::Project, :mock_storage do
     _(project.universe_domain).must_equal "googleapis.com"
   end
 
+  it "does not set Accept-Encoding gzip header by default" do
+    service = Google::Cloud::Storage::Service.new "my-project", default_credentials
+    _(service.service.request_options.header["Accept-Encoding"]).must_be :nil?
+  end
+
   it "supports setting a universe domain argument" do
     service = Google::Cloud::Storage::Service.new "my-project", default_credentials, universe_domain: "mydomain1.com"
     _(service.universe_domain).must_equal "mydomain1.com"

--- a/google-cloud-storage/test/google/cloud/storage/project_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/project_test.rb
@@ -72,6 +72,7 @@ describe Google::Cloud::Storage::Project, :mock_storage do
     _(service.service.request_options.header["Accept-Encoding"]).must_be :nil?
   end
 
+  
   it "supports setting a universe domain argument" do
     service = Google::Cloud::Storage::Service.new "my-project", default_credentials, universe_domain: "mydomain1.com"
     _(service.universe_domain).must_equal "mydomain1.com"

--- a/google-cloud-storage/test/google/cloud/storage/project_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/project_test.rb
@@ -71,7 +71,6 @@ describe Google::Cloud::Storage::Project, :mock_storage do
     service = Google::Cloud::Storage::Service.new "my-project", default_credentials
     _(service.service.request_options.header["Accept-Encoding"]).must_be :nil?
   end
-
   
   it "supports setting a universe domain argument" do
     service = Google::Cloud::Storage::Service.new "my-project", default_credentials, universe_domain: "mydomain1.com"


### PR DESCRIPTION
This pull request modifies the google-cloud-storage library to move the Accept-Encoding: gzip header from a global request.
associated Core library Pr where the header is being added back for media operation: https://github.com/googleapis/google-api-ruby-client/pull/26530