### PR TITLE
chore(gitignore): remove Gemfile.lock from root gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # Dependency installations and lockfiles
-Gemfile.lock
 .bundle/
 /*/vendor/bundle/
 /*/lib/bundler/man/


### PR DESCRIPTION
## Description
This PR completely removes `Gemfile.lock` from the root `.gitignore` file.

### Rationale
Previously, `Gemfile.lock` was ignored at the top-level repository root. Because Git recursively evaluates `.gitignore` rules across all subdirectories, this rule was indiscriminately excluding `Gemfile.lock` files across all nested GAPIC client libraries (e.g. `google-analytics-data/Gemfile.lock`).

Removing `Gemfile.lock` entirely allows us to:
1. Track and pin dependencies for the top-level repository root.
2. Allow nested client libraries to track their respective `Gemfile.lock` files for upcoming lockfile seeding and Renovate management.