### PR TITLE
chore: update gapic-generator-cloud

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -20,7 +20,7 @@ sources:
 tools:
   gem:
     - name: gapic-generator-cloud
-      version: 0.49.0
+      version: 0.50.0
     - name: grpc-tools
       version: 1.78.1
   protoc:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -20,7 +20,7 @@ sources:
 tools:
   gem:
     - name: gapic-generator-cloud
-      version: 0.50.0
+      version: 0.51.0
     - name: grpc-tools
       version: 1.78.1
   protoc:


### PR DESCRIPTION
Update gapic-generator-cloud to `0.51.0`.

For https://github.com/googleapis/librarian/issues/7161