### PR TITLE
chore: Add JUnit XML reporting to veneer test suites using shared require

### DIFF
--- a/google-cloud-bigquery/acceptance/bigquery_helper.rb
+++ b/google-cloud-bigquery/acceptance/bigquery_helper.rb
@@ -21,6 +21,7 @@ if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   begin
     require "gapic/minitest_junit_preloader"
   rescue LoadError
+    # Do nothing if preloader is not available (e.g. local runs)
   end
 end
 

--- a/google-cloud-bigquery/acceptance/bigquery_helper.rb
+++ b/google-cloud-bigquery/acceptance/bigquery_helper.rb
@@ -15,6 +15,12 @@
 require "simplecov"
 
 gem "minitest"
+
+if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
+  # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
+  require "gapic/minitest_junit_preloader" rescue nil
+end
+
 require "minitest/autorun"
 require "minitest/focus"
 require "minitest/rg"

--- a/google-cloud-bigquery/acceptance/bigquery_helper.rb
+++ b/google-cloud-bigquery/acceptance/bigquery_helper.rb
@@ -31,12 +31,6 @@ require "minitest/rg"
 require "google/cloud/bigquery"
 require "google/cloud/storage"
 
-# Generate JUnit format test reports
-if ENV["GCLOUD_TEST_GENERATE_XML_REPORT"]
-  require "minitest/reporters"
-  Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new, Minitest::Reporters::JUnitReporter.new]
-end
-
 # Create shared bigquery object so we don't create new for each test
 $bigquery = Google::Cloud::Bigquery.new retries: 10
 

--- a/google-cloud-bigquery/acceptance/bigquery_helper.rb
+++ b/google-cloud-bigquery/acceptance/bigquery_helper.rb
@@ -18,7 +18,10 @@ gem "minitest"
 
 if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
-  require "gapic/minitest_junit_preloader" rescue nil
+  begin
+    require "gapic/minitest_junit_preloader"
+  rescue LoadError
+  end
 end
 
 require "minitest/autorun"

--- a/google-cloud-bigquery/samples/snippets/acceptance/helper.rb
+++ b/google-cloud-bigquery/samples/snippets/acceptance/helper.rb
@@ -18,6 +18,7 @@ if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   begin
     require "gapic/minitest_junit_preloader"
   rescue LoadError
+    # Do nothing if preloader is not available (e.g. local runs)
   end
 end
 

--- a/google-cloud-bigquery/samples/snippets/acceptance/helper.rb
+++ b/google-cloud-bigquery/samples/snippets/acceptance/helper.rb
@@ -12,6 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
+  # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
+  require "gapic/minitest_junit_preloader" rescue nil
+end
+
 require "minitest/autorun"
 require "minitest/focus"
 require "securerandom"

--- a/google-cloud-bigquery/samples/snippets/acceptance/helper.rb
+++ b/google-cloud-bigquery/samples/snippets/acceptance/helper.rb
@@ -15,7 +15,10 @@
 
 if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
-  require "gapic/minitest_junit_preloader" rescue nil
+  begin
+    require "gapic/minitest_junit_preloader"
+  rescue LoadError
+  end
 end
 
 require "minitest/autorun"

--- a/google-cloud-bigquery/test/helper.rb
+++ b/google-cloud-bigquery/test/helper.rb
@@ -21,6 +21,7 @@ if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   begin
     require "gapic/minitest_junit_preloader"
   rescue LoadError
+    # Do nothing if preloader is not available (e.g. local runs)
   end
 end
 

--- a/google-cloud-bigquery/test/helper.rb
+++ b/google-cloud-bigquery/test/helper.rb
@@ -15,6 +15,12 @@
 require "simplecov"
 
 gem "minitest"
+
+if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
+  # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
+  require "gapic/minitest_junit_preloader" rescue nil
+end
+
 require "minitest/autorun"
 require "minitest/focus"
 require "minitest/mock"

--- a/google-cloud-bigquery/test/helper.rb
+++ b/google-cloud-bigquery/test/helper.rb
@@ -18,7 +18,10 @@ gem "minitest"
 
 if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
-  require "gapic/minitest_junit_preloader" rescue nil
+  begin
+    require "gapic/minitest_junit_preloader"
+  rescue LoadError
+  end
 end
 
 require "minitest/autorun"

--- a/google-cloud-bigtable/acceptance/bigtable_helper.rb
+++ b/google-cloud-bigtable/acceptance/bigtable_helper.rb
@@ -35,12 +35,6 @@ require "minitest/rg"
 require "google/cloud/bigtable"
 require "securerandom"
 
-# Generate JUnit format test reports
-if ENV["GCLOUD_TEST_GENERATE_XML_REPORT"]
-  require "minitest/reporters"
-  Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new, Minitest::Reporters::JUnitReporter.new]
-end
-
 # Create shared bigtable object so we don't create new for each test
 $bigtable = Google::Cloud.new.bigtable
 

--- a/google-cloud-bigtable/acceptance/bigtable_helper.rb
+++ b/google-cloud-bigtable/acceptance/bigtable_helper.rb
@@ -18,6 +18,12 @@
 require "simplecov"
 
 gem "minitest"
+
+if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
+  # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
+  require "gapic/minitest_junit_preloader" rescue nil
+end
+
 require "minitest/autorun"
 require "minitest/spec"
 require "minitest/focus"

--- a/google-cloud-bigtable/acceptance/bigtable_helper.rb
+++ b/google-cloud-bigtable/acceptance/bigtable_helper.rb
@@ -21,7 +21,10 @@ gem "minitest"
 
 if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
-  require "gapic/minitest_junit_preloader" rescue nil
+  begin
+    require "gapic/minitest_junit_preloader"
+  rescue LoadError
+  end
 end
 
 require "minitest/autorun"

--- a/google-cloud-bigtable/acceptance/bigtable_helper.rb
+++ b/google-cloud-bigtable/acceptance/bigtable_helper.rb
@@ -24,6 +24,7 @@ if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   begin
     require "gapic/minitest_junit_preloader"
   rescue LoadError
+    # Do nothing if preloader is not available (e.g. local runs)
   end
 end
 

--- a/google-cloud-bigtable/samples/acceptance/helper.rb
+++ b/google-cloud-bigtable/samples/acceptance/helper.rb
@@ -18,6 +18,7 @@ if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   begin
     require "gapic/minitest_junit_preloader"
   rescue LoadError
