### PR TITLE
chore(bigtable-admin-v2): Fix flakiness in wait_for_replication helper test

### DIFF
--- a/google-cloud-bigtable-admin-v2/test/google/cloud/bigtable/admin/v2/bigtable_table_admin_helpers_test.rb
+++ b/google-cloud-bigtable-admin-v2/test/google/cloud/bigtable/admin/v2/bigtable_table_admin_helpers_test.rb
@@ -153,7 +153,8 @@ describe "::Google::Cloud::Bigtable::Admin::V2::BigtableTableAdmin::Client helpe
         client = ::Google::Cloud::Bigtable::Admin::V2::BigtableTableAdmin::Client.new do |config|
           config.credentials = grpc_channel
         end
-        token = client.wait_for_replication(table_name, timeout: 1.5, mock_delay: true)
+        retry_policy = Gapic::Common::RetryPolicy.new timeout: 1.5, jitter: 0.0
+        token = client.wait_for_replication(table_name, retry_policy: retry_policy, mock_delay: true)
         assert_equal consistency_token, token
         assert client_stub.expectations_empty?
       end


### PR DESCRIPTION
Forces 0.0 jitter to make the timeout test deterministic.

By default, `gapic-common` adds a random jitter up to 1.0s to backoffs. In this test, any random jitter > 0.5s pushes the first delay past the 1.5s timeout limit.