### PR TITLE
chore: restrict release-please-now schedule to Mon-Thu

### DIFF
--- a/.github/workflows/release-please-now.yml
+++ b/.github/workflows/release-please-now.yml
@@ -1,7 +1,7 @@
 name: Release-Please Now
 on:
   schedule:
-    - cron: '21 10 * * *'
+    - cron: '21 10 * * 1-4'
   workflow_dispatch:
     inputs:
       args:


### PR DESCRIPTION
Avoid automated Friday and weekend release label runs to align with our oncall schedule (no Friday + weekend releases).