+    # Do nothing if preloader is not available (e.g. local runs)
   end
 end
 

--- a/google-cloud-bigtable/samples/acceptance/helper.rb
+++ b/google-cloud-bigtable/samples/acceptance/helper.rb
@@ -12,6 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
+  # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
+  require "gapic/minitest_junit_preloader" rescue nil
+end
+
 require "minitest/autorun"
 require "minitest/focus"
 require "minitest/hooks/default"

--- a/google-cloud-bigtable/samples/acceptance/helper.rb
+++ b/google-cloud-bigtable/samples/acceptance/helper.rb
@@ -15,7 +15,10 @@
 
 if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
-  require "gapic/minitest_junit_preloader" rescue nil
+  begin
+    require "gapic/minitest_junit_preloader"
+  rescue LoadError
+  end
 end
 
 require "minitest/autorun"

--- a/google-cloud-bigtable/test/helper.rb
+++ b/google-cloud-bigtable/test/helper.rb
@@ -16,6 +16,12 @@
 
 require "simplecov"
 
+
+if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
+  # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
+  require "gapic/minitest_junit_preloader" rescue nil
+end
+
 require "minitest/autorun"
 require "minitest/spec"
 require "minitest/autorun"

--- a/google-cloud-bigtable/test/helper.rb
+++ b/google-cloud-bigtable/test/helper.rb
@@ -19,7 +19,10 @@ require "simplecov"
 
 if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
-  require "gapic/minitest_junit_preloader" rescue nil
+  begin
+    require "gapic/minitest_junit_preloader"
+  rescue LoadError
+  end
 end
 
 require "minitest/autorun"

--- a/google-cloud-bigtable/test/helper.rb
+++ b/google-cloud-bigtable/test/helper.rb
@@ -22,6 +22,7 @@ if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   begin
     require "gapic/minitest_junit_preloader"
   rescue LoadError
+    # Do nothing if preloader is not available (e.g. local runs)
   end
 end
 

--- a/google-cloud-core/Gemfile
+++ b/google-cloud-core/Gemfile
@@ -11,6 +11,7 @@ gem "minitest", "~> 5.14"
 gem "minitest-autotest", "~> 1.0"
 gem "minitest-focus", "~> 1.1"
 gem "minitest-rg", "~> 5.2"
+gem "minitest-reporters", "~> 1.5.0", require: false
 gem "rake"
 gem "redcarpet", "~> 3.0"
 gem "simplecov", "~> 0.9"

--- a/google-cloud-core/Gemfile.lock
+++ b/google-cloud-core/Gemfile.lock
@@ -15,9 +15,11 @@ GEM
   specs:
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    ansi (1.6.0)
     ast (2.4.3)
     autotest-suffix (1.1.0)
     base64 (0.3.0)
+    builder (3.3.0)
     docile (1.4.1)
     drb (2.2.3)
     faraday (2.14.3)
@@ -52,6 +54,11 @@ GEM
       path_expander (~> 2.0)
     minitest-focus (1.4.1)
       minitest (> 5.0)
+    minitest-reporters (1.5.0)
+      ansi
+      builder
+      minitest (>= 5.0)
+      ruby-progressbar
     minitest-rg (5.4.0)
       minitest (>= 5.0, < 7)
     minitest-server (1.0.10)
@@ -121,6 +128,7 @@ DEPENDENCIES
   minitest (~> 5.14)
   minitest-autotest (~> 1.0)
   minitest-focus (~> 1.1)
+  minitest-reporters (~> 1.5.0)
   minitest-rg (~> 5.2)
   ostruct (~> 0.6.3)
   rake
@@ -131,9 +139,11 @@ DEPENDENCIES
 
 CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  ansi (1.6.0)
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   autotest-suffix (1.1.0) sha256=9bb29331b7b66a9659b01ef10839bd61fc1a6e95477c8ea710bd01e10c380977
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
+  builder (3.3.0)
   bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
   docile (1.4.1) sha256=96159be799bfa73cdb721b840e9802126e4e03dfc26863db73647204c727f21e
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
@@ -153,6 +163,7 @@ CHECKSUMS
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   minitest-autotest (1.2.0) sha256=60d031cba705215450662b0060f03f96507682b346a19c27f6756751ad92d2b4
   minitest-focus (1.4.1) sha256=394517cbe2dcb2d992d8ffc41a3b2b6315777a4daa69239de4fefe7110dd810e
+  minitest-reporters (1.5.0)
   minitest-rg (5.4.0) sha256=54d42bb8ce876381245be5866f3c1dd704ef79c06ba5c9ff280c0aa28c56effb
   minitest-server (1.0.10) sha256=275439bf3ffc433fcbe161733248f1d9749ebf122892cf010bf864aaa95cef75
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996

--- a/google-cloud-core/test/helper.rb
+++ b/google-cloud-core/test/helper.rb
@@ -21,6 +21,7 @@ if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   begin
     require "gapic/minitest_junit_preloader"
   rescue LoadError
+    # Do nothing if preloader is not available (e.g. local runs)
   end
 end
 

--- a/google-cloud-core/test/helper.rb
+++ b/google-cloud-core/test/helper.rb
@@ -15,6 +15,12 @@
 require "simplecov"
 
 gem "minitest"
+
+if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
+  # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
+  require "gapic/minitest_junit_preloader" rescue nil
+end
+
 require "minitest/autorun"
 require "minitest/focus"
 require "minitest/rg"

--- a/google-cloud-core/test/helper.rb
+++ b/google-cloud-core/test/helper.rb
@@ -18,7 +18,10 @@ gem "minitest"
 
 if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
-  require "gapic/minitest_junit_preloader" rescue nil
+  begin
+    require "gapic/minitest_junit_preloader"
+  rescue LoadError
+  end
 end
 
 require "minitest/autorun"

--- a/google-cloud-datastore/Gemfile
+++ b/google-cloud-datastore/Gemfile
@@ -28,6 +28,7 @@ gem "minitest-focus", "~> 1.4"
 gem "minitest-hooks", "~> 1.5"
 gem "minitest-mock", "~> 5.27"
 gem "minitest-rg", "~> 5.3"
