### PR TITLE
chore: Test upgrade to Protocol Buffers v36.0-rc1

### DIFF
--- a/google-cloud-bigquery/Gemfile
+++ b/google-cloud-bigquery/Gemfile
@@ -38,3 +38,5 @@ gem "redcarpet", "~> 3.6"
 gem "simplecov", "~> 0.22"
 gem "yard", "~> 0.9"
 gem "yard-doctest", "~> 0.1.13"
+
+gem "google-protobuf", "= 4.36.0.rc.1"

--- a/google-cloud-bigquery/Gemfile.lock
+++ b/google-cloud-bigquery/Gemfile.lock
@@ -15,12 +15,12 @@ PATH
 PATH
   remote: ../google-cloud-errors
   specs:
-    google-cloud-errors (1.6.0)
+    google-cloud-errors (1.7.0)
 
 PATH
   remote: ../google-cloud-storage
   specs:
-    google-cloud-storage (1.61.0)
+    google-cloud-storage (1.62.0)
       addressable (~> 2.8)
       digest-crc (~> 0.4)
       google-apis-core (>= 0.18, < 2)
@@ -112,31 +112,31 @@ GEM
       google-cloud-errors (~> 1.0)
       grpc-google-iam-v1 (~> 1.11)
     google-logging-utils (0.2.0)
-    google-protobuf (4.35.1)
+    google-protobuf (4.36.0.rc.1)
       bigdecimal
       rake (~> 13.3)
-    google-protobuf (4.35.1-aarch64-linux-gnu)
+    google-protobuf (4.36.0.rc.1-aarch64-linux-gnu)
       bigdecimal
       rake (~> 13.3)
-    google-protobuf (4.35.1-aarch64-linux-musl)
+    google-protobuf (4.36.0.rc.1-aarch64-linux-musl)
       bigdecimal
       rake (~> 13.3)
-    google-protobuf (4.35.1-arm64-darwin)
+    google-protobuf (4.36.0.rc.1-arm64-darwin)
       bigdecimal
       rake (~> 13.3)
-    google-protobuf (4.35.1-x86-linux-gnu)
+    google-protobuf (4.36.0.rc.1-x86-linux-gnu)
       bigdecimal
       rake (~> 13.3)
-    google-protobuf (4.35.1-x86-linux-musl)
+    google-protobuf (4.36.0.rc.1-x86-linux-musl)
       bigdecimal
       rake (~> 13.3)
-    google-protobuf (4.35.1-x86_64-darwin)
+    google-protobuf (4.36.0.rc.1-x86_64-darwin)
       bigdecimal
       rake (~> 13.3)
-    google-protobuf (4.35.1-x86_64-linux-gnu)
+    google-protobuf (4.36.0.rc.1-x86_64-linux-gnu)
       bigdecimal
       rake (~> 13.3)
-    google-protobuf (4.35.1-x86_64-linux-musl)
+    google-protobuf (4.36.0.rc.1-x86_64-linux-musl)
       bigdecimal
       rake (~> 13.3)
     google-style (1.32.0)
@@ -307,6 +307,7 @@ DEPENDENCIES
   google-cloud-data_catalog!
   google-cloud-errors!
   google-cloud-storage!
+  google-protobuf (= 4.36.0.rc.1)
   google-style (~> 1.32.0)
   irb (~> 1.17)
   minitest (~> 6.0.2)
@@ -330,7 +331,7 @@ CHECKSUMS
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
-  bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
+  bundler (4.0.13) sha256=19f08be7f27022cf0b89f27da0b044ae075e8270a9ef44ad248a932614e1ca3b
   concurrent-ruby (1.3.7) sha256=4412caec3a5ea2e5fdc52076724c071a81f2c0593d83b2ac8cbb8ca63b3151b0
   csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
   declarative (0.0.20) sha256=8021dd6cb17ab2b61233c56903d3f5a259c5cf43c80ff332d447d395b17d9ff9
@@ -353,19 +354,19 @@ CHECKSUMS
   google-cloud-data_catalog (2.3.0)
   google-cloud-data_catalog-v1 (2.8.0) sha256=12006f9bcb66dcfa39d146fefed2987cdd4b5b5ea8790780e5ef0e655a7c380a
   google-cloud-env (2.3.1) sha256=0faac01eb27be78c2591d64433663b1a114f8f7af55a4f819755426cac9178e7
