### PR TITLE
chore(ci): fix triggers for workflows broken by #34682

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -1,10 +1,10 @@
 # This workflow runs the Bigtable Conformance Test suite against the Bigtable
 # client library.
 # See https://github.com/googleapis/cloud-bigtable-clients-test
-on:
-
 permissions:
   contents: read
+
+on:
   push:
     branches:
     - main

--- a/.github/workflows/storage-retry-conformance-test-against-emulator.yaml
+++ b/.github/workflows/storage-retry-conformance-test-against-emulator.yaml
@@ -1,7 +1,7 @@
-on:
-
 permissions:
   contents: read
+
+on:
   push:
     branches:
       - main


### PR DESCRIPTION
The automated changes from #34682 inserted the `permissions` in the wrong place for these two files.

Other workflows do not have this issue as they start with `name:` at the top.