+gem "minitest-reporters", "~> 1.5.0", require: false
 gem "ostruct", "~> 0.5.5"
 gem "rake"
 gem "redcarpet", "~> 3.6"

--- a/google-cloud-datastore/acceptance/datastore_helper.rb
+++ b/google-cloud-datastore/acceptance/datastore_helper.rb
@@ -21,6 +21,7 @@ if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   begin
     require "gapic/minitest_junit_preloader"
   rescue LoadError
+    # Do nothing if preloader is not available (e.g. local runs)
   end
 end
 

--- a/google-cloud-datastore/acceptance/datastore_helper.rb
+++ b/google-cloud-datastore/acceptance/datastore_helper.rb
@@ -15,6 +15,12 @@
 require "simplecov"
 
 gem "minitest"
+
+if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
+  # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
+  require "gapic/minitest_junit_preloader" rescue nil
+end
+
 require "minitest/autorun"
 require "minitest/focus"
 require "minitest/rg"

--- a/google-cloud-datastore/acceptance/datastore_helper.rb
+++ b/google-cloud-datastore/acceptance/datastore_helper.rb
@@ -18,7 +18,10 @@ gem "minitest"
 
 if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
-  require "gapic/minitest_junit_preloader" rescue nil
+  begin
+    require "gapic/minitest_junit_preloader"
+  rescue LoadError
+  end
 end
 
 require "minitest/autorun"

--- a/google-cloud-datastore/samples/acceptance/helper.rb
+++ b/google-cloud-datastore/samples/acceptance/helper.rb
@@ -16,7 +16,10 @@ gem "minitest"
 
 if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
-  require "gapic/minitest_junit_preloader" rescue nil
+  begin
+    require "gapic/minitest_junit_preloader"
+  rescue LoadError
+  end
 end
 
 require "minitest/autorun"

--- a/google-cloud-datastore/samples/acceptance/helper.rb
+++ b/google-cloud-datastore/samples/acceptance/helper.rb
@@ -13,6 +13,12 @@
 # limitations under the License.
 
 gem "minitest"
+
+if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
+  # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
+  require "gapic/minitest_junit_preloader" rescue nil
+end
+
 require "minitest/autorun"
 require "minitest/focus"
 require "minitest/hooks/default"

--- a/google-cloud-datastore/samples/acceptance/helper.rb
+++ b/google-cloud-datastore/samples/acceptance/helper.rb
@@ -19,6 +19,7 @@ if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   begin
     require "gapic/minitest_junit_preloader"
   rescue LoadError
+    # Do nothing if preloader is not available (e.g. local runs)
   end
 end
 

--- a/google-cloud-datastore/test/helper.rb
+++ b/google-cloud-datastore/test/helper.rb
@@ -21,6 +21,7 @@ if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   begin
     require "gapic/minitest_junit_preloader"
   rescue LoadError
+    # Do nothing if preloader is not available (e.g. local runs)
   end
 end
 

--- a/google-cloud-datastore/test/helper.rb
+++ b/google-cloud-datastore/test/helper.rb
@@ -15,6 +15,12 @@
 require "simplecov"
 
 gem "minitest"
+
+if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
+  # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
+  require "gapic/minitest_junit_preloader" rescue nil
+end
+
 require "minitest/autorun"
 require "minitest/focus"
 require "minitest/rg"

--- a/google-cloud-datastore/test/helper.rb
+++ b/google-cloud-datastore/test/helper.rb
@@ -18,7 +18,10 @@ gem "minitest"
 
 if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
-  require "gapic/minitest_junit_preloader" rescue nil
+  begin
+    require "gapic/minitest_junit_preloader"
+  rescue LoadError
+  end
 end
 
 require "minitest/autorun"

--- a/google-cloud-dns/Gemfile
+++ b/google-cloud-dns/Gemfile
@@ -27,6 +27,7 @@ gem "minitest-autotest", "~> 1.0"
 gem "minitest-focus", "~> 1.4"
 gem "minitest-mock", "~> 5.27"
 gem "minitest-rg", "~> 5.3"
+gem "minitest-reporters", "~> 1.5.0", require: false
 gem "ostruct", "~> 0.5.5"
 gem "rake"
 gem "redcarpet", "~> 3.6"

--- a/google-cloud-dns/acceptance/dns_helper.rb
+++ b/google-cloud-dns/acceptance/dns_helper.rb
@@ -21,6 +21,7 @@ if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   begin
     require "gapic/minitest_junit_preloader"
   rescue LoadError
+    # Do nothing if preloader is not available (e.g. local runs)
   end
 end
 

--- a/google-cloud-dns/acceptance/dns_helper.rb
+++ b/google-cloud-dns/acceptance/dns_helper.rb
@@ -15,6 +15,12 @@
 require "simplecov"
 
 gem "minitest"
+
+if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
+  # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
+  require "gapic/minitest_junit_preloader" rescue nil
+end
+
 require "minitest/autorun"
 require "minitest/focus"
 require "minitest/rg"

--- a/google-cloud-dns/acceptance/dns_helper.rb
+++ b/google-cloud-dns/acceptance/dns_helper.rb
@@ -18,7 +18,10 @@ gem "minitest"
 
 if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
-  require "gapic/minitest_junit_preloader" rescue nil
+  begin
+    require "gapic/minitest_junit_preloader"
+  rescue LoadError
+  end
 end
 
 require "minitest/autorun"

--- a/google-cloud-dns/test/helper.rb
+++ b/google-cloud-dns/test/helper.rb
@@ -21,6 +21,7 @@ if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   begin
     require "gapic/minitest_junit_preloader"
   rescue LoadError
+    # Do nothing if preloader is not available (e.g. local runs)
   end
 end
 

--- a/google-cloud-dns/test/helper.rb
+++ b/google-cloud-dns/test/helper.rb
@@ -15,6 +15,12 @@
 require "simplecov"
 
 gem "minitest"
+
+if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
+  # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
+  require "gapic/minitest_junit_preloader" rescue nil
+end
+
 require "minitest/autorun"
 require "minitest/focus"
 require "minitest/rg"

--- a/google-cloud-dns/test/helper.rb
+++ b/google-cloud-dns/test/helper.rb
@@ -18,7 +18,10 @@ gem "minitest"
 
 if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