-  google-cloud-errors (1.6.0)
-  google-cloud-storage (1.61.0)
+  google-cloud-errors (1.7.0)
+  google-cloud-storage (1.62.0)
   google-iam-v1 (1.7.0) sha256=9e3ea9dcc59cbd5f8d2f62b00da41ec57a2e427b33c0e798207fa06c8fbb8b87
   google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
-  google-protobuf (4.35.1) sha256=a3a6471331d918f58dfa4d014a8f6286f0af2cf4840216bde52fcf2ea3fe3726
-  google-protobuf (4.35.1-aarch64-linux-gnu) sha256=50ca44d0eeff3f8475e630a1accdd974256f3510694d574e2c9d6119ea8bc9e1
-  google-protobuf (4.35.1-aarch64-linux-musl) sha256=d5c65cef6bd6498a9e5ed5f88cf6cf7e341c10b0a005e32137d5d1a2b6e8c18a
-  google-protobuf (4.35.1-arm64-darwin) sha256=d9c957df04fa89c749fa9a72a7b383eb4296efc9b2303dc6fd6fbe39c698ad6b
-  google-protobuf (4.35.1-x86-linux-gnu) sha256=cc7492566b27ad8b5dfa3a7b6f9b11e905050cc53c2fa8ff22de375a9e7a70fb
-  google-protobuf (4.35.1-x86-linux-musl) sha256=ab403790b59e4dc588ffbed1eaacf05d4ca2f0d12ac9c13d6c64e69380d8c99e
-  google-protobuf (4.35.1-x86_64-darwin) sha256=66b62b4df00931018a692806df66393efa960d6d2b7da69735187249f950d3ee
-  google-protobuf (4.35.1-x86_64-linux-gnu) sha256=c786439087512a3fbd199e9897d265b855f951d4027e218ea55e858d45969edd
-  google-protobuf (4.35.1-x86_64-linux-musl) sha256=91890eb0002934a339fdb7d77a147c46b7474b6799db27872b747b905837f744
+  google-protobuf (4.36.0.rc.1) sha256=5d0dd7513544e7f593d5ce749fea265ec39a8f26d7809db77a6e6e88c87974d8
+  google-protobuf (4.36.0.rc.1-aarch64-linux-gnu) sha256=a0be9190b6aacb17806b781eb1d9fb6c8d7826872f6546faa105cc933677b3dd
+  google-protobuf (4.36.0.rc.1-aarch64-linux-musl) sha256=e0ea920d58894de33c8ad18a916225436caf071d173bad46fb4295a60c7f151d
+  google-protobuf (4.36.0.rc.1-arm64-darwin) sha256=c8e709a09bc9af9835e95b2fe6ae662a6016bf0808cbfa4f78899ce06de3e8b4
+  google-protobuf (4.36.0.rc.1-x86-linux-gnu) sha256=22637c3c6094d0316976c6a67515bc0aee59c98cd2bda277fe2c906a3e38bf37
+  google-protobuf (4.36.0.rc.1-x86-linux-musl) sha256=e8db35b697642890b0016c8ec4b7cd76a2f218cebd87b80c5cec66ff8ed042a1
+  google-protobuf (4.36.0.rc.1-x86_64-darwin) sha256=8518b6c21ff49c4bfe13c612c8bd52aa80e392537812f5e0fa901d5a2290d9a8
+  google-protobuf (4.36.0.rc.1-x86_64-linux-gnu) sha256=e0f2e73ea8183deb7df4330cfbfaa50ebb9c9fabf9e46b3e77e6108984ec6766
+  google-protobuf (4.36.0.rc.1-x86_64-linux-musl) sha256=04a7aeb55ffdad5cae493c0e8113b0e0b91205c0d4eaa55991aa66c3041256a8
   google-style (1.32.0) sha256=3b13068979e5b8caa067ecce9bf818b6cf0e5eb706ead41c5b905f237d9bfb01
   googleapis-common-protos (1.9.0) sha256=207be372d8d25e3876e1e1155d057e14f3c92f8f5428772864a8ce04a0b756e4
   googleapis-common-protos-types (1.23.0) sha256=992e740a523794d9fc5f29a504465d8fc737aaa16c930fe7228e3346860faf0a
@@ -432,4 +433,4 @@ CHECKSUMS
   yard-doctest (0.1.17) sha256=7cb35a75d99f58fc42ee72d3542a36e227237b621a40aebc391c95988b72847f
 
 BUNDLED WITH
-  4.0.14
+  4.0.13

