### PR TITLE
chore(script): add automated lockfile seeder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Dependency installations and lockfiles
-Gemfile.lock
+/Gemfile.lock
 .bundle/
 /*/vendor/bundle/
 /*/lib/bundler/man/

--- a/seed_lockfiles.rb
+++ b/seed_lockfiles.rb
@@ -1,0 +1,117 @@
+#!/usr/bin/env ruby
+# seed_lockfiles.rb
+#
+# Usage:
+#   ruby seed_lockfiles.rb --continue --size 25 --push
+
+require 'optparse'
+require 'fileutils'
+require 'thread'
+
+options = {
+  batch_index: 0,
+  batch_size: 15,
+  auto_continue: false,
+  push: false
+}
+
+OptionParser.new do |opts|
+  opts.banner = "Usage: ruby seed_lockfiles.rb [options]"
+
+  opts.on("-s", "--size N", Integer, "Number of libraries in the batch (default: 15)") do |s|
+    options[:batch_size] = s
+  end
+
+  opts.on("-i", "--index N", Integer, "Manual batch index (0-indexed)") do |i|
+    options[:batch_index] = i
+  end
+
+  opts.on("-c", "--continue", "Automatically resume from the first unseeded library") do
+    options[:auto_continue] = true
+  end
+
+  opts.on("-p", "--push", "Create a branch, commit (but do not push automatically to allow review)") do
+    options[:push] = true
+  end
+end.parse!
+
+# 1. Discover all libraries
+all_gems = Dir.glob("*/").map { |d| d.chomp('/') }.select do |dir|
+  File.exist?(File.join(dir, "#{dir}.gemspec"))
+end.sort
+
+# 2. Filter unseeded libraries
+unseeded_gems = all_gems.select do |dir|
+  !File.exist?(File.join(dir, "Gemfile.lock"))
+end
+
+puts "🔍 [Seeder] Found #{unseeded_gems.size} libraries without a Gemfile.lock"
+
+if unseeded_gems.empty?
+  puts "🎉 All libraries have been seeded!"
+  exit 0
+end
+
+if options[:auto_continue]
+  puts "⏭️  [Seeder] --continue flag detected."
+  options[:batch_index] = 0
+end
+
+start_offset = options[:batch_index] * options[:batch_size]
+batch_gems = unseeded_gems[start_offset, options[:batch_size]]
+
+if batch_gems.nil? || batch_gems.empty?
+  puts "❌ [Seeder] Batch index #{options[:batch_index]} is out of bounds!"
+  exit 1
+end
+
+branch_name = "chore/seed-lockfiles-#{Time.now.to_i}"
+puts "📦 [Seeder] Batch targets #{batch_gems.size} gems."
+
+# 3. Create branch if requested
+if options[:push]
+  system("git checkout main && git pull", exception: true)
+  system("git checkout -b #{branch_name}", exception: true)
+end
+
+# 4. Generate lockfiles CONCURRENTLY
+# We use a thread-safe Queue and a Mutex to prevent terminal print interleaving
+queue = Queue.new
+batch_gems.each { |g| queue << g }
+STDOUT_MUTEX = Mutex.new
+
+platforms = %w[ruby x86_64-linux x86_64-darwin arm64-darwin x64-mingw-ucrt x64-mingw32]
+platform_args = platforms.map { |p| "--add-platform #{p}" }.join(" ")
+
+workers = 8.times.map do
+  Thread.new do
+    loop do
+      # Non-blocking pop; raises ThreadError when the queue is identically empty
+      gem_name = queue.pop(true) rescue break
+      
+      STDOUT_MUTEX.synchronize { puts "⏳ Seeding #{gem_name}..." }
+      
+      # Run bundle lock with all requested generic, Mac, and Windows platforms
+      system("cd #{gem_name} && bundle lock #{platform_args}", exception: true)
+      
+      system("git add #{gem_name}/Gemfile.lock", exception: true) if options[:push]
+    end
+  end
+end
+
+# Await completion of all threads
+workers.each(&:join)
+
+# 5. Commit if requested
+if options[:push]
+  commit_msg = "chore(lockfiles): seed Gemfile.lock for #{batch_gems.size} libraries\n\nGems included in this batch:\n" + batch_gems.map { |g| "- #{g}" }.join("\n")
+  File.write(".git/COMMIT_EDITMSG", commit_msg)
+  system("git commit -F .git/COMMIT_EDITMSG", exception: true)
+  File.delete(".git/COMMIT_EDITMSG")
+
+  puts "\n✅ Batch committed to local branch #{branch_name}!"
+  puts "👉 You can now review the commit and push it:"
+  puts "    git push -u origin #{branch_name}"
+else
+  puts "\n✅ Batch seeded locally. Run with --push to automatically branch and commit."
+end

--- a/seed_lockfiles.rb
+++ b/seed_lockfiles.rb
@@ -41,15 +41,15 @@ end.sort
 
 # 2. Filter unseeded & eligible libraries
 unseeded_gems = all_gems.select do |dir|
-  # Skip if it already has a lockfile physically present
-  next false if File.exist?(File.join(dir, "Gemfile.lock"))
+  lockfile_path = File.join(dir, "Gemfile.lock")
   
-  # Skip if Gemfile.lock is still listed inside this gem's .gitignore
-  gitignore_path = File.join(dir, ".gitignore")
-  if File.exist?(gitignore_path)
-    is_ignored = File.readlines(gitignore_path).any? { |line| line.strip == "Gemfile.lock" }
-    next false if is_ignored
-  end
+  # Skip if it already has a lockfile physically present
+  next false if File.exist?(lockfile_path)
+  
+  # Ask Git directly if this path is ignored
+  is_ignored = system("git check-ignore -q #{lockfile_path}")
+  
+  next false if is_ignored
   
   true
 end

