### PR TITLE
feat: support STORAGE_EMULATOR_HOST environment variable

### DIFF
--- a/google-cloud-storage/lib/google-cloud-storage.rb
+++ b/google-cloud-storage/lib/google-cloud-storage.rb
@@ -77,7 +77,8 @@ module Google
     #   readonly_storage = gcloud.storage scope: readonly_scope
     #
     def storage scope: nil, retries: nil, timeout: nil, open_timeout: nil, read_timeout: nil, send_timeout: nil,
-                max_elapsed_time: nil, base_interval: nil, max_interval: nil, multiplier: nil, upload_chunk_size: nil
+                max_elapsed_time: nil, base_interval: nil, max_interval: nil, multiplier: nil, upload_chunk_size: nil,
+                emulator_host: nil
       Google::Cloud.storage @project, @keyfile, scope: scope,
                                                 retries: retries || @retries,
                                                 timeout: timeout || @timeout,
@@ -88,7 +89,8 @@ module Google
                                                 base_interval: base_interval,
                                                 max_interval: max_interval,
                                                 multiplier: multiplier,
-                                                upload_chunk_size: upload_chunk_size
+                                                upload_chunk_size: upload_chunk_size,
+                                                emulator_host: emulator_host
     end
 
     ##
@@ -142,7 +144,7 @@ module Google
     def self.storage project_id = nil, credentials = nil, scope: nil,
                      retries: nil, timeout: nil, open_timeout: nil, read_timeout: nil, send_timeout: nil,
                      max_elapsed_time: nil, base_interval: nil, max_interval: nil, multiplier: nil,
-                     upload_chunk_size: nil
+                     upload_chunk_size: nil, emulator_host: nil
       require "google/cloud/storage"
       Google::Cloud::Storage.new project_id: project_id,
                                  credentials: credentials,
@@ -156,7 +158,8 @@ module Google
                                  base_interval: base_interval,
                                  max_interval: max_interval,
                                  multiplier: multiplier,
-                                 upload_chunk_size: upload_chunk_size
+                                 upload_chunk_size: upload_chunk_size,
+                                 emulator_host: emulator_host
     end
   end
 end
@@ -171,6 +174,9 @@ Google::Cloud.configure.add_config! :storage do |config|
       "STORAGE_CREDENTIALS", "STORAGE_CREDENTIALS_JSON",
       "STORAGE_KEYFILE", "STORAGE_KEYFILE_JSON"
     )
+  end
+  default_emulator = Google::Cloud::Config.deferred do
+    ENV["STORAGE_EMULATOR_HOST"]
   end
 
   config.add_field! :project_id, default_project, match: String, allow_nil: true
@@ -192,5 +198,6 @@ Google::Cloud.configure.add_config! :storage do |config|
   config.add_field! :send_timeout, nil, match: Integer
   config.add_field! :upload_chunk_size, nil, match: Integer
   config.add_field! :endpoint, nil, match: String, allow_nil: true
+  config.add_field! :emulator_host, default_emulator, match: String, allow_nil: true
   config.add_field! :universe_domain, nil, match: String, allow_nil: true
 end

--- a/google-cloud-storage/lib/google/cloud/storage.rb
+++ b/google-cloud-storage/lib/google/cloud/storage.rb
@@ -70,6 +70,11 @@ module Google
       # @param [Integer] send_timeout How long, in seconds, before receiving response from server times out. Optional.
       # @param [String] endpoint Override of the endpoint host name. Optional.
       #   If the param is nil, uses the default endpoint.
+      # @param [String] emulator_host Address of a Storage emulator to connect
+      #   to, including the scheme (e.g. `http://localhost:9000`). Optional.
+      #   Defaults to the `STORAGE_EMULATOR_HOST` environment variable when set.
+      #   When present, the client connects to the emulator and does not require
+      #   credentials (it connects anonymously unless credentials are provided).
       # @param universe_domain [String] Override of the universe domain. Optional.
       #   If unset or nil, uses the default unvierse domain
       # @param [Integer] upload_chunk_size The chunk size of storage upload, in bytes.
@@ -97,7 +102,8 @@ module Google
                    timeout: nil, open_timeout: nil, read_timeout: nil,
                    send_timeout: nil, endpoint: nil, project: nil, keyfile: nil,
                    max_elapsed_time: nil, base_interval: nil, max_interval: nil,
