### PR TITLE
chore: Add pubsub rollback schema sample

### DIFF
--- a/google-cloud-pubsub/samples/acceptance/schemas_test.rb
+++ b/google-cloud-pubsub/samples/acceptance/schemas_test.rb
@@ -29,6 +29,8 @@ require_relative "../pubsub_subscribe_avro_records"
 require_relative "../pubsub_publish_proto_messages"
 require_relative "../pubsub_subscribe_proto_messages"
 require_relative "../pubsub_subscribe_avro_records_with_revisions"
+require_relative "../pubsub_rollback_schema"
+require_relative "../pubsub_update_topic_schema"
 
 
 describe "schemas" do
@@ -432,6 +434,71 @@ describe "schemas" do
 
       assert_includes out, schema1.revision_id
       assert_includes out, schema2.revision_id
+    end
+
+    it "supports rollback_schema" do
+      schema = Google::Cloud::PubSub::V1::Schema.new name: schema_id,
+                                                     type: :PROTOCOL_BUFFER,
+                                                     definition: proto_definition
+      @schema = schemas.create_schema parent: pubsub.project_path,
+                                      schema: schema,
+                                      schema_id: schema_id
+
+      rev_1_id = @schema.revision_id
+
+      # Commit revision (Revision 2)
+      revised_schema = nil
+      capture_io do
+        revised_schema = commit_proto_schema schema_id: schema_id, proto_file: revision_file
+      end
+      rev_2_id = revised_schema.revision_id
+
+      # Rollback to Revision 1
+      assert_output /Rolled back schema:.*#{schema_id}.*New revision ID/m do
+        rollback_schema project_id: pubsub.project, schema_id: schema_id, revision_id: rev_1_id
+      end
+
+      # Verify the current schema revision is indeed a copy of revision 1
+      current_schema = schemas.get_schema name: pubsub.schema_path(schema_id)
+      # Normalize definitions by stripping whitespace for comparison
+      assert_equal proto_definition.strip, current_schema.definition.strip
+      refute_equal rev_1_id, current_schema.revision_id
+      refute_equal rev_2_id, current_schema.revision_id
+    end
+
+    it "supports pubsub_update_topic_schema" do
+      schema = Google::Cloud::PubSub::V1::Schema.new name: schema_id,
+                                                     type: :PROTOCOL_BUFFER,
+                                                     definition: proto_definition
+      @schema = schemas.create_schema parent: pubsub.project_path,
+                                      schema: schema,
+                                      schema_id: schema_id
+      rev_1_id = @schema.revision_id
+
+      # Commit revision (Revision 2)
+      revised_schema = nil
+      capture_io do
+        revised_schema = commit_proto_schema schema_id: schema_id, proto_file: revision_file
+      end
+      rev_2_id = revised_schema.revision_id
+
+      # Create topic with schema (Rev 1 to Rev 1 initially)
+      schema_settings = Google::Cloud::PubSub::V1::SchemaSettings.new schema: pubsub.schema_path(schema_id),
+                                                                      encoding: :BINARY,
+                                                                      first_revision_id: rev_1_id,
+                                                                      last_revision_id: rev_1_id
+      @topic = topic_admin.create_topic name: pubsub.topic_path(topic_id),
+                                        schema_settings: schema_settings
+
+      # Update topic schema settings (to allow Rev 2, i.e., first=Rev 2, last=Rev 2)
+      assert_output "Updated topic with schema: projects/#{pubsub.project}/topics/#{topic_id}\n" do
+        update_topic_schema topic_id: topic_id, first_revision_id: rev_2_id, last_revision_id: rev_2_id
+      end
+
+      # Verify topic schema settings on server
+      updated_topic = topic_admin.get_topic topic: pubsub.topic_path(topic_id)
+      assert_equal rev_2_id, updated_topic.schema_settings.first_revision_id
+      assert_equal rev_2_id, updated_topic.schema_settings.last_revision_id
     end
   end
 end

--- a/google-cloud-pubsub/samples/pubsub_rollback_schema.rb
+++ b/google-cloud-pubsub/samples/pubsub_rollback_schema.rb
@@ -1,0 +1,37 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START pubsub_rollback_schema]
+require "google/cloud/pubsub"
+
+def rollback_schema project_id:, schema_id:, revision_id:
+  # project_id = "your-project-id"
+  # schema_id = "your-schema-id"
+  # revision_id = "your-revision-id"
+
+  pubsub = Google::Cloud::PubSub.new project_id: project_id
+  schema_client = pubsub.schemas
+
+  schema_path = schema_client.schema_path project: project_id, schema: schema_id
+
+  begin
+    response = schema_client.rollback_schema name: schema_path,
+                                             revision_id: revision_id
+    puts "Rolled back schema: #{response.name}"
+    puts "New revision ID: #{response.revision_id}"
+  rescue Google::Cloud::NotFoundError => e
+    puts "Schema #{schema_id} not found."
+  end
+end
+# [END pubsub_rollback_schema]

--- a/google-cloud-pubsub/samples/pubsub_update_topic_schema.rb
+++ b/google-cloud-pubsub/samples/pubsub_update_topic_schema.rb
@@ -1,0 +1,44 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START pubsub_update_topic_schema]
+require "google/cloud/pubsub"
+
+def update_topic_schema topic_id:, first_revision_id:, last_revision_id:
+  # topic_id = "your-topic-id"
+  # first_revision_id = "your-revision-id"
+  # last_revision_id = "your-revision-id"
+
+  pubsub = Google::Cloud::PubSub.new
+  topic_admin = pubsub.topic_admin
+
+  schema_settings = Google::Cloud::PubSub::V1::SchemaSettings.new(
+    first_revision_id: first_revision_id,
+    last_revision_id: last_revision_id
+  )
+
+  topic = topic_admin.get_topic topic: pubsub.topic_path(topic_id)
+  topic.schema_settings = schema_settings
+
+  topic = topic_admin.update_topic topic: topic,
+                                   update_mask: {
+                                     paths: [
+                                       "schema_settings.first_revision_id",
+                                       "schema_settings.last_revision_id"
+                                     ]
+                                   }
+
+  puts "Updated topic with schema: #{topic.name}"
+end
+# [END pubsub_update_topic_schema]


### PR DESCRIPTION
Adds new samples and acceptance tests for Pub/Sub schema evolution features, mirroring the equivalent changes in Java (https://github.com/googleapis/java-pubsub/pull/1469).