-  require "gapic/minitest_junit_preloader" rescue nil
+  begin
+    require "gapic/minitest_junit_preloader"
+  rescue LoadError
+  end
 end
 
 require "minitest/autorun"

--- a/google-cloud-error_reporting/Gemfile
+++ b/google-cloud-error_reporting/Gemfile
@@ -30,6 +30,7 @@ gem "minitest", "~> 5.14"
 gem "minitest-autotest", "~> 1.0"
 gem "minitest-focus", "~> 1.1"
 gem "minitest-rg", "~> 5.2"
+gem "minitest-reporters", "~> 1.5.0", require: false
 gem "ostruct", "~> 0.6.3"
 gem "rack", ">= 0.1"
 gem "railties", ">= 5.0", "< 8.1.4"

--- a/google-cloud-error_reporting/acceptance/error_reporting_helper.rb
+++ b/google-cloud-error_reporting/acceptance/error_reporting_helper.rb
@@ -21,6 +21,7 @@ if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   begin
     require "gapic/minitest_junit_preloader"
   rescue LoadError
+    # Do nothing if preloader is not available (e.g. local runs)
   end
 end
 

--- a/google-cloud-error_reporting/acceptance/error_reporting_helper.rb
+++ b/google-cloud-error_reporting/acceptance/error_reporting_helper.rb
@@ -15,6 +15,12 @@
 require "simplecov"
 
 gem "minitest"
+
+if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
+  # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
+  require "gapic/minitest_junit_preloader" rescue nil
+end
+
 require "minitest/autorun"
 require "minitest/focus"
 require "minitest/rg"

--- a/google-cloud-error_reporting/acceptance/error_reporting_helper.rb
+++ b/google-cloud-error_reporting/acceptance/error_reporting_helper.rb
@@ -18,7 +18,10 @@ gem "minitest"
 
 if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
-  require "gapic/minitest_junit_preloader" rescue nil
+  begin
+    require "gapic/minitest_junit_preloader"
+  rescue LoadError
+  end
 end
 
 require "minitest/autorun"

--- a/google-cloud-error_reporting/test/helper.rb
+++ b/google-cloud-error_reporting/test/helper.rb
@@ -21,6 +21,7 @@ if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   begin
     require "gapic/minitest_junit_preloader"
   rescue LoadError
+    # Do nothing if preloader is not available (e.g. local runs)
   end
 end
 

--- a/google-cloud-error_reporting/test/helper.rb
+++ b/google-cloud-error_reporting/test/helper.rb
@@ -15,6 +15,12 @@
 require "simplecov"
 
 gem "minitest"
+
+if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
+  # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
+  require "gapic/minitest_junit_preloader" rescue nil
+end
+
 require "minitest/autorun"
 require "minitest/focus"
 require "minitest/rg"

--- a/google-cloud-error_reporting/test/helper.rb
+++ b/google-cloud-error_reporting/test/helper.rb
@@ -18,7 +18,10 @@ gem "minitest"
 
 if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
-  require "gapic/minitest_junit_preloader" rescue nil
+  begin
+    require "gapic/minitest_junit_preloader"
+  rescue LoadError
+  end
 end
 
 require "minitest/autorun"

--- a/google-cloud-errors/Gemfile
+++ b/google-cloud-errors/Gemfile
@@ -10,6 +10,7 @@ gem "minitest", "~> 5.14"
 gem "minitest-autotest", "~> 1.0"
 gem "minitest-focus", "~> 1.1"
 gem "minitest-rg", "~> 5.2"
+gem "minitest-reporters", "~> 1.5.0", require: false
 gem "rake"
 gem "redcarpet", "~> 3.0"
 gem "simplecov", "~> 0.9"

--- a/google-cloud-errors/Gemfile.lock
+++ b/google-cloud-errors/Gemfile.lock
@@ -8,9 +8,11 @@ GEM
   specs:
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    ansi (1.6.0)
     ast (2.4.3)
     autotest-suffix (1.1.0)
     base64 (0.3.0)
+    builder (3.3.0)
     declarative (0.0.20)
     docile (1.4.1)
     drb (2.2.3)
@@ -89,6 +91,11 @@ GEM
       path_expander (~> 2.0)
     minitest-focus (1.4.1)
       minitest (> 5.0)
+    minitest-reporters (1.5.0)
+      ansi
+      builder
+      minitest (>= 5.0)
+      ruby-progressbar
     minitest-rg (5.4.0)
       minitest (>= 5.0, < 7)
     minitest-server (1.0.10)
@@ -166,6 +173,7 @@ DEPENDENCIES
   minitest (~> 5.14)
   minitest-autotest (~> 1.0)
   minitest-focus (~> 1.1)
+  minitest-reporters (~> 1.5.0)
   minitest-rg (~> 5.2)
   rake
   redcarpet (~> 3.0)
@@ -175,9 +183,11 @@ DEPENDENCIES
 
 CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  ansi (1.6.0)
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   autotest-suffix (1.1.0) sha256=9bb29331b7b66a9659b01ef10839bd61fc1a6e95477c8ea710bd01e10c380977
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
+  builder (3.3.0)
   bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
   declarative (0.0.20) sha256=8021dd6cb17ab2b61233c56903d3f5a259c5cf43c80ff332d447d395b17d9ff9
   docile (1.4.1) sha256=96159be799bfa73cdb721b840e9802126e4e03dfc26863db73647204c727f21e
@@ -213,6 +223,7 @@ CHECKSUMS
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   minitest-autotest (1.2.0) sha256=60d031cba705215450662b0060f03f96507682b346a19c27f6756751ad92d2b4
   minitest-focus (1.4.1) sha256=394517cbe2dcb2d992d8ffc41a3b2b6315777a4daa69239de4fefe7110dd810e
+  minitest-reporters (1.5.0)
   minitest-rg (5.4.0) sha256=54d42bb8ce876381245be5866f3c1dd704ef79c06ba5c9ff280c0aa28c56effb
   minitest-server (1.0.10) sha256=275439bf3ffc433fcbe161733248f1d9749ebf122892cf010bf864aaa95cef75
   multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080

--- a/google-cloud-errors/test/helper.rb
+++ b/google-cloud-errors/test/helper.rb
@@ -21,6 +21,7 @@ if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   begin
     require "gapic/minitest_junit_preloader"
   rescue LoadError
