### PR TITLE
feat: Release GA version 1.0.0

### DIFF
--- a/google-cloud-api_hub-v1/CHANGELOG.md
+++ b/google-cloud-api_hub-v1/CHANGELOG.md
@@ -83,3 +83,4 @@
 * Initial generation of google-cloud-api_hub-v1 ([#26952](https://github.com/googleapis/google-cloud-ruby/issues/26952)) 
 
 ## Release History
+

--- a/google-cloud-api_hub/CHANGELOG.md
+++ b/google-cloud-api_hub/CHANGELOG.md
@@ -51,3 +51,4 @@
 * Initial generation of google-cloud-api_hub ([#26953](https://github.com/googleapis/google-cloud-ruby/issues/26953)) 
 
 ## Release History
+

--- a/google-cloud-app_optimize-v1beta/CHANGELOG.md
+++ b/google-cloud-app_optimize-v1beta/CHANGELOG.md
@@ -13,3 +13,4 @@
 * Initial generation of google-cloud-app_optimize-v1beta ([#33848](https://github.com/googleapis/google-cloud-ruby/issues/33848)) 
 
 ## Release History
+

--- a/google-cloud-app_optimize/CHANGELOG.md
+++ b/google-cloud-app_optimize/CHANGELOG.md
@@ -13,3 +13,4 @@
 * Initial generation of google-cloud-app_optimize ([#33849](https://github.com/googleapis/google-cloud-ruby/issues/33849)) 
 
 ## Release History
+

--- a/google-cloud-audit_manager-v1/CHANGELOG.md
+++ b/google-cloud-audit_manager-v1/CHANGELOG.md
@@ -13,3 +13,4 @@
 * Initial generation of google-cloud-audit_manager-v1 ([#33838](https://github.com/googleapis/google-cloud-ruby/issues/33838)) 
 
 ## Release History
+

--- a/google-cloud-audit_manager/CHANGELOG.md
+++ b/google-cloud-audit_manager/CHANGELOG.md
@@ -13,3 +13,4 @@
 * Initial generation of google-cloud-audit_manager ([#33843](https://github.com/googleapis/google-cloud-ruby/issues/33843)) 
 
 ## Release History
+

--- a/google-cloud-ces-v1/CHANGELOG.md
+++ b/google-cloud-ces-v1/CHANGELOG.md
@@ -25,3 +25,4 @@
 * Initial generation of google-cloud-ces-v1 ([#33841](https://github.com/googleapis/google-cloud-ruby/issues/33841)) 
 
 ## Release History
+

--- a/google-cloud-ces-v1beta/CHANGELOG.md
+++ b/google-cloud-ces-v1beta/CHANGELOG.md
@@ -36,3 +36,4 @@
 * Initial generation of google-cloud-ces-v1beta ([#33845](https://github.com/googleapis/google-cloud-ruby/issues/33845)) 
 
 ## Release History
+

--- a/google-cloud-ces/CHANGELOG.md
+++ b/google-cloud-ces/CHANGELOG.md
@@ -19,3 +19,4 @@
 * Initial generation of google-cloud-ces ([#33847](https://github.com/googleapis/google-cloud-ruby/issues/33847)) 
 
 ## Release History
+

--- a/google-cloud-chronicle-v1/CHANGELOG.md
+++ b/google-cloud-chronicle-v1/CHANGELOG.md
@@ -63,3 +63,4 @@
 * Initial generation of google-cloud-chronicle-v1 ([#30407](https://github.com/googleapis/google-cloud-ruby/issues/30407)) 
 
 ## Release History
+

--- a/google-cloud-chronicle/CHANGELOG.md
+++ b/google-cloud-chronicle/CHANGELOG.md
@@ -56,3 +56,4 @@
 * Initial generation of google-cloud-chronicle ([#30412](https://github.com/googleapis/google-cloud-ruby/issues/30412)) 
 
 ## Release History
+

--- a/google-cloud-cloud_security_compliance-v1/CHANGELOG.md
+++ b/google-cloud-cloud_security_compliance-v1/CHANGELOG.md
@@ -49,3 +49,4 @@
 * Initial generation of google-cloud-cloud_security_compliance-v1 ([#31534](https://github.com/googleapis/google-cloud-ruby/issues/31534)) 
 
 ## Release History
+

--- a/google-cloud-cloud_security_compliance/CHANGELOG.md
+++ b/google-cloud-cloud_security_compliance/CHANGELOG.md
@@ -29,3 +29,4 @@
 * Initial generation of google-cloud-cloud_security_compliance ([#31548](https://github.com/googleapis/google-cloud-ruby/issues/31548)) 
 
 ## Release History
+

--- a/google-cloud-config_delivery-v1/CHANGELOG.md
+++ b/google-cloud-config_delivery-v1/CHANGELOG.md
@@ -44,3 +44,4 @@
 * Initial generation of google-cloud-config_delivery-v1 ([#30761](https://github.com/googleapis/google-cloud-ruby/issues/30761)) 
 
 ## Release History
+

--- a/google-cloud-config_delivery/CHANGELOG.md
+++ b/google-cloud-config_delivery/CHANGELOG.md
@@ -25,3 +25,4 @@
 * Initial generation of google-cloud-config_delivery ([#30865](https://github.com/googleapis/google-cloud-ruby/issues/30865)) 
 
 ## Release History
+

--- a/google-cloud-dataform-v1/CHANGELOG.md
+++ b/google-cloud-dataform-v1/CHANGELOG.md
@@ -43,3 +43,4 @@
 * Initial generation of google-cloud-dataform-v1 ([#30396](https://github.com/googleapis/google-cloud-ruby/issues/30396)) 
 
 ## Release History
+

--- a/google-cloud-dataform-v1beta1/CHANGELOG.md
+++ b/google-cloud-dataform-v1beta1/CHANGELOG.md
@@ -168,3 +168,4 @@
 * Initial generation of google-cloud-dataform-v1beta1 ([#19345](https://github.com/googleapis/google-cloud-ruby/issues/19345)) 
 
 ## Release History
+

--- a/google-cloud-dataform/CHANGELOG.md
+++ b/google-cloud-dataform/CHANGELOG.md
@@ -74,3 +74,4 @@
 * Initial generation of google-cloud-dataform ([#19355](https://github.com/googleapis/google-cloud-ruby/issues/19355)) 
 
 ## Release History
+

--- a/google-cloud-device_streaming-v1/CHANGELOG.md
+++ b/google-cloud-device_streaming-v1/CHANGELOG.md
@@ -31,3 +31,4 @@
 * Initial generation of google-cloud-device_streaming-v1 ([#30408](https://github.com/googleapis/google-cloud-ruby/issues/30408)) 
 
 ## Release History
+

--- a/google-cloud-device_streaming/CHANGELOG.md
+++ b/google-cloud-device_streaming/CHANGELOG.md
@@ -25,3 +25,4 @@
 * Initial generation of google-cloud-device_streaming ([#30413](https://github.com/googleapis/google-cloud-ruby/issues/30413)) 
 
 ## Release History
+

--- a/google-cloud-financial_services-v1/CHANGELOG.md
+++ b/google-cloud-financial_services-v1/CHANGELOG.md
@@ -66,3 +66,4 @@
 * Initial generation of google-cloud-financial_services-v1 ([#29530](https://github.com/googleapis/google-cloud-ruby/issues/29530)) 
 
 ## Release History
+

--- a/google-cloud-financial_services/CHANGELOG.md
+++ b/google-cloud-financial_services/CHANGELOG.md
@@ -31,3 +31,4 @@
 * Initial generation of google-cloud-financial_services ([#29531](https://github.com/googleapis/google-cloud-ruby/issues/29531)) 
 
 ## Release History
+

--- a/google-cloud-gemini_data_analytics-v1/CHANGELOG.md
+++ b/google-cloud-gemini_data_analytics-v1/CHANGELOG.md
@@ -13,3 +13,4 @@
 * Initial generation of google-cloud-gemini_data_analytics-v1 ([#33989](https://github.com/googleapis/google-cloud-ruby/issues/33989)) 
 
 ## Release History
+

--- a/google-cloud-gemini_data_analytics-v1beta/CHANGELOG.md
+++ b/google-cloud-gemini_data_analytics-v1beta/CHANGELOG.md
@@ -96,3 +96,4 @@
 * Initial generation of google-cloud-gemini_data_analytics-v1beta ([#30905](https://github.com/googleapis/google-cloud-ruby/issues/30905)) 
 
 ## Release History
+

--- a/google-cloud-gemini_data_analytics/CHANGELOG.md
+++ b/google-cloud-gemini_data_analytics/CHANGELOG.md
@@ -35,3 +35,4 @@
 * Initial generation of google-cloud-gemini_data_analytics ([#30906](https://github.com/googleapis/google-cloud-ruby/issues/30906)) 
 
 ## Release History
+

--- a/google-cloud-gke_recommender-v1/CHANGELOG.md
+++ b/google-cloud-gke_recommender-v1/CHANGELOG.md
@@ -37,3 +37,4 @@
 * Initial generation of google-cloud-gke_recommender-v1 ([#31519](https://github.com/googleapis/google-cloud-ruby/issues/31519)) 
 
 ## Release History
+

--- a/google-cloud-gke_recommender/CHANGELOG.md
+++ b/google-cloud-gke_recommender/CHANGELOG.md
@@ -19,3 +19,4 @@
 * Initial generation of google-cloud-gke_recommender ([#31520](https://github.com/googleapis/google-cloud-ruby/issues/31520)) 
 
 ## Release History
+

--- a/google-cloud-hypercompute_cluster-v1beta/CHANGELOG.md
+++ b/google-cloud-hypercompute_cluster-v1beta/CHANGELOG.md
@@ -31,3 +31,4 @@
 * Initial generation of google-cloud-hypercompute_cluster-v1beta ([#32126](https://github.com/googleapis/google-cloud-ruby/issues/32126)) 
 
 ## Release History
+

--- a/google-cloud-hypercompute_cluster/CHANGELOG.md
+++ b/google-cloud-hypercompute_cluster/CHANGELOG.md
@@ -19,3 +19,4 @@
 * Initial generation of google-cloud-hypercompute_cluster ([#32127](https://github.com/googleapis/google-cloud-ruby/issues/32127)) 
 
 ## Release History
+

--- a/google-cloud-license_manager-v1/CHANGELOG.md
+++ b/google-cloud-license_manager-v1/CHANGELOG.md
@@ -47,3 +47,4 @@
 * Initial generation of google-cloud-license_manager-v1 ([#30883](https://github.com/googleapis/google-cloud-ruby/issues/30883)) 
 
 ## Release History
+

--- a/google-cloud-license_manager/CHANGELOG.md
+++ b/google-cloud-license_manager/CHANGELOG.md
@@ -25,3 +25,4 @@
 * Initial generation of google-cloud-license_manager ([#30885](https://github.com/googleapis/google-cloud-ruby/issues/30885)) 
 
 ## Release History
+

--- a/google-cloud-location_finder-v1/CHANGELOG.md
+++ b/google-cloud-location_finder-v1/CHANGELOG.md
@@ -34,3 +34,4 @@
 * Initial generation of google-cloud-location_finder-v1 ([#31780](https://github.com/googleapis/google-cloud-ruby/issues/31780)) 
 
 ## Release History
+

--- a/google-cloud-location_finder/CHANGELOG.md
+++ b/google-cloud-location_finder/CHANGELOG.md
@@ -19,3 +19,4 @@
 * Initial generation of google-cloud-location_finder ([#31781](https://github.com/googleapis/google-cloud-ruby/issues/31781)) 
 
 ## Release History
+

--- a/google-cloud-lustre-v1/CHANGELOG.md
+++ b/google-cloud-lustre-v1/CHANGELOG.md
@@ -65,3 +65,4 @@
 * Initial generation of google-cloud-lustre-v1 ([#30075](https://github.com/googleapis/google-cloud-ruby/issues/30075)) 
 
 ## Release History
+

--- a/google-cloud-lustre/CHANGELOG.md
+++ b/google-cloud-lustre/CHANGELOG.md
@@ -25,3 +25,4 @@
 * Initial generation of google-cloud-lustre ([#30076](https://github.com/googleapis/google-cloud-ruby/issues/30076)) 
 
 ## Release History
+

--- a/google-cloud-maintenance-api-v1/CHANGELOG.md
+++ b/google-cloud-maintenance-api-v1/CHANGELOG.md
@@ -28,3 +28,4 @@
 * Initial generation of google-cloud-maintenance-api-v1 ([#32390](https://github.com/googleapis/google-cloud-ruby/issues/32390)) 
 
 ## Release History
+

--- a/google-cloud-maintenance-api-v1beta/CHANGELOG.md
+++ b/google-cloud-maintenance-api-v1beta/CHANGELOG.md
@@ -40,3 +40,4 @@
 * Initial generation of google-cloud-maintenance-api-v1beta ([#30685](https://github.com/googleapis/google-cloud-ruby/issues/30685)) 
 
 ## Release History
+

--- a/google-cloud-maintenance-api/CHANGELOG.md
+++ b/google-cloud-maintenance-api/CHANGELOG.md
@@ -25,3 +25,4 @@
 * Initial generation of google-cloud-maintenance-api ([#30686](https://github.com/googleapis/google-cloud-ruby/issues/30686)) 
 
 ## Release History
+

--- a/google-cloud-oracle_database-v1/CHANGELOG.md
+++ b/google-cloud-oracle_database-v1/CHANGELOG.md
@@ -135,3 +135,4 @@
 * Initial general of google-cloud-oracle_database-v1 ([#27396](https://github.com/googleapis/google-cloud-ruby/issues/27396)) 
 
 ## Release History
+

--- a/google-cloud-oracle_database/CHANGELOG.md
+++ b/google-cloud-oracle_database/CHANGELOG.md
@@ -38,3 +38,4 @@
 * Initial generation of google-cloud-oracle_database ([#27398](https://github.com/googleapis/google-cloud-ruby/issues/27398)) 
 
 ## Release History
+

--- a/google-cloud-parameter_manager-v1/CHANGELOG.md
+++ b/google-cloud-parameter_manager-v1/CHANGELOG.md
@@ -68,3 +68,4 @@
 * Initial generation of google-cloud-parameter_manager-v1 ([#29265](https://github.com/googleapis/google-cloud-ruby/issues/29265)) 
 
 ## Release History
+

--- a/google-cloud-parameter_manager/CHANGELOG.md
+++ b/google-cloud-parameter_manager/CHANGELOG.md
@@ -37,3 +37,4 @@
 * Initial generation of google-cloud-parameter_manager ([#29266](https://github.com/googleapis/google-cloud-ruby/issues/29266)) 
 
 ## Release History
+

--- a/google-cloud-storage_batch_operations-v1/CHANGELOG.md
+++ b/google-cloud-storage_batch_operations-v1/CHANGELOG.md
@@ -98,3 +98,4 @@
 * Initial generation of google-cloud-storage_batch_operations-v1 ([#29487](https://github.com/googleapis/google-cloud-ruby/issues/29487)) 
 
 ## Release History
+

--- a/google-cloud-storage_batch_operations/CHANGELOG.md
+++ b/google-cloud-storage_batch_operations/CHANGELOG.md
@@ -38,3 +38,4 @@
 * Initial generation of google-cloud-storage_batch_operations ([#29488](https://github.com/googleapis/google-cloud-ruby/issues/29488)) 
 
 ## Release History
+


### PR DESCRIPTION
Release-As: 1.0.0

BEGIN_COMMIT_OVERRIDE
chore: Update CHANGELOG files
END_COMMIT_OVERRIDE


Run from terminal as: 

```
toys bump-version -v --fork \
  --version="1.0.0" \
  --changelog-entry="Release GA version 1.0.0" \
  -- \
  google-cloud-api_hub google-cloud-api_hub-v1 google-cloud-app_optimize google-cloud-app_optimize-v1beta google-cloud-audit_manager google-cloud-audit_manager-v1 google-cloud-ces google-cloud-ces-v1 google-cloud-ces-v1beta google-cloud-chronicle google-cloud-chronicle-v1 google-cloud-location_finder google-cloud-location_finder-v1 google-cloud-cloud_security_compliance google-cloud-cloud_security_compliance-v1 google-cloud-config_delivery google-cloud-config_delivery-v1 google-cloud-dataform google-cloud-dataform-v1 google-cloud-dataform-v1beta1 google-cloud-device_streaming google-cloud-device_streaming-v1 google-cloud-financial_services google-cloud-financial_services-v1 google-cloud-gemini_data_analytics google-cloud-gemini_data_analytics-v1 google-cloud-gemini_data_analytics-v1beta google-cloud-gke_recommender google-cloud-gke_recommender-v1 google-cloud-hypercompute_cluster google-cloud-hypercompute_cluster-v1beta google-cloud-license_manager google-cloud-license_manager-v1 google-cloud-lustre google-cloud-lustre-v1 google-cloud-maintenance-api google-cloud-maintenance-api-v1 google-cloud-maintenance-api-v1beta google-cloud-oracle_database google-cloud-oracle_database-v1 google-cloud-parameter_manager google-cloud-parameter_manager-v1 google-cloud-storage_batch_operations google-cloud-storage_batch_operations-v1
```

Context in b/517213984
