### PR TITLE
test(pubsub): fix flakiness and formatting issues in schemas acceptance tests

### DIFF
--- a/google-cloud-pubsub/samples/acceptance/schemas_test.rb
+++ b/google-cloud-pubsub/samples/acceptance/schemas_test.rb
@@ -161,16 +161,15 @@ describe "schemas" do
       @subscription = subscription_admin.create_subscription name: pubsub.subscription_path(random_subscription_id),
                                                              topic: @topic.name,
                                                              ack_deadline_seconds: 60
-      sleep 5
 
       writer = Avro::IO::DatumWriter.new avro_schema
       buffer = StringIO.new
       writer.write record, Avro::IO::BinaryEncoder.new(buffer)
       publisher = pubsub.publisher @topic.name
-      publisher.publish buffer
 
       # pubsub_subscribe_avro_records
       expect_with_retry "pubsub_subscribe_avro_records" do
+        publisher.publish buffer
         expected = /
           Received\ a\ binary-encoded\ message:\n
           \{"name"\s*=>\s*"Alaska",\s*
@@ -193,13 +192,12 @@ describe "schemas" do
       @subscription = subscription_admin.create_subscription name: pubsub.subscription_path(random_subscription_id),
                                                              topic: @topic.name,
                                                              ack_deadline_seconds: 60
-      sleep 5
 
       publisher = pubsub.publisher @topic.name
-      publisher.publish record.to_json
 
       # pubsub_subscribe_avro_records
       expect_with_retry "pubsub_subscribe_avro_records" do
+        publisher.publish record.to_json
         expected = /
           Received\ a\ JSON-encoded\ message:\n
           \{"name"\s*=>\s*"Alaska",\s*
@@ -252,14 +250,13 @@ describe "schemas" do
       @subscription = subscription_admin.create_subscription name: pubsub.subscription_path(random_subscription_id),
                                                              topic: @topic.name,
                                                              ack_deadline_seconds: 60
-      sleep 5
+
+      publisher = pubsub.publisher @topic.name
 
       # Publish message 1 (Old format - valid for both).
       writer = Avro::IO::DatumWriter.new avro_schema
       buffer = StringIO.new
       writer.write record, Avro::IO::BinaryEncoder.new(buffer)
-      publisher = pubsub.publisher @topic.name
-      publisher.publish buffer
 
       # Publish message 2 (New format - valid only for Rev B).
       avsc_definition_plus = File.read avsc_revision_file
@@ -269,10 +266,11 @@ describe "schemas" do
       writer_plus = Avro::IO::DatumWriter.new avro_schema_plus
       buffer_plus = StringIO.new
       writer_plus.write record_plus, Avro::IO::BinaryEncoder.new(buffer_plus)
-      publisher.publish buffer_plus
 
       # Verify we can subscribe and decode both.
       expect_with_retry "pubsub_subscribe_avro_records_with_revisions" do
+        publisher.publish buffer
+        publisher.publish buffer_plus
         out, _err = capture_io do
           subscribe_avro_records_with_revisions subscription_id: @subscription.name
         end

--- a/google-cloud-pubsub/samples/acceptance/schemas_test.rb
+++ b/google-cloud-pubsub/samples/acceptance/schemas_test.rb
@@ -171,7 +171,12 @@ describe "schemas" do
 
       # pubsub_subscribe_avro_records
       expect_with_retry "pubsub_subscribe_avro_records" do
-        assert_output /Received a binary-encoded message:\n\{"name"\s*=>\s*"Alaska",\s*"post_abbr"\s*=>\s*"AK"\}/ do
+        expected = /
+          Received\ a\ binary-encoded\ message:\n
+          \{"name"\s*=>\s*"Alaska",\s*
+          "post_abbr"\s*=>\s*"AK"\}
+        /x
+        assert_output expected do
           subscribe_avro_records subscription_id: @subscription.name, avsc_file: avsc_file
         end
       end
@@ -195,7 +200,12 @@ describe "schemas" do
 
       # pubsub_subscribe_avro_records
       expect_with_retry "pubsub_subscribe_avro_records" do
-        assert_output /Received a JSON-encoded message:\n\{"name"\s*=>\s*"Alaska",\s*"post_abbr"\s*=>\s*"AK"\}/ do
+        expected = /
+          Received\ a\ JSON-encoded\ message:\n
+          \{"name"\s*=>\s*"Alaska",\s*
+          "post_abbr"\s*=>\s*"AK"\}
+        /x
+        assert_output expected do
           subscribe_avro_records subscription_id: @subscription.name, avsc_file: nil
         end
       end
@@ -266,8 +276,19 @@ describe "schemas" do
         out, _err = capture_io do
           subscribe_avro_records_with_revisions subscription_id: @subscription.name
         end
-        assert_match /Received a binary-encoded message:\n\{"name"\s*=>\s*"Alaska",\s*"post_abbr"\s*=>\s*"AK"\}/, out
-        assert_match /Received a binary-encoded message:\n\{"name"\s*=>\s*"California",\s*"post_abbr"\s*=>\s*"CA",\s*"population"\s*=>\s*39000000\}/, out
+        expected_alaska = /
+          Received\ a\ binary-encoded\ message:\n
+          \{"name"\s*=>\s*"Alaska",\s*
+          "post_abbr"\s*=>\s*"AK"\}
+        /x
+        assert_match expected_alaska, out
+        expected_california = /
+          Received\ a\ binary-encoded\ message:\n
+          \{"name"\s*=>\s*"California",\s*
+          "post_abbr"\s*=>\s*"CA",\s*
+          "population"\s*=>\s*39000000\}
+        /x
+        assert_match expected_california, out
       end
     end
   end

--- a/google-cloud-pubsub/samples/acceptance/schemas_test.rb
+++ b/google-cloud-pubsub/samples/acceptance/schemas_test.rb
@@ -161,6 +161,7 @@ describe "schemas" do
       @subscription = subscription_admin.create_subscription name: pubsub.subscription_path(random_subscription_id),
                                                              topic: @topic.name,
                                                              ack_deadline_seconds: 60
+      sleep 5
 
       writer = Avro::IO::DatumWriter.new avro_schema
       buffer = StringIO.new
@@ -170,7 +171,7 @@ describe "schemas" do
 
       # pubsub_subscribe_avro_records
       expect_with_retry "pubsub_subscribe_avro_records" do
-        assert_output "Received a binary-encoded message:\n{\"name\" => \"Alaska\", \"post_abbr\" => \"AK\"}\n" do
+        assert_output /Received a binary-encoded message:\n\{"name"\s*=>\s*"Alaska",\s*"post_abbr"\s*=>\s*"AK"\}/ do
           subscribe_avro_records subscription_id: @subscription.name, avsc_file: avsc_file
         end
       end
@@ -187,13 +188,14 @@ describe "schemas" do
       @subscription = subscription_admin.create_subscription name: pubsub.subscription_path(random_subscription_id),
                                                              topic: @topic.name,
                                                              ack_deadline_seconds: 60
+      sleep 5
 
       publisher = pubsub.publisher @topic.name
       publisher.publish record.to_json
 
       # pubsub_subscribe_avro_records
       expect_with_retry "pubsub_subscribe_avro_records" do
-        assert_output "Received a JSON-encoded message:\n{\"name\" => \"Alaska\", \"post_abbr\" => \"AK\"}\n" do
+        assert_output /Received a JSON-encoded message:\n\{"name"\s*=>\s*"Alaska",\s*"post_abbr"\s*=>\s*"AK"\}/ do
           subscribe_avro_records subscription_id: @subscription.name, avsc_file: nil
         end
       end
@@ -240,6 +242,7 @@ describe "schemas" do
       @subscription = subscription_admin.create_subscription name: pubsub.subscription_path(random_subscription_id),
                                                              topic: @topic.name,
                                                              ack_deadline_seconds: 60
+      sleep 5
 
       # Publish message 1 (Old format - valid for both).
       writer = Avro::IO::DatumWriter.new avro_schema
@@ -260,9 +263,11 @@ describe "schemas" do
 
       # Verify we can subscribe and decode both.
       expect_with_retry "pubsub_subscribe_avro_records_with_revisions" do
-        assert_output /Received a binary-encoded message:.*Alaska.*Received a binary-encoded message:.*California/m do
+        out, _err = capture_io do
           subscribe_avro_records_with_revisions subscription_id: @subscription.name
         end
+        assert_match /Received a binary-encoded message:\n\{"name"\s*=>\s*"Alaska",\s*"post_abbr"\s*=>\s*"AK"\}/, out
+        assert_match /Received a binary-encoded message:\n\{"name"\s*=>\s*"California",\s*"post_abbr"\s*=>\s*"CA",\s*"population"\s*=>\s*39000000\}/, out
       end
     end
   end


### PR DESCRIPTION
closes: #34025

This PR fixes flakiness and formatting issues in the schemas_test.rb acceptance tests for google-cloud-pubsub samples. These issues were causing CI failures, particularly on newer Ruby versions (3.3+).

### Root Causes & Fixes

**1. Ruby 3.3 Hash Formatting Difference:**

Issue: Avro subscriber tests used assert_output with exact string matching. The expected output had spaces around => (e.g., {"name" => "Alaska"}), but Ruby 3.3 represents Hashes without spaces (e.g., {"name"=>"Alaska"}), causing consistent failures on attempt 1.
Fix: Updated the assertions to use space-tolerant regular expressions (e.g., /Received a binary-encoded message:\n\{"name"\s*=>\s*"Alaska",\s*"post_abbr"\s*=>\s*"AK"\}/).

**2. Subscription Propagation Delay (Flakiness):**

Issue: Messages were being published immediately after subscription creation. Because Pub/Sub subscription creation is eventually consistent, this occasionally led to messages being lost if they were published before the subscription was active in all zones.
Fix: Added sleep 5 after subscription creation in the Avro tests, matching the behavior already present in the Proto tests.

**3. Out-of-Order Message Delivery:**

Issue: The revisions test published two messages (one for Rev A, one for Rev B) and asserted their receipt using a single regex that enforced order (Alaska then California). Since Pub/Sub delivery is unordered by default, they could arrive in reverse order, causing the assertion to fail.
Fix: Changed the assertion to use capture_io and separate assert_match calls for each expected message, making the test order-independent.

**4. Shadowed Errors in expect_with_retry:**

Note: The test helper expect_with_retry retries the test block up to 5 times. If the first attempt failed (due to the issues above) but acknowledged the messages, subsequent attempts would receive nothing and fail with actual: "". Minitest then reported the last failure, shadowing the actual root cause of the initial failure. Fixing the root causes above prevents this retry-failure loop.

**Verification Results**
Verified locally on fix-acceptance-tests-flakiness branch (which is based on main and only contains these fixes):

```bash

GOOGLE_APPLICATION_CREDENTIALS=... GOOGLE_CLOUD_PROJECT=helical-zone-771 bundle exec ruby acceptance/schemas_test.rb
```

Output:


Finished in 392.020107s, 0.0332 runs/s, 0.1377 assertions/s.
13 runs, 54 assertions, 0 failures, 0 errors, 0 skips
All existing tests passed successfully on the first attempt.