+    # Do nothing if preloader is not available (e.g. local runs)
   end
 end
 

--- a/google-cloud-errors/test/helper.rb
+++ b/google-cloud-errors/test/helper.rb
@@ -15,6 +15,12 @@
 require "simplecov"
 
 gem "minitest"
+
+if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
+  # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
+  require "gapic/minitest_junit_preloader" rescue nil
+end
+
 require "minitest/autorun"
 require "minitest/focus"
 require "minitest/rg"

--- a/google-cloud-errors/test/helper.rb
+++ b/google-cloud-errors/test/helper.rb
@@ -18,7 +18,10 @@ gem "minitest"
 
 if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
-  require "gapic/minitest_junit_preloader" rescue nil
+  begin
+    require "gapic/minitest_junit_preloader"
+  rescue LoadError
+  end
 end
 
 require "minitest/autorun"

--- a/google-cloud-firestore/Gemfile
+++ b/google-cloud-firestore/Gemfile
@@ -27,6 +27,7 @@ gem "minitest-autotest", "~> 1.0"
 gem "minitest-focus", "~> 1.4"
 gem "minitest-mock", "~> 5.27"
 gem "minitest-rg", "~> 5.3"
+gem "minitest-reporters", "~> 1.5.0", require: false
 gem "ostruct", "~> 0.5.5"
 gem "rake"
 gem "redcarpet", "~> 3.6"

--- a/google-cloud-firestore/acceptance/firestore_helper.rb
+++ b/google-cloud-firestore/acceptance/firestore_helper.rb
@@ -21,6 +21,7 @@ if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   begin
     require "gapic/minitest_junit_preloader"
   rescue LoadError
+    # Do nothing if preloader is not available (e.g. local runs)
   end
 end
 

--- a/google-cloud-firestore/acceptance/firestore_helper.rb
+++ b/google-cloud-firestore/acceptance/firestore_helper.rb
@@ -15,6 +15,12 @@
 require "simplecov"
 
 gem "minitest"
+
+if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
+  # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
+  require "gapic/minitest_junit_preloader" rescue nil
+end
+
 require "minitest/autorun"
 require "minitest/focus"
 require "minitest/rg"

--- a/google-cloud-firestore/acceptance/firestore_helper.rb
+++ b/google-cloud-firestore/acceptance/firestore_helper.rb
@@ -18,7 +18,10 @@ gem "minitest"
 
 if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
-  require "gapic/minitest_junit_preloader" rescue nil
+  begin
+    require "gapic/minitest_junit_preloader"
+  rescue LoadError
+  end
 end
 
 require "minitest/autorun"

--- a/google-cloud-firestore/samples/acceptance/helper.rb
+++ b/google-cloud-firestore/samples/acceptance/helper.rb
@@ -18,6 +18,7 @@ if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   begin
     require "gapic/minitest_junit_preloader"
   rescue LoadError
+    # Do nothing if preloader is not available (e.g. local runs)
   end
 end
 

--- a/google-cloud-firestore/samples/acceptance/helper.rb
+++ b/google-cloud-firestore/samples/acceptance/helper.rb
@@ -12,6 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
+  # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
+  require "gapic/minitest_junit_preloader" rescue nil
+end
+
 require "minitest/autorun"
 require "minitest/focus"
 require "minitest/hooks/default"

--- a/google-cloud-firestore/samples/acceptance/helper.rb
+++ b/google-cloud-firestore/samples/acceptance/helper.rb
@@ -15,7 +15,10 @@
 
 if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
-  require "gapic/minitest_junit_preloader" rescue nil
+  begin
+    require "gapic/minitest_junit_preloader"
+  rescue LoadError
+  end
 end
 
 require "minitest/autorun"

--- a/google-cloud-firestore/test/helper.rb
+++ b/google-cloud-firestore/test/helper.rb
@@ -21,6 +21,7 @@ if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   begin
     require "gapic/minitest_junit_preloader"
   rescue LoadError
+    # Do nothing if preloader is not available (e.g. local runs)
   end
 end
 

--- a/google-cloud-firestore/test/helper.rb
+++ b/google-cloud-firestore/test/helper.rb
@@ -15,6 +15,12 @@
 require "simplecov"
 
 gem "minitest"
+
+if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
+  # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
+  require "gapic/minitest_junit_preloader" rescue nil
+end
+
 require "minitest/autorun"
 require "minitest/focus"
 require "minitest/rg"

--- a/google-cloud-firestore/test/helper.rb
+++ b/google-cloud-firestore/test/helper.rb
@@ -18,7 +18,10 @@ gem "minitest"
 
 if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
-  require "gapic/minitest_junit_preloader" rescue nil
+  begin
+    require "gapic/minitest_junit_preloader"
+  rescue LoadError
+  end
 end
 
 require "minitest/autorun"

--- a/google-cloud-logging/acceptance/logging_helper.rb
+++ b/google-cloud-logging/acceptance/logging_helper.rb
@@ -21,6 +21,7 @@ if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   begin
     require "gapic/minitest_junit_preloader"
   rescue LoadError
+    # Do nothing if preloader is not available (e.g. local runs)
   end
 end
 

--- a/google-cloud-logging/acceptance/logging_helper.rb
+++ b/google-cloud-logging/acceptance/logging_helper.rb
@@ -30,12 +30,6 @@ require "minitest/focus"
 require "minitest/rg"
 require "google/cloud/logging"
 
-# Generate JUnit format test reports
-if ENV["GCLOUD_TEST_GENERATE_XML_REPORT"]
-  require "minitest/reporters"
-  Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new, Minitest::Reporters::JUnitReporter.new]
-end
-
 # Create shared logging object so we don't create new for each test
 $logging = Google::Cloud::Logging.new
 

--- a/google-cloud-logging/acceptance/logging_helper.rb
+++ b/google-cloud-logging/acceptance/logging_helper.rb
@@ -15,6 +15,12 @@
 require "simplecov"
 
 gem "minitest"
+
+if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
+  # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
+  require "gapic/minitest_junit_preloader" rescue nil
+end
+
 require "minitest/autorun"
 require "minitest/focus"
 require "minitest/rg"

