### PR TITLE
chore(deps): widen Phase 1 lockfile maintenance coverage and schedule daily

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,7 +18,11 @@
         "!google-cloud-storage/**",
         "!google-cloud-pubsub/**",
         "!google-cloud-bigquery/**",
-        "!google-cloud-errors/**"
+        "!google-cloud-errors/**",
+        "!google-cloud-resource_manager/**",
+        "!google-cloud-bigtable/**",
+        "!google-cloud-logging/**",
+        "!google-cloud-monitoring/**"
       ],
       "enabled": false
     },
@@ -29,7 +33,11 @@
         "google-cloud-storage/**",
         "google-cloud-pubsub/**",
         "google-cloud-bigquery/**",
-        "google-cloud-errors/**"
+        "google-cloud-errors/**",
+        "google-cloud-resource_manager/**",
+        "google-cloud-bigtable/**",
+        "google-cloud-logging/**",
+        "google-cloud-monitoring/**"
       ],
       "groupName": "core handwritten gems lockfiles",
       "rangeStrategy": "update-lockfile",
@@ -37,7 +45,7 @@
         "enabled": true,
         "automerge": false,
         "schedule": [
-          "before 5am on monday"
+          "before 5am every day"
         ],
         "commitMessageAction": "maintain Gemfile.lock files"
       }


### PR DESCRIPTION
## Overview
Widens the Phase 1 `Gemfile.lock` Renovate automation coverage (`matchFileNames` in `.github/renovate.json`) to include 4 additional core wrapper gems:
- `google-cloud-resource_manager/**`
- `google-cloud-bigtable/**`
- `google-cloud-logging/**`
- `google-cloud-monitoring/**`

Additionally updates the `schedule` for lockfile maintenance from `"before 5am on monday"` to `"before 5am every day"` so we can validate automated daily lockfile generation and PR creation before proceeding with Phase 2 scale-out across remaining gems.

## Details
- Excludes these 4 additional gems from the negated non-Phase 1 exclusion rule (`!google-cloud-.../**`).
- Adds these 4 additional gems to the Phase 1 core & handwritten lockfile generation rule.
- Sets schedule to `"before 5am every day"` (`lockFileMaintenance.schedule`).