### PR TITLE
feat(bigquery): Support bigdecimal 4.x

### DIFF
--- a/google-cloud-bigquery/google-cloud-bigquery.gemspec
+++ b/google-cloud-bigquery/google-cloud-bigquery.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 3.2"
 
-  gem.add_dependency "bigdecimal", "~> 3.0"
+  gem.add_dependency "bigdecimal", ">= 3.0", "< 5"
   gem.add_dependency "concurrent-ruby", "~> 1.0"
   gem.add_dependency "google-apis-bigquery_v2", "~> 0.71"
   gem.add_dependency "google-apis-core", ">= 0.18", "< 2"


### PR DESCRIPTION
Updates the dependency constraint on bigdecimal to allow versions up to 5.0.

Tested via `toys test` after `bundle update bigdecimal` to 4.1.2.

`Gemfile.lock` snippet:
```
bigdecimal (4.1.2)
builder (3.3.0)
concurrent-ruby (1.3.6)
```

Fixes #33917 