--- a/google-cloud-logging/acceptance/logging_helper.rb
+++ b/google-cloud-logging/acceptance/logging_helper.rb
@@ -18,7 +18,10 @@ gem "minitest"
 
 if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
-  require "gapic/minitest_junit_preloader" rescue nil
+  begin
+    require "gapic/minitest_junit_preloader"
+  rescue LoadError
+  end
 end
 
 require "minitest/autorun"

--- a/google-cloud-logging/samples/acceptance/helper.rb
+++ b/google-cloud-logging/samples/acceptance/helper.rb
@@ -15,6 +15,12 @@
 require "google/cloud/logging"
 require "google/cloud/errors"
 require "google/cloud/storage"
+
+if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
+  # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
+  require "gapic/minitest_junit_preloader" rescue nil
+end
+
 require "minitest/autorun"
 require "minitest/focus"
 require "securerandom"

--- a/google-cloud-logging/samples/acceptance/helper.rb
+++ b/google-cloud-logging/samples/acceptance/helper.rb
@@ -18,7 +18,10 @@ require "google/cloud/storage"
 
 if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
-  require "gapic/minitest_junit_preloader" rescue nil
+  begin
+    require "gapic/minitest_junit_preloader"
+  rescue LoadError
+  end
 end
 
 require "minitest/autorun"

--- a/google-cloud-logging/samples/acceptance/helper.rb
+++ b/google-cloud-logging/samples/acceptance/helper.rb
@@ -21,6 +21,7 @@ if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   begin
     require "gapic/minitest_junit_preloader"
   rescue LoadError
+    # Do nothing if preloader is not available (e.g. local runs)
   end
 end
 

--- a/google-cloud-logging/test/helper.rb
+++ b/google-cloud-logging/test/helper.rb
@@ -21,6 +21,7 @@ if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   begin
     require "gapic/minitest_junit_preloader"
   rescue LoadError
+    # Do nothing if preloader is not available (e.g. local runs)
   end
 end
 

--- a/google-cloud-logging/test/helper.rb
+++ b/google-cloud-logging/test/helper.rb
@@ -15,6 +15,12 @@
 require "simplecov"
 
 gem "minitest"
+
+if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
+  # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
+  require "gapic/minitest_junit_preloader" rescue nil
+end
+
 require "minitest/autorun"
 require "minitest/focus"
 require "minitest/rg"

--- a/google-cloud-logging/test/helper.rb
+++ b/google-cloud-logging/test/helper.rb
@@ -18,7 +18,10 @@ gem "minitest"
 
 if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
-  require "gapic/minitest_junit_preloader" rescue nil
+  begin
+    require "gapic/minitest_junit_preloader"
+  rescue LoadError
+  end
 end
 
 require "minitest/autorun"

--- a/google-cloud-pubsub/acceptance/pubsub_helper.rb
+++ b/google-cloud-pubsub/acceptance/pubsub_helper.rb
@@ -30,12 +30,6 @@ require "minitest/focus"
 require "minitest/rg"
 require "google/cloud/pubsub"
 
-# Generate JUnit format test reports
-if ENV["GCLOUD_TEST_GENERATE_XML_REPORT"]
-  require "minitest/reporters"
-  Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new, Minitest::Reporters::JUnitReporter.new]
-end
-
 # Create shared pubsub object so we don't create new for each test
 $pubsub = Google::Cloud::PubSub.new
 $topic_admin = $pubsub.topic_admin

--- a/google-cloud-pubsub/acceptance/pubsub_helper.rb
+++ b/google-cloud-pubsub/acceptance/pubsub_helper.rb
@@ -21,6 +21,7 @@ if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   begin
     require "gapic/minitest_junit_preloader"
   rescue LoadError
+    # Do nothing if preloader is not available (e.g. local runs)
   end
 end
 

--- a/google-cloud-pubsub/acceptance/pubsub_helper.rb
+++ b/google-cloud-pubsub/acceptance/pubsub_helper.rb
@@ -15,6 +15,12 @@
 require "simplecov"
 
 gem "minitest"
+
+if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
+  # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
+  require "gapic/minitest_junit_preloader" rescue nil
+end
+
 require "minitest/autorun"
 require "minitest/focus"
 require "minitest/rg"

--- a/google-cloud-pubsub/acceptance/pubsub_helper.rb
+++ b/google-cloud-pubsub/acceptance/pubsub_helper.rb
@@ -18,7 +18,10 @@ gem "minitest"
 
 if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
-  require "gapic/minitest_junit_preloader" rescue nil
+  begin
+    require "gapic/minitest_junit_preloader"
+  rescue LoadError
+  end
 end
 
 require "minitest/autorun"

--- a/google-cloud-pubsub/samples/acceptance/helper.rb
+++ b/google-cloud-pubsub/samples/acceptance/helper.rb
@@ -18,6 +18,7 @@ if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   begin
     require "gapic/minitest_junit_preloader"
   rescue LoadError
+    # Do nothing if preloader is not available (e.g. local runs)
   end
 end
 

--- a/google-cloud-pubsub/samples/acceptance/helper.rb
+++ b/google-cloud-pubsub/samples/acceptance/helper.rb
@@ -12,6 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
+  # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
+  require "gapic/minitest_junit_preloader" rescue nil
+end
+
 require "minitest/autorun"
 require "minitest/focus"
 require "minitest/hooks/default"

--- a/google-cloud-pubsub/samples/acceptance/helper.rb
+++ b/google-cloud-pubsub/samples/acceptance/helper.rb
@@ -15,7 +15,10 @@
 
 if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
-  require "gapic/minitest_junit_preloader" rescue nil
+  begin
+    require "gapic/minitest_junit_preloader"
+  rescue LoadError
+  end
 end
 
 require "minitest/autorun"

--- a/google-cloud-pubsub/test/helper.rb
+++ b/google-cloud-pubsub/test/helper.rb
@@ -21,6 +21,7 @@ if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   begin
     require "gapic/minitest_junit_preloader"
   rescue LoadError
+    # Do nothing if preloader is not available (e.g. local runs)
   end
 end
 

--- a/google-cloud-pubsub/test/helper.rb
+++ b/google-cloud-pubsub/test/helper.rb
@@ -15,6 +15,12 @@
 require "simplecov"
 
 gem "minitest"
