### PR TITLE
fix(stackdriver): add Rakefile with bundler gem_tasks for release build

### DIFF
--- a/stackdriver/Rakefile
+++ b/stackdriver/Rakefile
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "bundler/setup"
+require "bundler/gem_tasks"


### PR DESCRIPTION
Restore a minimal Rakefile requiring bundler/gem_tasks. This allows Bundler to inspect stackdriver.gemspec and define the standard :build task mandated by release automation.

### Rationale
When the `stackdriver` gem was retired and replaced with a tombstone structure in #34614, its `Rakefile` was deleted. However, automated release packaging workflows still rely on executing `rake build` (or equivalent packaging tasks) to compile the `.gem` artifact prior to publication.

During automated release execution for `stackdriver/v1.0.0`, the packaging step aborted with:
```text
rake aborted!
Don't know how to build task 'build' (See the list of available tasks with `rake --tasks`)
```

Fixes b/525536697

BEGIN_COMMIT_OVERRIDE

fix(stackdriver): add Rakefile with bundler gem_tasks for release build

Release-As: 1.0.0

END_COMMIT_OVERRIDE