### PR TITLE
chore(storage): fix order dependency in get_object_contexts test

### DIFF
--- a/google-cloud-storage/Gemfile.lock
+++ b/google-cloud-storage/Gemfile.lock
@@ -79,7 +79,7 @@ GEM
       googleapis-common-protos-types (~> 1.15)
       googleauth (~> 1.12)
       grpc (~> 1.66)
-    google-apis-core (1.2.4)
+    google-apis-core (1.2.5)
       addressable (~> 2.9)
       faraday (~> 2.13)
       faraday-follow_redirects (~> 0.3)
@@ -332,7 +332,7 @@ CHECKSUMS
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
   faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
   gapic-common (1.3.0) sha256=4e5d9be1effb7366e2cda13c0f44922285d5613ac8de8b9b18c2c835fe4faa91
-  google-apis-core (1.2.4) sha256=da9d12dbc7a3fbf3a68fc461e23e6f23245e57ab3b47eb71137d4dcf61a686b3
+  google-apis-core (1.2.5) sha256=e21562b5627a0fc6a0c3165e429c3afed0f6a628eaa514e83f7204dda1adff69
   google-apis-iamcredentials_v1 (0.28.0) sha256=0a92ffe6cc39c569554af2a77a25dfc61519ed8bbb64ab04cffdd352dc5ef106
   google-apis-storage_v1 (0.64.0) sha256=75b11afa2edcee859b84c7a6972ee4456314eeef5f762827fd6cf5c5ffaf93f2
   google-cloud-core (1.9.0)

--- a/google-cloud-storage/samples/acceptance/files_test.rb
+++ b/google-cloud-storage/samples/acceptance/files_test.rb
@@ -77,7 +77,7 @@ describe "Files Snippets" do
   end
 
   after do
-    bucket.requester_pays = false
+    storage_client.bucket(bucket.name, user_project: storage_client.project).requester_pays = false
     bucket.files.each(&:delete)
   end
 
@@ -337,10 +337,13 @@ describe "Files Snippets" do
       set_object_contexts bucket_name: bucket.name, file_name: remote_file_name, custom_context_key: custom_context_key2, custom_context_value: custom_context_value2
     end
     it "fetches all object contexts" do
-
-      assert_output "Custom Contexts for #{remote_file_name} are:\nKey: #{custom_context_key1}, Value: #{custom_context_value1}\nKey: #{custom_context_key2}, Value: #{custom_context_value2}\n" do
+      out, _err = capture_io do
         get_object_contexts bucket_name: bucket.name, file_name: remote_file_name
       end
+
+      assert_includes out, "Custom Contexts for #{remote_file_name} are:\n"
+      assert_includes out, "Key: #{custom_context_key1}, Value: #{custom_context_value1}\n"
+      assert_includes out, "Key: #{custom_context_key2}, Value: #{custom_context_value2}\n"
     end
   end
 


### PR DESCRIPTION
Currently this fails if the order is incorrect, introducing flakiness:
```
1) Failure:
Files Snippets::get_object_contexts#test_0001_fetches all object contexts [acceptance/files_test.rb:341]:
In stdout.
--- expected
+++ actual
@@ -1,4 +1,4 @@
 "Custom Contexts for path/file_name_9d512d3ea21775ecf8d953f9f31138f6.txt are:
-Key: my-custom-key, Value: my-custom-value
 Key: my-custom-key-2, Value: my-custom-value-2
+Key: my-custom-key, Value: my-custom-value
 "

```

Noticed in https://github.com/googleapis/google-cloud-ruby/pull/34751

chore(storage): pass user_project when resetting requester_pays in samples cleanup

Fixes an order dependency where resetting `requester_pays` in the `after` cleanup hook failed
due to a missing `user_project` parameter, breaking subsequent tests.

Example error:
```
  1) Error:
Files Snippets#test_0001_list_files:
Google::Cloud::InvalidArgumentError: required: Bucket is a requester pays bucket but no user project provided.
    /workspace/google-cloud-storage/lib/google/cloud/storage/service.rb:1037:in 'Google::Cloud::Storage::Service#execute'
    /workspace/google-cloud-storage/lib/google/cloud/storage/service.rb:167:in 'Google::Cloud::Storage::Service#patch_bucket'
    /workspace/google-cloud-storage/lib/google/cloud/storage/bucket.rb:3467:in 'Google::Cloud::Storage::Bucket#patch_gapi!'
    /workspace/google-cloud-storage/lib/google/cloud/storage/bucket.rb:656:in 'Google::Cloud::Storage::Bucket#requester_pays='
    acceptance/files_test.rb:80:in 'block (2 levels) in <top (required)>'
```