+
+if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
+  # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
+  require "gapic/minitest_junit_preloader" rescue nil
+end
+
 require "minitest/autorun"
 require "minitest/focus"
 require "minitest/rg"

--- a/google-cloud-pubsub/test/helper.rb
+++ b/google-cloud-pubsub/test/helper.rb
@@ -18,7 +18,10 @@ gem "minitest"
 
 if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
-  require "gapic/minitest_junit_preloader" rescue nil
+  begin
+    require "gapic/minitest_junit_preloader"
+  rescue LoadError
+  end
 end
 
 require "minitest/autorun"

--- a/google-cloud-storage/acceptance/storage_helper.rb
+++ b/google-cloud-storage/acceptance/storage_helper.rb
@@ -21,6 +21,7 @@ if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   begin
     require "gapic/minitest_junit_preloader"
   rescue LoadError
+    # Do nothing if preloader is not available (e.g. local runs)
   end
 end
 

--- a/google-cloud-storage/acceptance/storage_helper.rb
+++ b/google-cloud-storage/acceptance/storage_helper.rb
@@ -15,6 +15,12 @@
 require "simplecov"
 
 gem "minitest"
+
+if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
+  # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
+  require "gapic/minitest_junit_preloader" rescue nil
+end
+
 require "minitest/autorun"
 require "minitest/focus"
 require "minitest/rg"

--- a/google-cloud-storage/acceptance/storage_helper.rb
+++ b/google-cloud-storage/acceptance/storage_helper.rb
@@ -18,7 +18,10 @@ gem "minitest"
 
 if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
-  require "gapic/minitest_junit_preloader" rescue nil
+  begin
+    require "gapic/minitest_junit_preloader"
+  rescue LoadError
+  end
 end
 
 require "minitest/autorun"

--- a/google-cloud-storage/acceptance/storage_helper.rb
+++ b/google-cloud-storage/acceptance/storage_helper.rb
@@ -37,12 +37,6 @@ PAP_SKIP_MESSAGE = "Skipping this test due to a change in GCS behavior that disa
                    "access prevention is enforced. See " \
                    "https://cloud.google.com/storage/docs/public-access-prevention for more details.".freeze
 
-# Generate JUnit format test reports
-if ENV["GCLOUD_TEST_GENERATE_XML_REPORT"]
-  require "minitest/reporters"
-  Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new, Minitest::Reporters::JUnitReporter.new]
-end
-
 # Create shared storage object so we don't create new for each test
 scopes = ["https://www.googleapis.com/auth/devstorage.full_control", "https://www.googleapis.com/auth/iam"]
 $storage = Google::Cloud.new.storage retries: 10, scope: scopes

--- a/google-cloud-storage/samples/acceptance/helper.rb
+++ b/google-cloud-storage/samples/acceptance/helper.rb
@@ -18,7 +18,10 @@ require "google/cloud/storage"
 
 if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
-  require "gapic/minitest_junit_preloader" rescue nil
+  begin
+    require "gapic/minitest_junit_preloader"
+  rescue LoadError
+  end
 end
 
 require "minitest/autorun"

--- a/google-cloud-storage/samples/acceptance/helper.rb
+++ b/google-cloud-storage/samples/acceptance/helper.rb
@@ -21,6 +21,7 @@ if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   begin
     require "gapic/minitest_junit_preloader"
   rescue LoadError
+    # Do nothing if preloader is not available (e.g. local runs)
   end
 end
 

--- a/google-cloud-storage/samples/acceptance/helper.rb
+++ b/google-cloud-storage/samples/acceptance/helper.rb
@@ -15,6 +15,12 @@
 require "google/cloud/errors"
 require "google/cloud/kms"
 require "google/cloud/storage"
+
+if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
+  # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
+  require "gapic/minitest_junit_preloader" rescue nil
+end
+
 require "minitest/autorun"
 require "minitest/focus"
 require "minitest/hooks/default"

--- a/google-cloud-storage/test/helper.rb
+++ b/google-cloud-storage/test/helper.rb
@@ -21,6 +21,7 @@ if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   begin
     require "gapic/minitest_junit_preloader"
   rescue LoadError
+    # Do nothing if preloader is not available (e.g. local runs)
   end
 end
 

--- a/google-cloud-storage/test/helper.rb
+++ b/google-cloud-storage/test/helper.rb
@@ -15,6 +15,12 @@
 require "simplecov"
 
 gem "minitest"
+
+if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
+  # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
+  require "gapic/minitest_junit_preloader" rescue nil
+end
+
 require "minitest/autorun"
 require "minitest/focus"
 require "minitest/rg"

--- a/google-cloud-storage/test/helper.rb
+++ b/google-cloud-storage/test/helper.rb
@@ -18,7 +18,10 @@ gem "minitest"
 
 if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
-  require "gapic/minitest_junit_preloader" rescue nil
+  begin
+    require "gapic/minitest_junit_preloader"
+  rescue LoadError
+  end
 end
 
 require "minitest/autorun"

--- a/google-cloud-trace/Gemfile
+++ b/google-cloud-trace/Gemfile
@@ -37,6 +37,7 @@ gem "minitest-autotest", "~> 1.0"
 gem "minitest-focus", "~> 1.4"
 gem "minitest-mock", "~> 5.27"
 gem "minitest-rg", "~> 5.3"
+gem "minitest-reporters", "~> 1.5.0", require: false
 gem "ostruct", "~> 0.5.5"
 gem "railties", ">= 5.0", "< 8.1.4"
 gem "rake"

--- a/google-cloud-trace/acceptance/trace_helper.rb
+++ b/google-cloud-trace/acceptance/trace_helper.rb
@@ -21,6 +21,7 @@ if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   begin
     require "gapic/minitest_junit_preloader"
   rescue LoadError
+    # Do nothing if preloader is not available (e.g. local runs)
   end
 end
 

--- a/google-cloud-trace/acceptance/trace_helper.rb
+++ b/google-cloud-trace/acceptance/trace_helper.rb
@@ -15,6 +15,12 @@
 require "simplecov"
 
 gem "minitest"
+
+if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
+  # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
+  require "gapic/minitest_junit_preloader" rescue nil
+end
+
 require "minitest/autorun"
 require "minitest/focus"
 require "minitest/rg"

