### PR TITLE
chore: populate version in google-cloud-asset-v1 in librarian.yaml

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -28,6 +28,7 @@ tools:
     sha256: b24b53f87c151bfd48b112fe4c3a6e6574e5198874f38036aff41df3456b8caf
 libraries:
   - name: google-cloud-asset-v1
+    version: 1.9.0
     apis:
       - path: google/cloud/asset/v1
         ruby:


### PR DESCRIPTION
The version field was missed. The Gem folder's version is 1.9.0 according to https://github.com/googleapis/google-cloud-ruby/blob/207f19517ecb84da5031d243b7900aaeee50d556/google-cloud-asset-v1/lib/google/cloud/asset/v1/version.rb#L24.

This is the follow-up of https://github.com/googleapis/google-cloud-ruby/pull/35034/changes#r3694027743.