### PR TITLE
chore(google-ads-ad_manager-v1): Remove Gemlock.file from static config

### DIFF
--- a/google-ads-ad_manager-v1/.owlbot-manifest.json
+++ b/google-ads-ad_manager-v1/.owlbot-manifest.json
@@ -1131,6 +1131,5 @@
   ],
   "static": [
     ".OwlBot.yaml",
-    "Gemfile.lock"
   ]
 }


### PR DESCRIPTION
This seems to be the only missing one. 

It missed it in https://github.com/googleapis/google-cloud-ruby/pull/34997 before reverting via https://github.com/googleapis/google-cloud-ruby/pull/34998