### PR TITLE
chore: introduce librarian.yaml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,7 @@
 # explicitly taken by someone else.
 *                                    @googleapis/cloud-sdk-ruby-team @yoshi-approver
 
+/librarian.yaml                      @googleapis/cloud-sdk-librarian-team
 /google-cloud-bigquery*/.            @googleapis/cloud-sdk-ruby-team @yoshi-approver @googleapis/bigquery-team
 /google-cloud-bigtable*/.            @googleapis/cloud-sdk-ruby-team @yoshi-approver @googleapis/bigtable-team
 /google-cloud-datastore*/.           @googleapis/cloud-sdk-ruby-team @yoshi-approver

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1,0 +1,27 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+language: ruby
+sources:
+  googleapis:
+    commit: 6145fa8cc2b137bf4c0ed114e2e39c1157ea9722
+    sha256: 489923d12c766c9e323b42de057037977b03f20c8a874bc8553d29f9dd3f0e3b
+tools:
+  gem:
+    - name: gapic-generator-cloud
+      version: 0.49.0
+    - name: grpc
+      version: 1.78.1
+  protoc:
+    version: "33.2"
+    sha256: b24b53f87c151bfd48b112fe4c3a6e6574e5198874f38036aff41df3456b8caf


### PR DESCRIPTION
go/sdk-librarian-ruby. Let's start small. This pull request creates
librarian.yaml without any library entries. The librarian version
in this file does not support Ruby yet.

This file still helps us (Librarian team) to create a diff focused
on a specific library being onboarded to Librarian.

As in the other repositories (e.g.,
https://github.com/googleapis/google-cloud-go/blob/main/.github/CODEOWNERS,
we put the Librarian team as the owner of the file.