-                   multiplier: nil, upload_chunk_size: nil, universe_domain: nil
+                   multiplier: nil, upload_chunk_size: nil, universe_domain: nil,
+                   emulator_host: nil
         scope             ||= configure.scope
         retries           ||= configure.retries
         timeout           ||= configure.timeout
@@ -105,20 +111,27 @@ module Google
         read_timeout      ||= configure.read_timeout || timeout
         send_timeout      ||= configure.send_timeout || timeout
         endpoint          ||= configure.endpoint
-        credentials       ||= keyfile || default_credentials(scope: scope)
         max_elapsed_time  ||= configure.max_elapsed_time
         base_interval     ||= configure.base_interval
         max_interval      ||= configure.max_interval
         multiplier        ||= configure.multiplier
         upload_chunk_size ||= configure.upload_chunk_size
         universe_domain   ||= configure.universe_domain
+        emulator_host     ||= configure.emulator_host
 
-        unless credentials.is_a? Google::Auth::Credentials
+        if emulator_host
+          endpoint = emulator_host
+          credentials ||= keyfile
+        else
+          credentials ||= keyfile || default_credentials(scope: scope)
+        end
+
+        if credentials && !credentials.is_a?(Google::Auth::Credentials)
           credentials = Storage::Credentials.new credentials, scope: scope
         end
 
         project_id = resolve_project_id(project_id || project, credentials)