--- a/google-cloud-logging/Gemfile
+++ b/google-cloud-logging/Gemfile
@@ -41,3 +41,5 @@ gem "simplecov", "~> 0.22"
 gem "stackdriver-core", path: "../stackdriver-core"
 gem "yard", "~> 0.9"
 gem "yard-doctest", "~> 0.1.13"
+
+gem "google-protobuf", "= 4.36.0.rc.1"

--- a/google-cloud-pubsub/Gemfile
+++ b/google-cloud-pubsub/Gemfile
@@ -36,3 +36,5 @@ gem "retriable", "~> 3.1.2"
 gem "simplecov", "~> 0.22"
 gem "yard", "~> 0.9.37"
 gem "yard-doctest", "~> 0.1.17"
+
+gem "google-protobuf", "= 4.36.0.rc.1"

--- a/google-cloud-pubsub/Gemfile.lock
+++ b/google-cloud-pubsub/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
 PATH
   remote: ../google-cloud-errors
   specs:
-    google-cloud-errors (1.6.0)
+    google-cloud-errors (1.7.0)
 
 PATH
   remote: ../google-cloud-pubsub-v1
@@ -70,31 +70,31 @@ GEM
       google-cloud-errors (~> 1.0)
       grpc-google-iam-v1 (~> 1.11)
     google-logging-utils (0.2.0)
-    google-protobuf (4.35.1)
+    google-protobuf (4.36.0.rc.1)
       bigdecimal
       rake (~> 13.3)
-    google-protobuf (4.35.1-aarch64-linux-gnu)
+    google-protobuf (4.36.0.rc.1-aarch64-linux-gnu)
       bigdecimal
       rake (~> 13.3)
-    google-protobuf (4.35.1-aarch64-linux-musl)
+    google-protobuf (4.36.0.rc.1-aarch64-linux-musl)
       bigdecimal
       rake (~> 13.3)
-    google-protobuf (4.35.1-arm64-darwin)
+    google-protobuf (4.36.0.rc.1-arm64-darwin)
       bigdecimal
       rake (~> 13.3)
-    google-protobuf (4.35.1-x86-linux-gnu)
+    google-protobuf (4.36.0.rc.1-x86-linux-gnu)
       bigdecimal
       rake (~> 13.3)
-    google-protobuf (4.35.1-x86-linux-musl)
+    google-protobuf (4.36.0.rc.1-x86-linux-musl)
       bigdecimal
       rake (~> 13.3)
-    google-protobuf (4.35.1-x86_64-darwin)
+    google-protobuf (4.36.0.rc.1-x86_64-darwin)
       bigdecimal
       rake (~> 13.3)
-    google-protobuf (4.35.1-x86_64-linux-gnu)
+    google-protobuf (4.36.0.rc.1-x86_64-linux-gnu)
       bigdecimal
       rake (~> 13.3)
-    google-protobuf (4.35.1-x86_64-linux-musl)
+    google-protobuf (4.36.0.rc.1-x86_64-linux-musl)
       bigdecimal
       rake (~> 13.3)
     google-style (1.31.1)
@@ -242,6 +242,7 @@ DEPENDENCIES
   google-cloud-errors!
   google-cloud-pubsub!
   google-cloud-pubsub-v1!
+  google-protobuf (= 4.36.0.rc.1)
   google-style (~> 1.31.1)
   minitest (~> 5.25)
   minitest-autotest (~> 1.1)
@@ -266,7 +267,7 @@ CHECKSUMS
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
-  bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
+  bundler (4.0.13) sha256=19f08be7f27022cf0b89f27da0b044ae075e8270a9ef44ad248a932614e1ca3b
   coderay (1.1.3) sha256=dc530018a4684512f8f38143cd2a096c9f02a1fc2459edcfe534787a7fc77d4b
   concurrent-ruby (1.3.7) sha256=4412caec3a5ea2e5fdc52076724c071a81f2c0593d83b2ac8cbb8ca63b3151b0
   docile (1.4.1) sha256=96159be799bfa73cdb721b840e9802126e4e03dfc26863db73647204c727f21e
@@ -277,20 +278,20 @@ CHECKSUMS
   gapic-common (1.3.0) sha256=4e5d9be1effb7366e2cda13c0f44922285d5613ac8de8b9b18c2c835fe4faa91
   google-cloud-core (1.9.0)
   google-cloud-env (2.3.1) sha256=0faac01eb27be78c2591d64433663b1a114f8f7af55a4f819755426cac9178e7
