### PR TITLE
feat(translate-v2): enable self-signed JWT by default

### DIFF
--- a/google-cloud-translate-v2/Gemfile
+++ b/google-cloud-translate-v2/Gemfile
@@ -4,7 +4,8 @@ gemspec
 
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-errors", path: "../google-cloud-errors"
-gem "google-style", "~> 1.30.1"
+gem "google-style", "~> 1.31.1"
+gem "ostruct"
 gem "minitest", "~> 5.16"
 gem "minitest-focus", "~> 1.1"
 gem "minitest-rg", "~> 5.2"

--- a/google-cloud-translate-v2/Gemfile
+++ b/google-cloud-translate-v2/Gemfile
@@ -4,8 +4,8 @@ gemspec
 
 gem "google-cloud-core", path: "../google-cloud-core"
 gem "google-cloud-errors", path: "../google-cloud-errors"
-gem "google-style", "~> 1.31.1"
-gem "ostruct"
+gem "google-style", "~> 1.32.0"
+gem "ostruct", "~> 0.6.3"
 gem "minitest", "~> 5.16"
 gem "minitest-focus", "~> 1.1"
 gem "minitest-rg", "~> 5.2"

--- a/google-cloud-translate-v2/lib/google/cloud/translate/v2.rb
+++ b/google-cloud-translate-v2/lib/google/cloud/translate/v2.rb
@@ -63,6 +63,8 @@ module Google
         # @param [Integer] timeout Default timeout to use in requests. Optional.
         # @param [String] endpoint Override of the endpoint host name. Optional. If the param is nil, uses the default
         #   endpoint.
+        # @param [Boolean] enable_self_signed_jwt Whether to enable self-signed JWT. Optional. If the param is nil,
+        #   it is computed based on the endpoint.
         #
         # @return [Google::Cloud::Translate::V2::Api]
         #

--- a/google-cloud-translate-v2/lib/google/cloud/translate/v2.rb
+++ b/google-cloud-translate-v2/lib/google/cloud/translate/v2.rb
@@ -98,7 +98,7 @@ module Google
         #   translation = translate.translate "Hello world!", to: "la"
         #   translation.text #=> "Salve mundi!"
         #
-        def self.new project_id: nil, credentials: nil, key: nil, scope: nil, retries: nil, timeout: nil, endpoint: nil
+        def self.new project_id: nil, credentials: nil, key: nil, scope: nil, retries: nil, timeout: nil, endpoint: nil, enable_self_signed_jwt: nil
           project_id ||= default_project_id
 
           configuration = translation_config
@@ -116,10 +116,18 @@ module Google
           end
 
           scope ||= configuration&.scope
-          credentials ||= default_credentials scope: scope
+
+          if enable_self_signed_jwt.nil?
+            # Use self-signed JWT if the endpoint is unchanged from default (nil or default host).
+            # This logic is adapted from gapic-generator-ruby templates,
+            # simplified here since the default host is known to be global.
+            enable_self_signed_jwt = endpoint.nil? || endpoint == Service::API_HOST
+          end
+
+          credentials ||= default_credentials scope: scope, enable_self_signed_jwt: enable_self_signed_jwt
 
           unless credentials.is_a? Google::Auth::Credentials
-            credentials = Google::Cloud::Translate::V2::Credentials.new credentials, scope: scope
+            credentials = Google::Cloud::Translate::V2::Credentials.new credentials, { scope: scope, enable_self_signed_jwt: enable_self_signed_jwt }
           end
 
           project_id = resolve_project_id project_id, credentials
@@ -143,13 +151,13 @@ module Google
 
         ##
         # @private Default credentials.
-        def self.default_credentials scope: nil
+        def self.default_credentials scope: nil, enable_self_signed_jwt: nil
           translation_config&.credentials ||
             Google::Cloud::Config.credentials_from_env(
               "TRANSLATE_CREDENTIALS", "TRANSLATE_CREDENTIALS_JSON", "TRANSLATE_KEYFILE", "TRANSLATE_KEYFILE_JSON"
             ) ||
             Google::Cloud.configure.credentials ||
-            Google::Cloud::Translate::V2::Credentials.default(scope: scope)
+            Google::Cloud::Translate::V2::Credentials.default({ scope: scope, enable_self_signed_jwt: enable_self_signed_jwt })
         end
 
         ##

--- a/google-cloud-translate-v2/test/google/cloud/translate/v2_test.rb
+++ b/google-cloud-translate-v2/test/google/cloud/translate/v2_test.rb
@@ -92,10 +92,38 @@ describe Google::Cloud::Translate::V2 do
       end
     end
 
+    it "enables self-signed JWT by default when using default endpoint" do
+      ENV.stub :[], nil do
+        Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
+          stubbed_default = ->(options = {}) {
+            _(options[:enable_self_signed_jwt]).must_equal true
+            default_credentials
+          }
+          Google::Cloud::Translate::V2::Credentials.stub :default, stubbed_default do
+            Google::Cloud::Translate::V2.new
+          end
+        end
+      end
+    end
+
+    it "does not enable self-signed JWT when using custom endpoint" do
+      ENV.stub :[], nil do
+        Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
+          stubbed_default = ->(options = {}) {
+            _(options[:enable_self_signed_jwt]).must_equal false
+            default_credentials
+          }
+          Google::Cloud::Translate::V2::Credentials.stub :default, stubbed_default do
+            Google::Cloud::Translate::V2.new endpoint: "custom-endpoint.com"
+          end
+        end
+      end
+    end
+
     it "uses provided project_id and credentials" do
-      stubbed_credentials = ->(keyfile, scope: nil) {
+      stubbed_credentials = ->(keyfile, options = {}) {
         _(keyfile).must_equal "path/to/keyfile.json"
-        _(scope).must_be :nil?
+        _(options[:scope]).must_be :nil?
         "translate-credentials"
       }
       stubbed_service = ->(project_id, credentials, scope: nil, key: nil, retries: nil, timeout: nil, host: nil) {
@@ -127,9 +155,9 @@ describe Google::Cloud::Translate::V2 do
     end
 
     it "gets project_id from credentials" do
-      stubbed_credentials = ->(keyfile, scope: nil) {
+      stubbed_credentials = ->(keyfile, options = {}) {
         _(keyfile).must_equal "path/to/keyfile.json"
-        _(scope).must_be :nil?
+        _(options[:scope]).must_be :nil?
         OpenStruct.new project_id: "project-id"
       }
       stubbed_service = ->(project_id, credentials, scope: nil, key: nil, retries: nil, timeout: nil, host: nil) {
@@ -165,9 +193,9 @@ describe Google::Cloud::Translate::V2 do
     end
 
     it "uses provided endpoint" do
-      stubbed_credentials = ->(keyfile, scope: nil) {
+      stubbed_credentials = ->(keyfile, options = {}) {
         _(keyfile).must_equal "path/to/keyfile.json"
-        _(scope).must_be :nil?
+        _(options[:scope]).must_be :nil?
         "translate-credentials"
       }
       stubbed_service = ->(project_id, credentials, scope: nil, key: nil, retries: nil, timeout: nil, host: nil) {


### PR DESCRIPTION
* Update Gemfile to allow google-style ~> 1.31.1.
* Add ostruct to Gemfile for Ruby 4.0.0+ compatibility.
* Fix test stubs to accept positional hash for Ruby 3+ keyword separation.