-        raise ArgumentError, "project_id is missing" if project_id.empty?
+        raise ArgumentError, "project_id is missing" if project_id.empty? && !emulator_host
 
         Storage::Project.new(
           Storage::Service.new(
@@ -203,6 +216,10 @@ module Google
       #   parameter `keyfile` is considered deprecated, but may also be used.)
       # * `endpoint` - (String) Override of the endpoint host name, or `nil`
       #   to use the default endpoint.
+      # * `emulator_host` - (String) Address of a Storage emulator to connect to,
+      #   including the scheme (e.g. `http://localhost:9000`), or `nil` to connect
+      #   to the live service. Defaults to the `STORAGE_EMULATOR_HOST` environment
+      #   variable when set.
       # * `scope` - (String, Array<String>) The OAuth 2.0 scopes controlling
       #   the set of resources and operations that the connection can access.
       # * `retries` - (Integer) Number of times to retry requests on server

--- a/google-cloud-storage/test/google/cloud/storage_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage_test.rb
@@ -19,7 +19,7 @@ describe Google::Cloud do
   describe "#storage" do
     it "calls out to Google::Cloud.storage" do
       gcloud = Google::Cloud.new
-      stubbed_storage = ->(project, keyfile, scope: nil, retries: nil, timeout: nil, open_timeout: nil, read_timeout: nil, send_timeout: nil, host: nil, max_elapsed_time: nil, base_interval: nil, max_interval: nil, multiplier: nil, upload_chunk_size: nil) {
+      stubbed_storage = ->(project, keyfile, scope: nil, retries: nil, timeout: nil, open_timeout: nil, read_timeout: nil, send_timeout: nil, host: nil, max_elapsed_time: nil, base_interval: nil, max_interval: nil, multiplier: nil, upload_chunk_size: nil, emulator_host: nil) {
         _(project).must_be :nil?
         _(keyfile).must_be :nil?
         _(scope).must_be :nil?
@@ -44,7 +44,7 @@ describe Google::Cloud do
 
     it "passes project and keyfile to Google::Cloud.storage" do
       gcloud = Google::Cloud.new "project-id", "keyfile-path"
-      stubbed_storage = ->(project, keyfile, scope: nil, retries: nil, timeout: nil, open_timeout: nil, read_timeout: nil, send_timeout: nil, host: nil, max_elapsed_time: nil, base_interval: nil, max_interval: nil, multiplier: nil, upload_chunk_size: nil) {
+      stubbed_storage = ->(project, keyfile, scope: nil, retries: nil, timeout: nil, open_timeout: nil, read_timeout: nil, send_timeout: nil, host: nil, max_elapsed_time: nil, base_interval: nil, max_interval: nil, multiplier: nil, upload_chunk_size: nil, emulator_host: nil) {
         _(project).must_equal "project-id"
         _(keyfile).must_equal "keyfile-path"
         _(scope).must_be :nil?
@@ -69,7 +69,7 @@ describe Google::Cloud do
 
     it "passes project and keyfile and options to Google::Cloud.storage" do
       gcloud = Google::Cloud.new "project-id", "keyfile-path"
-      stubbed_storage = ->(project, keyfile, scope: nil, retries: nil, timeout: nil, open_timeout: nil, read_timeout: nil, send_timeout: nil, host: nil, max_elapsed_time: nil, base_interval: nil, max_interval: nil, multiplier: nil, upload_chunk_size: nil) {
+      stubbed_storage = ->(project, keyfile, scope: nil, retries: nil, timeout: nil, open_timeout: nil, read_timeout: nil, send_timeout: nil, host: nil, max_elapsed_time: nil, base_interval: nil, max_interval: nil, multiplier: nil, upload_chunk_size: nil, emulator_host: nil) {
         _(project).must_equal "project-id"
         _(keyfile).must_equal "keyfile-path"
         _(scope).must_equal "http://example.com/scope"
@@ -387,6 +387,103 @@ describe Google::Cloud do
     end
   end
 
+  describe "Storage.emulator" do
+    let(:emulator_host) { "http://localhost:9000" }
+    let(:default_credentials) do
+      creds = OpenStruct.new empty: true
+      def creds.is_a? target
+        target == Google::Auth::Credentials
+      end
+      creds
+    end
+
+    it "uses STORAGE_EMULATOR_HOST environment variable" do
+      emulator_check = ->(name) { (name == "STORAGE_EMULATOR_HOST") ? emulator_host : nil }
+      stubbed_service = ->(project, credentials, retries: nil, timeout: nil, open_timeout: nil, read_timeout: nil, send_timeout: nil, host: nil, quota_project: nil, max_elapsed_time: nil, base_interval: nil,
+        max_interval: nil, multiplier: nil, upload_chunk_size: nil, universe_domain: nil) {
+        _(project).must_equal "project-id"
+        _(credentials).must_be :nil?
+        _(host).must_equal emulator_host
+        OpenStruct.new project: project
+      }
+
+      # Clear all environment variables, except STORAGE_EMULATOR_HOST
+      ENV.stub :[], emulator_check do
+        # Get project_id from Google Compute Engine
+        Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
+          Google::Cloud::Storage::Service.stub :new, stubbed_service do
+            storage = Google::Cloud::Storage.new
+            _(storage).must_be_kind_of Google::Cloud::Storage::Project
+            _(storage.project).must_equal "project-id"
+          end
+        end
+      end
+    end
+
+    it "allows emulator_host to be set" do
+      stubbed_service = ->(project, credentials, retries: nil, timeout: nil, open_timeout: nil, read_timeout: nil, send_timeout: nil, host: nil, quota_project: nil, max_elapsed_time: nil, base_interval: nil,
+        max_interval: nil, multiplier: nil, upload_chunk_size: nil, universe_domain: nil) {
+        _(project).must_equal "project-id"
+        _(credentials).must_be :nil?
+        _(host).must_equal emulator_host
+        OpenStruct.new project: project
+      }
+
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
+          Google::Cloud::Storage::Service.stub :new, stubbed_service do
+            storage = Google::Cloud::Storage.new emulator_host: emulator_host
+            _(storage).must_be_kind_of Google::Cloud::Storage::Project
+            _(storage.project).must_equal "project-id"
+          end
+        end
+      end
+    end
+
+    it "does not require a project_id when using an emulator" do
+      stubbed_service = ->(project, credentials, retries: nil, timeout: nil, open_timeout: nil, read_timeout: nil, send_timeout: nil, host: nil, quota_project: nil, max_elapsed_time: nil, base_interval: nil,
+        max_interval: nil, multiplier: nil, upload_chunk_size: nil, universe_domain: nil) {
+        _(project).must_equal ""
+        _(credentials).must_be :nil?
+        _(host).must_equal emulator_host
+        OpenStruct.new project: project
+      }
+
+      # Clear all environment variables, and provide no project_id from any source
+      ENV.stub :[], nil do
+        Google::Cloud.stub :env, OpenStruct.new(project_id: nil) do
+          Google::Cloud::Storage::Service.stub :new, stubbed_service do
+            storage = Google::Cloud::Storage.new emulator_host: emulator_host
+            _(storage).must_be_kind_of Google::Cloud::Storage::Project
+            _(storage.project).must_equal ""
+          end
+        end
+      end
+    end
+
+    it "honors provided credentials when using an emulator" do
+      stubbed_service = ->(project, credentials, retries: nil, timeout: nil, open_timeout: nil, read_timeout: nil, send_timeout: nil, host: nil, quota_project: nil, max_elapsed_time: nil, base_interval: nil,
+        max_interval: nil, multiplier: nil, upload_chunk_size: nil, universe_domain: nil) {
+        _(project).must_equal "project-id"
+        _(credentials).must_equal default_credentials
+        _(host).must_equal emulator_host
+        OpenStruct.new project: project
+      }
+
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        Google::Cloud.stub :env, OpenStruct.new(project_id: "project-id") do
+          Google::Cloud::Storage::Service.stub :new, stubbed_service do
+            storage = Google::Cloud::Storage.new credentials: default_credentials, emulator_host: emulator_host
+            _(storage).must_be_kind_of Google::Cloud::Storage::Project
+            _(storage.project).must_equal "project-id"
+          end
+        end
+      end
+    end
+  end
+
   describe "Storage.configure" do
     let(:found_credentials) { "{}" }
 
@@ -656,6 +753,31 @@ describe Google::Cloud do
               end
             end
           end
+        end
+      end
+    end
+
+    it "uses storage config for emulator_host" do
+      stubbed_service = ->(project, credentials, retries: nil, timeout: nil, open_timeout: nil, read_timeout: nil, send_timeout: nil, host: nil, quota_project: nil, max_elapsed_time: nil, base_interval: nil,
+        max_interval: nil, multiplier: nil, upload_chunk_size: nil, universe_domain: nil) {
+        _(project).must_equal "project-id"
+        _(credentials).must_be :nil?
+        _(host).must_equal "http://localhost:9000"
+        OpenStruct.new project: project
+      }
+
+      # Clear all environment variables
+      ENV.stub :[], nil do
+        # Set new configuration
+        Google::Cloud::Storage.configure do |config|
+          config.project_id = "project-id"
+          config.emulator_host = "http://localhost:9000"
+        end
+
+        Google::Cloud::Storage::Service.stub :new, stubbed_service do
+          storage = Google::Cloud::Storage.new
+          _(storage).must_be_kind_of Google::Cloud::Storage::Project
+          _(storage.project).must_equal "project-id"
         end
       end
     end


### PR DESCRIPTION
## Summary

Adds support for the `STORAGE_EMULATOR_HOST` environment variable to `google-cloud-storage`, so the client can be pointed at a local Cloud Storage emulator (e.g. `fake-gcs-server`, the gcloud storage emulator). This brings the Ruby library in line with the Python `google-cloud-storage` library (see [googleapis/google-cloud-python#9219](https://github.com/googleapis/google-cloud-python/pull/9219)) and the existing emulator-aware Ruby gems (pubsub, datastore, firestore, bigtable, bigquery).

Fixes #34022

## Behavior

The emulator can be selected in three ways (in precedence order):

- `Google::Cloud::Storage.new emulator_host: "http://localhost:9000"`
- `Google::Cloud::Storage.configure { |c| c.emulator_host = "http://localhost:9000" }`
- `STORAGE_EMULATOR_HOST=http://localhost:9000` environment variable

When an emulator host is set:

- It is used as the API endpoint (storage is REST-based, so this sets the underlying `root_url`).
- Authentication is not required: the client connects **anonymously** (no Application Default Credentials lookup), but any explicitly-provided credentials/keyfile are still honored.
- A project ID is **not required** (it is still resolved from the argument / config / `GOOGLE_CLOUD_PROJECT` when available).

This mirrors the Python client's use of anonymous credentials and an optional project when the emulator is active. Unlike the gRPC-based gems, storage does not use the `:this_channel_is_insecure` sentinel, since that is a gRPC concept; the REST equivalent is anonymous (`nil`) credentials, as already used by `Google::Cloud::Storage.anonymous`.

## Changes

- `lib/google-cloud-storage.rb`: register the `emulator_host` config field (defaulting to `STORAGE_EMULATOR_HOST`) and thread `emulator_host:` through the `Google::Cloud.storage` / `Google::Cloud#storage` convenience methods.
- `lib/google/cloud/storage.rb`: add the `emulator_host:` keyword to `Storage.new`, connect anonymously to the emulator without requiring credentials or a project, and document the option.
- `test/google/cloud/storage_test.rb`: unit tests covering the env var, the keyword argument, the config field, the optional project, and honoring explicitly-provided credentials.

## Testing

- `test/google/cloud/storage_test.rb`: 22 runs, 303 assertions, 0 failures.
- Rubocop clean on the changed library files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)