--- a/seed_lockfiles.rb
+++ b/seed_lockfiles.rb
@@ -2,11 +2,10 @@
 # seed_lockfiles.rb
 #
 # Usage:
-#   ruby seed_lockfiles.rb --continue --size 25 --push
+#   ruby seed_lockfiles.rb --continue --size 15 --push
 
 require 'optparse'
 require 'fileutils'
-require 'thread'
 
 options = {
   batch_index: 0,
@@ -40,15 +39,25 @@ all_gems = Dir.glob("*/").map { |d| d.chomp('/') }.select do |dir|
   File.exist?(File.join(dir, "#{dir}.gemspec"))
 end.sort
 
-# 2. Filter unseeded libraries
+# 2. Filter unseeded & eligible libraries
 unseeded_gems = all_gems.select do |dir|
-  !File.exist?(File.join(dir, "Gemfile.lock"))
+  # Skip if it already has a lockfile physically present
+  next false if File.exist?(File.join(dir, "Gemfile.lock"))
+  
+  # Skip if Gemfile.lock is still listed inside this gem's .gitignore
+  gitignore_path = File.join(dir, ".gitignore")
+  if File.exist?(gitignore_path)
+    is_ignored = File.readlines(gitignore_path).any? { |line| line.strip == "Gemfile.lock" }
+    next false if is_ignored
+  end
+  
+  true
 end
 
-puts "🔍 [Seeder] Found #{unseeded_gems.size} libraries without a Gemfile.lock"
+puts "🔍 [Seeder] Found #{unseeded_gems.size} eligible libraries (no lockfile AND not .gitignored)"
 
 if unseeded_gems.empty?
-  puts "🎉 All libraries have been seeded!"
+  puts "🎉 All eligible libraries have been seeded!"
   exit 0
 end
 
@@ -66,7 +75,8 @@ if batch_gems.nil? || batch_gems.empty?
 end
 
 branch_name = "chore/seed-lockfiles-#{Time.now.to_i}"
-puts "📦 [Seeder] Batch targets #{batch_gems.size} gems."
+puts "📦 [Seeder] Batch targets #{batch_gems.size} gems:"
+batch_gems.each { |g| puts "   - #{g}" }
 
 # 3. Create branch if requested
 if options[:push]
@@ -74,33 +84,21 @@ if options[:push]
   system("git checkout -b #{branch_name}", exception: true)
 end
 
-# 4. Generate lockfiles CONCURRENTLY
-# We use a thread-safe Queue and a Mutex to prevent terminal print interleaving
-queue = Queue.new
-batch_gems.each { |g| queue << g }
-STDOUT_MUTEX = Mutex.new
-
+# 4. Generate lockfiles SEQUENTIALLY
 platforms = %w[ruby x86_64-linux x86_64-darwin arm64-darwin x64-mingw-ucrt x64-mingw32]
 platform_args = platforms.map { |p| "--add-platform #{p}" }.join(" ")
 
-workers = 8.times.map do
-  Thread.new do
-    loop do
-      # Non-blocking pop; raises ThreadError when the queue is identically empty
-      gem_name = queue.pop(true) rescue break
-      
-      STDOUT_MUTEX.synchronize { puts "⏳ Seeding #{gem_name}..." }
-      
-      # Run bundle lock with all requested generic, Mac, and Windows platforms
-      system("cd #{gem_name} && bundle lock #{platform_args}", exception: true)
-      
-      system("git add #{gem_name}/Gemfile.lock", exception: true) if options[:push]
-    end
-  end
-end
+batch_gems.each_with_index do |gem_name, i|
+  puts "⏳ [#{i + 1}/#{batch_gems.size}] Seeding #{gem_name}..."
 
-# Await completion of all threads
-workers.each(&:join)
+  Dir.chdir(gem_name) do
+    # Run bundle lock synchronously 
+    system("bundle lock #{platform_args}", exception: true)
+  end
+
+  # Stage the file sequentially so we safely avoid Git index lock conflicts
+  system("git add #{gem_name}/Gemfile.lock", exception: true) if options[:push]
+end
 
 # 5. Commit if requested
 if options[:push]

--- a/seed_lockfiles.rb
+++ b/seed_lockfiles.rb
@@ -85,15 +85,12 @@ if options[:push]
 end
 
 # 4. Generate lockfiles SEQUENTIALLY
-platforms = %w[ruby x86_64-linux x86_64-darwin arm64-darwin x64-mingw-ucrt x64-mingw32]
-platform_args = platforms.map { |p| "--add-platform #{p}" }.join(" ")
-
 batch_gems.each_with_index do |gem_name, i|
   puts "⏳ [#{i + 1}/#{batch_gems.size}] Seeding #{gem_name}..."
 
   Dir.chdir(gem_name) do
     # Run bundle lock synchronously 
-    system("bundle lock #{platform_args}", exception: true)
+    system("bundle lock", exception: true)
   end
 
   # Stage the file sequentially so we safely avoid Git index lock conflicts


### PR DESCRIPTION
## How to Use This Script

The script dynamically scans the repo and filters out any libraries that either already have a `Gemfile.lock`, or still actively ignore it in their `.gitignore`.

### 1. The Standard Workflow (Queueing Batches)
To automatically pick up the next eligible batch of libraries, stage them on a new branch, and commit them, simply run:
```bash
ruby seed_lockfiles.rb --continue --size 15 --push