### PR TITLE
fix(google-ads-ad_manager-v1): fix JSON formatting in owlbot manifest

### DIFF
--- a/google-ads-ad_manager-v1/.owlbot-manifest.json
+++ b/google-ads-ad_manager-v1/.owlbot-manifest.json
@@ -1130,6 +1130,6 @@
     "test/helper.rb"
   ],
   "static": [
-    ".OwlBot.yaml",
+    ".OwlBot.yaml"
   ]
 }


### PR DESCRIPTION
Remove trailing comma in `.owlbot-manifest.json` to restore valid JSON syntax.

This syntax error causes migration tool in librarian to fail.