### PR TITLE
chore(storage): Error handling for open and unlinked files

### DIFF
--- a/google-cloud-storage/acceptance/storage/file_test.rb
+++ b/google-cloud-storage/acceptance/storage/file_test.rb
@@ -476,6 +476,28 @@ describe Google::Cloud::Storage::File, :storage do
     end
   end
 
+  it "should upload and download an unlinked tempfile" do
+    begin
+      data = "hello world"
+      tmpfile = Tempfile.new "unlinked_test"
+      tmpfile.write data
+      tmpfile.rewind
+      tmpfile.unlink
+
+      uploaded = bucket.create_file tmpfile, "uploaded/unlinked-file.txt"
+      _(uploaded.name).must_equal "uploaded/unlinked-file.txt"
+
+      downloadio = StringIO.new
+      downloaded = uploaded.download downloadio
+      _(downloaded).must_be_kind_of StringIO
+
+      downloaded_data = downloaded.string
+      _(downloaded_data).must_equal data
+    ensure
+      uploaded.delete if uploaded
+    end
+  end
+
   it "should download and verify when Content-Encoding gzip response header with skip_decompress" do
     bucket = bucket_public
     file = bucket.file bucket_public_file_gzip

--- a/google-cloud-storage/lib/google/cloud/storage/file/verifier.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/verifier.rb
@@ -81,18 +81,18 @@ module Google
           def self._digest_for local_file, digest_class
 
             if local_file.respond_to?(:read)
-              # Case 1: Input is an open stream (File, StringIO, ActionDispatch::Http::UploadedFile, etc.).
+              # Case 1: Input is an open stream (File or StringIO).
               local_file.rewind if local_file.respond_to?(:rewind)
-              digest = digest_class.new
-              while (chunk = local_file.read(16 * 1024))
-                digest.update(chunk)
-              end
+              digest = digest_class.base64digest local_file.read
               local_file.rewind if local_file.respond_to?(:rewind)
-              digest.base64digest
+              digest
             elsif local_file.respond_to?(:to_path) || local_file.is_a?(String)
-              # Case 2: Input is a file path (String, Pathname).
-              digest_class.file(Pathname(local_file).to_path).base64digest
+              # Case 2: Input is a file path (String, Pathname, or object that responds to :to_path).
+              ::File.open Pathname(local_file).to_path, "rb" do |f|
+                digest_class.file(f).base64digest
+              end
             end
+
           end
         end
       end

--- a/google-cloud-storage/lib/google/cloud/storage/file/verifier.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/verifier.rb
@@ -68,7 +68,7 @@ module Google
           #    the entire file into memory. The stream is rewound before and after
           #    reading to ensure its position is not permanently changed.
           # 2. A file path (String or Pathname): It efficiently streams the file
-          #    directly via the digest C-extension.
+          #    to compute the digest without loading the entire file into memory.
           #
           # @param local_file [String, Pathname, IO] The local file path or IO
           #   stream for which to compute the digest.

--- a/google-cloud-storage/lib/google/cloud/storage/file/verifier.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/verifier.rb
@@ -92,7 +92,6 @@ module Google
                 digest_class.file(f).base64digest
               end
             end
-
           end
         end
       end

--- a/google-cloud-storage/lib/google/cloud/storage/file/verifier.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/verifier.rb
@@ -79,13 +79,18 @@ module Google
           # @return [String] The base64-encoded digest of the file's content.
           #
           def self._digest_for local_file, digest_class
-
             if local_file.respond_to?(:read)
               # Case 1: Input is an open stream (File or StringIO).
               local_file.rewind if local_file.respond_to?(:rewind)
-              digest = digest_class.base64digest local_file.read
+              
+              digest = digest_class.new
+              buf = ""
+              while local_file.read(16_384, buf)
+                digest.update buf
+              end
+              
               local_file.rewind if local_file.respond_to?(:rewind)
-              digest
+              digest.base64digest
             elsif local_file.respond_to?(:to_path) || local_file.is_a?(String)
               # Case 2: Input is a file path (String, Pathname, or object that responds to :to_path).
               ::File.open Pathname(local_file).to_path, "rb" do |f|

--- a/google-cloud-storage/lib/google/cloud/storage/file/verifier.rb
+++ b/google-cloud-storage/lib/google/cloud/storage/file/verifier.rb
@@ -63,33 +63,35 @@ module Google
           # Computes a base64-encoded digest for a local file or IO stream.
           #
           # This method handles two types of inputs for `local_file`:
-          # 1. A file path (String or Pathname): It efficiently streams the file
-          #    to compute the digest without loading the entire file into memory.
-          # 2. An IO-like stream (e.g., File, StringIO): It reads the stream's
-          #    content to compute the digest. The stream is rewound before and after
+          # 1. An IO-like stream (e.g., File, Tempfile, StringIO): It reads the
+          #    stream's content in chunks to compute the digest without loading
+          #    the entire file into memory. The stream is rewound before and after
           #    reading to ensure its position is not permanently changed.
