### PR TITLE
chore: Showcase of generator updates 0.49.0

### DIFF
--- a/google-cloud-video_intelligence-v1/README.md
+++ b/google-cloud-video_intelligence-v1/README.md
@@ -85,7 +85,7 @@ To browse ready to use code samples check [Google Cloud Samples](https://cloud.g
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 3.0+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or

--- a/google-cloud-video_intelligence-v1/google-cloud-video_intelligence-v1.gemspec
+++ b/google-cloud-video_intelligence-v1/google-cloud-video_intelligence-v1.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 3.2"
 
-  gem.add_dependency "gapic-common", "~> 1.2"
+  gem.add_dependency "gapic-common", "~> 1.3"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 end

--- a/google-cloud-video_intelligence-v1/lib/google/cloud/video_intelligence/v1/video_intelligence_service/client.rb
+++ b/google-cloud-video_intelligence-v1/lib/google/cloud/video_intelligence/v1/video_intelligence_service/client.rb
@@ -416,6 +416,7 @@ module Google
             #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #       trigger a retry.
             #   @return [::Hash]
@@ -499,6 +500,7 @@ module Google
               #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
               #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
               #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
               #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
               #         trigger a retry.
               #

--- a/google-cloud-video_intelligence-v1/lib/google/cloud/video_intelligence/v1/video_intelligence_service/operations.rb
+++ b/google-cloud-video_intelligence-v1/lib/google/cloud/video_intelligence/v1/video_intelligence_service/operations.rb
@@ -703,6 +703,7 @@ module Google
             #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #       trigger a retry.
             #   @return [::Hash]
@@ -786,6 +787,7 @@ module Google
               #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
               #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
               #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
               #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
               #         trigger a retry.
               #

--- a/google-cloud-video_intelligence-v1/lib/google/cloud/video_intelligence/v1/video_intelligence_service/rest/client.rb
+++ b/google-cloud-video_intelligence-v1/lib/google/cloud/video_intelligence/v1/video_intelligence_service/rest/client.rb
@@ -384,6 +384,7 @@ module Google
               #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
               #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
               #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
               #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
               #       trigger a retry.
               #   @return [::Hash]
@@ -456,6 +457,7 @@ module Google
                 #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
                 #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
                 #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+                #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
                 #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
                 #         trigger a retry.
                 #

--- a/google-cloud-video_intelligence-v1/lib/google/cloud/video_intelligence/v1/video_intelligence_service/rest/operations.rb
+++ b/google-cloud-video_intelligence-v1/lib/google/cloud/video_intelligence/v1/video_intelligence_service/rest/operations.rb
@@ -541,6 +541,7 @@ module Google
               #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
               #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
               #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
               #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
               #       trigger a retry.
               #   @return [::Hash]
@@ -613,6 +614,7 @@ module Google
                 #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
                 #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
                 #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+                #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
                 #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
                 #         trigger a retry.
                 #

--- a/google-cloud-video_intelligence-v1/proto_docs/google/api/client.rb
+++ b/google-cloud-video_intelligence-v1/proto_docs/google/api/client.rb
@@ -31,6 +31,8 @@ module Google
     # @!attribute [rw] selective_gapic_generation
     #   @return [::Google::Api::SelectiveGapicGeneration]
     #     Configuration for which RPCs should be generated in the GAPIC client.
+    #
+    #     Note: This field should not be used in most cases.
     class CommonLanguageSettings
       include ::Google::Protobuf::MessageExts
       extend ::Google::Protobuf::MessageExts::ClassMethods
@@ -141,9 +143,10 @@ module Google
     #
     #     Example of a YAML configuration::
     #
-    #      publishing:
-    #        java_settings:
-    #          library_package: com.google.cloud.pubsub.v1
+    #         publishing:
+    #           library_settings:
+    #             java_settings:
+    #               library_package: com.google.cloud.pubsub.v1
     # @!attribute [rw] service_class_names
     #   @return [::Google::Protobuf::Map{::String => ::String}]
     #     Configure the Java class name to use instead of the service's for its
@@ -155,11 +158,11 @@ module Google
     #
     #     Example of a YAML configuration::
     #
-    #      publishing:
-    #        java_settings:
-    #          service_class_names:
-    #            - google.pubsub.v1.Publisher: TopicAdmin
-    #            - google.pubsub.v1.Subscriber: SubscriptionAdmin
+    #         publishing:
+    #           java_settings:
+    #             service_class_names:
+    #               - google.pubsub.v1.Publisher: TopicAdmin
+    #               - google.pubsub.v1.Subscriber: SubscriptionAdmin
     # @!attribute [rw] common
     #   @return [::Google::Api::CommonLanguageSettings]
     #     Some settings.
@@ -190,6 +193,20 @@ module Google
     # @!attribute [rw] common
     #   @return [::Google::Api::CommonLanguageSettings]
     #     Some settings.
+    # @!attribute [rw] library_package
+    #   @return [::String]
+    #     The package name to use in Php. Clobbers the php_namespace option
+    #     set in the protobuf. This should be used **only** by APIs
+    #     who have already set the language_settings.php.package_name" field
+    #     in gapic.yaml. API teams should use the protobuf php_namespace option
+    #     where possible.
+    #
+    #     Example of a YAML configuration::
+    #
+    #         publishing:
+    #           library_settings:
+    #             php_settings:
+    #               library_package: Google\Cloud\PubSub\V1
     class PhpSettings
       include ::Google::Protobuf::MessageExts
       extend ::Google::Protobuf::MessageExts::ClassMethods
@@ -318,10 +335,12 @@ module Google
     #     service names and values are the name to be used for the service client
     #     and call options.
     #
-    #     publishing:
-    #       go_settings:
-    #         renamed_services:
-    #           Publisher: TopicAdmin
+    #     Example:
+    #
+    #         publishing:
+    #           go_settings:
+    #             renamed_services:
+    #               Publisher: TopicAdmin
     class GoSettings
       include ::Google::Protobuf::MessageExts
       extend ::Google::Protobuf::MessageExts::ClassMethods
@@ -344,10 +363,10 @@ module Google
     #
     #     Example:
     #
-    #        publishing:
-    #          method_settings:
-    #          - selector: google.storage.control.v2.StorageControl.CreateFolder
-    #            # method settings for CreateFolder...
+    #         publishing:
+    #           method_settings:
+    #           - selector: google.storage.control.v2.StorageControl.CreateFolder
+    #             # method settings for CreateFolder...
     # @!attribute [rw] long_running
     #   @return [::Google::Api::MethodSettings::LongRunning]
     #     Describes settings to use for long-running operations when generating
@@ -356,14 +375,14 @@ module Google
     #
     #     Example of a YAML configuration::
     #
-    #        publishing:
-    #          method_settings:
-    #          - selector: google.cloud.speech.v2.Speech.BatchRecognize
-    #            long_running:
-    #              initial_poll_delay: 60s # 1 minute
-    #              poll_delay_multiplier: 1.5
-    #              max_poll_delay: 360s # 6 minutes
-    #              total_poll_timeout: 54000s # 90 minutes
+    #         publishing:
+    #           method_settings:
+    #           - selector: google.cloud.speech.v2.Speech.BatchRecognize
+    #             long_running:
+    #               initial_poll_delay: 60s # 1 minute
+    #               poll_delay_multiplier: 1.5
+    #               max_poll_delay: 360s # 6 minutes
+    #               total_poll_timeout: 54000s # 90 minutes
     # @!attribute [rw] auto_populated_fields
     #   @return [::Array<::String>]
     #     List of top-level fields of the request message, that should be
@@ -372,11 +391,24 @@ module Google
     #
     #     Example of a YAML configuration:
     #
-    #        publishing:
-    #          method_settings:
-    #          - selector: google.example.v1.ExampleService.CreateExample
-    #            auto_populated_fields:
-    #            - request_id
+    #         publishing:
+    #           method_settings:
+    #           - selector: google.example.v1.ExampleService.CreateExample
+    #             auto_populated_fields:
+    #             - request_id
+    # @!attribute [rw] batching
+    #   @return [::Google::Api::BatchingConfigProto]
+    #     Batching configuration for an API method in client libraries.
+    #
+    #     Example of a YAML configuration:
+    #
+    #         publishing:
+    #           method_settings:
+    #           - selector: google.example.v1.ExampleService.BatchCreateExample
+    #             batching:
+    #               element_count_threshold: 1000
+    #               request_byte_threshold: 100000000
+    #               delay_threshold_millis: 10
     class MethodSettings
       include ::Google::Protobuf::MessageExts
       extend ::Google::Protobuf::MessageExts::ClassMethods
@@ -411,6 +443,8 @@ module Google
 
     # This message is used to configure the generation of a subset of the RPCs in
     # a service for client libraries.
+    #
+    # Note: This feature should not be used in most cases.
     # @!attribute [rw] methods
     #   @return [::Array<::String>]
     #     An allowlist of the fully qualified names of RPCs that should be included
@@ -424,6 +458,77 @@ module Google
     #     implementations to decide. Some examples may be: added annotations,
     #     obfuscated identifiers, or other language idiomatic patterns.
     class SelectiveGapicGeneration
+      include ::Google::Protobuf::MessageExts
+      extend ::Google::Protobuf::MessageExts::ClassMethods
+    end
+
+    # `BatchingConfigProto` defines the batching configuration for an API method.
+    # @!attribute [rw] thresholds
+    #   @return [::Google::Api::BatchingSettingsProto]
+    #     The thresholds which trigger a batched request to be sent.
+    # @!attribute [rw] batch_descriptor
+    #   @return [::Google::Api::BatchingDescriptorProto]
+    #     The request and response fields used in batching.
+    class BatchingConfigProto
+      include ::Google::Protobuf::MessageExts
+      extend ::Google::Protobuf::MessageExts::ClassMethods
+    end
+
+    # `BatchingSettingsProto` specifies a set of batching thresholds, each of
+    # which acts as a trigger to send a batch of messages as a request. At least
+    # one threshold must be positive nonzero.
+    # @!attribute [rw] element_count_threshold
+    #   @return [::Integer]
+    #     The number of elements of a field collected into a batch which, if
+    #     exceeded, causes the batch to be sent.
+    # @!attribute [rw] request_byte_threshold
+    #   @return [::Integer]
+    #     The aggregated size of the batched field which, if exceeded, causes the
+    #     batch to be sent. This size is computed by aggregating the sizes of the
+    #     request field to be batched, not of the entire request message.
+    # @!attribute [rw] delay_threshold
+    #   @return [::Google::Protobuf::Duration]
+    #     The duration after which a batch should be sent, starting from the addition
+    #     of the first message to that batch.
+    # @!attribute [rw] element_count_limit
+    #   @return [::Integer]
+    #     The maximum number of elements collected in a batch that could be accepted
+    #     by server.
+    # @!attribute [rw] request_byte_limit
+    #   @return [::Integer]
+    #     The maximum size of the request that could be accepted by server.
+    # @!attribute [rw] flow_control_element_limit
+    #   @return [::Integer]
+    #     The maximum number of elements allowed by flow control.
+    # @!attribute [rw] flow_control_byte_limit
+    #   @return [::Integer]
+    #     The maximum size of data allowed by flow control.
+    # @!attribute [rw] flow_control_limit_exceeded_behavior
+    #   @return [::Google::Api::FlowControlLimitExceededBehaviorProto]
+    #     The behavior to take when the flow control limit is exceeded.
+    class BatchingSettingsProto
+      include ::Google::Protobuf::MessageExts
+      extend ::Google::Protobuf::MessageExts::ClassMethods
+    end
+
+    # `BatchingDescriptorProto` specifies the fields of the request message to be
+    # used for batching, and, optionally, the fields of the response message to be
+    # used for demultiplexing.
+    # @!attribute [rw] batched_field
+    #   @return [::String]
+    #     The repeated field in the request message to be aggregated by batching.
+    # @!attribute [rw] discriminator_fields
+    #   @return [::Array<::String>]
+    #     A list of the fields in the request message. Two requests will be batched
+    #     together only if the values of every field specified in
+    #     `request_discriminator_fields` is equal between the two requests.
+    # @!attribute [rw] subresponse_field
+    #   @return [::String]
+    #     Optional. When present, indicates the field in the response message to be
+    #     used to demultiplex the response into multiple response messages, in
+    #     correspondence with the multiple request messages originally batched
+    #     together.
+    class BatchingDescriptorProto
       include ::Google::Protobuf::MessageExts
       extend ::Google::Protobuf::MessageExts::ClassMethods
     end
@@ -468,6 +573,21 @@ module Google
 
       # Publish the library to package managers like nuget.org and npmjs.com.
       PACKAGE_MANAGER = 20
+    end
+
+    # The behavior to take when the flow control limit is exceeded.
+    module FlowControlLimitExceededBehaviorProto
+      # Default behavior, system-defined.
+      UNSET_BEHAVIOR = 0
+
+      # Stop operation, raise error.
+      THROW_EXCEPTION = 1
+
+      # Pause operation until limit clears.
+      BLOCK = 2
+
+      # Continue operation, disregard limit.
+      IGNORE = 3
     end
   end
 end

--- a/google-cloud-video_intelligence-v1/test/google/cloud/video_intelligence/v1/video_intelligence_service_operations_test.rb
+++ b/google-cloud-video_intelligence-v1/test/google/cloud/video_intelligence/v1/video_intelligence_service_operations_test.rb
@@ -91,40 +91,40 @@ class ::Google::Cloud::VideoIntelligence::V1::VideoIntelligenceService::Operatio
 
     Gapic::ServiceStub.stub :new, list_operations_client_stub do
       # Create client
-      client = ::Google::Cloud::VideoIntelligence::V1::VideoIntelligenceService::Operations.new do |config|
+      c = ::Google::Cloud::VideoIntelligence::V1::VideoIntelligenceService::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }) do |response, operation|
+      c.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success do |response, operation|
+      c.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.list_operations ::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success) do |response, operation|
+      c.list_operations ::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }, grpc_options) do |response, operation|
+      c.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.list_operations(::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success), grpc_options) do |response, operation|
+      c.list_operations(::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -154,40 +154,40 @@ class ::Google::Cloud::VideoIntelligence::V1::VideoIntelligenceService::Operatio
 
     Gapic::ServiceStub.stub :new, get_operation_client_stub do
       # Create client
-      client = ::Google::Cloud::VideoIntelligence::V1::VideoIntelligenceService::Operations.new do |config|
+      c = ::Google::Cloud::VideoIntelligence::V1::VideoIntelligenceService::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_operation({ name: name }) do |response, operation|
+      c.get_operation({ name: name }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_operation name: name do |response, operation|
+      c.get_operation name: name do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_operation ::Google::Longrunning::GetOperationRequest.new(name: name) do |response, operation|
+      c.get_operation ::Google::Longrunning::GetOperationRequest.new(name: name) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_operation({ name: name }, grpc_options) do |response, operation|
+      c.get_operation({ name: name }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_operation(::Google::Longrunning::GetOperationRequest.new(name: name), grpc_options) do |response, operation|
+      c.get_operation(::Google::Longrunning::GetOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -217,36 +217,36 @@ class ::Google::Cloud::VideoIntelligence::V1::VideoIntelligenceService::Operatio
 
     Gapic::ServiceStub.stub :new, delete_operation_client_stub do
       # Create client
-      client = ::Google::Cloud::VideoIntelligence::V1::VideoIntelligenceService::Operations.new do |config|
+      c = ::Google::Cloud::VideoIntelligence::V1::VideoIntelligenceService::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.delete_operation({ name: name }) do |response, operation|
+      c.delete_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.delete_operation name: name do |response, operation|
+      c.delete_operation name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.delete_operation ::Google::Longrunning::DeleteOperationRequest.new(name: name) do |response, operation|
+      c.delete_operation ::Google::Longrunning::DeleteOperationRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.delete_operation({ name: name }, grpc_options) do |response, operation|
+      c.delete_operation({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.delete_operation(::Google::Longrunning::DeleteOperationRequest.new(name: name), grpc_options) do |response, operation|
+      c.delete_operation(::Google::Longrunning::DeleteOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -275,36 +275,36 @@ class ::Google::Cloud::VideoIntelligence::V1::VideoIntelligenceService::Operatio
 
     Gapic::ServiceStub.stub :new, cancel_operation_client_stub do
       # Create client
-      client = ::Google::Cloud::VideoIntelligence::V1::VideoIntelligenceService::Operations.new do |config|
+      c = ::Google::Cloud::VideoIntelligence::V1::VideoIntelligenceService::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.cancel_operation({ name: name }) do |response, operation|
+      c.cancel_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.cancel_operation name: name do |response, operation|
+      c.cancel_operation name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.cancel_operation ::Google::Longrunning::CancelOperationRequest.new(name: name) do |response, operation|
+      c.cancel_operation ::Google::Longrunning::CancelOperationRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.cancel_operation({ name: name }, grpc_options) do |response, operation|
+      c.cancel_operation({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.cancel_operation(::Google::Longrunning::CancelOperationRequest.new(name: name), grpc_options) do |response, operation|
+      c.cancel_operation(::Google::Longrunning::CancelOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -335,40 +335,40 @@ class ::Google::Cloud::VideoIntelligence::V1::VideoIntelligenceService::Operatio
 
     Gapic::ServiceStub.stub :new, wait_operation_client_stub do
       # Create client
-      client = ::Google::Cloud::VideoIntelligence::V1::VideoIntelligenceService::Operations.new do |config|
+      c = ::Google::Cloud::VideoIntelligence::V1::VideoIntelligenceService::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.wait_operation({ name: name, timeout: timeout }) do |response, operation|
+      c.wait_operation({ name: name, timeout: timeout }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.wait_operation name: name, timeout: timeout do |response, operation|
+      c.wait_operation name: name, timeout: timeout do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.wait_operation ::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout) do |response, operation|
+      c.wait_operation ::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.wait_operation({ name: name, timeout: timeout }, grpc_options) do |response, operation|
+      c.wait_operation({ name: name, timeout: timeout }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.wait_operation(::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout), grpc_options) do |response, operation|
+      c.wait_operation(::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation

--- a/google-cloud-video_intelligence-v1/test/google/cloud/video_intelligence/v1/video_intelligence_service_rest_test.rb
+++ b/google-cloud-video_intelligence-v1/test/google/cloud/video_intelligence/v1/video_intelligence_service_rest_test.rb
@@ -102,32 +102,32 @@ class ::Google::Cloud::VideoIntelligence::V1::VideoIntelligenceService::Rest::Cl
     ::Google::Cloud::VideoIntelligence::V1::VideoIntelligenceService::Rest::ServiceStub.stub :transcode_annotate_video_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, annotate_video_client_stub do
         # Create client
-        client = ::Google::Cloud::VideoIntelligence::V1::VideoIntelligenceService::Rest::Client.new do |config|
+        c = ::Google::Cloud::VideoIntelligence::V1::VideoIntelligenceService::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.annotate_video({ input_uri: input_uri, input_content: input_content, features: features, video_context: video_context, output_uri: output_uri, location_id: location_id }) do |_result, response|
+        c.annotate_video({ input_uri: input_uri, input_content: input_content, features: features, video_context: video_context, output_uri: output_uri, location_id: location_id }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.annotate_video input_uri: input_uri, input_content: input_content, features: features, video_context: video_context, output_uri: output_uri, location_id: location_id do |_result, response|
+        c.annotate_video input_uri: input_uri, input_content: input_content, features: features, video_context: video_context, output_uri: output_uri, location_id: location_id do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.annotate_video ::Google::Cloud::VideoIntelligence::V1::AnnotateVideoRequest.new(input_uri: input_uri, input_content: input_content, features: features, video_context: video_context, output_uri: output_uri, location_id: location_id) do |_result, response|
+        c.annotate_video ::Google::Cloud::VideoIntelligence::V1::AnnotateVideoRequest.new(input_uri: input_uri, input_content: input_content, features: features, video_context: video_context, output_uri: output_uri, location_id: location_id) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.annotate_video({ input_uri: input_uri, input_content: input_content, features: features, video_context: video_context, output_uri: output_uri, location_id: location_id }, call_options) do |_result, response|
+        c.annotate_video({ input_uri: input_uri, input_content: input_content, features: features, video_context: video_context, output_uri: output_uri, location_id: location_id }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.annotate_video(::Google::Cloud::VideoIntelligence::V1::AnnotateVideoRequest.new(input_uri: input_uri, input_content: input_content, features: features, video_context: video_context, output_uri: output_uri, location_id: location_id), call_options) do |_result, response|
+        c.annotate_video(::Google::Cloud::VideoIntelligence::V1::AnnotateVideoRequest.new(input_uri: input_uri, input_content: input_content, features: features, video_context: video_context, output_uri: output_uri, location_id: location_id), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/google-cloud-video_intelligence-v1/test/google/cloud/video_intelligence/v1/video_intelligence_service_test.rb
+++ b/google-cloud-video_intelligence-v1/test/google/cloud/video_intelligence/v1/video_intelligence_service_test.rb
@@ -92,40 +92,40 @@ class ::Google::Cloud::VideoIntelligence::V1::VideoIntelligenceService::ClientTe
 
     Gapic::ServiceStub.stub :new, annotate_video_client_stub do
       # Create client
-      client = ::Google::Cloud::VideoIntelligence::V1::VideoIntelligenceService::Client.new do |config|
+      c = ::Google::Cloud::VideoIntelligence::V1::VideoIntelligenceService::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.annotate_video({ input_uri: input_uri, input_content: input_content, features: features, video_context: video_context, output_uri: output_uri, location_id: location_id }) do |response, operation|
+      c.annotate_video({ input_uri: input_uri, input_content: input_content, features: features, video_context: video_context, output_uri: output_uri, location_id: location_id }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.annotate_video input_uri: input_uri, input_content: input_content, features: features, video_context: video_context, output_uri: output_uri, location_id: location_id do |response, operation|
+      c.annotate_video input_uri: input_uri, input_content: input_content, features: features, video_context: video_context, output_uri: output_uri, location_id: location_id do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.annotate_video ::Google::Cloud::VideoIntelligence::V1::AnnotateVideoRequest.new(input_uri: input_uri, input_content: input_content, features: features, video_context: video_context, output_uri: output_uri, location_id: location_id) do |response, operation|
+      c.annotate_video ::Google::Cloud::VideoIntelligence::V1::AnnotateVideoRequest.new(input_uri: input_uri, input_content: input_content, features: features, video_context: video_context, output_uri: output_uri, location_id: location_id) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.annotate_video({ input_uri: input_uri, input_content: input_content, features: features, video_context: video_context, output_uri: output_uri, location_id: location_id }, grpc_options) do |response, operation|
+      c.annotate_video({ input_uri: input_uri, input_content: input_content, features: features, video_context: video_context, output_uri: output_uri, location_id: location_id }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.annotate_video(::Google::Cloud::VideoIntelligence::V1::AnnotateVideoRequest.new(input_uri: input_uri, input_content: input_content, features: features, video_context: video_context, output_uri: output_uri, location_id: location_id), grpc_options) do |response, operation|
+      c.annotate_video(::Google::Cloud::VideoIntelligence::V1::AnnotateVideoRequest.new(input_uri: input_uri, input_content: input_content, features: features, video_context: video_context, output_uri: output_uri, location_id: location_id), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation

--- a/google-cloud-vision-v1/README.md
+++ b/google-cloud-vision-v1/README.md
@@ -86,7 +86,7 @@ To browse ready to use code samples check [Google Cloud Samples](https://cloud.g
 
 ## Supported Ruby Versions
 
-This library is supported on Ruby 3.0+.
+This library is supported on Ruby 3.2+.
 
 Google provides official support for Ruby versions that are actively supported
 by Ruby Core—that is, Ruby versions that are either in normal maintenance or

--- a/google-cloud-vision-v1/google-cloud-vision-v1.gemspec
+++ b/google-cloud-vision-v1/google-cloud-vision-v1.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 3.2"
 
-  gem.add_dependency "gapic-common", "~> 1.2"
+  gem.add_dependency "gapic-common", "~> 1.3"
   gem.add_dependency "google-cloud-errors", "~> 1.0"
 end

--- a/google-cloud-vision-v1/lib/google/cloud/vision/v1/image_annotator/client.rb
+++ b/google-cloud-vision-v1/lib/google/cloud/vision/v1/image_annotator/client.rb
@@ -743,6 +743,7 @@ module Google
             #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #       trigger a retry.
             #   @return [::Hash]
@@ -826,6 +827,7 @@ module Google
               #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
               #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
               #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
               #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
               #         trigger a retry.
               #

--- a/google-cloud-vision-v1/lib/google/cloud/vision/v1/image_annotator/operations.rb
+++ b/google-cloud-vision-v1/lib/google/cloud/vision/v1/image_annotator/operations.rb
@@ -703,6 +703,7 @@ module Google
             #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #       trigger a retry.
             #   @return [::Hash]
@@ -786,6 +787,7 @@ module Google
               #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
               #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
               #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
               #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
               #         trigger a retry.
               #

--- a/google-cloud-vision-v1/lib/google/cloud/vision/v1/image_annotator/rest/client.rb
+++ b/google-cloud-vision-v1/lib/google/cloud/vision/v1/image_annotator/rest/client.rb
@@ -714,6 +714,7 @@ module Google
               #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
               #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
               #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
               #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
               #       trigger a retry.
               #   @return [::Hash]
@@ -786,6 +787,7 @@ module Google
                 #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
                 #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
                 #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+                #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
                 #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
                 #         trigger a retry.
                 #

--- a/google-cloud-vision-v1/lib/google/cloud/vision/v1/image_annotator/rest/operations.rb
+++ b/google-cloud-vision-v1/lib/google/cloud/vision/v1/image_annotator/rest/operations.rb
@@ -541,6 +541,7 @@ module Google
               #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
               #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
               #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
               #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
               #       trigger a retry.
               #   @return [::Hash]
@@ -613,6 +614,7 @@ module Google
                 #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
                 #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
                 #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+                #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
                 #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
                 #         trigger a retry.
                 #

--- a/google-cloud-vision-v1/lib/google/cloud/vision/v1/product_search/client.rb
+++ b/google-cloud-vision-v1/lib/google/cloud/vision/v1/product_search/client.rb
@@ -2323,6 +2323,7 @@ module Google
             #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #       trigger a retry.
             #   @return [::Hash]
@@ -2406,6 +2407,7 @@ module Google
               #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
               #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
               #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
               #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
               #         trigger a retry.
               #

--- a/google-cloud-vision-v1/lib/google/cloud/vision/v1/product_search/operations.rb
+++ b/google-cloud-vision-v1/lib/google/cloud/vision/v1/product_search/operations.rb
@@ -703,6 +703,7 @@ module Google
             #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
             #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
             #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+            #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
             #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
             #       trigger a retry.
             #   @return [::Hash]
@@ -786,6 +787,7 @@ module Google
               #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
               #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
               #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
               #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
               #         trigger a retry.
               #

--- a/google-cloud-vision-v1/lib/google/cloud/vision/v1/product_search/rest/client.rb
+++ b/google-cloud-vision-v1/lib/google/cloud/vision/v1/product_search/rest/client.rb
@@ -2157,6 +2157,7 @@ module Google
               #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
               #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
               #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
               #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
               #       trigger a retry.
               #   @return [::Hash]
@@ -2229,6 +2230,7 @@ module Google
                 #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
                 #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
                 #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+                #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
                 #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
                 #         trigger a retry.
                 #

--- a/google-cloud-vision-v1/lib/google/cloud/vision/v1/product_search/rest/operations.rb
+++ b/google-cloud-vision-v1/lib/google/cloud/vision/v1/product_search/rest/operations.rb
@@ -541,6 +541,7 @@ module Google
               #    *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
               #    *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
               #    *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+              #    *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
               #    *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
               #       trigger a retry.
               #   @return [::Hash]
@@ -613,6 +614,7 @@ module Google
                 #      *  `:initial_delay` (*type:* `Numeric`) - The initial delay in seconds.
                 #      *  `:max_delay` (*type:* `Numeric`) - The max delay in seconds.
                 #      *  `:multiplier` (*type:* `Numeric`) - The incremental backoff multiplier.
+                #      *  `:jitter` (*type:* `Numeric`) - The jitter in seconds. Default: 1.0.
                 #      *  `:retry_codes` (*type:* `Array<String>`) - The error codes that should
                 #         trigger a retry.
                 #

--- a/google-cloud-vision-v1/proto_docs/google/api/client.rb
+++ b/google-cloud-vision-v1/proto_docs/google/api/client.rb
@@ -31,6 +31,8 @@ module Google
     # @!attribute [rw] selective_gapic_generation
     #   @return [::Google::Api::SelectiveGapicGeneration]
     #     Configuration for which RPCs should be generated in the GAPIC client.
+    #
+    #     Note: This field should not be used in most cases.
     class CommonLanguageSettings
       include ::Google::Protobuf::MessageExts
       extend ::Google::Protobuf::MessageExts::ClassMethods
@@ -441,6 +443,8 @@ module Google
 
     # This message is used to configure the generation of a subset of the RPCs in
     # a service for client libraries.
+    #
+    # Note: This feature should not be used in most cases.
     # @!attribute [rw] methods
     #   @return [::Array<::String>]
     #     An allowlist of the fully qualified names of RPCs that should be included

--- a/google-cloud-vision-v1/test/google/cloud/vision/v1/image_annotator_operations_test.rb
+++ b/google-cloud-vision-v1/test/google/cloud/vision/v1/image_annotator_operations_test.rb
@@ -91,40 +91,40 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::OperationsTest < Minitest::Te
 
     Gapic::ServiceStub.stub :new, list_operations_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ImageAnnotator::Operations.new do |config|
+      c = ::Google::Cloud::Vision::V1::ImageAnnotator::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }) do |response, operation|
+      c.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success do |response, operation|
+      c.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.list_operations ::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success) do |response, operation|
+      c.list_operations ::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }, grpc_options) do |response, operation|
+      c.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.list_operations(::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success), grpc_options) do |response, operation|
+      c.list_operations(::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -154,40 +154,40 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::OperationsTest < Minitest::Te
 
     Gapic::ServiceStub.stub :new, get_operation_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ImageAnnotator::Operations.new do |config|
+      c = ::Google::Cloud::Vision::V1::ImageAnnotator::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_operation({ name: name }) do |response, operation|
+      c.get_operation({ name: name }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_operation name: name do |response, operation|
+      c.get_operation name: name do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_operation ::Google::Longrunning::GetOperationRequest.new(name: name) do |response, operation|
+      c.get_operation ::Google::Longrunning::GetOperationRequest.new(name: name) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_operation({ name: name }, grpc_options) do |response, operation|
+      c.get_operation({ name: name }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_operation(::Google::Longrunning::GetOperationRequest.new(name: name), grpc_options) do |response, operation|
+      c.get_operation(::Google::Longrunning::GetOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -217,36 +217,36 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::OperationsTest < Minitest::Te
 
     Gapic::ServiceStub.stub :new, delete_operation_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ImageAnnotator::Operations.new do |config|
+      c = ::Google::Cloud::Vision::V1::ImageAnnotator::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.delete_operation({ name: name }) do |response, operation|
+      c.delete_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.delete_operation name: name do |response, operation|
+      c.delete_operation name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.delete_operation ::Google::Longrunning::DeleteOperationRequest.new(name: name) do |response, operation|
+      c.delete_operation ::Google::Longrunning::DeleteOperationRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.delete_operation({ name: name }, grpc_options) do |response, operation|
+      c.delete_operation({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.delete_operation(::Google::Longrunning::DeleteOperationRequest.new(name: name), grpc_options) do |response, operation|
+      c.delete_operation(::Google::Longrunning::DeleteOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -275,36 +275,36 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::OperationsTest < Minitest::Te
 
     Gapic::ServiceStub.stub :new, cancel_operation_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ImageAnnotator::Operations.new do |config|
+      c = ::Google::Cloud::Vision::V1::ImageAnnotator::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.cancel_operation({ name: name }) do |response, operation|
+      c.cancel_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.cancel_operation name: name do |response, operation|
+      c.cancel_operation name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.cancel_operation ::Google::Longrunning::CancelOperationRequest.new(name: name) do |response, operation|
+      c.cancel_operation ::Google::Longrunning::CancelOperationRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.cancel_operation({ name: name }, grpc_options) do |response, operation|
+      c.cancel_operation({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.cancel_operation(::Google::Longrunning::CancelOperationRequest.new(name: name), grpc_options) do |response, operation|
+      c.cancel_operation(::Google::Longrunning::CancelOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -335,40 +335,40 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::OperationsTest < Minitest::Te
 
     Gapic::ServiceStub.stub :new, wait_operation_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ImageAnnotator::Operations.new do |config|
+      c = ::Google::Cloud::Vision::V1::ImageAnnotator::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.wait_operation({ name: name, timeout: timeout }) do |response, operation|
+      c.wait_operation({ name: name, timeout: timeout }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.wait_operation name: name, timeout: timeout do |response, operation|
+      c.wait_operation name: name, timeout: timeout do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.wait_operation ::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout) do |response, operation|
+      c.wait_operation ::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.wait_operation({ name: name, timeout: timeout }, grpc_options) do |response, operation|
+      c.wait_operation({ name: name, timeout: timeout }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.wait_operation(::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout), grpc_options) do |response, operation|
+      c.wait_operation(::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation

--- a/google-cloud-vision-v1/test/google/cloud/vision/v1/image_annotator_rest_test.rb
+++ b/google-cloud-vision-v1/test/google/cloud/vision/v1/image_annotator_rest_test.rb
@@ -99,32 +99,32 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::ClientTest < Minitest::
     ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::ServiceStub.stub :transcode_batch_annotate_images_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, batch_annotate_images_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.batch_annotate_images({ requests: requests, parent: parent, labels: labels }) do |_result, response|
+        c.batch_annotate_images({ requests: requests, parent: parent, labels: labels }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.batch_annotate_images requests: requests, parent: parent, labels: labels do |_result, response|
+        c.batch_annotate_images requests: requests, parent: parent, labels: labels do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.batch_annotate_images ::Google::Cloud::Vision::V1::BatchAnnotateImagesRequest.new(requests: requests, parent: parent, labels: labels) do |_result, response|
+        c.batch_annotate_images ::Google::Cloud::Vision::V1::BatchAnnotateImagesRequest.new(requests: requests, parent: parent, labels: labels) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.batch_annotate_images({ requests: requests, parent: parent, labels: labels }, call_options) do |_result, response|
+        c.batch_annotate_images({ requests: requests, parent: parent, labels: labels }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.batch_annotate_images(::Google::Cloud::Vision::V1::BatchAnnotateImagesRequest.new(requests: requests, parent: parent, labels: labels), call_options) do |_result, response|
+        c.batch_annotate_images(::Google::Cloud::Vision::V1::BatchAnnotateImagesRequest.new(requests: requests, parent: parent, labels: labels), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -155,32 +155,32 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::ClientTest < Minitest::
     ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::ServiceStub.stub :transcode_batch_annotate_files_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, batch_annotate_files_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.batch_annotate_files({ requests: requests, parent: parent, labels: labels }) do |_result, response|
+        c.batch_annotate_files({ requests: requests, parent: parent, labels: labels }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.batch_annotate_files requests: requests, parent: parent, labels: labels do |_result, response|
+        c.batch_annotate_files requests: requests, parent: parent, labels: labels do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.batch_annotate_files ::Google::Cloud::Vision::V1::BatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels) do |_result, response|
+        c.batch_annotate_files ::Google::Cloud::Vision::V1::BatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.batch_annotate_files({ requests: requests, parent: parent, labels: labels }, call_options) do |_result, response|
+        c.batch_annotate_files({ requests: requests, parent: parent, labels: labels }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.batch_annotate_files(::Google::Cloud::Vision::V1::BatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels), call_options) do |_result, response|
+        c.batch_annotate_files(::Google::Cloud::Vision::V1::BatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -212,32 +212,32 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::ClientTest < Minitest::
     ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::ServiceStub.stub :transcode_async_batch_annotate_images_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, async_batch_annotate_images_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.async_batch_annotate_images({ requests: requests, output_config: output_config, parent: parent, labels: labels }) do |_result, response|
+        c.async_batch_annotate_images({ requests: requests, output_config: output_config, parent: parent, labels: labels }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.async_batch_annotate_images requests: requests, output_config: output_config, parent: parent, labels: labels do |_result, response|
+        c.async_batch_annotate_images requests: requests, output_config: output_config, parent: parent, labels: labels do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.async_batch_annotate_images ::Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest.new(requests: requests, output_config: output_config, parent: parent, labels: labels) do |_result, response|
+        c.async_batch_annotate_images ::Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest.new(requests: requests, output_config: output_config, parent: parent, labels: labels) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.async_batch_annotate_images({ requests: requests, output_config: output_config, parent: parent, labels: labels }, call_options) do |_result, response|
+        c.async_batch_annotate_images({ requests: requests, output_config: output_config, parent: parent, labels: labels }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.async_batch_annotate_images(::Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest.new(requests: requests, output_config: output_config, parent: parent, labels: labels), call_options) do |_result, response|
+        c.async_batch_annotate_images(::Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest.new(requests: requests, output_config: output_config, parent: parent, labels: labels), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -268,32 +268,32 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::ClientTest < Minitest::
     ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::ServiceStub.stub :transcode_async_batch_annotate_files_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, async_batch_annotate_files_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ImageAnnotator::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.async_batch_annotate_files({ requests: requests, parent: parent, labels: labels }) do |_result, response|
+        c.async_batch_annotate_files({ requests: requests, parent: parent, labels: labels }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.async_batch_annotate_files requests: requests, parent: parent, labels: labels do |_result, response|
+        c.async_batch_annotate_files requests: requests, parent: parent, labels: labels do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.async_batch_annotate_files ::Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels) do |_result, response|
+        c.async_batch_annotate_files ::Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.async_batch_annotate_files({ requests: requests, parent: parent, labels: labels }, call_options) do |_result, response|
+        c.async_batch_annotate_files({ requests: requests, parent: parent, labels: labels }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.async_batch_annotate_files(::Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels), call_options) do |_result, response|
+        c.async_batch_annotate_files(::Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/google-cloud-vision-v1/test/google/cloud/vision/v1/image_annotator_test.rb
+++ b/google-cloud-vision-v1/test/google/cloud/vision/v1/image_annotator_test.rb
@@ -86,36 +86,36 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, batch_annotate_images_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ImageAnnotator::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ImageAnnotator::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.batch_annotate_images({ requests: requests, parent: parent, labels: labels }) do |response, operation|
+      c.batch_annotate_images({ requests: requests, parent: parent, labels: labels }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.batch_annotate_images requests: requests, parent: parent, labels: labels do |response, operation|
+      c.batch_annotate_images requests: requests, parent: parent, labels: labels do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.batch_annotate_images ::Google::Cloud::Vision::V1::BatchAnnotateImagesRequest.new(requests: requests, parent: parent, labels: labels) do |response, operation|
+      c.batch_annotate_images ::Google::Cloud::Vision::V1::BatchAnnotateImagesRequest.new(requests: requests, parent: parent, labels: labels) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.batch_annotate_images({ requests: requests, parent: parent, labels: labels }, grpc_options) do |response, operation|
+      c.batch_annotate_images({ requests: requests, parent: parent, labels: labels }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.batch_annotate_images(::Google::Cloud::Vision::V1::BatchAnnotateImagesRequest.new(requests: requests, parent: parent, labels: labels), grpc_options) do |response, operation|
+      c.batch_annotate_images(::Google::Cloud::Vision::V1::BatchAnnotateImagesRequest.new(requests: requests, parent: parent, labels: labels), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -148,36 +148,36 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, batch_annotate_files_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ImageAnnotator::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ImageAnnotator::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.batch_annotate_files({ requests: requests, parent: parent, labels: labels }) do |response, operation|
+      c.batch_annotate_files({ requests: requests, parent: parent, labels: labels }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.batch_annotate_files requests: requests, parent: parent, labels: labels do |response, operation|
+      c.batch_annotate_files requests: requests, parent: parent, labels: labels do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.batch_annotate_files ::Google::Cloud::Vision::V1::BatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels) do |response, operation|
+      c.batch_annotate_files ::Google::Cloud::Vision::V1::BatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.batch_annotate_files({ requests: requests, parent: parent, labels: labels }, grpc_options) do |response, operation|
+      c.batch_annotate_files({ requests: requests, parent: parent, labels: labels }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.batch_annotate_files(::Google::Cloud::Vision::V1::BatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels), grpc_options) do |response, operation|
+      c.batch_annotate_files(::Google::Cloud::Vision::V1::BatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -212,40 +212,40 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, async_batch_annotate_images_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ImageAnnotator::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ImageAnnotator::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.async_batch_annotate_images({ requests: requests, output_config: output_config, parent: parent, labels: labels }) do |response, operation|
+      c.async_batch_annotate_images({ requests: requests, output_config: output_config, parent: parent, labels: labels }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.async_batch_annotate_images requests: requests, output_config: output_config, parent: parent, labels: labels do |response, operation|
+      c.async_batch_annotate_images requests: requests, output_config: output_config, parent: parent, labels: labels do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.async_batch_annotate_images ::Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest.new(requests: requests, output_config: output_config, parent: parent, labels: labels) do |response, operation|
+      c.async_batch_annotate_images ::Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest.new(requests: requests, output_config: output_config, parent: parent, labels: labels) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.async_batch_annotate_images({ requests: requests, output_config: output_config, parent: parent, labels: labels }, grpc_options) do |response, operation|
+      c.async_batch_annotate_images({ requests: requests, output_config: output_config, parent: parent, labels: labels }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.async_batch_annotate_images(::Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest.new(requests: requests, output_config: output_config, parent: parent, labels: labels), grpc_options) do |response, operation|
+      c.async_batch_annotate_images(::Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest.new(requests: requests, output_config: output_config, parent: parent, labels: labels), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -279,40 +279,40 @@ class ::Google::Cloud::Vision::V1::ImageAnnotator::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, async_batch_annotate_files_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ImageAnnotator::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ImageAnnotator::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.async_batch_annotate_files({ requests: requests, parent: parent, labels: labels }) do |response, operation|
+      c.async_batch_annotate_files({ requests: requests, parent: parent, labels: labels }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.async_batch_annotate_files requests: requests, parent: parent, labels: labels do |response, operation|
+      c.async_batch_annotate_files requests: requests, parent: parent, labels: labels do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.async_batch_annotate_files ::Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels) do |response, operation|
+      c.async_batch_annotate_files ::Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.async_batch_annotate_files({ requests: requests, parent: parent, labels: labels }, grpc_options) do |response, operation|
+      c.async_batch_annotate_files({ requests: requests, parent: parent, labels: labels }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.async_batch_annotate_files(::Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels), grpc_options) do |response, operation|
+      c.async_batch_annotate_files(::Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest.new(requests: requests, parent: parent, labels: labels), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation

--- a/google-cloud-vision-v1/test/google/cloud/vision/v1/product_search_operations_test.rb
+++ b/google-cloud-vision-v1/test/google/cloud/vision/v1/product_search_operations_test.rb
@@ -91,40 +91,40 @@ class ::Google::Cloud::Vision::V1::ProductSearch::OperationsTest < Minitest::Tes
 
     Gapic::ServiceStub.stub :new, list_operations_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Operations.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }) do |response, operation|
+      c.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success do |response, operation|
+      c.list_operations name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.list_operations ::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success) do |response, operation|
+      c.list_operations ::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }, grpc_options) do |response, operation|
+      c.list_operations({ name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.list_operations(::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success), grpc_options) do |response, operation|
+      c.list_operations(::Google::Longrunning::ListOperationsRequest.new(name: name, filter: filter, page_size: page_size, page_token: page_token, return_partial_success: return_partial_success), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -154,40 +154,40 @@ class ::Google::Cloud::Vision::V1::ProductSearch::OperationsTest < Minitest::Tes
 
     Gapic::ServiceStub.stub :new, get_operation_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Operations.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_operation({ name: name }) do |response, operation|
+      c.get_operation({ name: name }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_operation name: name do |response, operation|
+      c.get_operation name: name do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_operation ::Google::Longrunning::GetOperationRequest.new(name: name) do |response, operation|
+      c.get_operation ::Google::Longrunning::GetOperationRequest.new(name: name) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_operation({ name: name }, grpc_options) do |response, operation|
+      c.get_operation({ name: name }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_operation(::Google::Longrunning::GetOperationRequest.new(name: name), grpc_options) do |response, operation|
+      c.get_operation(::Google::Longrunning::GetOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -217,36 +217,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::OperationsTest < Minitest::Tes
 
     Gapic::ServiceStub.stub :new, delete_operation_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Operations.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.delete_operation({ name: name }) do |response, operation|
+      c.delete_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.delete_operation name: name do |response, operation|
+      c.delete_operation name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.delete_operation ::Google::Longrunning::DeleteOperationRequest.new(name: name) do |response, operation|
+      c.delete_operation ::Google::Longrunning::DeleteOperationRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.delete_operation({ name: name }, grpc_options) do |response, operation|
+      c.delete_operation({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.delete_operation(::Google::Longrunning::DeleteOperationRequest.new(name: name), grpc_options) do |response, operation|
+      c.delete_operation(::Google::Longrunning::DeleteOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -275,36 +275,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::OperationsTest < Minitest::Tes
 
     Gapic::ServiceStub.stub :new, cancel_operation_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Operations.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.cancel_operation({ name: name }) do |response, operation|
+      c.cancel_operation({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.cancel_operation name: name do |response, operation|
+      c.cancel_operation name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.cancel_operation ::Google::Longrunning::CancelOperationRequest.new(name: name) do |response, operation|
+      c.cancel_operation ::Google::Longrunning::CancelOperationRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.cancel_operation({ name: name }, grpc_options) do |response, operation|
+      c.cancel_operation({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.cancel_operation(::Google::Longrunning::CancelOperationRequest.new(name: name), grpc_options) do |response, operation|
+      c.cancel_operation(::Google::Longrunning::CancelOperationRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -335,40 +335,40 @@ class ::Google::Cloud::Vision::V1::ProductSearch::OperationsTest < Minitest::Tes
 
     Gapic::ServiceStub.stub :new, wait_operation_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Operations.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Operations.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.wait_operation({ name: name, timeout: timeout }) do |response, operation|
+      c.wait_operation({ name: name, timeout: timeout }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.wait_operation name: name, timeout: timeout do |response, operation|
+      c.wait_operation name: name, timeout: timeout do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.wait_operation ::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout) do |response, operation|
+      c.wait_operation ::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.wait_operation({ name: name, timeout: timeout }, grpc_options) do |response, operation|
+      c.wait_operation({ name: name, timeout: timeout }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.wait_operation(::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout), grpc_options) do |response, operation|
+      c.wait_operation(::Google::Longrunning::WaitOperationRequest.new(name: name, timeout: timeout), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation

--- a/google-cloud-vision-v1/test/google/cloud/vision/v1/product_search_rest_test.rb
+++ b/google-cloud-vision-v1/test/google/cloud/vision/v1/product_search_rest_test.rb
@@ -99,32 +99,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_create_product_set_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, create_product_set_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.create_product_set({ parent: parent, product_set: product_set, product_set_id: product_set_id }) do |_result, response|
+        c.create_product_set({ parent: parent, product_set: product_set, product_set_id: product_set_id }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.create_product_set parent: parent, product_set: product_set, product_set_id: product_set_id do |_result, response|
+        c.create_product_set parent: parent, product_set: product_set, product_set_id: product_set_id do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.create_product_set ::Google::Cloud::Vision::V1::CreateProductSetRequest.new(parent: parent, product_set: product_set, product_set_id: product_set_id) do |_result, response|
+        c.create_product_set ::Google::Cloud::Vision::V1::CreateProductSetRequest.new(parent: parent, product_set: product_set, product_set_id: product_set_id) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.create_product_set({ parent: parent, product_set: product_set, product_set_id: product_set_id }, call_options) do |_result, response|
+        c.create_product_set({ parent: parent, product_set: product_set, product_set_id: product_set_id }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.create_product_set(::Google::Cloud::Vision::V1::CreateProductSetRequest.new(parent: parent, product_set: product_set, product_set_id: product_set_id), call_options) do |_result, response|
+        c.create_product_set(::Google::Cloud::Vision::V1::CreateProductSetRequest.new(parent: parent, product_set: product_set, product_set_id: product_set_id), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -155,32 +155,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_list_product_sets_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, list_product_sets_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.list_product_sets({ parent: parent, page_size: page_size, page_token: page_token }) do |_result, response|
+        c.list_product_sets({ parent: parent, page_size: page_size, page_token: page_token }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.list_product_sets parent: parent, page_size: page_size, page_token: page_token do |_result, response|
+        c.list_product_sets parent: parent, page_size: page_size, page_token: page_token do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.list_product_sets ::Google::Cloud::Vision::V1::ListProductSetsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |_result, response|
+        c.list_product_sets ::Google::Cloud::Vision::V1::ListProductSetsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.list_product_sets({ parent: parent, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
+        c.list_product_sets({ parent: parent, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.list_product_sets(::Google::Cloud::Vision::V1::ListProductSetsRequest.new(parent: parent, page_size: page_size, page_token: page_token), call_options) do |_result, response|
+        c.list_product_sets(::Google::Cloud::Vision::V1::ListProductSetsRequest.new(parent: parent, page_size: page_size, page_token: page_token), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -209,32 +209,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_get_product_set_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, get_product_set_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.get_product_set({ name: name }) do |_result, response|
+        c.get_product_set({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.get_product_set name: name do |_result, response|
+        c.get_product_set name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.get_product_set ::Google::Cloud::Vision::V1::GetProductSetRequest.new(name: name) do |_result, response|
+        c.get_product_set ::Google::Cloud::Vision::V1::GetProductSetRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.get_product_set({ name: name }, call_options) do |_result, response|
+        c.get_product_set({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.get_product_set(::Google::Cloud::Vision::V1::GetProductSetRequest.new(name: name), call_options) do |_result, response|
+        c.get_product_set(::Google::Cloud::Vision::V1::GetProductSetRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -264,32 +264,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_update_product_set_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, update_product_set_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.update_product_set({ product_set: product_set, update_mask: update_mask }) do |_result, response|
+        c.update_product_set({ product_set: product_set, update_mask: update_mask }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.update_product_set product_set: product_set, update_mask: update_mask do |_result, response|
+        c.update_product_set product_set: product_set, update_mask: update_mask do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.update_product_set ::Google::Cloud::Vision::V1::UpdateProductSetRequest.new(product_set: product_set, update_mask: update_mask) do |_result, response|
+        c.update_product_set ::Google::Cloud::Vision::V1::UpdateProductSetRequest.new(product_set: product_set, update_mask: update_mask) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.update_product_set({ product_set: product_set, update_mask: update_mask }, call_options) do |_result, response|
+        c.update_product_set({ product_set: product_set, update_mask: update_mask }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.update_product_set(::Google::Cloud::Vision::V1::UpdateProductSetRequest.new(product_set: product_set, update_mask: update_mask), call_options) do |_result, response|
+        c.update_product_set(::Google::Cloud::Vision::V1::UpdateProductSetRequest.new(product_set: product_set, update_mask: update_mask), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -318,32 +318,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_delete_product_set_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, delete_product_set_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.delete_product_set({ name: name }) do |_result, response|
+        c.delete_product_set({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.delete_product_set name: name do |_result, response|
+        c.delete_product_set name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.delete_product_set ::Google::Cloud::Vision::V1::DeleteProductSetRequest.new(name: name) do |_result, response|
+        c.delete_product_set ::Google::Cloud::Vision::V1::DeleteProductSetRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.delete_product_set({ name: name }, call_options) do |_result, response|
+        c.delete_product_set({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.delete_product_set(::Google::Cloud::Vision::V1::DeleteProductSetRequest.new(name: name), call_options) do |_result, response|
+        c.delete_product_set(::Google::Cloud::Vision::V1::DeleteProductSetRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -374,32 +374,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_create_product_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, create_product_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.create_product({ parent: parent, product: product, product_id: product_id }) do |_result, response|
+        c.create_product({ parent: parent, product: product, product_id: product_id }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.create_product parent: parent, product: product, product_id: product_id do |_result, response|
+        c.create_product parent: parent, product: product, product_id: product_id do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.create_product ::Google::Cloud::Vision::V1::CreateProductRequest.new(parent: parent, product: product, product_id: product_id) do |_result, response|
+        c.create_product ::Google::Cloud::Vision::V1::CreateProductRequest.new(parent: parent, product: product, product_id: product_id) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.create_product({ parent: parent, product: product, product_id: product_id }, call_options) do |_result, response|
+        c.create_product({ parent: parent, product: product, product_id: product_id }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.create_product(::Google::Cloud::Vision::V1::CreateProductRequest.new(parent: parent, product: product, product_id: product_id), call_options) do |_result, response|
+        c.create_product(::Google::Cloud::Vision::V1::CreateProductRequest.new(parent: parent, product: product, product_id: product_id), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -430,32 +430,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_list_products_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, list_products_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.list_products({ parent: parent, page_size: page_size, page_token: page_token }) do |_result, response|
+        c.list_products({ parent: parent, page_size: page_size, page_token: page_token }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.list_products parent: parent, page_size: page_size, page_token: page_token do |_result, response|
+        c.list_products parent: parent, page_size: page_size, page_token: page_token do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.list_products ::Google::Cloud::Vision::V1::ListProductsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |_result, response|
+        c.list_products ::Google::Cloud::Vision::V1::ListProductsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.list_products({ parent: parent, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
+        c.list_products({ parent: parent, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.list_products(::Google::Cloud::Vision::V1::ListProductsRequest.new(parent: parent, page_size: page_size, page_token: page_token), call_options) do |_result, response|
+        c.list_products(::Google::Cloud::Vision::V1::ListProductsRequest.new(parent: parent, page_size: page_size, page_token: page_token), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -484,32 +484,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_get_product_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, get_product_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.get_product({ name: name }) do |_result, response|
+        c.get_product({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.get_product name: name do |_result, response|
+        c.get_product name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.get_product ::Google::Cloud::Vision::V1::GetProductRequest.new(name: name) do |_result, response|
+        c.get_product ::Google::Cloud::Vision::V1::GetProductRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.get_product({ name: name }, call_options) do |_result, response|
+        c.get_product({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.get_product(::Google::Cloud::Vision::V1::GetProductRequest.new(name: name), call_options) do |_result, response|
+        c.get_product(::Google::Cloud::Vision::V1::GetProductRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -539,32 +539,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_update_product_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, update_product_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.update_product({ product: product, update_mask: update_mask }) do |_result, response|
+        c.update_product({ product: product, update_mask: update_mask }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.update_product product: product, update_mask: update_mask do |_result, response|
+        c.update_product product: product, update_mask: update_mask do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.update_product ::Google::Cloud::Vision::V1::UpdateProductRequest.new(product: product, update_mask: update_mask) do |_result, response|
+        c.update_product ::Google::Cloud::Vision::V1::UpdateProductRequest.new(product: product, update_mask: update_mask) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.update_product({ product: product, update_mask: update_mask }, call_options) do |_result, response|
+        c.update_product({ product: product, update_mask: update_mask }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.update_product(::Google::Cloud::Vision::V1::UpdateProductRequest.new(product: product, update_mask: update_mask), call_options) do |_result, response|
+        c.update_product(::Google::Cloud::Vision::V1::UpdateProductRequest.new(product: product, update_mask: update_mask), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -593,32 +593,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_delete_product_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, delete_product_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.delete_product({ name: name }) do |_result, response|
+        c.delete_product({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.delete_product name: name do |_result, response|
+        c.delete_product name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.delete_product ::Google::Cloud::Vision::V1::DeleteProductRequest.new(name: name) do |_result, response|
+        c.delete_product ::Google::Cloud::Vision::V1::DeleteProductRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.delete_product({ name: name }, call_options) do |_result, response|
+        c.delete_product({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.delete_product(::Google::Cloud::Vision::V1::DeleteProductRequest.new(name: name), call_options) do |_result, response|
+        c.delete_product(::Google::Cloud::Vision::V1::DeleteProductRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -649,32 +649,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_create_reference_image_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, create_reference_image_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.create_reference_image({ parent: parent, reference_image: reference_image, reference_image_id: reference_image_id }) do |_result, response|
+        c.create_reference_image({ parent: parent, reference_image: reference_image, reference_image_id: reference_image_id }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.create_reference_image parent: parent, reference_image: reference_image, reference_image_id: reference_image_id do |_result, response|
+        c.create_reference_image parent: parent, reference_image: reference_image, reference_image_id: reference_image_id do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.create_reference_image ::Google::Cloud::Vision::V1::CreateReferenceImageRequest.new(parent: parent, reference_image: reference_image, reference_image_id: reference_image_id) do |_result, response|
+        c.create_reference_image ::Google::Cloud::Vision::V1::CreateReferenceImageRequest.new(parent: parent, reference_image: reference_image, reference_image_id: reference_image_id) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.create_reference_image({ parent: parent, reference_image: reference_image, reference_image_id: reference_image_id }, call_options) do |_result, response|
+        c.create_reference_image({ parent: parent, reference_image: reference_image, reference_image_id: reference_image_id }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.create_reference_image(::Google::Cloud::Vision::V1::CreateReferenceImageRequest.new(parent: parent, reference_image: reference_image, reference_image_id: reference_image_id), call_options) do |_result, response|
+        c.create_reference_image(::Google::Cloud::Vision::V1::CreateReferenceImageRequest.new(parent: parent, reference_image: reference_image, reference_image_id: reference_image_id), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -703,32 +703,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_delete_reference_image_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, delete_reference_image_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.delete_reference_image({ name: name }) do |_result, response|
+        c.delete_reference_image({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.delete_reference_image name: name do |_result, response|
+        c.delete_reference_image name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.delete_reference_image ::Google::Cloud::Vision::V1::DeleteReferenceImageRequest.new(name: name) do |_result, response|
+        c.delete_reference_image ::Google::Cloud::Vision::V1::DeleteReferenceImageRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.delete_reference_image({ name: name }, call_options) do |_result, response|
+        c.delete_reference_image({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.delete_reference_image(::Google::Cloud::Vision::V1::DeleteReferenceImageRequest.new(name: name), call_options) do |_result, response|
+        c.delete_reference_image(::Google::Cloud::Vision::V1::DeleteReferenceImageRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -759,32 +759,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_list_reference_images_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, list_reference_images_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.list_reference_images({ parent: parent, page_size: page_size, page_token: page_token }) do |_result, response|
+        c.list_reference_images({ parent: parent, page_size: page_size, page_token: page_token }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.list_reference_images parent: parent, page_size: page_size, page_token: page_token do |_result, response|
+        c.list_reference_images parent: parent, page_size: page_size, page_token: page_token do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.list_reference_images ::Google::Cloud::Vision::V1::ListReferenceImagesRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |_result, response|
+        c.list_reference_images ::Google::Cloud::Vision::V1::ListReferenceImagesRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.list_reference_images({ parent: parent, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
+        c.list_reference_images({ parent: parent, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.list_reference_images(::Google::Cloud::Vision::V1::ListReferenceImagesRequest.new(parent: parent, page_size: page_size, page_token: page_token), call_options) do |_result, response|
+        c.list_reference_images(::Google::Cloud::Vision::V1::ListReferenceImagesRequest.new(parent: parent, page_size: page_size, page_token: page_token), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -813,32 +813,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_get_reference_image_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, get_reference_image_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.get_reference_image({ name: name }) do |_result, response|
+        c.get_reference_image({ name: name }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.get_reference_image name: name do |_result, response|
+        c.get_reference_image name: name do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.get_reference_image ::Google::Cloud::Vision::V1::GetReferenceImageRequest.new(name: name) do |_result, response|
+        c.get_reference_image ::Google::Cloud::Vision::V1::GetReferenceImageRequest.new(name: name) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.get_reference_image({ name: name }, call_options) do |_result, response|
+        c.get_reference_image({ name: name }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.get_reference_image(::Google::Cloud::Vision::V1::GetReferenceImageRequest.new(name: name), call_options) do |_result, response|
+        c.get_reference_image(::Google::Cloud::Vision::V1::GetReferenceImageRequest.new(name: name), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -868,32 +868,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_add_product_to_product_set_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, add_product_to_product_set_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.add_product_to_product_set({ name: name, product: product }) do |_result, response|
+        c.add_product_to_product_set({ name: name, product: product }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.add_product_to_product_set name: name, product: product do |_result, response|
+        c.add_product_to_product_set name: name, product: product do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.add_product_to_product_set ::Google::Cloud::Vision::V1::AddProductToProductSetRequest.new(name: name, product: product) do |_result, response|
+        c.add_product_to_product_set ::Google::Cloud::Vision::V1::AddProductToProductSetRequest.new(name: name, product: product) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.add_product_to_product_set({ name: name, product: product }, call_options) do |_result, response|
+        c.add_product_to_product_set({ name: name, product: product }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.add_product_to_product_set(::Google::Cloud::Vision::V1::AddProductToProductSetRequest.new(name: name, product: product), call_options) do |_result, response|
+        c.add_product_to_product_set(::Google::Cloud::Vision::V1::AddProductToProductSetRequest.new(name: name, product: product), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -923,32 +923,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_remove_product_from_product_set_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, remove_product_from_product_set_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.remove_product_from_product_set({ name: name, product: product }) do |_result, response|
+        c.remove_product_from_product_set({ name: name, product: product }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.remove_product_from_product_set name: name, product: product do |_result, response|
+        c.remove_product_from_product_set name: name, product: product do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.remove_product_from_product_set ::Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest.new(name: name, product: product) do |_result, response|
+        c.remove_product_from_product_set ::Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest.new(name: name, product: product) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.remove_product_from_product_set({ name: name, product: product }, call_options) do |_result, response|
+        c.remove_product_from_product_set({ name: name, product: product }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.remove_product_from_product_set(::Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest.new(name: name, product: product), call_options) do |_result, response|
+        c.remove_product_from_product_set(::Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest.new(name: name, product: product), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -979,32 +979,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_list_products_in_product_set_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, list_products_in_product_set_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.list_products_in_product_set({ name: name, page_size: page_size, page_token: page_token }) do |_result, response|
+        c.list_products_in_product_set({ name: name, page_size: page_size, page_token: page_token }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.list_products_in_product_set name: name, page_size: page_size, page_token: page_token do |_result, response|
+        c.list_products_in_product_set name: name, page_size: page_size, page_token: page_token do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.list_products_in_product_set ::Google::Cloud::Vision::V1::ListProductsInProductSetRequest.new(name: name, page_size: page_size, page_token: page_token) do |_result, response|
+        c.list_products_in_product_set ::Google::Cloud::Vision::V1::ListProductsInProductSetRequest.new(name: name, page_size: page_size, page_token: page_token) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.list_products_in_product_set({ name: name, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
+        c.list_products_in_product_set({ name: name, page_size: page_size, page_token: page_token }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.list_products_in_product_set(::Google::Cloud::Vision::V1::ListProductsInProductSetRequest.new(name: name, page_size: page_size, page_token: page_token), call_options) do |_result, response|
+        c.list_products_in_product_set(::Google::Cloud::Vision::V1::ListProductsInProductSetRequest.new(name: name, page_size: page_size, page_token: page_token), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -1034,32 +1034,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_import_product_sets_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, import_product_sets_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.import_product_sets({ parent: parent, input_config: input_config }) do |_result, response|
+        c.import_product_sets({ parent: parent, input_config: input_config }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.import_product_sets parent: parent, input_config: input_config do |_result, response|
+        c.import_product_sets parent: parent, input_config: input_config do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.import_product_sets ::Google::Cloud::Vision::V1::ImportProductSetsRequest.new(parent: parent, input_config: input_config) do |_result, response|
+        c.import_product_sets ::Google::Cloud::Vision::V1::ImportProductSetsRequest.new(parent: parent, input_config: input_config) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.import_product_sets({ parent: parent, input_config: input_config }, call_options) do |_result, response|
+        c.import_product_sets({ parent: parent, input_config: input_config }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.import_product_sets(::Google::Cloud::Vision::V1::ImportProductSetsRequest.new(parent: parent, input_config: input_config), call_options) do |_result, response|
+        c.import_product_sets(::Google::Cloud::Vision::V1::ImportProductSetsRequest.new(parent: parent, input_config: input_config), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
@@ -1090,32 +1090,32 @@ class ::Google::Cloud::Vision::V1::ProductSearch::Rest::ClientTest < Minitest::T
     ::Google::Cloud::Vision::V1::ProductSearch::Rest::ServiceStub.stub :transcode_purge_products_request, ["", "", {}] do
       Gapic::Rest::ClientStub.stub :new, purge_products_client_stub do
         # Create client
-        client = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
+        c = ::Google::Cloud::Vision::V1::ProductSearch::Rest::Client.new do |config|
           config.credentials = :dummy_value
         end
 
         # Use hash object
-        client.purge_products({ product_set_purge_config: product_set_purge_config, parent: parent, force: force }) do |_result, response|
+        c.purge_products({ product_set_purge_config: product_set_purge_config, parent: parent, force: force }) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use named arguments
-        client.purge_products product_set_purge_config: product_set_purge_config, parent: parent, force: force do |_result, response|
+        c.purge_products product_set_purge_config: product_set_purge_config, parent: parent, force: force do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object
-        client.purge_products ::Google::Cloud::Vision::V1::PurgeProductsRequest.new(product_set_purge_config: product_set_purge_config, parent: parent, force: force) do |_result, response|
+        c.purge_products ::Google::Cloud::Vision::V1::PurgeProductsRequest.new(product_set_purge_config: product_set_purge_config, parent: parent, force: force) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use hash object with options
-        client.purge_products({ product_set_purge_config: product_set_purge_config, parent: parent, force: force }, call_options) do |_result, response|
+        c.purge_products({ product_set_purge_config: product_set_purge_config, parent: parent, force: force }, call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 
         # Use protobuf object with options
-        client.purge_products(::Google::Cloud::Vision::V1::PurgeProductsRequest.new(product_set_purge_config: product_set_purge_config, parent: parent, force: force), call_options) do |_result, response|
+        c.purge_products(::Google::Cloud::Vision::V1::PurgeProductsRequest.new(product_set_purge_config: product_set_purge_config, parent: parent, force: force), call_options) do |_result, response|
           assert_equal http_response, response.underlying_op
         end
 

--- a/google-cloud-vision-v1/test/google/cloud/vision/v1/product_search_test.rb
+++ b/google-cloud-vision-v1/test/google/cloud/vision/v1/product_search_test.rb
@@ -86,36 +86,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, create_product_set_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.create_product_set({ parent: parent, product_set: product_set, product_set_id: product_set_id }) do |response, operation|
+      c.create_product_set({ parent: parent, product_set: product_set, product_set_id: product_set_id }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.create_product_set parent: parent, product_set: product_set, product_set_id: product_set_id do |response, operation|
+      c.create_product_set parent: parent, product_set: product_set, product_set_id: product_set_id do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.create_product_set ::Google::Cloud::Vision::V1::CreateProductSetRequest.new(parent: parent, product_set: product_set, product_set_id: product_set_id) do |response, operation|
+      c.create_product_set ::Google::Cloud::Vision::V1::CreateProductSetRequest.new(parent: parent, product_set: product_set, product_set_id: product_set_id) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.create_product_set({ parent: parent, product_set: product_set, product_set_id: product_set_id }, grpc_options) do |response, operation|
+      c.create_product_set({ parent: parent, product_set: product_set, product_set_id: product_set_id }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.create_product_set(::Google::Cloud::Vision::V1::CreateProductSetRequest.new(parent: parent, product_set: product_set, product_set_id: product_set_id), grpc_options) do |response, operation|
+      c.create_product_set(::Google::Cloud::Vision::V1::CreateProductSetRequest.new(parent: parent, product_set: product_set, product_set_id: product_set_id), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -148,40 +148,40 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, list_product_sets_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.list_product_sets({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
+      c.list_product_sets({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.list_product_sets parent: parent, page_size: page_size, page_token: page_token do |response, operation|
+      c.list_product_sets parent: parent, page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.list_product_sets ::Google::Cloud::Vision::V1::ListProductSetsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
+      c.list_product_sets ::Google::Cloud::Vision::V1::ListProductSetsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.list_product_sets({ parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      c.list_product_sets({ parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.list_product_sets(::Google::Cloud::Vision::V1::ListProductSetsRequest.new(parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      c.list_product_sets(::Google::Cloud::Vision::V1::ListProductSetsRequest.new(parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -211,36 +211,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_product_set_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_product_set({ name: name }) do |response, operation|
+      c.get_product_set({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_product_set name: name do |response, operation|
+      c.get_product_set name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_product_set ::Google::Cloud::Vision::V1::GetProductSetRequest.new(name: name) do |response, operation|
+      c.get_product_set ::Google::Cloud::Vision::V1::GetProductSetRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_product_set({ name: name }, grpc_options) do |response, operation|
+      c.get_product_set({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_product_set(::Google::Cloud::Vision::V1::GetProductSetRequest.new(name: name), grpc_options) do |response, operation|
+      c.get_product_set(::Google::Cloud::Vision::V1::GetProductSetRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -271,36 +271,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, update_product_set_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.update_product_set({ product_set: product_set, update_mask: update_mask }) do |response, operation|
+      c.update_product_set({ product_set: product_set, update_mask: update_mask }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.update_product_set product_set: product_set, update_mask: update_mask do |response, operation|
+      c.update_product_set product_set: product_set, update_mask: update_mask do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.update_product_set ::Google::Cloud::Vision::V1::UpdateProductSetRequest.new(product_set: product_set, update_mask: update_mask) do |response, operation|
+      c.update_product_set ::Google::Cloud::Vision::V1::UpdateProductSetRequest.new(product_set: product_set, update_mask: update_mask) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.update_product_set({ product_set: product_set, update_mask: update_mask }, grpc_options) do |response, operation|
+      c.update_product_set({ product_set: product_set, update_mask: update_mask }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.update_product_set(::Google::Cloud::Vision::V1::UpdateProductSetRequest.new(product_set: product_set, update_mask: update_mask), grpc_options) do |response, operation|
+      c.update_product_set(::Google::Cloud::Vision::V1::UpdateProductSetRequest.new(product_set: product_set, update_mask: update_mask), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -329,36 +329,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, delete_product_set_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.delete_product_set({ name: name }) do |response, operation|
+      c.delete_product_set({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.delete_product_set name: name do |response, operation|
+      c.delete_product_set name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.delete_product_set ::Google::Cloud::Vision::V1::DeleteProductSetRequest.new(name: name) do |response, operation|
+      c.delete_product_set ::Google::Cloud::Vision::V1::DeleteProductSetRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.delete_product_set({ name: name }, grpc_options) do |response, operation|
+      c.delete_product_set({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.delete_product_set(::Google::Cloud::Vision::V1::DeleteProductSetRequest.new(name: name), grpc_options) do |response, operation|
+      c.delete_product_set(::Google::Cloud::Vision::V1::DeleteProductSetRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -391,36 +391,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, create_product_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.create_product({ parent: parent, product: product, product_id: product_id }) do |response, operation|
+      c.create_product({ parent: parent, product: product, product_id: product_id }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.create_product parent: parent, product: product, product_id: product_id do |response, operation|
+      c.create_product parent: parent, product: product, product_id: product_id do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.create_product ::Google::Cloud::Vision::V1::CreateProductRequest.new(parent: parent, product: product, product_id: product_id) do |response, operation|
+      c.create_product ::Google::Cloud::Vision::V1::CreateProductRequest.new(parent: parent, product: product, product_id: product_id) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.create_product({ parent: parent, product: product, product_id: product_id }, grpc_options) do |response, operation|
+      c.create_product({ parent: parent, product: product, product_id: product_id }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.create_product(::Google::Cloud::Vision::V1::CreateProductRequest.new(parent: parent, product: product, product_id: product_id), grpc_options) do |response, operation|
+      c.create_product(::Google::Cloud::Vision::V1::CreateProductRequest.new(parent: parent, product: product, product_id: product_id), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -453,40 +453,40 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, list_products_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.list_products({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
+      c.list_products({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.list_products parent: parent, page_size: page_size, page_token: page_token do |response, operation|
+      c.list_products parent: parent, page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.list_products ::Google::Cloud::Vision::V1::ListProductsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
+      c.list_products ::Google::Cloud::Vision::V1::ListProductsRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.list_products({ parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      c.list_products({ parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.list_products(::Google::Cloud::Vision::V1::ListProductsRequest.new(parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      c.list_products(::Google::Cloud::Vision::V1::ListProductsRequest.new(parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -516,36 +516,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_product_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_product({ name: name }) do |response, operation|
+      c.get_product({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_product name: name do |response, operation|
+      c.get_product name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_product ::Google::Cloud::Vision::V1::GetProductRequest.new(name: name) do |response, operation|
+      c.get_product ::Google::Cloud::Vision::V1::GetProductRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_product({ name: name }, grpc_options) do |response, operation|
+      c.get_product({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_product(::Google::Cloud::Vision::V1::GetProductRequest.new(name: name), grpc_options) do |response, operation|
+      c.get_product(::Google::Cloud::Vision::V1::GetProductRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -576,36 +576,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, update_product_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.update_product({ product: product, update_mask: update_mask }) do |response, operation|
+      c.update_product({ product: product, update_mask: update_mask }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.update_product product: product, update_mask: update_mask do |response, operation|
+      c.update_product product: product, update_mask: update_mask do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.update_product ::Google::Cloud::Vision::V1::UpdateProductRequest.new(product: product, update_mask: update_mask) do |response, operation|
+      c.update_product ::Google::Cloud::Vision::V1::UpdateProductRequest.new(product: product, update_mask: update_mask) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.update_product({ product: product, update_mask: update_mask }, grpc_options) do |response, operation|
+      c.update_product({ product: product, update_mask: update_mask }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.update_product(::Google::Cloud::Vision::V1::UpdateProductRequest.new(product: product, update_mask: update_mask), grpc_options) do |response, operation|
+      c.update_product(::Google::Cloud::Vision::V1::UpdateProductRequest.new(product: product, update_mask: update_mask), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -634,36 +634,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, delete_product_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.delete_product({ name: name }) do |response, operation|
+      c.delete_product({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.delete_product name: name do |response, operation|
+      c.delete_product name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.delete_product ::Google::Cloud::Vision::V1::DeleteProductRequest.new(name: name) do |response, operation|
+      c.delete_product ::Google::Cloud::Vision::V1::DeleteProductRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.delete_product({ name: name }, grpc_options) do |response, operation|
+      c.delete_product({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.delete_product(::Google::Cloud::Vision::V1::DeleteProductRequest.new(name: name), grpc_options) do |response, operation|
+      c.delete_product(::Google::Cloud::Vision::V1::DeleteProductRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -696,36 +696,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, create_reference_image_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.create_reference_image({ parent: parent, reference_image: reference_image, reference_image_id: reference_image_id }) do |response, operation|
+      c.create_reference_image({ parent: parent, reference_image: reference_image, reference_image_id: reference_image_id }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.create_reference_image parent: parent, reference_image: reference_image, reference_image_id: reference_image_id do |response, operation|
+      c.create_reference_image parent: parent, reference_image: reference_image, reference_image_id: reference_image_id do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.create_reference_image ::Google::Cloud::Vision::V1::CreateReferenceImageRequest.new(parent: parent, reference_image: reference_image, reference_image_id: reference_image_id) do |response, operation|
+      c.create_reference_image ::Google::Cloud::Vision::V1::CreateReferenceImageRequest.new(parent: parent, reference_image: reference_image, reference_image_id: reference_image_id) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.create_reference_image({ parent: parent, reference_image: reference_image, reference_image_id: reference_image_id }, grpc_options) do |response, operation|
+      c.create_reference_image({ parent: parent, reference_image: reference_image, reference_image_id: reference_image_id }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.create_reference_image(::Google::Cloud::Vision::V1::CreateReferenceImageRequest.new(parent: parent, reference_image: reference_image, reference_image_id: reference_image_id), grpc_options) do |response, operation|
+      c.create_reference_image(::Google::Cloud::Vision::V1::CreateReferenceImageRequest.new(parent: parent, reference_image: reference_image, reference_image_id: reference_image_id), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -754,36 +754,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, delete_reference_image_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.delete_reference_image({ name: name }) do |response, operation|
+      c.delete_reference_image({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.delete_reference_image name: name do |response, operation|
+      c.delete_reference_image name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.delete_reference_image ::Google::Cloud::Vision::V1::DeleteReferenceImageRequest.new(name: name) do |response, operation|
+      c.delete_reference_image ::Google::Cloud::Vision::V1::DeleteReferenceImageRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.delete_reference_image({ name: name }, grpc_options) do |response, operation|
+      c.delete_reference_image({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.delete_reference_image(::Google::Cloud::Vision::V1::DeleteReferenceImageRequest.new(name: name), grpc_options) do |response, operation|
+      c.delete_reference_image(::Google::Cloud::Vision::V1::DeleteReferenceImageRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -816,40 +816,40 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, list_reference_images_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.list_reference_images({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
+      c.list_reference_images({ parent: parent, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.list_reference_images parent: parent, page_size: page_size, page_token: page_token do |response, operation|
+      c.list_reference_images parent: parent, page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.list_reference_images ::Google::Cloud::Vision::V1::ListReferenceImagesRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
+      c.list_reference_images ::Google::Cloud::Vision::V1::ListReferenceImagesRequest.new(parent: parent, page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.list_reference_images({ parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      c.list_reference_images({ parent: parent, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.list_reference_images(::Google::Cloud::Vision::V1::ListReferenceImagesRequest.new(parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      c.list_reference_images(::Google::Cloud::Vision::V1::ListReferenceImagesRequest.new(parent: parent, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -879,36 +879,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, get_reference_image_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.get_reference_image({ name: name }) do |response, operation|
+      c.get_reference_image({ name: name }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.get_reference_image name: name do |response, operation|
+      c.get_reference_image name: name do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.get_reference_image ::Google::Cloud::Vision::V1::GetReferenceImageRequest.new(name: name) do |response, operation|
+      c.get_reference_image ::Google::Cloud::Vision::V1::GetReferenceImageRequest.new(name: name) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.get_reference_image({ name: name }, grpc_options) do |response, operation|
+      c.get_reference_image({ name: name }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.get_reference_image(::Google::Cloud::Vision::V1::GetReferenceImageRequest.new(name: name), grpc_options) do |response, operation|
+      c.get_reference_image(::Google::Cloud::Vision::V1::GetReferenceImageRequest.new(name: name), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -939,36 +939,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, add_product_to_product_set_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.add_product_to_product_set({ name: name, product: product }) do |response, operation|
+      c.add_product_to_product_set({ name: name, product: product }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.add_product_to_product_set name: name, product: product do |response, operation|
+      c.add_product_to_product_set name: name, product: product do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.add_product_to_product_set ::Google::Cloud::Vision::V1::AddProductToProductSetRequest.new(name: name, product: product) do |response, operation|
+      c.add_product_to_product_set ::Google::Cloud::Vision::V1::AddProductToProductSetRequest.new(name: name, product: product) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.add_product_to_product_set({ name: name, product: product }, grpc_options) do |response, operation|
+      c.add_product_to_product_set({ name: name, product: product }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.add_product_to_product_set(::Google::Cloud::Vision::V1::AddProductToProductSetRequest.new(name: name, product: product), grpc_options) do |response, operation|
+      c.add_product_to_product_set(::Google::Cloud::Vision::V1::AddProductToProductSetRequest.new(name: name, product: product), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -999,36 +999,36 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, remove_product_from_product_set_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.remove_product_from_product_set({ name: name, product: product }) do |response, operation|
+      c.remove_product_from_product_set({ name: name, product: product }) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.remove_product_from_product_set name: name, product: product do |response, operation|
+      c.remove_product_from_product_set name: name, product: product do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.remove_product_from_product_set ::Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest.new(name: name, product: product) do |response, operation|
+      c.remove_product_from_product_set ::Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest.new(name: name, product: product) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.remove_product_from_product_set({ name: name, product: product }, grpc_options) do |response, operation|
+      c.remove_product_from_product_set({ name: name, product: product }, grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.remove_product_from_product_set(::Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest.new(name: name, product: product), grpc_options) do |response, operation|
+      c.remove_product_from_product_set(::Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest.new(name: name, product: product), grpc_options) do |response, operation|
         assert_equal grpc_response, response
         assert_equal grpc_operation, operation
       end
@@ -1061,40 +1061,40 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, list_products_in_product_set_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.list_products_in_product_set({ name: name, page_size: page_size, page_token: page_token }) do |response, operation|
+      c.list_products_in_product_set({ name: name, page_size: page_size, page_token: page_token }) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.list_products_in_product_set name: name, page_size: page_size, page_token: page_token do |response, operation|
+      c.list_products_in_product_set name: name, page_size: page_size, page_token: page_token do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.list_products_in_product_set ::Google::Cloud::Vision::V1::ListProductsInProductSetRequest.new(name: name, page_size: page_size, page_token: page_token) do |response, operation|
+      c.list_products_in_product_set ::Google::Cloud::Vision::V1::ListProductsInProductSetRequest.new(name: name, page_size: page_size, page_token: page_token) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.list_products_in_product_set({ name: name, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
+      c.list_products_in_product_set({ name: name, page_size: page_size, page_token: page_token }, grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.list_products_in_product_set(::Google::Cloud::Vision::V1::ListProductsInProductSetRequest.new(name: name, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
+      c.list_products_in_product_set(::Google::Cloud::Vision::V1::ListProductsInProductSetRequest.new(name: name, page_size: page_size, page_token: page_token), grpc_options) do |response, operation|
         assert_kind_of Gapic::PagedEnumerable, response
         assert_equal grpc_response, response.response
         assert_equal grpc_operation, operation
@@ -1126,40 +1126,40 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, import_product_sets_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.import_product_sets({ parent: parent, input_config: input_config }) do |response, operation|
+      c.import_product_sets({ parent: parent, input_config: input_config }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.import_product_sets parent: parent, input_config: input_config do |response, operation|
+      c.import_product_sets parent: parent, input_config: input_config do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.import_product_sets ::Google::Cloud::Vision::V1::ImportProductSetsRequest.new(parent: parent, input_config: input_config) do |response, operation|
+      c.import_product_sets ::Google::Cloud::Vision::V1::ImportProductSetsRequest.new(parent: parent, input_config: input_config) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.import_product_sets({ parent: parent, input_config: input_config }, grpc_options) do |response, operation|
+      c.import_product_sets({ parent: parent, input_config: input_config }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.import_product_sets(::Google::Cloud::Vision::V1::ImportProductSetsRequest.new(parent: parent, input_config: input_config), grpc_options) do |response, operation|
+      c.import_product_sets(::Google::Cloud::Vision::V1::ImportProductSetsRequest.new(parent: parent, input_config: input_config), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
@@ -1194,40 +1194,40 @@ class ::Google::Cloud::Vision::V1::ProductSearch::ClientTest < Minitest::Test
 
     Gapic::ServiceStub.stub :new, purge_products_client_stub do
       # Create client
-      client = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
+      c = ::Google::Cloud::Vision::V1::ProductSearch::Client.new do |config|
         config.credentials = grpc_channel
       end
 
       # Use hash object
-      client.purge_products({ product_set_purge_config: product_set_purge_config, parent: parent, force: force }) do |response, operation|
+      c.purge_products({ product_set_purge_config: product_set_purge_config, parent: parent, force: force }) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use named arguments
-      client.purge_products product_set_purge_config: product_set_purge_config, parent: parent, force: force do |response, operation|
+      c.purge_products product_set_purge_config: product_set_purge_config, parent: parent, force: force do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object
-      client.purge_products ::Google::Cloud::Vision::V1::PurgeProductsRequest.new(product_set_purge_config: product_set_purge_config, parent: parent, force: force) do |response, operation|
+      c.purge_products ::Google::Cloud::Vision::V1::PurgeProductsRequest.new(product_set_purge_config: product_set_purge_config, parent: parent, force: force) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use hash object with options
-      client.purge_products({ product_set_purge_config: product_set_purge_config, parent: parent, force: force }, grpc_options) do |response, operation|
+      c.purge_products({ product_set_purge_config: product_set_purge_config, parent: parent, force: force }, grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation
       end
 
       # Use protobuf object with options
-      client.purge_products(::Google::Cloud::Vision::V1::PurgeProductsRequest.new(product_set_purge_config: product_set_purge_config, parent: parent, force: force), grpc_options) do |response, operation|
+      c.purge_products(::Google::Cloud::Vision::V1::PurgeProductsRequest.new(product_set_purge_config: product_set_purge_config, parent: parent, force: force), grpc_options) do |response, operation|
         assert_kind_of Gapic::Operation, response
         assert_equal grpc_response, response.grpc_op
         assert_equal grpc_operation, operation


### PR DESCRIPTION
Ran via `toys owlbot --pull google-cloud-vision-v1 google-cloud-video_intelligence-v1 --protos-path=~/Code/googleapis` while using the latest generator version locally.