--- a/google-cloud-trace/acceptance/trace_helper.rb
+++ b/google-cloud-trace/acceptance/trace_helper.rb
@@ -18,7 +18,10 @@ gem "minitest"
 
 if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
-  require "gapic/minitest_junit_preloader" rescue nil
+  begin
+    require "gapic/minitest_junit_preloader"
+  rescue LoadError
+  end
 end
 
 require "minitest/autorun"

--- a/google-cloud-trace/test/helper.rb
+++ b/google-cloud-trace/test/helper.rb
@@ -21,6 +21,7 @@ if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   begin
     require "gapic/minitest_junit_preloader"
   rescue LoadError
+    # Do nothing if preloader is not available (e.g. local runs)
   end
 end
 

--- a/google-cloud-trace/test/helper.rb
+++ b/google-cloud-trace/test/helper.rb
@@ -15,6 +15,12 @@
 require "simplecov"
 
 gem "minitest"
+
+if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
+  # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
+  require "gapic/minitest_junit_preloader" rescue nil
+end
+
 require "minitest/autorun"
 require "minitest/focus"
 require "minitest/rg"

--- a/google-cloud-trace/test/helper.rb
+++ b/google-cloud-trace/test/helper.rb
@@ -18,7 +18,10 @@ gem "minitest"
 
 if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
-  require "gapic/minitest_junit_preloader" rescue nil
+  begin
+    require "gapic/minitest_junit_preloader"
+  rescue LoadError
+  end
 end
 
 require "minitest/autorun"

--- a/google-cloud-translate-v2/Gemfile
+++ b/google-cloud-translate-v2/Gemfile
@@ -9,6 +9,7 @@ gem "ostruct", "~> 0.6.3"
 gem "minitest", "~> 5.16"
 gem "minitest-focus", "~> 1.1"
 gem "minitest-rg", "~> 5.2"
+gem "minitest-reporters", "~> 1.5.0", require: false
 gem "ostruct", "~> 0.6.3"
 gem "rake", ">= 12.0"
 gem "redcarpet", "~> 3.0"

--- a/google-cloud-translate-v2/acceptance/translate_helper.rb
+++ b/google-cloud-translate-v2/acceptance/translate_helper.rb
@@ -21,6 +21,7 @@ if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   begin
     require "gapic/minitest_junit_preloader"
   rescue LoadError
+    # Do nothing if preloader is not available (e.g. local runs)
   end
 end
 

--- a/google-cloud-translate-v2/acceptance/translate_helper.rb
+++ b/google-cloud-translate-v2/acceptance/translate_helper.rb
@@ -15,6 +15,12 @@
 require "simplecov"
 
 gem "minitest"
+
+if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
+  # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
+  require "gapic/minitest_junit_preloader" rescue nil
+end
+
 require "minitest/autorun"
 require "minitest/focus"
 require "minitest/rg"

--- a/google-cloud-translate-v2/acceptance/translate_helper.rb
+++ b/google-cloud-translate-v2/acceptance/translate_helper.rb
@@ -18,7 +18,10 @@ gem "minitest"
 
 if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
-  require "gapic/minitest_junit_preloader" rescue nil
+  begin
+    require "gapic/minitest_junit_preloader"
+  rescue LoadError
+  end
 end
 
 require "minitest/autorun"

--- a/google-cloud-translate-v2/test/helper.rb
+++ b/google-cloud-translate-v2/test/helper.rb
@@ -21,6 +21,7 @@ if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   begin
     require "gapic/minitest_junit_preloader"
   rescue LoadError
+    # Do nothing if preloader is not available (e.g. local runs)
   end
 end
 

--- a/google-cloud-translate-v2/test/helper.rb
+++ b/google-cloud-translate-v2/test/helper.rb
@@ -15,6 +15,12 @@
 require "simplecov"
 
 gem "minitest"
+
+if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
+  # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
+  require "gapic/minitest_junit_preloader" rescue nil
+end
+
 require "minitest/autorun"
 require "minitest/focus"
 require "minitest/rg"

--- a/google-cloud-translate-v2/test/helper.rb
+++ b/google-cloud-translate-v2/test/helper.rb
@@ -18,7 +18,10 @@ gem "minitest"
 
 if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
-  require "gapic/minitest_junit_preloader" rescue nil
+  begin
+    require "gapic/minitest_junit_preloader"
+  rescue LoadError
+  end
 end
 
 require "minitest/autorun"

--- a/stackdriver-core/Gemfile
+++ b/stackdriver-core/Gemfile
@@ -10,6 +10,7 @@ gem "minitest", "~> 5.14"
 gem "minitest-autotest", "~> 1.0"
 gem "minitest-focus", "~> 1.1"
 gem "minitest-rg", "~> 5.2"
+gem "minitest-reporters", "~> 1.5.0", require: false
 gem "rake"
 gem "redcarpet", "~> 3.0"
 gem "simplecov", "~> 0.9"

--- a/stackdriver-core/test/helper.rb
+++ b/stackdriver-core/test/helper.rb
@@ -21,6 +21,7 @@ if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   begin
     require "gapic/minitest_junit_preloader"
   rescue LoadError
+    # Do nothing if preloader is not available (e.g. local runs)
   end
 end
 

--- a/stackdriver-core/test/helper.rb
+++ b/stackdriver-core/test/helper.rb
@@ -15,6 +15,12 @@
 require "simplecov"
 
 gem "minitest"
+
+if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
+  # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
+  require "gapic/minitest_junit_preloader" rescue nil
+end
+
 require "minitest/autorun"
 require "minitest/focus"
 require "minitest/rg"

--- a/stackdriver-core/test/helper.rb
+++ b/stackdriver-core/test/helper.rb
@@ -18,7 +18,10 @@ gem "minitest"
 
 if ENV["CI"] || ENV["KOKORO_JOB_NAME"]
   # Load JUnit XML formatter from googleapis/ruby-common-tools to write tmp/reports/sponge_log.xml for Kokoro/TestGrid.
-  require "gapic/minitest_junit_preloader" rescue nil
+  begin
+    require "gapic/minitest_junit_preloader"
+  rescue LoadError
+  end
 end
 
 require "minitest/autorun"


### PR DESCRIPTION
Write minitest execution output to JUnit XML reports. This enables centralized test result indexing, flake tracing, and build health metrics reporting inside TestGrid dashboards.