### PR TITLE
chore: Update dependencies to unblock CI

### DIFF
--- a/google-cloud-dataform-v1beta1/Gemfile
+++ b/google-cloud-dataform-v1beta1/Gemfile
@@ -2,10 +2,13 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "google-style", "~> 1.31.1"
-gem "minitest", "~> 5.22"
+gem "google-style", "~> 1.32.0"
+gem "irb", "~> 1.17"
+gem "minitest", "~> 6.0.2"
 gem "minitest-focus", "~> 1.4"
+gem "minitest-mock", "~> 5.27"
 gem "minitest-rg", "~> 5.3"
+gem "ostruct", "~> 0.5.5"
 gem "rake", ">= 13.0"
 gem "redcarpet", "~> 3.6"
 gem "yard", "~> 0.9"

--- a/google-cloud-dataform-v1beta1/google-cloud-dataform-v1beta1.gemspec
+++ b/google-cloud-dataform-v1beta1/google-cloud-dataform-v1beta1.gemspec
@@ -21,9 +21,10 @@ Gem::Specification.new do |gem|
                       ["README.md", "LICENSE.md", "AUTHENTICATION.md", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 3.1"
+  gem.required_ruby_version = ">= 3.2"
 
   gem.add_dependency "gapic-common", "~> 1.2"
+  gem.add_dependency "google-cloud-common", "~> 1.9"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
   gem.add_dependency "google-cloud-location", "~> 1.0"
   gem.add_dependency "google-iam-v1", "~> 1.3"

--- a/google-cloud-dataplex-v1/Gemfile
+++ b/google-cloud-dataplex-v1/Gemfile
@@ -2,10 +2,13 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "google-style", "~> 1.31.1"
-gem "minitest", "~> 5.22"
+gem "google-style", "~> 1.32.0"
+gem "irb", "~> 1.17"
+gem "minitest", "~> 6.0.2"
 gem "minitest-focus", "~> 1.4"
+gem "minitest-mock", "~> 5.27"
 gem "minitest-rg", "~> 5.3"
+gem "ostruct", "~> 0.5.5"
 gem "rake", ">= 13.0"
 gem "redcarpet", "~> 3.6"
 gem "yard", "~> 0.9"

--- a/google-cloud-dataplex-v1/google-cloud-dataplex-v1.gemspec
+++ b/google-cloud-dataplex-v1/google-cloud-dataplex-v1.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
                       ["README.md", "LICENSE.md", "AUTHENTICATION.md", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 3.1"
+  gem.required_ruby_version = ">= 3.2"
 
   gem.add_dependency "gapic-common", "~> 1.2"
   gem.add_dependency "google-cloud-errors", "~> 1.0"

--- a/google-cloud-firestore-v1/Gemfile
+++ b/google-cloud-firestore-v1/Gemfile
@@ -2,10 +2,13 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "google-style", "~> 1.31.1"
-gem "minitest", "~> 5.22"
+gem "google-style", "~> 1.32.0"
+gem "irb", "~> 1.17"
+gem "minitest", "~> 6.0.2"
 gem "minitest-focus", "~> 1.4"
+gem "minitest-mock", "~> 5.27"
 gem "minitest-rg", "~> 5.3"
+gem "ostruct", "~> 0.5.5"
 gem "rake", ">= 13.0"
 gem "redcarpet", "~> 3.6"
 gem "yard", "~> 0.9"

--- a/google-cloud-firestore-v1/google-cloud-firestore-v1.gemspec
+++ b/google-cloud-firestore-v1/google-cloud-firestore-v1.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
                       ["README.md", "LICENSE.md", "AUTHENTICATION.md", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 3.1"
+  gem.required_ruby_version = ">= 3.2"
 
   gem.add_dependency "gapic-common", "~> 1.2"
   gem.add_dependency "google-cloud-errors", "~> 1.0"

--- a/google-cloud-run-v2/Gemfile
+++ b/google-cloud-run-v2/Gemfile
@@ -2,10 +2,13 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "google-style", "~> 1.31.1"
-gem "minitest", "~> 5.22"
+gem "google-style", "~> 1.32.0"
+gem "irb", "~> 1.17"
+gem "minitest", "~> 6.0.2"
 gem "minitest-focus", "~> 1.4"
+gem "minitest-mock", "~> 5.27"
 gem "minitest-rg", "~> 5.3"
+gem "ostruct", "~> 0.5.5"
 gem "rake", ">= 13.0"
 gem "redcarpet", "~> 3.6"
 gem "yard", "~> 0.9"

--- a/google-cloud-run-v2/google-cloud-run-v2.gemspec
+++ b/google-cloud-run-v2/google-cloud-run-v2.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
                       ["README.md", "LICENSE.md", "AUTHENTICATION.md", ".yardopts"]
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 3.1"
+  gem.required_ruby_version = ">= 3.2"
 
   gem.add_dependency "gapic-common", "~> 1.2"
   gem.add_dependency "google-cloud-errors", "~> 1.0"


### PR DESCRIPTION
These GAPICs need to wait for the next generator run to be unblock their actual releases. 

I manually ran the generator with minimal fixes to unblock CI. 

chore is correct as of these GAPICs have pending PRs.