### PR TITLE
chore: add grpc-tools gem to librarian.yaml

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -22,6 +22,8 @@ tools:
       version: 0.49.0
     - name: grpc
       version: 1.78.1
+    - name: grpc-tools
+      version: 1.78.1
   protoc:
     version: "33.2"
     sha256: b24b53f87c151bfd48b112fe4c3a6e6574e5198874f38036aff41df3456b8caf

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -20,8 +20,6 @@ tools:
   gem:
     - name: gapic-generator-cloud
       version: 0.49.0
-    - name: grpc
-      version: 1.78.1
     - name: grpc-tools
       version: 1.78.1
   protoc:


### PR DESCRIPTION
Adds `grpc-tools` (version `1.78.1`) to `tools.gem` in `librarian.yaml`.

### Rationale

When `librarian generate` executes `protoc` for Ruby client library generation, `protoc` is passed `--grpc_out` to generate gRPC client code alongside `--ruby_cloud_out` and `--ruby_out`.

This matches Bazel code generation in `gapic-generator-ruby`:
1. The Bazel rule `ruby_grpc_library` defined in [`rules_ruby_gapic/ruby_gapic.bzl#L181-L196` (commit `8fed6b7c117c7cebaeb5aa5c45eb3f866164eb75`)](https://github.com/googleapis/gapic-generator-ruby/blob/8fed6b7c117c7cebaeb5aa5c45eb3f866164eb75/rules_ruby_gapic/ruby_gapic.bzl#L181-L196) configures `protoc` with `output_type = "grpc"`.
2. Bazel sets up generator tools via [`rules_ruby_gapic/gapic-generator-cloud/repositories.bzl#L35-L48`](https://github.com/googleapis/gapic-generator-ruby/blob/8fed6b7c117c7cebaeb5aa5c45eb3f866164eb75/rules_ruby_gapic/gapic-generator-cloud/repositories.bzl#L35-L48), which runs `bundle_install` on [`gapic-generator-cloud/Gemfile#L12`](https://github.com/googleapis/gapic-generator-ruby/blob/8fed6b7c117c7cebaeb5aa5c45eb3f866164eb75/gapic-generator-cloud/Gemfile#L12), installing `grpc-tools` (and `gapic-generator-cloud`).

Executing `--grpc_out` requires the `grpc_tools_ruby_protoc_plugin` executable binary. This binary and the underlying `grpc_ruby_plugin` protoc plugin (implemented in C++ in [`src/compiler/ruby_generator.cc`](https://github.com/grpc/grpc/blob/master/src/compiler/ruby_generator.cc)) are packaged and exposed as binstubs by the [`grpc-tools`](https://rubygems.org/gems/grpc-tools) gem (see [`grpc-tools.gemspec#L23`](https://github.com/grpc/grpc/blob/master/src/ruby/tools/grpc-tools.gemspec#L23) and [`bin/grpc_tools_ruby_protoc_plugin`](https://github.com/grpc/grpc/blob/master/src/ruby/tools/bin/grpc_tools_ruby_protoc_plugin)). By contrast, the standard [`grpc`](https://rubygems.org/gems/grpc) gem only provides runtime C extensions (`grpc_c`) for running gRPC requests, not code generation tooling.

Adding `grpc-tools` to `librarian.yaml` ensures `librarian install ruby` installs `grpc_tools_ruby_protoc_plugin` into the tool binary directory so `librarian generate` can run successfully.

### Other `gapic-generator-cloud/Gemfile` Dependencies

Other gems listed in `gapic-generator-cloud/Gemfile` are not needed in `librarian.yaml`:

| Gem | Purpose | Needed by `librarian generate`? |
| :--- | :--- | :--- |
| `minitest`, `minitest-autotest`, `minitest-focus` | Testing framework & plugins for generator unit tests | No (only used during generator development) |
| `pry` | Interactive Ruby REPL / debugger for development | No (developer debugging tool) |
| `yard`, `redcarpet` | Documentation generator and Markdown parser for generator source docs | No (only used for generating generator YARD docs) |
| `ostruct` | Ruby `OpenStruct` stdlib gem dependency | No (automatically pulled in by RubyGems if required) |
