### PR TITLE
chore: Remove Ruby 3.1 from CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            ruby: "3.1"
-            task: "--test"
-          - os: ubuntu-latest
             ruby: "3.2"
             task: "--test"
           - os: ubuntu-latest


### PR DESCRIPTION
Gems have been migrated from minimum Ruby version 3.1.