-  google-cloud-errors (1.6.0)
+  google-cloud-errors (1.7.0)
   google-cloud-pubsub (3.3.0)
   google-cloud-pubsub-v1 (1.16.0)
   google-iam-v1 (1.7.0) sha256=9e3ea9dcc59cbd5f8d2f62b00da41ec57a2e427b33c0e798207fa06c8fbb8b87
   google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
-  google-protobuf (4.35.1) sha256=a3a6471331d918f58dfa4d014a8f6286f0af2cf4840216bde52fcf2ea3fe3726
-  google-protobuf (4.35.1-aarch64-linux-gnu) sha256=50ca44d0eeff3f8475e630a1accdd974256f3510694d574e2c9d6119ea8bc9e1
-  google-protobuf (4.35.1-aarch64-linux-musl) sha256=d5c65cef6bd6498a9e5ed5f88cf6cf7e341c10b0a005e32137d5d1a2b6e8c18a
-  google-protobuf (4.35.1-arm64-darwin) sha256=d9c957df04fa89c749fa9a72a7b383eb4296efc9b2303dc6fd6fbe39c698ad6b
-  google-protobuf (4.35.1-x86-linux-gnu) sha256=cc7492566b27ad8b5dfa3a7b6f9b11e905050cc53c2fa8ff22de375a9e7a70fb
-  google-protobuf (4.35.1-x86-linux-musl) sha256=ab403790b59e4dc588ffbed1eaacf05d4ca2f0d12ac9c13d6c64e69380d8c99e
-  google-protobuf (4.35.1-x86_64-darwin) sha256=66b62b4df00931018a692806df66393efa960d6d2b7da69735187249f950d3ee
-  google-protobuf (4.35.1-x86_64-linux-gnu) sha256=c786439087512a3fbd199e9897d265b855f951d4027e218ea55e858d45969edd
-  google-protobuf (4.35.1-x86_64-linux-musl) sha256=91890eb0002934a339fdb7d77a147c46b7474b6799db27872b747b905837f744
+  google-protobuf (4.36.0.rc.1) sha256=5d0dd7513544e7f593d5ce749fea265ec39a8f26d7809db77a6e6e88c87974d8
+  google-protobuf (4.36.0.rc.1-aarch64-linux-gnu) sha256=a0be9190b6aacb17806b781eb1d9fb6c8d7826872f6546faa105cc933677b3dd
+  google-protobuf (4.36.0.rc.1-aarch64-linux-musl) sha256=e0ea920d58894de33c8ad18a916225436caf071d173bad46fb4295a60c7f151d
+  google-protobuf (4.36.0.rc.1-arm64-darwin) sha256=c8e709a09bc9af9835e95b2fe6ae662a6016bf0808cbfa4f78899ce06de3e8b4
+  google-protobuf (4.36.0.rc.1-x86-linux-gnu) sha256=22637c3c6094d0316976c6a67515bc0aee59c98cd2bda277fe2c906a3e38bf37
+  google-protobuf (4.36.0.rc.1-x86-linux-musl) sha256=e8db35b697642890b0016c8ec4b7cd76a2f218cebd87b80c5cec66ff8ed042a1
+  google-protobuf (4.36.0.rc.1-x86_64-darwin) sha256=8518b6c21ff49c4bfe13c612c8bd52aa80e392537812f5e0fa901d5a2290d9a8
+  google-protobuf (4.36.0.rc.1-x86_64-linux-gnu) sha256=e0f2e73ea8183deb7df4330cfbfaa50ebb9c9fabf9e46b3e77e6108984ec6766
+  google-protobuf (4.36.0.rc.1-x86_64-linux-musl) sha256=04a7aeb55ffdad5cae493c0e8113b0e0b91205c0d4eaa55991aa66c3041256a8
   google-style (1.31.1) sha256=62680dc303d3fecd9de124cdb4da42dc4c4b2445118baefb5d77aa6411b6b6ff
   googleapis-common-protos (1.9.0) sha256=207be372d8d25e3876e1e1155d057e14f3c92f8f5428772864a8ce04a0b756e4
   googleapis-common-protos-types (1.23.0) sha256=992e740a523794d9fc5f29a504465d8fc737aaa16c930fe7228e3346860faf0a
@@ -348,4 +349,4 @@ CHECKSUMS
   yard-doctest (0.1.17) sha256=7cb35a75d99f58fc42ee72d3542a36e227237b621a40aebc391c95988b72847f
 
 BUNDLED WITH
-  4.0.14
+  4.0.13


### PR DESCRIPTION
Do not merge, used for testing purposes only.