+          # 2. A file path (String or Pathname): It efficiently streams the file
+          #    directly via the digest C-extension.
           #
           # @param local_file [String, Pathname, IO] The local file path or IO
           #   stream for which to compute the digest.
           # @param digest_class [Class] The digest class to use for the
-          #   calculation (e.g., `Digest::MD5`). It must respond to `.file` and
-          #   `.base64digest`.
+          #   calculation (e.g., `Digest::MD5`). It must respond to `.new`,
+          #   `.file` and `.base64digest`.
           #
           # @return [String] The base64-encoded digest of the file's content.
           #
           def self._digest_for local_file, digest_class
 
-            if local_file.respond_to?(:to_path) || local_file.is_a?(String)
-              # Case 1: Input is a file path (String, Pathname, or object that responds to :to_path).
-              ::File.open Pathname(local_file).to_path, "rb" do |f|
-                digest_class.file(f).base64digest
+            if local_file.respond_to?(:read)
+              # Case 1: Input is an open stream (File, StringIO, ActionDispatch::Http::UploadedFile, etc.).
+              local_file.rewind if local_file.respond_to?(:rewind)
+              digest = digest_class.new
+              while (chunk = local_file.read(16 * 1024))
+                digest.update(chunk)
               end
-            else
-              # Case 2: Input is an open stream (File or StringIO).
-              local_file.rewind
-              digest = digest_class.base64digest local_file.read
-              local_file.rewind
-              digest
+              local_file.rewind if local_file.respond_to?(:rewind)
+              digest.base64digest
+            elsif local_file.respond_to?(:to_path) || local_file.is_a?(String)
+              # Case 2: Input is a file path (String, Pathname).
+              digest_class.file(Pathname(local_file).to_path).base64digest
             end
           end
         end

--- a/google-cloud-storage/test/google/cloud/storage/project_anonymous_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/project_anonymous_test.rb
@@ -116,8 +116,9 @@ describe Google::Cloud::Storage::Project, :anonymous, :mock_storage do
 
       # Stub the crc32c to match.
       def file.crc32c
-        "AAAAAA=="
+        "ltgT7g=="
       end
+
 
       downloaded = file.download tmpfile
       _(downloaded).must_be_kind_of Tempfile
@@ -144,7 +145,7 @@ describe Google::Cloud::Storage::Project, :anonymous, :mock_storage do
 
       # Stub the crc32c to match.
       def file.crc32c
-        "AAAAAA=="
+        "ltgT7g=="
       end
 
       downloaded = file.download tmpfile
@@ -153,7 +154,7 @@ describe Google::Cloud::Storage::Project, :anonymous, :mock_storage do
 
       local_data = downloaded.read
       local_crc32c = Digest::CRC32c.base64digest local_data
-      _(local_crc32c).must_equal "AAAAAA=="
+      _(local_crc32c).must_equal "ltgT7g=="
 
       mock.verify
     end

--- a/google-cloud-storage/test/google/cloud/storage/verifier_test.rb
+++ b/google-cloud-storage/test/google/cloud/storage/verifier_test.rb
@@ -16,8 +16,8 @@ require "helper"
 
 describe Google::Cloud::Storage::File::Verifier, :mock_storage do
   let(:file_contents) { "The quick brown fox jumps over the lazy dog." }
-  let(:md5_digest) { "1B2M2Y8AsgTpgAmY7PhCfg==" }
-  let(:crc32c_digest) { "AAAAAA==" }
+  let(:md5_digest) { "5NkJwpDQ+xygaP+t3yLL0A==" }
+  let(:crc32c_digest) { "GQCXsw==" }
   let(:file_gapi) { Google::Apis::StorageV1::Object.from_json corrected_file_hash.to_json }
   let(:file) { Google::Cloud::Storage::File.from_gapi file_gapi, OpenStruct.new }
 
@@ -46,6 +46,26 @@ describe Google::Cloud::Storage::File::Verifier, :mock_storage do
   it "calculates crc32c digest" do
     Tempfile.open "google-cloud" do |tmpfile|
       tmpfile.write file_contents
+      digest = Google::Cloud::Storage::File::Verifier.crc32c_for tmpfile
+      _(digest).must_equal crc32c_digest
+    end
+  end
+
+  it "calculates md5 digest for an unlinked file" do
+    Tempfile.open "google-cloud" do |tmpfile|
+      tmpfile.write file_contents
+      tmpfile.rewind
+      tmpfile.unlink
+      digest = Google::Cloud::Storage::File::Verifier.md5_for tmpfile
+      _(digest).must_equal md5_digest
+    end
+  end
+
+  it "calculates crc32c digest for an unlinked file" do
+    Tempfile.open "google-cloud" do |tmpfile|
+      tmpfile.write file_contents
+      tmpfile.rewind
+      tmpfile.unlink
       digest = Google::Cloud::Storage::File::Verifier.crc32c_for tmpfile
       _(digest).must_equal crc32c_digest
     end


### PR DESCRIPTION
Fixes issue where uploading unlinked temporary files (such as large payloads handled by the Puma web server) fails during the CRC32c digest computation.
closes https://github.com/googleapis/google-cloud-ruby/issues/34987