### PR TITLE
chore(deps): align Renovate config with gapic-generator-ruby lockfile scaffolding

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -26,9 +26,11 @@
       ],
       "groupName": "all patch updates"
     },
-    // Disable Renovate processing for non-enrolled gems during our phased rollout
+    // Disable Renovate processing for non-enrolled gems during phased rollout.
+    // Note: As gapic-generator-ruby scaffolds !Gemfile.lock across all generated client libraries,
+    // gems with tracked Gemfile.lock files are automatically maintained via lockFileMaintenance.
     {
-      "description": "Disable Renovate processing for non-enrolled (non-Phase 1 and non-Phase 2 sample) gems during phased rollout",
+      "description": "Disable Renovate processing for non-enrolled gems during phased rollout",
       "matchFileNames": [
         "!google-cloud-core/**",
         "!google-cloud-storage/**",


### PR DESCRIPTION
## Overview

Prepares `google-cloud-ruby`'s Renovate configuration to align with automated lockfile scaffolding from `gapic-generator-ruby`.

## Details

- **Generator Alignment**: Documents that as `gapic-generator-ruby` scaffolds `!Gemfile.lock` across generated client libraries, gems with tracked `Gemfile.lock` files will automatically participate in scheduled `lockFileMaintenance`.
- **Companion Generator Draft PR**: [googleapis/gapic-generator-ruby#1320](https://github.com/googleapis/gapic-generator-ruby/pull/1320)