### PR TITLE
chore(deps): seed reproducible Gemfile.lock across 29 samples directories

### DIFF
--- a/google-cloud-ai_platform/samples/Gemfile.lock
+++ b/google-cloud-ai_platform/samples/Gemfile.lock
@@ -3,18 +3,13 @@ GEM
   specs:
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.1.2)
-    concurrent-ruby (1.3.8)
-    declarative (0.0.20)
-    digest-crc (0.7.0)
-      rake (>= 12.0.0, < 14.0.0)
     faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-follow_redirects (0.5.0)
-      faraday (>= 1, < 3)
     faraday-net_http (3.4.4)
       net-http (~> 0.5)
     faraday-retry (2.4.0)
@@ -29,47 +24,14 @@ GEM
       googleapis-common-protos-types (~> 1.15)
       googleauth (~> 1.12)
       grpc (~> 1.66)
-    google-apis-bigquery_v2 (0.106.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-<<<<<<< HEAD
-    google-apis-core (1.2.99)
-      addressable (~> 2.8, >= 2.8.7)
-=======
-    google-apis-core (1.2.5)
-      addressable (~> 2.9)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-      faraday (~> 2.13)
-      faraday-follow_redirects (~> 0.3)
-      googleauth (~> 1.14)
-      mini_mime (~> 1.1)
-      multi_json (~> 1.11)
-      representable (~> 3.0)
-<<<<<<< HEAD
-      retriable (~> 3.1)
-=======
-      retriable (>= 3.1, < 5.0)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-    google-apis-iamcredentials_v1 (0.28.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-    google-apis-storage_v1 (0.65.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-    google-cloud-asset (1.10.0)
-      google-cloud-asset-v1 (>= 0.29, < 2.a)
+    google-cloud-ai_platform (2.4.0)
+      google-cloud-ai_platform-v1 (~> 1.0)
       google-cloud-core (~> 1.6)
-    google-cloud-asset-v1 (1.9.0)
+    google-cloud-ai_platform-v1 (1.47.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
-      google-cloud-os_config-v1 (> 0.0, < 2.a)
-      google-identity-access_context_manager-v1 (> 0.0, < 2.a)
-      grpc-google-iam-v1 (~> 1.11)
-    google-cloud-bigquery (1.64.0)
-      bigdecimal (>= 3.0, < 5)
-      concurrent-ruby (~> 1.0)
-      google-apis-bigquery_v2 (~> 0.71)
-      google-apis-core (>= 0.18, < 2)
-      google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
+      google-cloud-location (~> 1.0)
+      google-iam-v1 (~> 1.3)
     google-cloud-core (1.9.0)
       google-cloud-env (>= 1.0, < 3.a)
       google-cloud-errors (~> 1.0)
@@ -77,32 +39,10 @@ GEM
       base64 (~> 0.2)
       faraday (>= 1.0, < 3.a)
     google-cloud-errors (1.7.0)
-    google-cloud-os_config-v1 (1.9.0)
+    google-cloud-location (1.5.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
-    google-cloud-pubsub (3.4.0)
-      concurrent-ruby (~> 1.3)
-      google-cloud-core (~> 1.8)
-      google-cloud-pubsub-v1 (~> 1.11)
-      retriable (~> 3.1)
-    google-cloud-pubsub-v1 (1.16.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-iam-v1 (~> 1.3)
-    google-cloud-storage (1.62.0)
-      addressable (~> 2.8)
-      digest-crc (~> 0.4)
-      google-apis-core (>= 0.18, < 2)
-      google-apis-iamcredentials_v1 (~> 0.18)
-      google-apis-storage_v1 (>= 0.42)
-      google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
     google-iam-v1 (1.7.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      grpc-google-iam-v1 (~> 1.11)
-    google-identity-access_context_manager-v1 (0.15.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
       grpc-google-iam-v1 (~> 1.11)
@@ -134,6 +74,8 @@ GEM
     google-protobuf (4.35.1-x86_64-linux-musl)
       bigdecimal
       rake (~> 13.3)
+    google-style (1.26.4)
+      rubocop (~> 1.57.2)
     googleapis-common-protos (1.9.0)
       google-protobuf (~> 4.26)
       googleapis-common-protos-types (~> 1.21)
@@ -182,29 +124,48 @@ GEM
     json (2.21.2)
     jwt (3.2.0)
       base64
+    language_server-protocol (3.17.0.6)
     logger (1.7.0)
-    mini_mime (1.1.5)
     minitest (5.27.0)
     minitest-focus (1.4.1)
       minitest (> 5.0)
-    multi_json (1.21.1)
+    minitest-rg (5.4.0)
+      minitest (>= 5.0, < 7)
     net-http (0.9.1)
       uri (>= 0.11.1)
     os (1.1.4)
+    parallel (1.28.0)
+    parser (3.3.12.0)
+      ast (~> 2.4.1)
+      racc
+    prism (1.9.0)
     pstore (0.2.1)
     public_suffix (7.0.5)
+    racc (1.8.1)
+    rainbow (3.1.1)
     rake (13.4.2)
-    representable (3.2.0)
-      declarative (< 0.1.0)
-      trailblazer-option (>= 0.1.1, < 0.2.0)
-      uber (< 0.2.0)
-    retriable (3.8.0)
+    regexp_parser (2.12.0)
+    rexml (3.4.4)
+    rubocop (1.57.2)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.2.2.4)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.28.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.50.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    ruby-progressbar (1.13.0)
     signet (0.22.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 4.0)
-    trailblazer-option (0.1.2)
-    uber (0.1.0)
+    unicode-display_width (2.6.0)
     uri (1.1.1)
 
 PLATFORMS
@@ -219,47 +180,30 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  google-cloud-asset
-  google-cloud-bigquery
-  google-cloud-pubsub
-  google-cloud-storage
-  minitest (~> 5.14)
-  minitest-focus
+  google-cloud-ai_platform
+  google-style (~> 1.26.2)
+  minitest (~> 5.17)
+  minitest-focus (~> 1.4)
+  minitest-rg (~> 5.2)
   rake
 
 CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
-  concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
-  declarative (0.0.20) sha256=8021dd6cb17ab2b61233c56903d3f5a259c5cf43c80ff332d447d395b17d9ff9
-  digest-crc (0.7.0) sha256=64adc23a26a241044cbe6732477ca1b3c281d79e2240bcff275a37a5a0d78c07
   faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
-  faraday-follow_redirects (0.5.0) sha256=5cde93c894b30943a5d2b93c2fe9284216a6b756f7af406a1e55f211d97d10ad
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
   faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
   gapic-common (1.3.0) sha256=4e5d9be1effb7366e2cda13c0f44922285d5613ac8de8b9b18c2c835fe4faa91
-  google-apis-bigquery_v2 (0.106.0) sha256=a0f4243b634a0c79c29b7dacdd79233bd9c9ba2eda6fde9c2b19414fd165dd93
-<<<<<<< HEAD
-  google-apis-core (1.2.99)
-=======
-  google-apis-core (1.2.5) sha256=e21562b5627a0fc6a0c3165e429c3afed0f6a628eaa514e83f7204dda1adff69
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-  google-apis-iamcredentials_v1 (0.28.0) sha256=0a92ffe6cc39c569554af2a77a25dfc61519ed8bbb64ab04cffdd352dc5ef106
-  google-apis-storage_v1 (0.65.0) sha256=4247aa542931691f6988ab61e45cdea2878cbfe897a98eec4af9cdcb678eb359
-  google-cloud-asset (1.10.0) sha256=6ea6fd9e0735873884094c14d84d5a6d826b0e07aaeec245d34735ab2c5828e0
-  google-cloud-asset-v1 (1.9.0) sha256=ecfb654d0d350ed98209d46937c8095ec867c8ff6c3f7d70b8889f6fb70fd397
-  google-cloud-bigquery (1.64.0) sha256=d807363903e08958c3bc09ccc1f9d1218646c8f18176751879348a1a4a884d57
+  google-cloud-ai_platform (2.4.0) sha256=de6e37f0118aa9bf0382a960334fac419b57b1ca12bc9416cc83fd1f773ff941
+  google-cloud-ai_platform-v1 (1.47.0) sha256=b5feebbc5bf95f9faf6950a7aaceebcd848ecaf809a15da0433d158ca9950ed8
   google-cloud-core (1.9.0) sha256=ab55409f51488e8deefb6edcc1ce4771dfb5da2fe7b3bc075709a030c2b682a4
   google-cloud-env (2.4.0) sha256=01cb35ecee5d1c4d1cd4deaed8bb5bddc838e296bcc2a35c5d1ddd07ce40d28d
   google-cloud-errors (1.7.0) sha256=6e682f42d89aae08689f36f28495de629d756da076bafff0003bac7f8042ebb3
-  google-cloud-os_config-v1 (1.9.0) sha256=693c13690cfd7cf9d307c25d005ff33b823b6709791d3714c344ff1597ec3a30
-  google-cloud-pubsub (3.4.0) sha256=6a6390a6f605701945d5be233dea51e0b04009f157b5d701b092423fbc690edd
-  google-cloud-pubsub-v1 (1.16.0) sha256=ffe128821208bd3d2f27cb0d25eb6accb3893c99e0b736d1740b8b5e1570426b
-  google-cloud-storage (1.62.0) sha256=e2c3c08bf8fd40d50be92304084942203314d4fc0ee52028e99f9359c3ad1330
+  google-cloud-location (1.5.0) sha256=336f94609b1fb18fce1929048fac964f4d5a87d27c1e5444bfed3605469c7532
   google-iam-v1 (1.7.0) sha256=9e3ea9dcc59cbd5f8d2f62b00da41ec57a2e427b33c0e798207fa06c8fbb8b87
-  google-identity-access_context_manager-v1 (0.15.0) sha256=8f105320bcbdc03c7fdb05369886117b4f341b792ed4ab81a144929bbcd7820b
   google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
   google-protobuf (4.35.1) sha256=a3a6471331d918f58dfa4d014a8f6286f0af2cf4840216bde52fcf2ea3fe3726
   google-protobuf (4.35.1-aarch64-linux-gnu) sha256=50ca44d0eeff3f8475e630a1accdd974256f3510694d574e2c9d6119ea8bc9e1
@@ -270,6 +214,7 @@ CHECKSUMS
   google-protobuf (4.35.1-x86_64-darwin) sha256=66b62b4df00931018a692806df66393efa960d6d2b7da69735187249f950d3ee
   google-protobuf (4.35.1-x86_64-linux-gnu) sha256=c786439087512a3fbd199e9897d265b855f951d4027e218ea55e858d45969edd
   google-protobuf (4.35.1-x86_64-linux-musl) sha256=91890eb0002934a339fdb7d77a147c46b7474b6799db27872b747b905837f744
+  google-style (1.26.4) sha256=a8a24a5a020bd608d55a32462caaef7b02ae9b9d4dd36ea3945f80fdbaa11846
   googleapis-common-protos (1.9.0) sha256=207be372d8d25e3876e1e1155d057e14f3c92f8f5428772864a8ce04a0b756e4
   googleapis-common-protos-types (1.23.0) sha256=992e740a523794d9fc5f29a504465d8fc737aaa16c930fe7228e3346860faf0a
   googleauth (1.17.3) sha256=9a655455885c0c17a8b70537acd2a992a7c7842c43c06c6612dfb0d93e755d58
@@ -285,21 +230,28 @@ CHECKSUMS
   grpc-google-iam-v1 (1.12.0) sha256=a70ecad8987e340d5e22e7bf01be31256c84b29a3f78bebd385a4a110e1f2aef
   json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
+  language_server-protocol (3.17.0.6) sha256=5ef2c0c138f8267e1bc631d3328347d354f96724b0af22f2c79516120443b7f0
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
-  mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   minitest-focus (1.4.1) sha256=394517cbe2dcb2d992d8ffc41a3b2b6315777a4daa69239de4fefe7110dd810e
-  multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080
+  minitest-rg (5.4.0) sha256=54d42bb8ce876381245be5866f3c1dd704ef79c06ba5c9ff280c0aa28c56effb
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
   os (1.1.4) sha256=57816d6a334e7bd6aed048f4b0308226c5fb027433b67d90a9ab435f35108d3f
+  parallel (1.28.0) sha256=33e6de1484baf2524792d178b0913fc8eb94c628d6cfe45599ad4458c638c970
+  parser (3.3.12.0) sha256=21a6d7f755d5a24dfbdc6e6b772e4e879a52e7631a88bc5a3a134606052c9828
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   pstore (0.2.1) sha256=03904d0f2c66579e96d1e6704cdabc0c88df7ea8ed8782d9f3569f6f6c702c1a
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
-  representable (3.2.0) sha256=cc29bf7eebc31653586849371a43ffe36c60b54b0a6365b5f7d95ec34d1ebace
-  retriable (3.8.0) sha256=9f2f1b0207594c7817f17f671587b8ec7587387ac6cebda6c941a802bb98a8e5
+  regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rubocop (1.57.2) sha256=8f679dfe42d7821dc61dafb17d14b1294343157a197b9f8a23720ca17fb9161b
+  rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   signet (0.22.0) sha256=b76d495ccb07ad35dbc89f3e920665a9d8ed717141955034005d7843dcfe4780
-  trailblazer-option (0.1.2) sha256=20e4f12ea4e1f718c8007e7944ca21a329eee4eed9e0fa5dde6e8ad8ac4344a3
-  uber (0.1.0) sha256=5beeb407ff807b5db994f82fa9ee07cfceaa561dad8af20be880bc67eba935dc
+  unicode-display_width (2.6.0) sha256=12279874bba6d5e4d2728cef814b19197dbb10d7a7837a869bab65da943b7f5a
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
 
 BUNDLED WITH

--- a/google-cloud-bigquery-data_transfer/samples/Gemfile.lock
+++ b/google-cloud-bigquery-data_transfer/samples/Gemfile.lock
@@ -3,18 +3,13 @@ GEM
   specs:
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.1.2)
-    concurrent-ruby (1.3.8)
-    declarative (0.0.20)
-    digest-crc (0.7.0)
-      rake (>= 12.0.0, < 14.0.0)
     faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-follow_redirects (0.5.0)
-      faraday (>= 1, < 3)
     faraday-net_http (3.4.4)
       net-http (~> 0.5)
     faraday-retry (2.4.0)
@@ -29,47 +24,13 @@ GEM
       googleapis-common-protos-types (~> 1.15)
       googleauth (~> 1.12)
       grpc (~> 1.66)
-    google-apis-bigquery_v2 (0.106.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-<<<<<<< HEAD
-    google-apis-core (1.2.99)
-      addressable (~> 2.8, >= 2.8.7)
-=======
-    google-apis-core (1.2.5)
-      addressable (~> 2.9)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-      faraday (~> 2.13)
-      faraday-follow_redirects (~> 0.3)
-      googleauth (~> 1.14)
-      mini_mime (~> 1.1)
-      multi_json (~> 1.11)
-      representable (~> 3.0)
-<<<<<<< HEAD
-      retriable (~> 3.1)
-=======
-      retriable (>= 3.1, < 5.0)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-    google-apis-iamcredentials_v1 (0.28.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-    google-apis-storage_v1 (0.65.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-    google-cloud-asset (1.10.0)
-      google-cloud-asset-v1 (>= 0.29, < 2.a)
+    google-cloud-bigquery-data_transfer (1.9.0)
+      google-cloud-bigquery-data_transfer-v1 (>= 0.12, < 2.a)
       google-cloud-core (~> 1.6)
-    google-cloud-asset-v1 (1.9.0)
+    google-cloud-bigquery-data_transfer-v1 (1.7.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
-      google-cloud-os_config-v1 (> 0.0, < 2.a)
-      google-identity-access_context_manager-v1 (> 0.0, < 2.a)
-      grpc-google-iam-v1 (~> 1.11)
-    google-cloud-bigquery (1.64.0)
-      bigdecimal (>= 3.0, < 5)
-      concurrent-ruby (~> 1.0)
-      google-apis-bigquery_v2 (~> 0.71)
-      google-apis-core (>= 0.18, < 2)
-      google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
+      google-cloud-location (~> 1.0)
     google-cloud-core (1.9.0)
       google-cloud-env (>= 1.0, < 3.a)
       google-cloud-errors (~> 1.0)
@@ -77,35 +38,9 @@ GEM
       base64 (~> 0.2)
       faraday (>= 1.0, < 3.a)
     google-cloud-errors (1.7.0)
-    google-cloud-os_config-v1 (1.9.0)
+    google-cloud-location (1.5.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
-    google-cloud-pubsub (3.4.0)
-      concurrent-ruby (~> 1.3)
-      google-cloud-core (~> 1.8)
-      google-cloud-pubsub-v1 (~> 1.11)
-      retriable (~> 3.1)
-    google-cloud-pubsub-v1 (1.16.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-iam-v1 (~> 1.3)
-    google-cloud-storage (1.62.0)
-      addressable (~> 2.8)
-      digest-crc (~> 0.4)
-      google-apis-core (>= 0.18, < 2)
-      google-apis-iamcredentials_v1 (~> 0.18)
-      google-apis-storage_v1 (>= 0.42)
-      google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
-    google-iam-v1 (1.7.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      grpc-google-iam-v1 (~> 1.11)
-    google-identity-access_context_manager-v1 (0.15.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      grpc-google-iam-v1 (~> 1.11)
     google-logging-utils (0.2.0)
     google-protobuf (4.35.1)
       bigdecimal
@@ -134,7 +69,9 @@ GEM
     google-protobuf (4.35.1-x86_64-linux-musl)
       bigdecimal
       rake (~> 13.3)
-    googleapis-common-protos (1.9.0)
+    google-style (1.25.3)
+      rubocop (~> 1.28.2)
+    googleapis-common-protos (1.10.0)
       google-protobuf (~> 4.26)
       googleapis-common-protos-types (~> 1.21)
       grpc (~> 1.41)
@@ -175,36 +112,44 @@ GEM
     grpc (1.83.0-x86_64-linux-musl)
       google-protobuf (>= 3.25, < 5.0)
       googleapis-common-protos-types (~> 1.0)
-    grpc-google-iam-v1 (1.12.0)
-      google-protobuf (>= 3.18, < 5.a)
-      googleapis-common-protos (~> 1.9.0)
-      grpc (~> 1.41)
     json (2.21.2)
     jwt (3.2.0)
       base64
     logger (1.7.0)
-    mini_mime (1.1.5)
     minitest (5.27.0)
-    minitest-focus (1.4.1)
-      minitest (> 5.0)
-    multi_json (1.21.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
     os (1.1.4)
+    parallel (1.28.0)
+    parser (3.3.12.0)
+      ast (~> 2.4.1)
+      racc
+    prism (1.9.0)
     pstore (0.2.1)
     public_suffix (7.0.5)
+    racc (1.8.1)
+    rainbow (3.1.1)
     rake (13.4.2)
-    representable (3.2.0)
-      declarative (< 0.1.0)
-      trailblazer-option (>= 0.1.1, < 0.2.0)
-      uber (< 0.2.0)
-    retriable (3.8.0)
+    regexp_parser (2.12.0)
+    rexml (3.4.4)
+    rubocop (1.28.2)
+      parallel (~> 1.10)
+      parser (>= 3.1.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.17.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.50.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    ruby-progressbar (1.13.0)
     signet (0.22.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 4.0)
-    trailblazer-option (0.1.2)
-    uber (0.1.0)
+    unicode-display_width (2.6.0)
     uri (1.1.1)
 
 PLATFORMS
@@ -219,47 +164,27 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  google-cloud-asset
-  google-cloud-bigquery
-  google-cloud-pubsub
-  google-cloud-storage
+  google-cloud-bigquery-data_transfer
+  google-style (~> 1.25.1)
   minitest (~> 5.14)
-  minitest-focus
   rake
 
 CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
-  concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
-  declarative (0.0.20) sha256=8021dd6cb17ab2b61233c56903d3f5a259c5cf43c80ff332d447d395b17d9ff9
-  digest-crc (0.7.0) sha256=64adc23a26a241044cbe6732477ca1b3c281d79e2240bcff275a37a5a0d78c07
   faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
-  faraday-follow_redirects (0.5.0) sha256=5cde93c894b30943a5d2b93c2fe9284216a6b756f7af406a1e55f211d97d10ad
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
   faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
   gapic-common (1.3.0) sha256=4e5d9be1effb7366e2cda13c0f44922285d5613ac8de8b9b18c2c835fe4faa91
-  google-apis-bigquery_v2 (0.106.0) sha256=a0f4243b634a0c79c29b7dacdd79233bd9c9ba2eda6fde9c2b19414fd165dd93
-<<<<<<< HEAD
-  google-apis-core (1.2.99)
-=======
-  google-apis-core (1.2.5) sha256=e21562b5627a0fc6a0c3165e429c3afed0f6a628eaa514e83f7204dda1adff69
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-  google-apis-iamcredentials_v1 (0.28.0) sha256=0a92ffe6cc39c569554af2a77a25dfc61519ed8bbb64ab04cffdd352dc5ef106
-  google-apis-storage_v1 (0.65.0) sha256=4247aa542931691f6988ab61e45cdea2878cbfe897a98eec4af9cdcb678eb359
-  google-cloud-asset (1.10.0) sha256=6ea6fd9e0735873884094c14d84d5a6d826b0e07aaeec245d34735ab2c5828e0
-  google-cloud-asset-v1 (1.9.0) sha256=ecfb654d0d350ed98209d46937c8095ec867c8ff6c3f7d70b8889f6fb70fd397
-  google-cloud-bigquery (1.64.0) sha256=d807363903e08958c3bc09ccc1f9d1218646c8f18176751879348a1a4a884d57
+  google-cloud-bigquery-data_transfer (1.9.0) sha256=17ae64fd98635e5d8e29ef8ba731b14df3a286858dbc212275f89303adff3254
+  google-cloud-bigquery-data_transfer-v1 (1.7.0) sha256=64bc3dd4d4a7e61803440d93b7f2a7dcf2aa344ed6468383457aa0c84e5fc2fb
   google-cloud-core (1.9.0) sha256=ab55409f51488e8deefb6edcc1ce4771dfb5da2fe7b3bc075709a030c2b682a4
   google-cloud-env (2.4.0) sha256=01cb35ecee5d1c4d1cd4deaed8bb5bddc838e296bcc2a35c5d1ddd07ce40d28d
   google-cloud-errors (1.7.0) sha256=6e682f42d89aae08689f36f28495de629d756da076bafff0003bac7f8042ebb3
-  google-cloud-os_config-v1 (1.9.0) sha256=693c13690cfd7cf9d307c25d005ff33b823b6709791d3714c344ff1597ec3a30
-  google-cloud-pubsub (3.4.0) sha256=6a6390a6f605701945d5be233dea51e0b04009f157b5d701b092423fbc690edd
-  google-cloud-pubsub-v1 (1.16.0) sha256=ffe128821208bd3d2f27cb0d25eb6accb3893c99e0b736d1740b8b5e1570426b
-  google-cloud-storage (1.62.0) sha256=e2c3c08bf8fd40d50be92304084942203314d4fc0ee52028e99f9359c3ad1330
-  google-iam-v1 (1.7.0) sha256=9e3ea9dcc59cbd5f8d2f62b00da41ec57a2e427b33c0e798207fa06c8fbb8b87
-  google-identity-access_context_manager-v1 (0.15.0) sha256=8f105320bcbdc03c7fdb05369886117b4f341b792ed4ab81a144929bbcd7820b
+  google-cloud-location (1.5.0) sha256=336f94609b1fb18fce1929048fac964f4d5a87d27c1e5444bfed3605469c7532
   google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
   google-protobuf (4.35.1) sha256=a3a6471331d918f58dfa4d014a8f6286f0af2cf4840216bde52fcf2ea3fe3726
   google-protobuf (4.35.1-aarch64-linux-gnu) sha256=50ca44d0eeff3f8475e630a1accdd974256f3510694d574e2c9d6119ea8bc9e1
@@ -270,7 +195,8 @@ CHECKSUMS
   google-protobuf (4.35.1-x86_64-darwin) sha256=66b62b4df00931018a692806df66393efa960d6d2b7da69735187249f950d3ee
   google-protobuf (4.35.1-x86_64-linux-gnu) sha256=c786439087512a3fbd199e9897d265b855f951d4027e218ea55e858d45969edd
   google-protobuf (4.35.1-x86_64-linux-musl) sha256=91890eb0002934a339fdb7d77a147c46b7474b6799db27872b747b905837f744
-  googleapis-common-protos (1.9.0) sha256=207be372d8d25e3876e1e1155d057e14f3c92f8f5428772864a8ce04a0b756e4
+  google-style (1.25.3) sha256=d417fd0f6d6a9f4bb2ff69e1cfaa1c4d0e19230589cdf4383df4540082c395d4
+  googleapis-common-protos (1.10.0) sha256=13e47ad0ce85d3d30065c03863efd302a82b0e08ba576f2a9b9dbbfeecb57ee0
   googleapis-common-protos-types (1.23.0) sha256=992e740a523794d9fc5f29a504465d8fc737aaa16c930fe7228e3346860faf0a
   googleauth (1.17.3) sha256=9a655455885c0c17a8b70537acd2a992a7c7842c43c06c6612dfb0d93e755d58
   grpc (1.83.0) sha256=38119e7f9f7cbc98e79145201da4be470a7542b0befad454651d35015ea55c59
@@ -282,24 +208,27 @@ CHECKSUMS
   grpc (1.83.0-x86_64-darwin) sha256=cfad91d559d1907159a5247fb12dc112a8ea0ebe2027ca7f5ab648d01a645716
   grpc (1.83.0-x86_64-linux-gnu) sha256=25d66bfa3cb1b05258b3f9632478c7e7ceb52cb16ccc0b4b26d7df36be7158b1
   grpc (1.83.0-x86_64-linux-musl) sha256=a5023264dbb8038c23b147bbf80adb06932ef11b5ab493412e9e37a43114fa8c
-  grpc-google-iam-v1 (1.12.0) sha256=a70ecad8987e340d5e22e7bf01be31256c84b29a3f78bebd385a4a110e1f2aef
   json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
-  mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
-  minitest-focus (1.4.1) sha256=394517cbe2dcb2d992d8ffc41a3b2b6315777a4daa69239de4fefe7110dd810e
-  multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
   os (1.1.4) sha256=57816d6a334e7bd6aed048f4b0308226c5fb027433b67d90a9ab435f35108d3f
+  parallel (1.28.0) sha256=33e6de1484baf2524792d178b0913fc8eb94c628d6cfe45599ad4458c638c970
+  parser (3.3.12.0) sha256=21a6d7f755d5a24dfbdc6e6b772e4e879a52e7631a88bc5a3a134606052c9828
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   pstore (0.2.1) sha256=03904d0f2c66579e96d1e6704cdabc0c88df7ea8ed8782d9f3569f6f6c702c1a
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
-  representable (3.2.0) sha256=cc29bf7eebc31653586849371a43ffe36c60b54b0a6365b5f7d95ec34d1ebace
-  retriable (3.8.0) sha256=9f2f1b0207594c7817f17f671587b8ec7587387ac6cebda6c941a802bb98a8e5
+  regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rubocop (1.28.2) sha256=0d9bf4108fd86ede43c6cf30adcb3dd2e0c6750941c5ec2a00621478157cb377
+  rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   signet (0.22.0) sha256=b76d495ccb07ad35dbc89f3e920665a9d8ed717141955034005d7843dcfe4780
-  trailblazer-option (0.1.2) sha256=20e4f12ea4e1f718c8007e7944ca21a329eee4eed9e0fa5dde6e8ad8ac4344a3
-  uber (0.1.0) sha256=5beeb407ff807b5db994f82fa9ee07cfceaa561dad8af20be880bc67eba935dc
+  unicode-display_width (2.6.0) sha256=12279874bba6d5e4d2728cef814b19197dbb10d7a7837a869bab65da943b7f5a
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
 
 BUNDLED WITH

--- a/google-cloud-bigtable/samples/Gemfile.lock
+++ b/google-cloud-bigtable/samples/Gemfile.lock
@@ -3,18 +3,14 @@ GEM
   specs:
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.1.2)
     concurrent-ruby (1.3.8)
-    declarative (0.0.20)
-    digest-crc (0.7.0)
-      rake (>= 12.0.0, < 14.0.0)
     faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-follow_redirects (0.5.0)
-      faraday (>= 1, < 3)
     faraday-net_http (3.4.4)
       net-http (~> 0.5)
     faraday-retry (2.4.0)
@@ -29,47 +25,18 @@ GEM
       googleapis-common-protos-types (~> 1.15)
       googleauth (~> 1.12)
       grpc (~> 1.66)
-    google-apis-bigquery_v2 (0.106.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-<<<<<<< HEAD
-    google-apis-core (1.2.99)
-      addressable (~> 2.8, >= 2.8.7)
-=======
-    google-apis-core (1.2.5)
-      addressable (~> 2.9)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-      faraday (~> 2.13)
-      faraday-follow_redirects (~> 0.3)
-      googleauth (~> 1.14)
-      mini_mime (~> 1.1)
-      multi_json (~> 1.11)
-      representable (~> 3.0)
-<<<<<<< HEAD
-      retriable (~> 3.1)
-=======
-      retriable (>= 3.1, < 5.0)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-    google-apis-iamcredentials_v1 (0.28.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-    google-apis-storage_v1 (0.65.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-    google-cloud-asset (1.10.0)
-      google-cloud-asset-v1 (>= 0.29, < 2.a)
-      google-cloud-core (~> 1.6)
-    google-cloud-asset-v1 (1.9.0)
+    google-cloud-bigtable (2.13.0)
+      concurrent-ruby (~> 1.0)
+      google-cloud-bigtable-admin-v2 (~> 1.7)
+      google-cloud-bigtable-v2 (~> 1.5)
+      google-cloud-core (~> 1.5)
+    google-cloud-bigtable-admin-v2 (1.18.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
-      google-cloud-os_config-v1 (> 0.0, < 2.a)
-      google-identity-access_context_manager-v1 (> 0.0, < 2.a)
       grpc-google-iam-v1 (~> 1.11)
-    google-cloud-bigquery (1.64.0)
-      bigdecimal (>= 3.0, < 5)
-      concurrent-ruby (~> 1.0)
-      google-apis-bigquery_v2 (~> 0.71)
-      google-apis-core (>= 0.18, < 2)
-      google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
+    google-cloud-bigtable-v2 (1.15.0)
+      gapic-common (~> 1.3)
+      google-cloud-errors (~> 1.0)
     google-cloud-core (1.9.0)
       google-cloud-env (>= 1.0, < 3.a)
       google-cloud-errors (~> 1.0)
@@ -77,35 +44,6 @@ GEM
       base64 (~> 0.2)
       faraday (>= 1.0, < 3.a)
     google-cloud-errors (1.7.0)
-    google-cloud-os_config-v1 (1.9.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-    google-cloud-pubsub (3.4.0)
-      concurrent-ruby (~> 1.3)
-      google-cloud-core (~> 1.8)
-      google-cloud-pubsub-v1 (~> 1.11)
-      retriable (~> 3.1)
-    google-cloud-pubsub-v1 (1.16.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-iam-v1 (~> 1.3)
-    google-cloud-storage (1.62.0)
-      addressable (~> 2.8)
-      digest-crc (~> 0.4)
-      google-apis-core (>= 0.18, < 2)
-      google-apis-iamcredentials_v1 (~> 0.18)
-      google-apis-storage_v1 (>= 0.42)
-      google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
-    google-iam-v1 (1.7.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      grpc-google-iam-v1 (~> 1.11)
-    google-identity-access_context_manager-v1 (0.15.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      grpc-google-iam-v1 (~> 1.11)
     google-logging-utils (0.2.0)
     google-protobuf (4.35.1)
       bigdecimal
@@ -134,6 +72,8 @@ GEM
     google-protobuf (4.35.1-x86_64-linux-musl)
       bigdecimal
       rake (~> 13.3)
+    google-style (1.25.3)
+      rubocop (~> 1.28.2)
     googleapis-common-protos (1.9.0)
       google-protobuf (~> 4.26)
       googleapis-common-protos-types (~> 1.21)
@@ -183,28 +123,44 @@ GEM
     jwt (3.2.0)
       base64
     logger (1.7.0)
-    mini_mime (1.1.5)
     minitest (5.27.0)
     minitest-focus (1.4.1)
       minitest (> 5.0)
-    multi_json (1.21.1)
+    minitest-hooks (1.5.4)
+      minitest (> 5.3)
     net-http (0.9.1)
       uri (>= 0.11.1)
     os (1.1.4)
+    parallel (1.28.0)
+    parser (3.3.12.0)
+      ast (~> 2.4.1)
+      racc
+    prism (1.9.0)
     pstore (0.2.1)
     public_suffix (7.0.5)
+    racc (1.8.1)
+    rainbow (3.1.1)
     rake (13.4.2)
-    representable (3.2.0)
-      declarative (< 0.1.0)
-      trailblazer-option (>= 0.1.1, < 0.2.0)
-      uber (< 0.2.0)
-    retriable (3.8.0)
+    regexp_parser (2.12.0)
+    rexml (3.4.4)
+    rubocop (1.28.2)
+      parallel (~> 1.10)
+      parser (>= 3.1.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.17.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.50.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    ruby-progressbar (1.13.0)
     signet (0.22.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 4.0)
-    trailblazer-option (0.1.2)
-    uber (0.1.0)
+    unicode-display_width (2.6.0)
     uri (1.1.1)
 
 PLATFORMS
@@ -219,47 +175,30 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  google-cloud-asset
-  google-cloud-bigquery
-  google-cloud-pubsub
-  google-cloud-storage
+  google-cloud-bigtable
+  google-style (~> 1.25.1)
   minitest (~> 5.14)
-  minitest-focus
+  minitest-focus (~> 1.1)
+  minitest-hooks (~> 1.5)
   rake
 
 CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
   concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
-  declarative (0.0.20) sha256=8021dd6cb17ab2b61233c56903d3f5a259c5cf43c80ff332d447d395b17d9ff9
-  digest-crc (0.7.0) sha256=64adc23a26a241044cbe6732477ca1b3c281d79e2240bcff275a37a5a0d78c07
   faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
-  faraday-follow_redirects (0.5.0) sha256=5cde93c894b30943a5d2b93c2fe9284216a6b756f7af406a1e55f211d97d10ad
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
   faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
   gapic-common (1.3.0) sha256=4e5d9be1effb7366e2cda13c0f44922285d5613ac8de8b9b18c2c835fe4faa91
-  google-apis-bigquery_v2 (0.106.0) sha256=a0f4243b634a0c79c29b7dacdd79233bd9c9ba2eda6fde9c2b19414fd165dd93
-<<<<<<< HEAD
-  google-apis-core (1.2.99)
-=======
-  google-apis-core (1.2.5) sha256=e21562b5627a0fc6a0c3165e429c3afed0f6a628eaa514e83f7204dda1adff69
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-  google-apis-iamcredentials_v1 (0.28.0) sha256=0a92ffe6cc39c569554af2a77a25dfc61519ed8bbb64ab04cffdd352dc5ef106
-  google-apis-storage_v1 (0.65.0) sha256=4247aa542931691f6988ab61e45cdea2878cbfe897a98eec4af9cdcb678eb359
-  google-cloud-asset (1.10.0) sha256=6ea6fd9e0735873884094c14d84d5a6d826b0e07aaeec245d34735ab2c5828e0
-  google-cloud-asset-v1 (1.9.0) sha256=ecfb654d0d350ed98209d46937c8095ec867c8ff6c3f7d70b8889f6fb70fd397
-  google-cloud-bigquery (1.64.0) sha256=d807363903e08958c3bc09ccc1f9d1218646c8f18176751879348a1a4a884d57
+  google-cloud-bigtable (2.13.0) sha256=73d8deeae1249321fecf366c29ece95e0ddd0a94004d1bf89d55cd6aa02103c2
+  google-cloud-bigtable-admin-v2 (1.18.0) sha256=f95429eff84d5f229de845cda6421ae690b1bb1383f3b37afd9bc986d0efc5f8
+  google-cloud-bigtable-v2 (1.15.0) sha256=0bffc27d0406791500a4ece74deecdfc5721cf92fc0fb22d41964e9b0d8e0db7
   google-cloud-core (1.9.0) sha256=ab55409f51488e8deefb6edcc1ce4771dfb5da2fe7b3bc075709a030c2b682a4
   google-cloud-env (2.4.0) sha256=01cb35ecee5d1c4d1cd4deaed8bb5bddc838e296bcc2a35c5d1ddd07ce40d28d
   google-cloud-errors (1.7.0) sha256=6e682f42d89aae08689f36f28495de629d756da076bafff0003bac7f8042ebb3
-  google-cloud-os_config-v1 (1.9.0) sha256=693c13690cfd7cf9d307c25d005ff33b823b6709791d3714c344ff1597ec3a30
-  google-cloud-pubsub (3.4.0) sha256=6a6390a6f605701945d5be233dea51e0b04009f157b5d701b092423fbc690edd
-  google-cloud-pubsub-v1 (1.16.0) sha256=ffe128821208bd3d2f27cb0d25eb6accb3893c99e0b736d1740b8b5e1570426b
-  google-cloud-storage (1.62.0) sha256=e2c3c08bf8fd40d50be92304084942203314d4fc0ee52028e99f9359c3ad1330
-  google-iam-v1 (1.7.0) sha256=9e3ea9dcc59cbd5f8d2f62b00da41ec57a2e427b33c0e798207fa06c8fbb8b87
-  google-identity-access_context_manager-v1 (0.15.0) sha256=8f105320bcbdc03c7fdb05369886117b4f341b792ed4ab81a144929bbcd7820b
   google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
   google-protobuf (4.35.1) sha256=a3a6471331d918f58dfa4d014a8f6286f0af2cf4840216bde52fcf2ea3fe3726
   google-protobuf (4.35.1-aarch64-linux-gnu) sha256=50ca44d0eeff3f8475e630a1accdd974256f3510694d574e2c9d6119ea8bc9e1
@@ -270,6 +209,7 @@ CHECKSUMS
   google-protobuf (4.35.1-x86_64-darwin) sha256=66b62b4df00931018a692806df66393efa960d6d2b7da69735187249f950d3ee
   google-protobuf (4.35.1-x86_64-linux-gnu) sha256=c786439087512a3fbd199e9897d265b855f951d4027e218ea55e858d45969edd
   google-protobuf (4.35.1-x86_64-linux-musl) sha256=91890eb0002934a339fdb7d77a147c46b7474b6799db27872b747b905837f744
+  google-style (1.25.3) sha256=d417fd0f6d6a9f4bb2ff69e1cfaa1c4d0e19230589cdf4383df4540082c395d4
   googleapis-common-protos (1.9.0) sha256=207be372d8d25e3876e1e1155d057e14f3c92f8f5428772864a8ce04a0b756e4
   googleapis-common-protos-types (1.23.0) sha256=992e740a523794d9fc5f29a504465d8fc737aaa16c930fe7228e3346860faf0a
   googleauth (1.17.3) sha256=9a655455885c0c17a8b70537acd2a992a7c7842c43c06c6612dfb0d93e755d58
@@ -286,20 +226,26 @@ CHECKSUMS
   json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
-  mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   minitest-focus (1.4.1) sha256=394517cbe2dcb2d992d8ffc41a3b2b6315777a4daa69239de4fefe7110dd810e
-  multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080
+  minitest-hooks (1.5.4) sha256=1254069f3da51fea234dc4ff974108d03d19260ad5c4b78eed9695726a5069b8
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
   os (1.1.4) sha256=57816d6a334e7bd6aed048f4b0308226c5fb027433b67d90a9ab435f35108d3f
+  parallel (1.28.0) sha256=33e6de1484baf2524792d178b0913fc8eb94c628d6cfe45599ad4458c638c970
+  parser (3.3.12.0) sha256=21a6d7f755d5a24dfbdc6e6b772e4e879a52e7631a88bc5a3a134606052c9828
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   pstore (0.2.1) sha256=03904d0f2c66579e96d1e6704cdabc0c88df7ea8ed8782d9f3569f6f6c702c1a
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
-  representable (3.2.0) sha256=cc29bf7eebc31653586849371a43ffe36c60b54b0a6365b5f7d95ec34d1ebace
-  retriable (3.8.0) sha256=9f2f1b0207594c7817f17f671587b8ec7587387ac6cebda6c941a802bb98a8e5
+  regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rubocop (1.28.2) sha256=0d9bf4108fd86ede43c6cf30adcb3dd2e0c6750941c5ec2a00621478157cb377
+  rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   signet (0.22.0) sha256=b76d495ccb07ad35dbc89f3e920665a9d8ed717141955034005d7843dcfe4780
-  trailblazer-option (0.1.2) sha256=20e4f12ea4e1f718c8007e7944ca21a329eee4eed9e0fa5dde6e8ad8ac4344a3
-  uber (0.1.0) sha256=5beeb407ff807b5db994f82fa9ee07cfceaa561dad8af20be880bc67eba935dc
+  unicode-display_width (2.6.0) sha256=12279874bba6d5e4d2728cef814b19197dbb10d7a7837a869bab65da943b7f5a
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
 
 BUNDLED WITH

--- a/google-cloud-compute-v1/samples/Gemfile.lock
+++ b/google-cloud-compute-v1/samples/Gemfile.lock
@@ -3,9 +3,9 @@ GEM
   specs:
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.1.2)
-    concurrent-ruby (1.3.8)
     declarative (0.0.20)
     digest-crc (0.7.0)
       rake (>= 12.0.0, < 14.0.0)
@@ -29,47 +29,26 @@ GEM
       googleapis-common-protos-types (~> 1.15)
       googleauth (~> 1.12)
       grpc (~> 1.66)
-    google-apis-bigquery_v2 (0.106.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-<<<<<<< HEAD
-    google-apis-core (1.2.99)
-      addressable (~> 2.8, >= 2.8.7)
-=======
     google-apis-core (1.2.5)
       addressable (~> 2.9)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
       faraday (~> 2.13)
       faraday-follow_redirects (~> 0.3)
       googleauth (~> 1.14)
       mini_mime (~> 1.1)
       multi_json (~> 1.11)
       representable (~> 3.0)
-<<<<<<< HEAD
-      retriable (~> 3.1)
-=======
       retriable (>= 3.1, < 5.0)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
     google-apis-iamcredentials_v1 (0.28.0)
       google-apis-core (>= 0.15.0, < 2.a)
     google-apis-storage_v1 (0.65.0)
       google-apis-core (>= 0.15.0, < 2.a)
-    google-cloud-asset (1.10.0)
-      google-cloud-asset-v1 (>= 0.29, < 2.a)
-      google-cloud-core (~> 1.6)
-    google-cloud-asset-v1 (1.9.0)
+    google-cloud-common (1.10.0)
+      google-protobuf (>= 3.18, < 5.a)
+      googleapis-common-protos-types (~> 1.20)
+    google-cloud-compute-v1 (3.9.0)
       gapic-common (~> 1.3)
+      google-cloud-common (~> 1.0)
       google-cloud-errors (~> 1.0)
-      google-cloud-os_config-v1 (> 0.0, < 2.a)
-      google-identity-access_context_manager-v1 (> 0.0, < 2.a)
-      grpc-google-iam-v1 (~> 1.11)
-    google-cloud-bigquery (1.64.0)
-      bigdecimal (>= 3.0, < 5)
-      concurrent-ruby (~> 1.0)
-      google-apis-bigquery_v2 (~> 0.71)
-      google-apis-core (>= 0.18, < 2)
-      google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
     google-cloud-core (1.9.0)
       google-cloud-env (>= 1.0, < 3.a)
       google-cloud-errors (~> 1.0)
@@ -77,18 +56,6 @@ GEM
       base64 (~> 0.2)
       faraday (>= 1.0, < 3.a)
     google-cloud-errors (1.7.0)
-    google-cloud-os_config-v1 (1.9.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-    google-cloud-pubsub (3.4.0)
-      concurrent-ruby (~> 1.3)
-      google-cloud-core (~> 1.8)
-      google-cloud-pubsub-v1 (~> 1.11)
-      retriable (~> 3.1)
-    google-cloud-pubsub-v1 (1.16.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-iam-v1 (~> 1.3)
     google-cloud-storage (1.62.0)
       addressable (~> 2.8)
       digest-crc (~> 0.4)
@@ -98,14 +65,6 @@ GEM
       google-cloud-core (~> 1.6)
       googleauth (~> 1.9)
       mini_mime (~> 1.0)
-    google-iam-v1 (1.7.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      grpc-google-iam-v1 (~> 1.11)
-    google-identity-access_context_manager-v1 (0.15.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      grpc-google-iam-v1 (~> 1.11)
     google-logging-utils (0.2.0)
     google-protobuf (4.35.1)
       bigdecimal
@@ -134,7 +93,9 @@ GEM
     google-protobuf (4.35.1-x86_64-linux-musl)
       bigdecimal
       rake (~> 13.3)
-    googleapis-common-protos (1.9.0)
+    google-style (1.25.3)
+      rubocop (~> 1.28.2)
+    googleapis-common-protos (1.10.0)
       google-protobuf (~> 4.26)
       googleapis-common-protos-types (~> 1.21)
       grpc (~> 1.41)
@@ -175,36 +136,53 @@ GEM
     grpc (1.83.0-x86_64-linux-musl)
       google-protobuf (>= 3.25, < 5.0)
       googleapis-common-protos-types (~> 1.0)
-    grpc-google-iam-v1 (1.12.0)
-      google-protobuf (>= 3.18, < 5.a)
-      googleapis-common-protos (~> 1.9.0)
-      grpc (~> 1.41)
     json (2.21.2)
     jwt (3.2.0)
       base64
     logger (1.7.0)
     mini_mime (1.1.5)
     minitest (5.27.0)
-    minitest-focus (1.4.1)
-      minitest (> 5.0)
     multi_json (1.21.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
     os (1.1.4)
+    parallel (1.28.0)
+    parser (3.3.12.0)
+      ast (~> 2.4.1)
+      racc
+    prism (1.9.0)
     pstore (0.2.1)
     public_suffix (7.0.5)
+    racc (1.8.1)
+    rainbow (3.1.1)
     rake (13.4.2)
+    regexp_parser (2.12.0)
     representable (3.2.0)
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
-    retriable (3.8.0)
+    retriable (4.2.0)
+    rexml (3.4.4)
+    rubocop (1.28.2)
+      parallel (~> 1.10)
+      parser (>= 3.1.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.17.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.50.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    ruby-progressbar (1.13.0)
     signet (0.22.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 4.0)
     trailblazer-option (0.1.2)
     uber (0.1.0)
+    unicode-display_width (2.6.0)
     uri (1.1.1)
 
 PLATFORMS
@@ -219,20 +197,18 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  google-cloud-asset
-  google-cloud-bigquery
-  google-cloud-pubsub
+  google-cloud-compute-v1
   google-cloud-storage
+  google-style (~> 1.25.1)
   minitest (~> 5.14)
-  minitest-focus
-  rake
+  rake (>= 12.0)
 
 CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
-  concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
   declarative (0.0.20) sha256=8021dd6cb17ab2b61233c56903d3f5a259c5cf43c80ff332d447d395b17d9ff9
   digest-crc (0.7.0) sha256=64adc23a26a241044cbe6732477ca1b3c281d79e2240bcff275a37a5a0d78c07
   faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
@@ -240,26 +216,15 @@ CHECKSUMS
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
   faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
   gapic-common (1.3.0) sha256=4e5d9be1effb7366e2cda13c0f44922285d5613ac8de8b9b18c2c835fe4faa91
-  google-apis-bigquery_v2 (0.106.0) sha256=a0f4243b634a0c79c29b7dacdd79233bd9c9ba2eda6fde9c2b19414fd165dd93
-<<<<<<< HEAD
-  google-apis-core (1.2.99)
-=======
   google-apis-core (1.2.5) sha256=e21562b5627a0fc6a0c3165e429c3afed0f6a628eaa514e83f7204dda1adff69
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
   google-apis-iamcredentials_v1 (0.28.0) sha256=0a92ffe6cc39c569554af2a77a25dfc61519ed8bbb64ab04cffdd352dc5ef106
   google-apis-storage_v1 (0.65.0) sha256=4247aa542931691f6988ab61e45cdea2878cbfe897a98eec4af9cdcb678eb359
-  google-cloud-asset (1.10.0) sha256=6ea6fd9e0735873884094c14d84d5a6d826b0e07aaeec245d34735ab2c5828e0
-  google-cloud-asset-v1 (1.9.0) sha256=ecfb654d0d350ed98209d46937c8095ec867c8ff6c3f7d70b8889f6fb70fd397
-  google-cloud-bigquery (1.64.0) sha256=d807363903e08958c3bc09ccc1f9d1218646c8f18176751879348a1a4a884d57
+  google-cloud-common (1.10.0) sha256=f8036aa5a5f6a32d9ccab652f0f52a996ac02f5be83f403075465e8ba99238ee
+  google-cloud-compute-v1 (3.9.0) sha256=663473524bb13d279b09a2de290aa696171d26ccdc26862c3bd0dab61db4248d
   google-cloud-core (1.9.0) sha256=ab55409f51488e8deefb6edcc1ce4771dfb5da2fe7b3bc075709a030c2b682a4
   google-cloud-env (2.4.0) sha256=01cb35ecee5d1c4d1cd4deaed8bb5bddc838e296bcc2a35c5d1ddd07ce40d28d
   google-cloud-errors (1.7.0) sha256=6e682f42d89aae08689f36f28495de629d756da076bafff0003bac7f8042ebb3
-  google-cloud-os_config-v1 (1.9.0) sha256=693c13690cfd7cf9d307c25d005ff33b823b6709791d3714c344ff1597ec3a30
-  google-cloud-pubsub (3.4.0) sha256=6a6390a6f605701945d5be233dea51e0b04009f157b5d701b092423fbc690edd
-  google-cloud-pubsub-v1 (1.16.0) sha256=ffe128821208bd3d2f27cb0d25eb6accb3893c99e0b736d1740b8b5e1570426b
   google-cloud-storage (1.62.0) sha256=e2c3c08bf8fd40d50be92304084942203314d4fc0ee52028e99f9359c3ad1330
-  google-iam-v1 (1.7.0) sha256=9e3ea9dcc59cbd5f8d2f62b00da41ec57a2e427b33c0e798207fa06c8fbb8b87
-  google-identity-access_context_manager-v1 (0.15.0) sha256=8f105320bcbdc03c7fdb05369886117b4f341b792ed4ab81a144929bbcd7820b
   google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
   google-protobuf (4.35.1) sha256=a3a6471331d918f58dfa4d014a8f6286f0af2cf4840216bde52fcf2ea3fe3726
   google-protobuf (4.35.1-aarch64-linux-gnu) sha256=50ca44d0eeff3f8475e630a1accdd974256f3510694d574e2c9d6119ea8bc9e1
@@ -270,7 +235,8 @@ CHECKSUMS
   google-protobuf (4.35.1-x86_64-darwin) sha256=66b62b4df00931018a692806df66393efa960d6d2b7da69735187249f950d3ee
   google-protobuf (4.35.1-x86_64-linux-gnu) sha256=c786439087512a3fbd199e9897d265b855f951d4027e218ea55e858d45969edd
   google-protobuf (4.35.1-x86_64-linux-musl) sha256=91890eb0002934a339fdb7d77a147c46b7474b6799db27872b747b905837f744
-  googleapis-common-protos (1.9.0) sha256=207be372d8d25e3876e1e1155d057e14f3c92f8f5428772864a8ce04a0b756e4
+  google-style (1.25.3) sha256=d417fd0f6d6a9f4bb2ff69e1cfaa1c4d0e19230589cdf4383df4540082c395d4
+  googleapis-common-protos (1.10.0) sha256=13e47ad0ce85d3d30065c03863efd302a82b0e08ba576f2a9b9dbbfeecb57ee0
   googleapis-common-protos-types (1.23.0) sha256=992e740a523794d9fc5f29a504465d8fc737aaa16c930fe7228e3346860faf0a
   googleauth (1.17.3) sha256=9a655455885c0c17a8b70537acd2a992a7c7842c43c06c6612dfb0d93e755d58
   grpc (1.83.0) sha256=38119e7f9f7cbc98e79145201da4be470a7542b0befad454651d35015ea55c59
@@ -282,24 +248,33 @@ CHECKSUMS
   grpc (1.83.0-x86_64-darwin) sha256=cfad91d559d1907159a5247fb12dc112a8ea0ebe2027ca7f5ab648d01a645716
   grpc (1.83.0-x86_64-linux-gnu) sha256=25d66bfa3cb1b05258b3f9632478c7e7ceb52cb16ccc0b4b26d7df36be7158b1
   grpc (1.83.0-x86_64-linux-musl) sha256=a5023264dbb8038c23b147bbf80adb06932ef11b5ab493412e9e37a43114fa8c
-  grpc-google-iam-v1 (1.12.0) sha256=a70ecad8987e340d5e22e7bf01be31256c84b29a3f78bebd385a4a110e1f2aef
   json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
-  minitest-focus (1.4.1) sha256=394517cbe2dcb2d992d8ffc41a3b2b6315777a4daa69239de4fefe7110dd810e
   multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
   os (1.1.4) sha256=57816d6a334e7bd6aed048f4b0308226c5fb027433b67d90a9ab435f35108d3f
+  parallel (1.28.0) sha256=33e6de1484baf2524792d178b0913fc8eb94c628d6cfe45599ad4458c638c970
+  parser (3.3.12.0) sha256=21a6d7f755d5a24dfbdc6e6b772e4e879a52e7631a88bc5a3a134606052c9828
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   pstore (0.2.1) sha256=03904d0f2c66579e96d1e6704cdabc0c88df7ea8ed8782d9f3569f6f6c702c1a
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
+  regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
   representable (3.2.0) sha256=cc29bf7eebc31653586849371a43ffe36c60b54b0a6365b5f7d95ec34d1ebace
-  retriable (3.8.0) sha256=9f2f1b0207594c7817f17f671587b8ec7587387ac6cebda6c941a802bb98a8e5
+  retriable (4.2.0) sha256=90c3b257472a1c02f2a3dfa64dd35a420f7a624cef1a5981e20fdac5730f8cdc
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rubocop (1.28.2) sha256=0d9bf4108fd86ede43c6cf30adcb3dd2e0c6750941c5ec2a00621478157cb377
+  rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   signet (0.22.0) sha256=b76d495ccb07ad35dbc89f3e920665a9d8ed717141955034005d7843dcfe4780
   trailblazer-option (0.1.2) sha256=20e4f12ea4e1f718c8007e7944ca21a329eee4eed9e0fa5dde6e8ad8ac4344a3
   uber (0.1.0) sha256=5beeb407ff807b5db994f82fa9ee07cfceaa561dad8af20be880bc67eba935dc
+  unicode-display_width (2.6.0) sha256=12279874bba6d5e4d2728cef814b19197dbb10d7a7837a869bab65da943b7f5a
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
 
 BUNDLED WITH

--- a/google-cloud-container_analysis/samples/Gemfile.lock
+++ b/google-cloud-container_analysis/samples/Gemfile.lock
@@ -3,18 +3,15 @@ GEM
   specs:
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.1.2)
     concurrent-ruby (1.3.8)
-    declarative (0.0.20)
-    digest-crc (0.7.0)
-      rake (>= 12.0.0, < 14.0.0)
+    erb (6.0.6)
     faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-follow_redirects (0.5.0)
-      faraday (>= 1, < 3)
     faraday-net_http (3.4.4)
       net-http (~> 0.5)
     faraday-retry (2.4.0)
@@ -29,47 +26,14 @@ GEM
       googleapis-common-protos-types (~> 1.15)
       googleauth (~> 1.12)
       grpc (~> 1.66)
-    google-apis-bigquery_v2 (0.106.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-<<<<<<< HEAD
-    google-apis-core (1.2.99)
-      addressable (~> 2.8, >= 2.8.7)
-=======
-    google-apis-core (1.2.5)
-      addressable (~> 2.9)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-      faraday (~> 2.13)
-      faraday-follow_redirects (~> 0.3)
-      googleauth (~> 1.14)
-      mini_mime (~> 1.1)
-      multi_json (~> 1.11)
-      representable (~> 3.0)
-<<<<<<< HEAD
-      retriable (~> 3.1)
-=======
-      retriable (>= 3.1, < 5.0)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-    google-apis-iamcredentials_v1 (0.28.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-    google-apis-storage_v1 (0.65.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-    google-cloud-asset (1.10.0)
-      google-cloud-asset-v1 (>= 0.29, < 2.a)
+    google-cloud-container_analysis (1.7.0)
+      google-cloud-container_analysis-v1 (>= 0.9, < 2.a)
       google-cloud-core (~> 1.6)
-    google-cloud-asset-v1 (1.9.0)
+    google-cloud-container_analysis-v1 (1.8.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
-      google-cloud-os_config-v1 (> 0.0, < 2.a)
-      google-identity-access_context_manager-v1 (> 0.0, < 2.a)
+      grafeas-v1 (>= 0.4, < 2.a)
       grpc-google-iam-v1 (~> 1.11)
-    google-cloud-bigquery (1.64.0)
-      bigdecimal (>= 3.0, < 5)
-      concurrent-ruby (~> 1.0)
-      google-apis-bigquery_v2 (~> 0.71)
-      google-apis-core (>= 0.18, < 2)
-      google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
     google-cloud-core (1.9.0)
       google-cloud-env (>= 1.0, < 3.a)
       google-cloud-errors (~> 1.0)
@@ -77,9 +41,6 @@ GEM
       base64 (~> 0.2)
       faraday (>= 1.0, < 3.a)
     google-cloud-errors (1.7.0)
-    google-cloud-os_config-v1 (1.9.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
     google-cloud-pubsub (3.4.0)
       concurrent-ruby (~> 1.3)
       google-cloud-core (~> 1.8)
@@ -89,20 +50,7 @@ GEM
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
       google-iam-v1 (~> 1.3)
-    google-cloud-storage (1.62.0)
-      addressable (~> 2.8)
-      digest-crc (~> 0.4)
-      google-apis-core (>= 0.18, < 2)
-      google-apis-iamcredentials_v1 (~> 0.18)
-      google-apis-storage_v1 (>= 0.42)
-      google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
     google-iam-v1 (1.7.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      grpc-google-iam-v1 (~> 1.11)
-    google-identity-access_context_manager-v1 (0.15.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
       grpc-google-iam-v1 (~> 1.11)
@@ -134,6 +82,8 @@ GEM
     google-protobuf (4.35.1-x86_64-linux-musl)
       bigdecimal
       rake (~> 13.3)
+    google-style (1.25.3)
+      rubocop (~> 1.28.2)
     googleapis-common-protos (1.9.0)
       google-protobuf (~> 4.26)
       googleapis-common-protos-types (~> 1.21)
@@ -148,6 +98,9 @@ GEM
       os (>= 0.9, < 2.0)
       pstore (~> 0.1)
       signet (>= 0.16, < 2.a)
+    grafeas-v1 (1.10.0)
+      gapic-common (~> 1.3)
+      google-cloud-errors (~> 1.0)
     grpc (1.83.0)
       google-protobuf (>= 3.25, < 5.0)
       googleapis-common-protos-types (~> 1.0)
@@ -179,32 +132,68 @@ GEM
       google-protobuf (>= 3.18, < 5.a)
       googleapis-common-protos (~> 1.9.0)
       grpc (~> 1.41)
+    io-console (0.8.2)
+    irb (1.18.0)
+      pp (>= 0.6.0)
+      prism (>= 1.3.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
     json (2.21.2)
     jwt (3.2.0)
       base64
     logger (1.7.0)
-    mini_mime (1.1.5)
     minitest (5.27.0)
     minitest-focus (1.4.1)
       minitest (> 5.0)
-    multi_json (1.21.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
     os (1.1.4)
+    parallel (1.28.0)
+    parser (3.3.12.0)
+      ast (~> 2.4.1)
+      racc
+    pp (0.6.4)
+      prettyprint
+    prettyprint (0.2.0)
+    prism (1.9.0)
     pstore (0.2.1)
     public_suffix (7.0.5)
+    racc (1.8.1)
+    rainbow (3.1.1)
     rake (13.4.2)
-    representable (3.2.0)
-      declarative (< 0.1.0)
-      trailblazer-option (>= 0.1.1, < 0.2.0)
-      uber (< 0.2.0)
+    rbs (4.1.2)
+      logger
+      prism (>= 1.6.0)
+      tsort
+    rdoc (8.0.0)
+      erb
+      prism (>= 1.6.0)
+      rbs (>= 4.0.0)
+      tsort
+    regexp_parser (2.12.0)
+    reline (0.6.3)
+      io-console (~> 0.5)
     retriable (3.8.0)
+    rexml (3.4.4)
+    rubocop (1.28.2)
+      parallel (~> 1.10)
+      parser (>= 3.1.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.17.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.50.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    ruby-progressbar (1.13.0)
     signet (0.22.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 4.0)
-    trailblazer-option (0.1.2)
-    uber (0.1.0)
+    tsort (0.2.0)
+    unicode-display_width (2.6.0)
     uri (1.1.1)
 
 PLATFORMS
@@ -219,47 +208,36 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  google-cloud-asset
-  google-cloud-bigquery
-  google-cloud-pubsub
-  google-cloud-storage
+  google-cloud-container_analysis
+  google-cloud-container_analysis-v1
+  google-cloud-pubsub (~> 3.0)
+  google-style (~> 1.25.1)
+  grafeas-v1
+  irb
   minitest (~> 5.14)
-  minitest-focus
-  rake
+  minitest-focus (~> 1.1)
+  rake (>= 12.0)
 
 CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
   concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
-  declarative (0.0.20) sha256=8021dd6cb17ab2b61233c56903d3f5a259c5cf43c80ff332d447d395b17d9ff9
-  digest-crc (0.7.0) sha256=64adc23a26a241044cbe6732477ca1b3c281d79e2240bcff275a37a5a0d78c07
+  erb (6.0.6) sha256=a9b24986700f5bf127c4f297c5403c3ca41b83b0a316c0cd09a096b56e644ae5
   faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
-  faraday-follow_redirects (0.5.0) sha256=5cde93c894b30943a5d2b93c2fe9284216a6b756f7af406a1e55f211d97d10ad
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
   faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
   gapic-common (1.3.0) sha256=4e5d9be1effb7366e2cda13c0f44922285d5613ac8de8b9b18c2c835fe4faa91
-  google-apis-bigquery_v2 (0.106.0) sha256=a0f4243b634a0c79c29b7dacdd79233bd9c9ba2eda6fde9c2b19414fd165dd93
-<<<<<<< HEAD
-  google-apis-core (1.2.99)
-=======
-  google-apis-core (1.2.5) sha256=e21562b5627a0fc6a0c3165e429c3afed0f6a628eaa514e83f7204dda1adff69
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-  google-apis-iamcredentials_v1 (0.28.0) sha256=0a92ffe6cc39c569554af2a77a25dfc61519ed8bbb64ab04cffdd352dc5ef106
-  google-apis-storage_v1 (0.65.0) sha256=4247aa542931691f6988ab61e45cdea2878cbfe897a98eec4af9cdcb678eb359
-  google-cloud-asset (1.10.0) sha256=6ea6fd9e0735873884094c14d84d5a6d826b0e07aaeec245d34735ab2c5828e0
-  google-cloud-asset-v1 (1.9.0) sha256=ecfb654d0d350ed98209d46937c8095ec867c8ff6c3f7d70b8889f6fb70fd397
-  google-cloud-bigquery (1.64.0) sha256=d807363903e08958c3bc09ccc1f9d1218646c8f18176751879348a1a4a884d57
+  google-cloud-container_analysis (1.7.0) sha256=c9d0250e5f9dce78e84f6b6f405c154f72569177762e69c49652d312227b1c99
+  google-cloud-container_analysis-v1 (1.8.0) sha256=d906b639e0cf3318fff35eb0e60f2eea5a83823221298305b1d09de0c98fce69
   google-cloud-core (1.9.0) sha256=ab55409f51488e8deefb6edcc1ce4771dfb5da2fe7b3bc075709a030c2b682a4
   google-cloud-env (2.4.0) sha256=01cb35ecee5d1c4d1cd4deaed8bb5bddc838e296bcc2a35c5d1ddd07ce40d28d
   google-cloud-errors (1.7.0) sha256=6e682f42d89aae08689f36f28495de629d756da076bafff0003bac7f8042ebb3
-  google-cloud-os_config-v1 (1.9.0) sha256=693c13690cfd7cf9d307c25d005ff33b823b6709791d3714c344ff1597ec3a30
   google-cloud-pubsub (3.4.0) sha256=6a6390a6f605701945d5be233dea51e0b04009f157b5d701b092423fbc690edd
   google-cloud-pubsub-v1 (1.16.0) sha256=ffe128821208bd3d2f27cb0d25eb6accb3893c99e0b736d1740b8b5e1570426b
-  google-cloud-storage (1.62.0) sha256=e2c3c08bf8fd40d50be92304084942203314d4fc0ee52028e99f9359c3ad1330
   google-iam-v1 (1.7.0) sha256=9e3ea9dcc59cbd5f8d2f62b00da41ec57a2e427b33c0e798207fa06c8fbb8b87
-  google-identity-access_context_manager-v1 (0.15.0) sha256=8f105320bcbdc03c7fdb05369886117b4f341b792ed4ab81a144929bbcd7820b
   google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
   google-protobuf (4.35.1) sha256=a3a6471331d918f58dfa4d014a8f6286f0af2cf4840216bde52fcf2ea3fe3726
   google-protobuf (4.35.1-aarch64-linux-gnu) sha256=50ca44d0eeff3f8475e630a1accdd974256f3510694d574e2c9d6119ea8bc9e1
@@ -270,9 +248,11 @@ CHECKSUMS
   google-protobuf (4.35.1-x86_64-darwin) sha256=66b62b4df00931018a692806df66393efa960d6d2b7da69735187249f950d3ee
   google-protobuf (4.35.1-x86_64-linux-gnu) sha256=c786439087512a3fbd199e9897d265b855f951d4027e218ea55e858d45969edd
   google-protobuf (4.35.1-x86_64-linux-musl) sha256=91890eb0002934a339fdb7d77a147c46b7474b6799db27872b747b905837f744
+  google-style (1.25.3) sha256=d417fd0f6d6a9f4bb2ff69e1cfaa1c4d0e19230589cdf4383df4540082c395d4
   googleapis-common-protos (1.9.0) sha256=207be372d8d25e3876e1e1155d057e14f3c92f8f5428772864a8ce04a0b756e4
   googleapis-common-protos-types (1.23.0) sha256=992e740a523794d9fc5f29a504465d8fc737aaa16c930fe7228e3346860faf0a
   googleauth (1.17.3) sha256=9a655455885c0c17a8b70537acd2a992a7c7842c43c06c6612dfb0d93e755d58
+  grafeas-v1 (1.10.0) sha256=a6c4e6c6a952ba87c771411fa63537fd1299a30b9d2c6b792f3bc5a7bf2c3e15
   grpc (1.83.0) sha256=38119e7f9f7cbc98e79145201da4be470a7542b0befad454651d35015ea55c59
   grpc (1.83.0-aarch64-linux-gnu) sha256=11562efdded494b2277fd9c3c530dfdf90177faa111526ae9e748d0be29f1a9d
   grpc (1.83.0-aarch64-linux-musl) sha256=ee745eab4f3922ed27d379cbc4bc0a99e58db367fa96312e9fe258aafd3afeb2
@@ -283,23 +263,37 @@ CHECKSUMS
   grpc (1.83.0-x86_64-linux-gnu) sha256=25d66bfa3cb1b05258b3f9632478c7e7ceb52cb16ccc0b4b26d7df36be7158b1
   grpc (1.83.0-x86_64-linux-musl) sha256=a5023264dbb8038c23b147bbf80adb06932ef11b5ab493412e9e37a43114fa8c
   grpc-google-iam-v1 (1.12.0) sha256=a70ecad8987e340d5e22e7bf01be31256c84b29a3f78bebd385a4a110e1f2aef
+  io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
+  irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
   json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
-  mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   minitest-focus (1.4.1) sha256=394517cbe2dcb2d992d8ffc41a3b2b6315777a4daa69239de4fefe7110dd810e
-  multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
   os (1.1.4) sha256=57816d6a334e7bd6aed048f4b0308226c5fb027433b67d90a9ab435f35108d3f
+  parallel (1.28.0) sha256=33e6de1484baf2524792d178b0913fc8eb94c628d6cfe45599ad4458c638c970
+  parser (3.3.12.0) sha256=21a6d7f755d5a24dfbdc6e6b772e4e879a52e7631a88bc5a3a134606052c9828
+  pp (0.6.4) sha256=dfcb0fce700c41456265922884f9fe195d7fbb0674a3578e6c0f69588e82b570
+  prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   pstore (0.2.1) sha256=03904d0f2c66579e96d1e6704cdabc0c88df7ea8ed8782d9f3569f6f6c702c1a
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
-  representable (3.2.0) sha256=cc29bf7eebc31653586849371a43ffe36c60b54b0a6365b5f7d95ec34d1ebace
+  rbs (4.1.2) sha256=050eb1d8b508f1233bed929c0f2c7052302f7adf295230d9cb314e9024078f48
+  rdoc (8.0.0) sha256=03bf8c08a9639658855a0cfd77c0abca8325c227693f7f33f82957811348c469
+  regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
+  reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
   retriable (3.8.0) sha256=9f2f1b0207594c7817f17f671587b8ec7587387ac6cebda6c941a802bb98a8e5
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rubocop (1.28.2) sha256=0d9bf4108fd86ede43c6cf30adcb3dd2e0c6750941c5ec2a00621478157cb377
+  rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   signet (0.22.0) sha256=b76d495ccb07ad35dbc89f3e920665a9d8ed717141955034005d7843dcfe4780
-  trailblazer-option (0.1.2) sha256=20e4f12ea4e1f718c8007e7944ca21a329eee4eed9e0fa5dde6e8ad8ac4344a3
-  uber (0.1.0) sha256=5beeb407ff807b5db994f82fa9ee07cfceaa561dad8af20be880bc67eba935dc
+  tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
+  unicode-display_width (2.6.0) sha256=12279874bba6d5e4d2728cef814b19197dbb10d7a7837a869bab65da943b7f5a
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
 
 BUNDLED WITH

--- a/google-cloud-datastore-admin-v1/samples/Gemfile.lock
+++ b/google-cloud-datastore-admin-v1/samples/Gemfile.lock
@@ -3,9 +3,9 @@ GEM
   specs:
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.1.2)
-    concurrent-ruby (1.3.8)
     declarative (0.0.20)
     digest-crc (0.7.0)
       rake (>= 12.0.0, < 14.0.0)
@@ -29,66 +29,29 @@ GEM
       googleapis-common-protos-types (~> 1.15)
       googleauth (~> 1.12)
       grpc (~> 1.66)
-    google-apis-bigquery_v2 (0.106.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-<<<<<<< HEAD
-    google-apis-core (1.2.99)
-      addressable (~> 2.8, >= 2.8.7)
-=======
     google-apis-core (1.2.5)
       addressable (~> 2.9)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
       faraday (~> 2.13)
       faraday-follow_redirects (~> 0.3)
       googleauth (~> 1.14)
       mini_mime (~> 1.1)
       multi_json (~> 1.11)
       representable (~> 3.0)
-<<<<<<< HEAD
-      retriable (~> 3.1)
-=======
       retriable (>= 3.1, < 5.0)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
     google-apis-iamcredentials_v1 (0.28.0)
       google-apis-core (>= 0.15.0, < 2.a)
     google-apis-storage_v1 (0.65.0)
       google-apis-core (>= 0.15.0, < 2.a)
-    google-cloud-asset (1.10.0)
-      google-cloud-asset-v1 (>= 0.29, < 2.a)
-      google-cloud-core (~> 1.6)
-    google-cloud-asset-v1 (1.9.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-cloud-os_config-v1 (> 0.0, < 2.a)
-      google-identity-access_context_manager-v1 (> 0.0, < 2.a)
-      grpc-google-iam-v1 (~> 1.11)
-    google-cloud-bigquery (1.64.0)
-      bigdecimal (>= 3.0, < 5)
-      concurrent-ruby (~> 1.0)
-      google-apis-bigquery_v2 (~> 0.71)
-      google-apis-core (>= 0.18, < 2)
-      google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
     google-cloud-core (1.9.0)
       google-cloud-env (>= 1.0, < 3.a)
+      google-cloud-errors (~> 1.0)
+    google-cloud-datastore-admin-v1 (1.7.0)
+      gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
     google-cloud-env (2.4.0)
       base64 (~> 0.2)
       faraday (>= 1.0, < 3.a)
     google-cloud-errors (1.7.0)
-    google-cloud-os_config-v1 (1.9.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-    google-cloud-pubsub (3.4.0)
-      concurrent-ruby (~> 1.3)
-      google-cloud-core (~> 1.8)
-      google-cloud-pubsub-v1 (~> 1.11)
-      retriable (~> 3.1)
-    google-cloud-pubsub-v1 (1.16.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-iam-v1 (~> 1.3)
     google-cloud-storage (1.62.0)
       addressable (~> 2.8)
       digest-crc (~> 0.4)
@@ -98,14 +61,6 @@ GEM
       google-cloud-core (~> 1.6)
       googleauth (~> 1.9)
       mini_mime (~> 1.0)
-    google-iam-v1 (1.7.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      grpc-google-iam-v1 (~> 1.11)
-    google-identity-access_context_manager-v1 (0.15.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      grpc-google-iam-v1 (~> 1.11)
     google-logging-utils (0.2.0)
     google-protobuf (4.35.1)
       bigdecimal
@@ -134,7 +89,9 @@ GEM
     google-protobuf (4.35.1-x86_64-linux-musl)
       bigdecimal
       rake (~> 13.3)
-    googleapis-common-protos (1.9.0)
+    google-style (1.25.3)
+      rubocop (~> 1.28.2)
+    googleapis-common-protos (1.10.0)
       google-protobuf (~> 4.26)
       googleapis-common-protos-types (~> 1.21)
       grpc (~> 1.41)
@@ -175,10 +132,6 @@ GEM
     grpc (1.83.0-x86_64-linux-musl)
       google-protobuf (>= 3.25, < 5.0)
       googleapis-common-protos-types (~> 1.0)
-    grpc-google-iam-v1 (1.12.0)
-      google-protobuf (>= 3.18, < 5.a)
-      googleapis-common-protos (~> 1.9.0)
-      grpc (~> 1.41)
     json (2.21.2)
     jwt (3.2.0)
       base64
@@ -187,24 +140,49 @@ GEM
     minitest (5.27.0)
     minitest-focus (1.4.1)
       minitest (> 5.0)
+    minitest-hooks (1.5.4)
+      minitest (> 5.3)
     multi_json (1.21.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
     os (1.1.4)
+    parallel (1.28.0)
+    parser (3.3.12.0)
+      ast (~> 2.4.1)
+      racc
+    prism (1.9.0)
     pstore (0.2.1)
     public_suffix (7.0.5)
+    racc (1.8.1)
+    rainbow (3.1.1)
     rake (13.4.2)
+    regexp_parser (2.12.0)
     representable (3.2.0)
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
-    retriable (3.8.0)
+    retriable (4.2.0)
+    rexml (3.4.4)
+    rubocop (1.28.2)
+      parallel (~> 1.10)
+      parser (>= 3.1.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.17.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.50.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    ruby-progressbar (1.13.0)
     signet (0.22.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 4.0)
     trailblazer-option (0.1.2)
     uber (0.1.0)
+    unicode-display_width (2.6.0)
     uri (1.1.1)
 
 PLATFORMS
@@ -219,20 +197,20 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  google-cloud-asset
-  google-cloud-bigquery
-  google-cloud-pubsub
+  google-cloud-datastore-admin-v1
   google-cloud-storage
+  google-style (~> 1.25.1)
   minitest (~> 5.14)
-  minitest-focus
+  minitest-focus (~> 1.1)
+  minitest-hooks (~> 1.5)
   rake
 
 CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
-  concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
   declarative (0.0.20) sha256=8021dd6cb17ab2b61233c56903d3f5a259c5cf43c80ff332d447d395b17d9ff9
   digest-crc (0.7.0) sha256=64adc23a26a241044cbe6732477ca1b3c281d79e2240bcff275a37a5a0d78c07
   faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
@@ -240,26 +218,14 @@ CHECKSUMS
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
   faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
   gapic-common (1.3.0) sha256=4e5d9be1effb7366e2cda13c0f44922285d5613ac8de8b9b18c2c835fe4faa91
-  google-apis-bigquery_v2 (0.106.0) sha256=a0f4243b634a0c79c29b7dacdd79233bd9c9ba2eda6fde9c2b19414fd165dd93
-<<<<<<< HEAD
-  google-apis-core (1.2.99)
-=======
   google-apis-core (1.2.5) sha256=e21562b5627a0fc6a0c3165e429c3afed0f6a628eaa514e83f7204dda1adff69
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
   google-apis-iamcredentials_v1 (0.28.0) sha256=0a92ffe6cc39c569554af2a77a25dfc61519ed8bbb64ab04cffdd352dc5ef106
   google-apis-storage_v1 (0.65.0) sha256=4247aa542931691f6988ab61e45cdea2878cbfe897a98eec4af9cdcb678eb359
-  google-cloud-asset (1.10.0) sha256=6ea6fd9e0735873884094c14d84d5a6d826b0e07aaeec245d34735ab2c5828e0
-  google-cloud-asset-v1 (1.9.0) sha256=ecfb654d0d350ed98209d46937c8095ec867c8ff6c3f7d70b8889f6fb70fd397
-  google-cloud-bigquery (1.64.0) sha256=d807363903e08958c3bc09ccc1f9d1218646c8f18176751879348a1a4a884d57
   google-cloud-core (1.9.0) sha256=ab55409f51488e8deefb6edcc1ce4771dfb5da2fe7b3bc075709a030c2b682a4
+  google-cloud-datastore-admin-v1 (1.7.0) sha256=db571c0b72828d1215641bf05212b6fdc45f170231c9c49b5e3d81d933f068ba
   google-cloud-env (2.4.0) sha256=01cb35ecee5d1c4d1cd4deaed8bb5bddc838e296bcc2a35c5d1ddd07ce40d28d
   google-cloud-errors (1.7.0) sha256=6e682f42d89aae08689f36f28495de629d756da076bafff0003bac7f8042ebb3
-  google-cloud-os_config-v1 (1.9.0) sha256=693c13690cfd7cf9d307c25d005ff33b823b6709791d3714c344ff1597ec3a30
-  google-cloud-pubsub (3.4.0) sha256=6a6390a6f605701945d5be233dea51e0b04009f157b5d701b092423fbc690edd
-  google-cloud-pubsub-v1 (1.16.0) sha256=ffe128821208bd3d2f27cb0d25eb6accb3893c99e0b736d1740b8b5e1570426b
   google-cloud-storage (1.62.0) sha256=e2c3c08bf8fd40d50be92304084942203314d4fc0ee52028e99f9359c3ad1330
-  google-iam-v1 (1.7.0) sha256=9e3ea9dcc59cbd5f8d2f62b00da41ec57a2e427b33c0e798207fa06c8fbb8b87
-  google-identity-access_context_manager-v1 (0.15.0) sha256=8f105320bcbdc03c7fdb05369886117b4f341b792ed4ab81a144929bbcd7820b
   google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
   google-protobuf (4.35.1) sha256=a3a6471331d918f58dfa4d014a8f6286f0af2cf4840216bde52fcf2ea3fe3726
   google-protobuf (4.35.1-aarch64-linux-gnu) sha256=50ca44d0eeff3f8475e630a1accdd974256f3510694d574e2c9d6119ea8bc9e1
@@ -270,7 +236,8 @@ CHECKSUMS
   google-protobuf (4.35.1-x86_64-darwin) sha256=66b62b4df00931018a692806df66393efa960d6d2b7da69735187249f950d3ee
   google-protobuf (4.35.1-x86_64-linux-gnu) sha256=c786439087512a3fbd199e9897d265b855f951d4027e218ea55e858d45969edd
   google-protobuf (4.35.1-x86_64-linux-musl) sha256=91890eb0002934a339fdb7d77a147c46b7474b6799db27872b747b905837f744
-  googleapis-common-protos (1.9.0) sha256=207be372d8d25e3876e1e1155d057e14f3c92f8f5428772864a8ce04a0b756e4
+  google-style (1.25.3) sha256=d417fd0f6d6a9f4bb2ff69e1cfaa1c4d0e19230589cdf4383df4540082c395d4
+  googleapis-common-protos (1.10.0) sha256=13e47ad0ce85d3d30065c03863efd302a82b0e08ba576f2a9b9dbbfeecb57ee0
   googleapis-common-protos-types (1.23.0) sha256=992e740a523794d9fc5f29a504465d8fc737aaa16c930fe7228e3346860faf0a
   googleauth (1.17.3) sha256=9a655455885c0c17a8b70537acd2a992a7c7842c43c06c6612dfb0d93e755d58
   grpc (1.83.0) sha256=38119e7f9f7cbc98e79145201da4be470a7542b0befad454651d35015ea55c59
@@ -282,24 +249,35 @@ CHECKSUMS
   grpc (1.83.0-x86_64-darwin) sha256=cfad91d559d1907159a5247fb12dc112a8ea0ebe2027ca7f5ab648d01a645716
   grpc (1.83.0-x86_64-linux-gnu) sha256=25d66bfa3cb1b05258b3f9632478c7e7ceb52cb16ccc0b4b26d7df36be7158b1
   grpc (1.83.0-x86_64-linux-musl) sha256=a5023264dbb8038c23b147bbf80adb06932ef11b5ab493412e9e37a43114fa8c
-  grpc-google-iam-v1 (1.12.0) sha256=a70ecad8987e340d5e22e7bf01be31256c84b29a3f78bebd385a4a110e1f2aef
   json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   minitest-focus (1.4.1) sha256=394517cbe2dcb2d992d8ffc41a3b2b6315777a4daa69239de4fefe7110dd810e
+  minitest-hooks (1.5.4) sha256=1254069f3da51fea234dc4ff974108d03d19260ad5c4b78eed9695726a5069b8
   multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
   os (1.1.4) sha256=57816d6a334e7bd6aed048f4b0308226c5fb027433b67d90a9ab435f35108d3f
+  parallel (1.28.0) sha256=33e6de1484baf2524792d178b0913fc8eb94c628d6cfe45599ad4458c638c970
+  parser (3.3.12.0) sha256=21a6d7f755d5a24dfbdc6e6b772e4e879a52e7631a88bc5a3a134606052c9828
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   pstore (0.2.1) sha256=03904d0f2c66579e96d1e6704cdabc0c88df7ea8ed8782d9f3569f6f6c702c1a
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
+  regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
   representable (3.2.0) sha256=cc29bf7eebc31653586849371a43ffe36c60b54b0a6365b5f7d95ec34d1ebace
-  retriable (3.8.0) sha256=9f2f1b0207594c7817f17f671587b8ec7587387ac6cebda6c941a802bb98a8e5
+  retriable (4.2.0) sha256=90c3b257472a1c02f2a3dfa64dd35a420f7a624cef1a5981e20fdac5730f8cdc
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rubocop (1.28.2) sha256=0d9bf4108fd86ede43c6cf30adcb3dd2e0c6750941c5ec2a00621478157cb377
+  rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   signet (0.22.0) sha256=b76d495ccb07ad35dbc89f3e920665a9d8ed717141955034005d7843dcfe4780
   trailblazer-option (0.1.2) sha256=20e4f12ea4e1f718c8007e7944ca21a329eee4eed9e0fa5dde6e8ad8ac4344a3
   uber (0.1.0) sha256=5beeb407ff807b5db994f82fa9ee07cfceaa561dad8af20be880bc67eba935dc
+  unicode-display_width (2.6.0) sha256=12279874bba6d5e4d2728cef814b19197dbb10d7a7837a869bab65da943b7f5a
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
 
 BUNDLED WITH

--- a/google-cloud-datastore/samples/Gemfile.lock
+++ b/google-cloud-datastore/samples/Gemfile.lock
@@ -3,18 +3,13 @@ GEM
   specs:
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.1.2)
-    concurrent-ruby (1.3.8)
-    declarative (0.0.20)
-    digest-crc (0.7.0)
-      rake (>= 12.0.0, < 14.0.0)
     faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-follow_redirects (0.5.0)
-      faraday (>= 1, < 3)
     faraday-net_http (3.4.4)
       net-http (~> 0.5)
     faraday-retry (2.4.0)
@@ -29,83 +24,19 @@ GEM
       googleapis-common-protos-types (~> 1.15)
       googleauth (~> 1.12)
       grpc (~> 1.66)
-    google-apis-bigquery_v2 (0.106.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-<<<<<<< HEAD
-    google-apis-core (1.2.99)
-      addressable (~> 2.8, >= 2.8.7)
-=======
-    google-apis-core (1.2.5)
-      addressable (~> 2.9)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-      faraday (~> 2.13)
-      faraday-follow_redirects (~> 0.3)
-      googleauth (~> 1.14)
-      mini_mime (~> 1.1)
-      multi_json (~> 1.11)
-      representable (~> 3.0)
-<<<<<<< HEAD
-      retriable (~> 3.1)
-=======
-      retriable (>= 3.1, < 5.0)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-    google-apis-iamcredentials_v1 (0.28.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-    google-apis-storage_v1 (0.65.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-    google-cloud-asset (1.10.0)
-      google-cloud-asset-v1 (>= 0.29, < 2.a)
-      google-cloud-core (~> 1.6)
-    google-cloud-asset-v1 (1.9.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-cloud-os_config-v1 (> 0.0, < 2.a)
-      google-identity-access_context_manager-v1 (> 0.0, < 2.a)
-      grpc-google-iam-v1 (~> 1.11)
-    google-cloud-bigquery (1.64.0)
-      bigdecimal (>= 3.0, < 5)
-      concurrent-ruby (~> 1.0)
-      google-apis-bigquery_v2 (~> 0.71)
-      google-apis-core (>= 0.18, < 2)
-      google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
     google-cloud-core (1.9.0)
       google-cloud-env (>= 1.0, < 3.a)
+      google-cloud-errors (~> 1.0)
+    google-cloud-datastore (2.14.0)
+      google-cloud-core (~> 1.5)
+      google-cloud-datastore-v1 (>= 0.0, < 2.a)
+    google-cloud-datastore-v1 (1.8.0)
+      gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
     google-cloud-env (2.4.0)
       base64 (~> 0.2)
       faraday (>= 1.0, < 3.a)
     google-cloud-errors (1.7.0)
-    google-cloud-os_config-v1 (1.9.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-    google-cloud-pubsub (3.4.0)
-      concurrent-ruby (~> 1.3)
-      google-cloud-core (~> 1.8)
-      google-cloud-pubsub-v1 (~> 1.11)
-      retriable (~> 3.1)
-    google-cloud-pubsub-v1 (1.16.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-iam-v1 (~> 1.3)
-    google-cloud-storage (1.62.0)
-      addressable (~> 2.8)
-      digest-crc (~> 0.4)
-      google-apis-core (>= 0.18, < 2)
-      google-apis-iamcredentials_v1 (~> 0.18)
-      google-apis-storage_v1 (>= 0.42)
-      google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
-    google-iam-v1 (1.7.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      grpc-google-iam-v1 (~> 1.11)
-    google-identity-access_context_manager-v1 (0.15.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      grpc-google-iam-v1 (~> 1.11)
     google-logging-utils (0.2.0)
     google-protobuf (4.35.1)
       bigdecimal
@@ -134,7 +65,9 @@ GEM
     google-protobuf (4.35.1-x86_64-linux-musl)
       bigdecimal
       rake (~> 13.3)
-    googleapis-common-protos (1.9.0)
+    google-style (1.25.3)
+      rubocop (~> 1.28.2)
+    googleapis-common-protos (1.10.0)
       google-protobuf (~> 4.26)
       googleapis-common-protos-types (~> 1.21)
       grpc (~> 1.41)
@@ -175,36 +108,48 @@ GEM
     grpc (1.83.0-x86_64-linux-musl)
       google-protobuf (>= 3.25, < 5.0)
       googleapis-common-protos-types (~> 1.0)
-    grpc-google-iam-v1 (1.12.0)
-      google-protobuf (>= 3.18, < 5.a)
-      googleapis-common-protos (~> 1.9.0)
-      grpc (~> 1.41)
     json (2.21.2)
     jwt (3.2.0)
       base64
     logger (1.7.0)
-    mini_mime (1.1.5)
     minitest (5.27.0)
     minitest-focus (1.4.1)
       minitest (> 5.0)
-    multi_json (1.21.1)
+    minitest-hooks (1.5.4)
+      minitest (> 5.3)
     net-http (0.9.1)
       uri (>= 0.11.1)
     os (1.1.4)
+    parallel (1.28.0)
+    parser (3.3.12.0)
+      ast (~> 2.4.1)
+      racc
+    prism (1.9.0)
     pstore (0.2.1)
     public_suffix (7.0.5)
+    racc (1.8.1)
+    rainbow (3.1.1)
     rake (13.4.2)
-    representable (3.2.0)
-      declarative (< 0.1.0)
-      trailblazer-option (>= 0.1.1, < 0.2.0)
-      uber (< 0.2.0)
-    retriable (3.8.0)
+    regexp_parser (2.12.0)
+    rexml (3.4.4)
+    rubocop (1.28.2)
+      parallel (~> 1.10)
+      parser (>= 3.1.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.17.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.50.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    ruby-progressbar (1.13.0)
     signet (0.22.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 4.0)
-    trailblazer-option (0.1.2)
-    uber (0.1.0)
+    unicode-display_width (2.6.0)
     uri (1.1.1)
 
 PLATFORMS
@@ -219,47 +164,28 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  google-cloud-asset
-  google-cloud-bigquery
-  google-cloud-pubsub
-  google-cloud-storage
+  google-cloud-datastore
+  google-style (~> 1.25.1)
   minitest (~> 5.14)
-  minitest-focus
+  minitest-focus (~> 1.1)
+  minitest-hooks (~> 1.5)
   rake
 
 CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
-  concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
-  declarative (0.0.20) sha256=8021dd6cb17ab2b61233c56903d3f5a259c5cf43c80ff332d447d395b17d9ff9
-  digest-crc (0.7.0) sha256=64adc23a26a241044cbe6732477ca1b3c281d79e2240bcff275a37a5a0d78c07
   faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
-  faraday-follow_redirects (0.5.0) sha256=5cde93c894b30943a5d2b93c2fe9284216a6b756f7af406a1e55f211d97d10ad
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
   faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
   gapic-common (1.3.0) sha256=4e5d9be1effb7366e2cda13c0f44922285d5613ac8de8b9b18c2c835fe4faa91
-  google-apis-bigquery_v2 (0.106.0) sha256=a0f4243b634a0c79c29b7dacdd79233bd9c9ba2eda6fde9c2b19414fd165dd93
-<<<<<<< HEAD
-  google-apis-core (1.2.99)
-=======
-  google-apis-core (1.2.5) sha256=e21562b5627a0fc6a0c3165e429c3afed0f6a628eaa514e83f7204dda1adff69
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-  google-apis-iamcredentials_v1 (0.28.0) sha256=0a92ffe6cc39c569554af2a77a25dfc61519ed8bbb64ab04cffdd352dc5ef106
-  google-apis-storage_v1 (0.65.0) sha256=4247aa542931691f6988ab61e45cdea2878cbfe897a98eec4af9cdcb678eb359
-  google-cloud-asset (1.10.0) sha256=6ea6fd9e0735873884094c14d84d5a6d826b0e07aaeec245d34735ab2c5828e0
-  google-cloud-asset-v1 (1.9.0) sha256=ecfb654d0d350ed98209d46937c8095ec867c8ff6c3f7d70b8889f6fb70fd397
-  google-cloud-bigquery (1.64.0) sha256=d807363903e08958c3bc09ccc1f9d1218646c8f18176751879348a1a4a884d57
   google-cloud-core (1.9.0) sha256=ab55409f51488e8deefb6edcc1ce4771dfb5da2fe7b3bc075709a030c2b682a4
+  google-cloud-datastore (2.14.0) sha256=eb21a5a9c7794c4082b896a5579f88246cc204630d7d93c4ef4f92b904590f86
+  google-cloud-datastore-v1 (1.8.0) sha256=338c34f837e7f9cfef61b9e000e7e12ebca697e4d91d9505a404639fb38029c8
   google-cloud-env (2.4.0) sha256=01cb35ecee5d1c4d1cd4deaed8bb5bddc838e296bcc2a35c5d1ddd07ce40d28d
   google-cloud-errors (1.7.0) sha256=6e682f42d89aae08689f36f28495de629d756da076bafff0003bac7f8042ebb3
-  google-cloud-os_config-v1 (1.9.0) sha256=693c13690cfd7cf9d307c25d005ff33b823b6709791d3714c344ff1597ec3a30
-  google-cloud-pubsub (3.4.0) sha256=6a6390a6f605701945d5be233dea51e0b04009f157b5d701b092423fbc690edd
-  google-cloud-pubsub-v1 (1.16.0) sha256=ffe128821208bd3d2f27cb0d25eb6accb3893c99e0b736d1740b8b5e1570426b
-  google-cloud-storage (1.62.0) sha256=e2c3c08bf8fd40d50be92304084942203314d4fc0ee52028e99f9359c3ad1330
-  google-iam-v1 (1.7.0) sha256=9e3ea9dcc59cbd5f8d2f62b00da41ec57a2e427b33c0e798207fa06c8fbb8b87
-  google-identity-access_context_manager-v1 (0.15.0) sha256=8f105320bcbdc03c7fdb05369886117b4f341b792ed4ab81a144929bbcd7820b
   google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
   google-protobuf (4.35.1) sha256=a3a6471331d918f58dfa4d014a8f6286f0af2cf4840216bde52fcf2ea3fe3726
   google-protobuf (4.35.1-aarch64-linux-gnu) sha256=50ca44d0eeff3f8475e630a1accdd974256f3510694d574e2c9d6119ea8bc9e1
@@ -270,7 +196,8 @@ CHECKSUMS
   google-protobuf (4.35.1-x86_64-darwin) sha256=66b62b4df00931018a692806df66393efa960d6d2b7da69735187249f950d3ee
   google-protobuf (4.35.1-x86_64-linux-gnu) sha256=c786439087512a3fbd199e9897d265b855f951d4027e218ea55e858d45969edd
   google-protobuf (4.35.1-x86_64-linux-musl) sha256=91890eb0002934a339fdb7d77a147c46b7474b6799db27872b747b905837f744
-  googleapis-common-protos (1.9.0) sha256=207be372d8d25e3876e1e1155d057e14f3c92f8f5428772864a8ce04a0b756e4
+  google-style (1.25.3) sha256=d417fd0f6d6a9f4bb2ff69e1cfaa1c4d0e19230589cdf4383df4540082c395d4
+  googleapis-common-protos (1.10.0) sha256=13e47ad0ce85d3d30065c03863efd302a82b0e08ba576f2a9b9dbbfeecb57ee0
   googleapis-common-protos-types (1.23.0) sha256=992e740a523794d9fc5f29a504465d8fc737aaa16c930fe7228e3346860faf0a
   googleauth (1.17.3) sha256=9a655455885c0c17a8b70537acd2a992a7c7842c43c06c6612dfb0d93e755d58
   grpc (1.83.0) sha256=38119e7f9f7cbc98e79145201da4be470a7542b0befad454651d35015ea55c59
@@ -282,24 +209,29 @@ CHECKSUMS
   grpc (1.83.0-x86_64-darwin) sha256=cfad91d559d1907159a5247fb12dc112a8ea0ebe2027ca7f5ab648d01a645716
   grpc (1.83.0-x86_64-linux-gnu) sha256=25d66bfa3cb1b05258b3f9632478c7e7ceb52cb16ccc0b4b26d7df36be7158b1
   grpc (1.83.0-x86_64-linux-musl) sha256=a5023264dbb8038c23b147bbf80adb06932ef11b5ab493412e9e37a43114fa8c
-  grpc-google-iam-v1 (1.12.0) sha256=a70ecad8987e340d5e22e7bf01be31256c84b29a3f78bebd385a4a110e1f2aef
   json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
-  mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   minitest-focus (1.4.1) sha256=394517cbe2dcb2d992d8ffc41a3b2b6315777a4daa69239de4fefe7110dd810e
-  multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080
+  minitest-hooks (1.5.4) sha256=1254069f3da51fea234dc4ff974108d03d19260ad5c4b78eed9695726a5069b8
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
   os (1.1.4) sha256=57816d6a334e7bd6aed048f4b0308226c5fb027433b67d90a9ab435f35108d3f
+  parallel (1.28.0) sha256=33e6de1484baf2524792d178b0913fc8eb94c628d6cfe45599ad4458c638c970
+  parser (3.3.12.0) sha256=21a6d7f755d5a24dfbdc6e6b772e4e879a52e7631a88bc5a3a134606052c9828
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   pstore (0.2.1) sha256=03904d0f2c66579e96d1e6704cdabc0c88df7ea8ed8782d9f3569f6f6c702c1a
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
-  representable (3.2.0) sha256=cc29bf7eebc31653586849371a43ffe36c60b54b0a6365b5f7d95ec34d1ebace
-  retriable (3.8.0) sha256=9f2f1b0207594c7817f17f671587b8ec7587387ac6cebda6c941a802bb98a8e5
+  regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rubocop (1.28.2) sha256=0d9bf4108fd86ede43c6cf30adcb3dd2e0c6750941c5ec2a00621478157cb377
+  rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   signet (0.22.0) sha256=b76d495ccb07ad35dbc89f3e920665a9d8ed717141955034005d7843dcfe4780
-  trailblazer-option (0.1.2) sha256=20e4f12ea4e1f718c8007e7944ca21a329eee4eed9e0fa5dde6e8ad8ac4344a3
-  uber (0.1.0) sha256=5beeb407ff807b5db994f82fa9ee07cfceaa561dad8af20be880bc67eba935dc
+  unicode-display_width (2.6.0) sha256=12279874bba6d5e4d2728cef814b19197dbb10d7a7837a869bab65da943b7f5a
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
 
 BUNDLED WITH

--- a/google-cloud-dlp/samples/Gemfile.lock
+++ b/google-cloud-dlp/samples/Gemfile.lock
@@ -5,16 +5,10 @@ GEM
       public_suffix (>= 2.0.2, < 8.0)
     base64 (0.3.0)
     bigdecimal (4.1.2)
-    concurrent-ruby (1.3.8)
-    declarative (0.0.20)
-    digest-crc (0.7.0)
-      rake (>= 12.0.0, < 14.0.0)
     faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-follow_redirects (0.5.0)
-      faraday (>= 1, < 3)
     faraday-net_http (3.4.4)
       net-http (~> 0.5)
     faraday-retry (2.4.0)
@@ -29,83 +23,23 @@ GEM
       googleapis-common-protos-types (~> 1.15)
       googleauth (~> 1.12)
       grpc (~> 1.66)
-    google-apis-bigquery_v2 (0.106.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-<<<<<<< HEAD
-    google-apis-core (1.2.99)
-      addressable (~> 2.8, >= 2.8.7)
-=======
-    google-apis-core (1.2.5)
-      addressable (~> 2.9)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-      faraday (~> 2.13)
-      faraday-follow_redirects (~> 0.3)
-      googleauth (~> 1.14)
-      mini_mime (~> 1.1)
-      multi_json (~> 1.11)
-      representable (~> 3.0)
-<<<<<<< HEAD
-      retriable (~> 3.1)
-=======
-      retriable (>= 3.1, < 5.0)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-    google-apis-iamcredentials_v1 (0.28.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-    google-apis-storage_v1 (0.65.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-    google-cloud-asset (1.10.0)
-      google-cloud-asset-v1 (>= 0.29, < 2.a)
-      google-cloud-core (~> 1.6)
-    google-cloud-asset-v1 (1.9.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-cloud-os_config-v1 (> 0.0, < 2.a)
-      google-identity-access_context_manager-v1 (> 0.0, < 2.a)
-      grpc-google-iam-v1 (~> 1.11)
-    google-cloud-bigquery (1.64.0)
-      bigdecimal (>= 3.0, < 5)
-      concurrent-ruby (~> 1.0)
-      google-apis-bigquery_v2 (~> 0.71)
-      google-apis-core (>= 0.18, < 2)
-      google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
     google-cloud-core (1.9.0)
       google-cloud-env (>= 1.0, < 3.a)
       google-cloud-errors (~> 1.0)
+    google-cloud-dlp (1.10.0)
+      google-cloud-core (~> 1.6)
+      google-cloud-dlp-v2 (>= 0.20, < 2.a)
+    google-cloud-dlp-v2 (1.18.0)
+      gapic-common (~> 1.3)
+      google-cloud-errors (~> 1.0)
+      google-cloud-location (~> 1.0)
     google-cloud-env (2.4.0)
       base64 (~> 0.2)
       faraday (>= 1.0, < 3.a)
     google-cloud-errors (1.7.0)
-    google-cloud-os_config-v1 (1.9.0)
+    google-cloud-location (1.5.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
-    google-cloud-pubsub (3.4.0)
-      concurrent-ruby (~> 1.3)
-      google-cloud-core (~> 1.8)
-      google-cloud-pubsub-v1 (~> 1.11)
-      retriable (~> 3.1)
-    google-cloud-pubsub-v1 (1.16.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-iam-v1 (~> 1.3)
-    google-cloud-storage (1.62.0)
-      addressable (~> 2.8)
-      digest-crc (~> 0.4)
-      google-apis-core (>= 0.18, < 2)
-      google-apis-iamcredentials_v1 (~> 0.18)
-      google-apis-storage_v1 (>= 0.42)
-      google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
-    google-iam-v1 (1.7.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      grpc-google-iam-v1 (~> 1.11)
-    google-identity-access_context_manager-v1 (0.15.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      grpc-google-iam-v1 (~> 1.11)
     google-logging-utils (0.2.0)
     google-protobuf (4.35.1)
       bigdecimal
@@ -134,7 +68,7 @@ GEM
     google-protobuf (4.35.1-x86_64-linux-musl)
       bigdecimal
       rake (~> 13.3)
-    googleapis-common-protos (1.9.0)
+    googleapis-common-protos (1.10.0)
       google-protobuf (~> 4.26)
       googleapis-common-protos-types (~> 1.21)
       grpc (~> 1.41)
@@ -175,36 +109,21 @@ GEM
     grpc (1.83.0-x86_64-linux-musl)
       google-protobuf (>= 3.25, < 5.0)
       googleapis-common-protos-types (~> 1.0)
-    grpc-google-iam-v1 (1.12.0)
-      google-protobuf (>= 3.18, < 5.a)
-      googleapis-common-protos (~> 1.9.0)
-      grpc (~> 1.41)
     json (2.21.2)
     jwt (3.2.0)
       base64
     logger (1.7.0)
-    mini_mime (1.1.5)
     minitest (5.27.0)
-    minitest-focus (1.4.1)
-      minitest (> 5.0)
-    multi_json (1.21.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
     os (1.1.4)
     pstore (0.2.1)
     public_suffix (7.0.5)
     rake (13.4.2)
-    representable (3.2.0)
-      declarative (< 0.1.0)
-      trailblazer-option (>= 0.1.1, < 0.2.0)
-      uber (< 0.2.0)
-    retriable (3.8.0)
     signet (0.22.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 4.0)
-    trailblazer-option (0.1.2)
-    uber (0.1.0)
     uri (1.1.1)
 
 PLATFORMS
@@ -219,47 +138,26 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  google-cloud-asset
-  google-cloud-bigquery
-  google-cloud-pubsub
-  google-cloud-storage
+  google-cloud-dlp
+  google-cloud-dlp-v2
   minitest (~> 5.14)
-  minitest-focus
-  rake
+  rake (>= 12.0)
 
 CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
-  concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
-  declarative (0.0.20) sha256=8021dd6cb17ab2b61233c56903d3f5a259c5cf43c80ff332d447d395b17d9ff9
-  digest-crc (0.7.0) sha256=64adc23a26a241044cbe6732477ca1b3c281d79e2240bcff275a37a5a0d78c07
   faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
-  faraday-follow_redirects (0.5.0) sha256=5cde93c894b30943a5d2b93c2fe9284216a6b756f7af406a1e55f211d97d10ad
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
   faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
   gapic-common (1.3.0) sha256=4e5d9be1effb7366e2cda13c0f44922285d5613ac8de8b9b18c2c835fe4faa91
-  google-apis-bigquery_v2 (0.106.0) sha256=a0f4243b634a0c79c29b7dacdd79233bd9c9ba2eda6fde9c2b19414fd165dd93
-<<<<<<< HEAD
-  google-apis-core (1.2.99)
-=======
-  google-apis-core (1.2.5) sha256=e21562b5627a0fc6a0c3165e429c3afed0f6a628eaa514e83f7204dda1adff69
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-  google-apis-iamcredentials_v1 (0.28.0) sha256=0a92ffe6cc39c569554af2a77a25dfc61519ed8bbb64ab04cffdd352dc5ef106
-  google-apis-storage_v1 (0.65.0) sha256=4247aa542931691f6988ab61e45cdea2878cbfe897a98eec4af9cdcb678eb359
-  google-cloud-asset (1.10.0) sha256=6ea6fd9e0735873884094c14d84d5a6d826b0e07aaeec245d34735ab2c5828e0
-  google-cloud-asset-v1 (1.9.0) sha256=ecfb654d0d350ed98209d46937c8095ec867c8ff6c3f7d70b8889f6fb70fd397
-  google-cloud-bigquery (1.64.0) sha256=d807363903e08958c3bc09ccc1f9d1218646c8f18176751879348a1a4a884d57
   google-cloud-core (1.9.0) sha256=ab55409f51488e8deefb6edcc1ce4771dfb5da2fe7b3bc075709a030c2b682a4
+  google-cloud-dlp (1.10.0) sha256=358deff0fc667dbe37c5b96f7da6d1066a048158c6746005fa324ac329ca6654
+  google-cloud-dlp-v2 (1.18.0) sha256=ebdea0d0faa8b6246accfabf0d504b234920303c87c2f69aa42202df053097a8
   google-cloud-env (2.4.0) sha256=01cb35ecee5d1c4d1cd4deaed8bb5bddc838e296bcc2a35c5d1ddd07ce40d28d
   google-cloud-errors (1.7.0) sha256=6e682f42d89aae08689f36f28495de629d756da076bafff0003bac7f8042ebb3
-  google-cloud-os_config-v1 (1.9.0) sha256=693c13690cfd7cf9d307c25d005ff33b823b6709791d3714c344ff1597ec3a30
-  google-cloud-pubsub (3.4.0) sha256=6a6390a6f605701945d5be233dea51e0b04009f157b5d701b092423fbc690edd
-  google-cloud-pubsub-v1 (1.16.0) sha256=ffe128821208bd3d2f27cb0d25eb6accb3893c99e0b736d1740b8b5e1570426b
-  google-cloud-storage (1.62.0) sha256=e2c3c08bf8fd40d50be92304084942203314d4fc0ee52028e99f9359c3ad1330
-  google-iam-v1 (1.7.0) sha256=9e3ea9dcc59cbd5f8d2f62b00da41ec57a2e427b33c0e798207fa06c8fbb8b87
-  google-identity-access_context_manager-v1 (0.15.0) sha256=8f105320bcbdc03c7fdb05369886117b4f341b792ed4ab81a144929bbcd7820b
+  google-cloud-location (1.5.0) sha256=336f94609b1fb18fce1929048fac964f4d5a87d27c1e5444bfed3605469c7532
   google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
   google-protobuf (4.35.1) sha256=a3a6471331d918f58dfa4d014a8f6286f0af2cf4840216bde52fcf2ea3fe3726
   google-protobuf (4.35.1-aarch64-linux-gnu) sha256=50ca44d0eeff3f8475e630a1accdd974256f3510694d574e2c9d6119ea8bc9e1
@@ -270,7 +168,7 @@ CHECKSUMS
   google-protobuf (4.35.1-x86_64-darwin) sha256=66b62b4df00931018a692806df66393efa960d6d2b7da69735187249f950d3ee
   google-protobuf (4.35.1-x86_64-linux-gnu) sha256=c786439087512a3fbd199e9897d265b855f951d4027e218ea55e858d45969edd
   google-protobuf (4.35.1-x86_64-linux-musl) sha256=91890eb0002934a339fdb7d77a147c46b7474b6799db27872b747b905837f744
-  googleapis-common-protos (1.9.0) sha256=207be372d8d25e3876e1e1155d057e14f3c92f8f5428772864a8ce04a0b756e4
+  googleapis-common-protos (1.10.0) sha256=13e47ad0ce85d3d30065c03863efd302a82b0e08ba576f2a9b9dbbfeecb57ee0
   googleapis-common-protos-types (1.23.0) sha256=992e740a523794d9fc5f29a504465d8fc737aaa16c930fe7228e3346860faf0a
   googleauth (1.17.3) sha256=9a655455885c0c17a8b70537acd2a992a7c7842c43c06c6612dfb0d93e755d58
   grpc (1.83.0) sha256=38119e7f9f7cbc98e79145201da4be470a7542b0befad454651d35015ea55c59
@@ -282,24 +180,16 @@ CHECKSUMS
   grpc (1.83.0-x86_64-darwin) sha256=cfad91d559d1907159a5247fb12dc112a8ea0ebe2027ca7f5ab648d01a645716
   grpc (1.83.0-x86_64-linux-gnu) sha256=25d66bfa3cb1b05258b3f9632478c7e7ceb52cb16ccc0b4b26d7df36be7158b1
   grpc (1.83.0-x86_64-linux-musl) sha256=a5023264dbb8038c23b147bbf80adb06932ef11b5ab493412e9e37a43114fa8c
-  grpc-google-iam-v1 (1.12.0) sha256=a70ecad8987e340d5e22e7bf01be31256c84b29a3f78bebd385a4a110e1f2aef
   json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
-  mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
-  minitest-focus (1.4.1) sha256=394517cbe2dcb2d992d8ffc41a3b2b6315777a4daa69239de4fefe7110dd810e
-  multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
   os (1.1.4) sha256=57816d6a334e7bd6aed048f4b0308226c5fb027433b67d90a9ab435f35108d3f
   pstore (0.2.1) sha256=03904d0f2c66579e96d1e6704cdabc0c88df7ea8ed8782d9f3569f6f6c702c1a
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
-  representable (3.2.0) sha256=cc29bf7eebc31653586849371a43ffe36c60b54b0a6365b5f7d95ec34d1ebace
-  retriable (3.8.0) sha256=9f2f1b0207594c7817f17f671587b8ec7587387ac6cebda6c941a802bb98a8e5
   signet (0.22.0) sha256=b76d495ccb07ad35dbc89f3e920665a9d8ed717141955034005d7843dcfe4780
-  trailblazer-option (0.1.2) sha256=20e4f12ea4e1f718c8007e7944ca21a329eee4eed9e0fa5dde6e8ad8ac4344a3
-  uber (0.1.0) sha256=5beeb407ff807b5db994f82fa9ee07cfceaa561dad8af20be880bc67eba935dc
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
 
 BUNDLED WITH

--- a/google-cloud-document_ai/samples/Gemfile.lock
+++ b/google-cloud-document_ai/samples/Gemfile.lock
@@ -3,18 +3,13 @@ GEM
   specs:
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.1.2)
-    concurrent-ruby (1.3.8)
-    declarative (0.0.20)
-    digest-crc (0.7.0)
-      rake (>= 12.0.0, < 14.0.0)
     faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-follow_redirects (0.5.0)
-      faraday (>= 1, < 3)
     faraday-net_http (3.4.4)
       net-http (~> 0.5)
     faraday-retry (2.4.0)
@@ -29,83 +24,23 @@ GEM
       googleapis-common-protos-types (~> 1.15)
       googleauth (~> 1.12)
       grpc (~> 1.66)
-    google-apis-bigquery_v2 (0.106.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-<<<<<<< HEAD
-    google-apis-core (1.2.99)
-      addressable (~> 2.8, >= 2.8.7)
-=======
-    google-apis-core (1.2.5)
-      addressable (~> 2.9)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-      faraday (~> 2.13)
-      faraday-follow_redirects (~> 0.3)
-      googleauth (~> 1.14)
-      mini_mime (~> 1.1)
-      multi_json (~> 1.11)
-      representable (~> 3.0)
-<<<<<<< HEAD
-      retriable (~> 3.1)
-=======
-      retriable (>= 3.1, < 5.0)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-    google-apis-iamcredentials_v1 (0.28.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-    google-apis-storage_v1 (0.65.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-    google-cloud-asset (1.10.0)
-      google-cloud-asset-v1 (>= 0.29, < 2.a)
-      google-cloud-core (~> 1.6)
-    google-cloud-asset-v1 (1.9.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-cloud-os_config-v1 (> 0.0, < 2.a)
-      google-identity-access_context_manager-v1 (> 0.0, < 2.a)
-      grpc-google-iam-v1 (~> 1.11)
-    google-cloud-bigquery (1.64.0)
-      bigdecimal (>= 3.0, < 5)
-      concurrent-ruby (~> 1.0)
-      google-apis-bigquery_v2 (~> 0.71)
-      google-apis-core (>= 0.18, < 2)
-      google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
     google-cloud-core (1.9.0)
       google-cloud-env (>= 1.0, < 3.a)
       google-cloud-errors (~> 1.0)
+    google-cloud-document_ai (2.2.0)
+      google-cloud-core (~> 1.6)
+      google-cloud-document_ai-v1 (~> 1.4)
+    google-cloud-document_ai-v1 (1.13.0)
+      gapic-common (~> 1.3)
+      google-cloud-errors (~> 1.0)
+      google-cloud-location (~> 1.0)
     google-cloud-env (2.4.0)
       base64 (~> 0.2)
       faraday (>= 1.0, < 3.a)
     google-cloud-errors (1.7.0)
-    google-cloud-os_config-v1 (1.9.0)
+    google-cloud-location (1.5.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
-    google-cloud-pubsub (3.4.0)
-      concurrent-ruby (~> 1.3)
-      google-cloud-core (~> 1.8)
-      google-cloud-pubsub-v1 (~> 1.11)
-      retriable (~> 3.1)
-    google-cloud-pubsub-v1 (1.16.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-iam-v1 (~> 1.3)
-    google-cloud-storage (1.62.0)
-      addressable (~> 2.8)
-      digest-crc (~> 0.4)
-      google-apis-core (>= 0.18, < 2)
-      google-apis-iamcredentials_v1 (~> 0.18)
-      google-apis-storage_v1 (>= 0.42)
-      google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
-    google-iam-v1 (1.7.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      grpc-google-iam-v1 (~> 1.11)
-    google-identity-access_context_manager-v1 (0.15.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      grpc-google-iam-v1 (~> 1.11)
     google-logging-utils (0.2.0)
     google-protobuf (4.35.1)
       bigdecimal
@@ -134,7 +69,9 @@ GEM
     google-protobuf (4.35.1-x86_64-linux-musl)
       bigdecimal
       rake (~> 13.3)
-    googleapis-common-protos (1.9.0)
+    google-style (1.26.4)
+      rubocop (~> 1.57.2)
+    googleapis-common-protos (1.10.0)
       google-protobuf (~> 4.26)
       googleapis-common-protos-types (~> 1.21)
       grpc (~> 1.41)
@@ -175,36 +112,51 @@ GEM
     grpc (1.83.0-x86_64-linux-musl)
       google-protobuf (>= 3.25, < 5.0)
       googleapis-common-protos-types (~> 1.0)
-    grpc-google-iam-v1 (1.12.0)
-      google-protobuf (>= 3.18, < 5.a)
-      googleapis-common-protos (~> 1.9.0)
-      grpc (~> 1.41)
     json (2.21.2)
     jwt (3.2.0)
       base64
+    language_server-protocol (3.17.0.6)
     logger (1.7.0)
-    mini_mime (1.1.5)
     minitest (5.27.0)
     minitest-focus (1.4.1)
       minitest (> 5.0)
-    multi_json (1.21.1)
+    minitest-rg (5.4.0)
+      minitest (>= 5.0, < 7)
     net-http (0.9.1)
       uri (>= 0.11.1)
     os (1.1.4)
+    parallel (1.28.0)
+    parser (3.3.12.0)
+      ast (~> 2.4.1)
+      racc
+    prism (1.9.0)
     pstore (0.2.1)
     public_suffix (7.0.5)
+    racc (1.8.1)
+    rainbow (3.1.1)
     rake (13.4.2)
-    representable (3.2.0)
-      declarative (< 0.1.0)
-      trailblazer-option (>= 0.1.1, < 0.2.0)
-      uber (< 0.2.0)
-    retriable (3.8.0)
+    regexp_parser (2.12.0)
+    rexml (3.4.4)
+    rubocop (1.57.2)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.2.2.4)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.28.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.50.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    ruby-progressbar (1.13.0)
     signet (0.22.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 4.0)
-    trailblazer-option (0.1.2)
-    uber (0.1.0)
+    unicode-display_width (2.6.0)
     uri (1.1.1)
 
 PLATFORMS
@@ -219,47 +171,29 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  google-cloud-asset
-  google-cloud-bigquery
-  google-cloud-pubsub
-  google-cloud-storage
-  minitest (~> 5.14)
-  minitest-focus
+  google-cloud-document_ai
+  google-style (~> 1.26.2)
+  minitest (~> 5.17)
+  minitest-focus (~> 1.4)
+  minitest-rg (~> 5.2)
   rake
 
 CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
-  concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
-  declarative (0.0.20) sha256=8021dd6cb17ab2b61233c56903d3f5a259c5cf43c80ff332d447d395b17d9ff9
-  digest-crc (0.7.0) sha256=64adc23a26a241044cbe6732477ca1b3c281d79e2240bcff275a37a5a0d78c07
   faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
-  faraday-follow_redirects (0.5.0) sha256=5cde93c894b30943a5d2b93c2fe9284216a6b756f7af406a1e55f211d97d10ad
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
   faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
   gapic-common (1.3.0) sha256=4e5d9be1effb7366e2cda13c0f44922285d5613ac8de8b9b18c2c835fe4faa91
-  google-apis-bigquery_v2 (0.106.0) sha256=a0f4243b634a0c79c29b7dacdd79233bd9c9ba2eda6fde9c2b19414fd165dd93
-<<<<<<< HEAD
-  google-apis-core (1.2.99)
-=======
-  google-apis-core (1.2.5) sha256=e21562b5627a0fc6a0c3165e429c3afed0f6a628eaa514e83f7204dda1adff69
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-  google-apis-iamcredentials_v1 (0.28.0) sha256=0a92ffe6cc39c569554af2a77a25dfc61519ed8bbb64ab04cffdd352dc5ef106
-  google-apis-storage_v1 (0.65.0) sha256=4247aa542931691f6988ab61e45cdea2878cbfe897a98eec4af9cdcb678eb359
-  google-cloud-asset (1.10.0) sha256=6ea6fd9e0735873884094c14d84d5a6d826b0e07aaeec245d34735ab2c5828e0
-  google-cloud-asset-v1 (1.9.0) sha256=ecfb654d0d350ed98209d46937c8095ec867c8ff6c3f7d70b8889f6fb70fd397
-  google-cloud-bigquery (1.64.0) sha256=d807363903e08958c3bc09ccc1f9d1218646c8f18176751879348a1a4a884d57
   google-cloud-core (1.9.0) sha256=ab55409f51488e8deefb6edcc1ce4771dfb5da2fe7b3bc075709a030c2b682a4
+  google-cloud-document_ai (2.2.0) sha256=b2c4bb5b94af85147dc7aa7919503271af3ef143f0f3a0ccd6d65dfef97d5682
+  google-cloud-document_ai-v1 (1.13.0) sha256=c831078378cbfe510e780968518ecb9b872376a350b66554af7f97d31f38e97b
   google-cloud-env (2.4.0) sha256=01cb35ecee5d1c4d1cd4deaed8bb5bddc838e296bcc2a35c5d1ddd07ce40d28d
   google-cloud-errors (1.7.0) sha256=6e682f42d89aae08689f36f28495de629d756da076bafff0003bac7f8042ebb3
-  google-cloud-os_config-v1 (1.9.0) sha256=693c13690cfd7cf9d307c25d005ff33b823b6709791d3714c344ff1597ec3a30
-  google-cloud-pubsub (3.4.0) sha256=6a6390a6f605701945d5be233dea51e0b04009f157b5d701b092423fbc690edd
-  google-cloud-pubsub-v1 (1.16.0) sha256=ffe128821208bd3d2f27cb0d25eb6accb3893c99e0b736d1740b8b5e1570426b
-  google-cloud-storage (1.62.0) sha256=e2c3c08bf8fd40d50be92304084942203314d4fc0ee52028e99f9359c3ad1330
-  google-iam-v1 (1.7.0) sha256=9e3ea9dcc59cbd5f8d2f62b00da41ec57a2e427b33c0e798207fa06c8fbb8b87
-  google-identity-access_context_manager-v1 (0.15.0) sha256=8f105320bcbdc03c7fdb05369886117b4f341b792ed4ab81a144929bbcd7820b
+  google-cloud-location (1.5.0) sha256=336f94609b1fb18fce1929048fac964f4d5a87d27c1e5444bfed3605469c7532
   google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
   google-protobuf (4.35.1) sha256=a3a6471331d918f58dfa4d014a8f6286f0af2cf4840216bde52fcf2ea3fe3726
   google-protobuf (4.35.1-aarch64-linux-gnu) sha256=50ca44d0eeff3f8475e630a1accdd974256f3510694d574e2c9d6119ea8bc9e1
@@ -270,7 +204,8 @@ CHECKSUMS
   google-protobuf (4.35.1-x86_64-darwin) sha256=66b62b4df00931018a692806df66393efa960d6d2b7da69735187249f950d3ee
   google-protobuf (4.35.1-x86_64-linux-gnu) sha256=c786439087512a3fbd199e9897d265b855f951d4027e218ea55e858d45969edd
   google-protobuf (4.35.1-x86_64-linux-musl) sha256=91890eb0002934a339fdb7d77a147c46b7474b6799db27872b747b905837f744
-  googleapis-common-protos (1.9.0) sha256=207be372d8d25e3876e1e1155d057e14f3c92f8f5428772864a8ce04a0b756e4
+  google-style (1.26.4) sha256=a8a24a5a020bd608d55a32462caaef7b02ae9b9d4dd36ea3945f80fdbaa11846
+  googleapis-common-protos (1.10.0) sha256=13e47ad0ce85d3d30065c03863efd302a82b0e08ba576f2a9b9dbbfeecb57ee0
   googleapis-common-protos-types (1.23.0) sha256=992e740a523794d9fc5f29a504465d8fc737aaa16c930fe7228e3346860faf0a
   googleauth (1.17.3) sha256=9a655455885c0c17a8b70537acd2a992a7c7842c43c06c6612dfb0d93e755d58
   grpc (1.83.0) sha256=38119e7f9f7cbc98e79145201da4be470a7542b0befad454651d35015ea55c59
@@ -282,24 +217,30 @@ CHECKSUMS
   grpc (1.83.0-x86_64-darwin) sha256=cfad91d559d1907159a5247fb12dc112a8ea0ebe2027ca7f5ab648d01a645716
   grpc (1.83.0-x86_64-linux-gnu) sha256=25d66bfa3cb1b05258b3f9632478c7e7ceb52cb16ccc0b4b26d7df36be7158b1
   grpc (1.83.0-x86_64-linux-musl) sha256=a5023264dbb8038c23b147bbf80adb06932ef11b5ab493412e9e37a43114fa8c
-  grpc-google-iam-v1 (1.12.0) sha256=a70ecad8987e340d5e22e7bf01be31256c84b29a3f78bebd385a4a110e1f2aef
   json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
+  language_server-protocol (3.17.0.6) sha256=5ef2c0c138f8267e1bc631d3328347d354f96724b0af22f2c79516120443b7f0
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
-  mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   minitest-focus (1.4.1) sha256=394517cbe2dcb2d992d8ffc41a3b2b6315777a4daa69239de4fefe7110dd810e
-  multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080
+  minitest-rg (5.4.0) sha256=54d42bb8ce876381245be5866f3c1dd704ef79c06ba5c9ff280c0aa28c56effb
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
   os (1.1.4) sha256=57816d6a334e7bd6aed048f4b0308226c5fb027433b67d90a9ab435f35108d3f
+  parallel (1.28.0) sha256=33e6de1484baf2524792d178b0913fc8eb94c628d6cfe45599ad4458c638c970
+  parser (3.3.12.0) sha256=21a6d7f755d5a24dfbdc6e6b772e4e879a52e7631a88bc5a3a134606052c9828
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   pstore (0.2.1) sha256=03904d0f2c66579e96d1e6704cdabc0c88df7ea8ed8782d9f3569f6f6c702c1a
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
-  representable (3.2.0) sha256=cc29bf7eebc31653586849371a43ffe36c60b54b0a6365b5f7d95ec34d1ebace
-  retriable (3.8.0) sha256=9f2f1b0207594c7817f17f671587b8ec7587387ac6cebda6c941a802bb98a8e5
+  regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rubocop (1.57.2) sha256=8f679dfe42d7821dc61dafb17d14b1294343157a197b9f8a23720ca17fb9161b
+  rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   signet (0.22.0) sha256=b76d495ccb07ad35dbc89f3e920665a9d8ed717141955034005d7843dcfe4780
-  trailblazer-option (0.1.2) sha256=20e4f12ea4e1f718c8007e7944ca21a329eee4eed9e0fa5dde6e8ad8ac4344a3
-  uber (0.1.0) sha256=5beeb407ff807b5db994f82fa9ee07cfceaa561dad8af20be880bc67eba935dc
+  unicode-display_width (2.6.0) sha256=12279874bba6d5e4d2728cef814b19197dbb10d7a7837a869bab65da943b7f5a
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
 
 BUNDLED WITH

--- a/google-cloud-firestore/samples/Gemfile.lock
+++ b/google-cloud-firestore/samples/Gemfile.lock
@@ -3,18 +3,14 @@ GEM
   specs:
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    ast (2.4.3)
     base64 (0.3.0)
-    bigdecimal (4.1.2)
+    bigdecimal (3.3.1)
     concurrent-ruby (1.3.8)
-    declarative (0.0.20)
-    digest-crc (0.7.0)
-      rake (>= 12.0.0, < 14.0.0)
     faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-follow_redirects (0.5.0)
-      faraday (>= 1, < 3)
     faraday-net_http (3.4.4)
       net-http (~> 0.5)
     faraday-retry (2.4.0)
@@ -29,47 +25,6 @@ GEM
       googleapis-common-protos-types (~> 1.15)
       googleauth (~> 1.12)
       grpc (~> 1.66)
-    google-apis-bigquery_v2 (0.106.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-<<<<<<< HEAD
-    google-apis-core (1.2.99)
-      addressable (~> 2.8, >= 2.8.7)
-=======
-    google-apis-core (1.2.5)
-      addressable (~> 2.9)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-      faraday (~> 2.13)
-      faraday-follow_redirects (~> 0.3)
-      googleauth (~> 1.14)
-      mini_mime (~> 1.1)
-      multi_json (~> 1.11)
-      representable (~> 3.0)
-<<<<<<< HEAD
-      retriable (~> 3.1)
-=======
-      retriable (>= 3.1, < 5.0)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-    google-apis-iamcredentials_v1 (0.28.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-    google-apis-storage_v1 (0.65.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-    google-cloud-asset (1.10.0)
-      google-cloud-asset-v1 (>= 0.29, < 2.a)
-      google-cloud-core (~> 1.6)
-    google-cloud-asset-v1 (1.9.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-cloud-os_config-v1 (> 0.0, < 2.a)
-      google-identity-access_context_manager-v1 (> 0.0, < 2.a)
-      grpc-google-iam-v1 (~> 1.11)
-    google-cloud-bigquery (1.64.0)
-      bigdecimal (>= 3.0, < 5)
-      concurrent-ruby (~> 1.0)
-      google-apis-bigquery_v2 (~> 0.71)
-      google-apis-core (>= 0.18, < 2)
-      google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
     google-cloud-core (1.9.0)
       google-cloud-env (>= 1.0, < 3.a)
       google-cloud-errors (~> 1.0)
@@ -77,35 +32,23 @@ GEM
       base64 (~> 0.2)
       faraday (>= 1.0, < 3.a)
     google-cloud-errors (1.7.0)
-    google-cloud-os_config-v1 (1.9.0)
+    google-cloud-firestore (3.2.0)
+      bigdecimal (~> 3.0)
+      concurrent-ruby (~> 1.0)
+      google-cloud-core (~> 1.7)
+      google-cloud-firestore-v1 (~> 2.0)
+      rbtree (~> 0.4.2)
+    google-cloud-firestore-admin-v1 (1.14.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
-    google-cloud-pubsub (3.4.0)
-      concurrent-ruby (~> 1.3)
-      google-cloud-core (~> 1.8)
-      google-cloud-pubsub-v1 (~> 1.11)
-      retriable (~> 3.1)
-    google-cloud-pubsub-v1 (1.16.0)
+      google-cloud-location (~> 1.0)
+    google-cloud-firestore-v1 (2.4.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
-      google-iam-v1 (~> 1.3)
-    google-cloud-storage (1.62.0)
-      addressable (~> 2.8)
-      digest-crc (~> 0.4)
-      google-apis-core (>= 0.18, < 2)
-      google-apis-iamcredentials_v1 (~> 0.18)
-      google-apis-storage_v1 (>= 0.42)
-      google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
-    google-iam-v1 (1.7.0)
+      google-cloud-location (~> 1.0)
+    google-cloud-location (1.5.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
-      grpc-google-iam-v1 (~> 1.11)
-    google-identity-access_context_manager-v1 (0.15.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      grpc-google-iam-v1 (~> 1.11)
     google-logging-utils (0.2.0)
     google-protobuf (4.35.1)
       bigdecimal
@@ -134,7 +77,9 @@ GEM
     google-protobuf (4.35.1-x86_64-linux-musl)
       bigdecimal
       rake (~> 13.3)
-    googleapis-common-protos (1.9.0)
+    google-style (1.30.1)
+      rubocop (~> 1.63)
+    googleapis-common-protos (1.10.0)
       google-protobuf (~> 4.26)
       googleapis-common-protos-types (~> 1.21)
       grpc (~> 1.41)
@@ -175,36 +120,54 @@ GEM
     grpc (1.83.0-x86_64-linux-musl)
       google-protobuf (>= 3.25, < 5.0)
       googleapis-common-protos-types (~> 1.0)
-    grpc-google-iam-v1 (1.12.0)
-      google-protobuf (>= 3.18, < 5.a)
-      googleapis-common-protos (~> 1.9.0)
-      grpc (~> 1.41)
     json (2.21.2)
     jwt (3.2.0)
       base64
+    language_server-protocol (3.17.0.6)
+    lint_roller (1.1.0)
     logger (1.7.0)
-    mini_mime (1.1.5)
     minitest (5.27.0)
     minitest-focus (1.4.1)
       minitest (> 5.0)
-    multi_json (1.21.1)
+    minitest-hooks (1.5.4)
+      minitest (> 5.3)
     net-http (0.9.1)
       uri (>= 0.11.1)
     os (1.1.4)
+    parallel (1.28.0)
+    parser (3.3.12.0)
+      ast (~> 2.4.1)
+      racc
+    prism (1.9.0)
     pstore (0.2.1)
     public_suffix (7.0.5)
+    racc (1.8.1)
+    rainbow (3.1.1)
     rake (13.4.2)
-    representable (3.2.0)
-      declarative (< 0.1.0)
-      trailblazer-option (>= 0.1.1, < 0.2.0)
-      uber (< 0.2.0)
-    retriable (3.8.0)
+    rbtree (0.4.7)
+    regexp_parser (2.12.0)
+    rubocop (1.88.2)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (>= 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.50.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    ruby-progressbar (1.13.0)
     signet (0.22.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 4.0)
-    trailblazer-option (0.1.2)
-    uber (0.1.0)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
     uri (1.1.1)
 
 PLATFORMS
@@ -219,47 +182,33 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  google-cloud-asset
-  google-cloud-bigquery
-  google-cloud-pubsub
-  google-cloud-storage
-  minitest (~> 5.14)
-  minitest-focus
-  rake
+  google-cloud-firestore
+  google-cloud-firestore-admin-v1
+  google-cloud-firestore-v1
+  google-style (~> 1.30.1)
+  minitest (~> 5.25)
+  minitest-focus (~> 1.4)
+  minitest-hooks (~> 1.5)
+  rake (>= 12.0)
 
 CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
-  bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
+  bigdecimal (3.3.1) sha256=eaa01e228be54c4f9f53bf3cc34fe3d5e845c31963e7fcc5bedb05a4e7d52218
   bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
   concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
-  declarative (0.0.20) sha256=8021dd6cb17ab2b61233c56903d3f5a259c5cf43c80ff332d447d395b17d9ff9
-  digest-crc (0.7.0) sha256=64adc23a26a241044cbe6732477ca1b3c281d79e2240bcff275a37a5a0d78c07
   faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
-  faraday-follow_redirects (0.5.0) sha256=5cde93c894b30943a5d2b93c2fe9284216a6b756f7af406a1e55f211d97d10ad
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
   faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
   gapic-common (1.3.0) sha256=4e5d9be1effb7366e2cda13c0f44922285d5613ac8de8b9b18c2c835fe4faa91
-  google-apis-bigquery_v2 (0.106.0) sha256=a0f4243b634a0c79c29b7dacdd79233bd9c9ba2eda6fde9c2b19414fd165dd93
-<<<<<<< HEAD
-  google-apis-core (1.2.99)
-=======
-  google-apis-core (1.2.5) sha256=e21562b5627a0fc6a0c3165e429c3afed0f6a628eaa514e83f7204dda1adff69
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-  google-apis-iamcredentials_v1 (0.28.0) sha256=0a92ffe6cc39c569554af2a77a25dfc61519ed8bbb64ab04cffdd352dc5ef106
-  google-apis-storage_v1 (0.65.0) sha256=4247aa542931691f6988ab61e45cdea2878cbfe897a98eec4af9cdcb678eb359
-  google-cloud-asset (1.10.0) sha256=6ea6fd9e0735873884094c14d84d5a6d826b0e07aaeec245d34735ab2c5828e0
-  google-cloud-asset-v1 (1.9.0) sha256=ecfb654d0d350ed98209d46937c8095ec867c8ff6c3f7d70b8889f6fb70fd397
-  google-cloud-bigquery (1.64.0) sha256=d807363903e08958c3bc09ccc1f9d1218646c8f18176751879348a1a4a884d57
   google-cloud-core (1.9.0) sha256=ab55409f51488e8deefb6edcc1ce4771dfb5da2fe7b3bc075709a030c2b682a4
   google-cloud-env (2.4.0) sha256=01cb35ecee5d1c4d1cd4deaed8bb5bddc838e296bcc2a35c5d1ddd07ce40d28d
   google-cloud-errors (1.7.0) sha256=6e682f42d89aae08689f36f28495de629d756da076bafff0003bac7f8042ebb3
-  google-cloud-os_config-v1 (1.9.0) sha256=693c13690cfd7cf9d307c25d005ff33b823b6709791d3714c344ff1597ec3a30
-  google-cloud-pubsub (3.4.0) sha256=6a6390a6f605701945d5be233dea51e0b04009f157b5d701b092423fbc690edd
-  google-cloud-pubsub-v1 (1.16.0) sha256=ffe128821208bd3d2f27cb0d25eb6accb3893c99e0b736d1740b8b5e1570426b
-  google-cloud-storage (1.62.0) sha256=e2c3c08bf8fd40d50be92304084942203314d4fc0ee52028e99f9359c3ad1330
-  google-iam-v1 (1.7.0) sha256=9e3ea9dcc59cbd5f8d2f62b00da41ec57a2e427b33c0e798207fa06c8fbb8b87
-  google-identity-access_context_manager-v1 (0.15.0) sha256=8f105320bcbdc03c7fdb05369886117b4f341b792ed4ab81a144929bbcd7820b
+  google-cloud-firestore (3.2.0) sha256=62e07950bc6f69d12a64f3615fc597f57cae69469de0d923d63831afd0ae7ac7
+  google-cloud-firestore-admin-v1 (1.14.0) sha256=54c0eeaca2c5f30e3d5d46a4c6d6ab4d5a34216fc8c37670a7de4a68569664f9
+  google-cloud-firestore-v1 (2.4.0) sha256=0ad5ac58d728b14cc4074bab468debd8df47edb41c712990147ff04ac57ae033
+  google-cloud-location (1.5.0) sha256=336f94609b1fb18fce1929048fac964f4d5a87d27c1e5444bfed3605469c7532
   google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
   google-protobuf (4.35.1) sha256=a3a6471331d918f58dfa4d014a8f6286f0af2cf4840216bde52fcf2ea3fe3726
   google-protobuf (4.35.1-aarch64-linux-gnu) sha256=50ca44d0eeff3f8475e630a1accdd974256f3510694d574e2c9d6119ea8bc9e1
@@ -270,7 +219,8 @@ CHECKSUMS
   google-protobuf (4.35.1-x86_64-darwin) sha256=66b62b4df00931018a692806df66393efa960d6d2b7da69735187249f950d3ee
   google-protobuf (4.35.1-x86_64-linux-gnu) sha256=c786439087512a3fbd199e9897d265b855f951d4027e218ea55e858d45969edd
   google-protobuf (4.35.1-x86_64-linux-musl) sha256=91890eb0002934a339fdb7d77a147c46b7474b6799db27872b747b905837f744
-  googleapis-common-protos (1.9.0) sha256=207be372d8d25e3876e1e1155d057e14f3c92f8f5428772864a8ce04a0b756e4
+  google-style (1.30.1) sha256=ae9260c1f86856d8179a17fb270ccc2137ec0c0baa2a728ab5c8e7d76ce4032a
+  googleapis-common-protos (1.10.0) sha256=13e47ad0ce85d3d30065c03863efd302a82b0e08ba576f2a9b9dbbfeecb57ee0
   googleapis-common-protos-types (1.23.0) sha256=992e740a523794d9fc5f29a504465d8fc737aaa16c930fe7228e3346860faf0a
   googleauth (1.17.3) sha256=9a655455885c0c17a8b70537acd2a992a7c7842c43c06c6612dfb0d93e755d58
   grpc (1.83.0) sha256=38119e7f9f7cbc98e79145201da4be470a7542b0befad454651d35015ea55c59
@@ -282,24 +232,32 @@ CHECKSUMS
   grpc (1.83.0-x86_64-darwin) sha256=cfad91d559d1907159a5247fb12dc112a8ea0ebe2027ca7f5ab648d01a645716
   grpc (1.83.0-x86_64-linux-gnu) sha256=25d66bfa3cb1b05258b3f9632478c7e7ceb52cb16ccc0b4b26d7df36be7158b1
   grpc (1.83.0-x86_64-linux-musl) sha256=a5023264dbb8038c23b147bbf80adb06932ef11b5ab493412e9e37a43114fa8c
-  grpc-google-iam-v1 (1.12.0) sha256=a70ecad8987e340d5e22e7bf01be31256c84b29a3f78bebd385a4a110e1f2aef
   json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
+  language_server-protocol (3.17.0.6) sha256=5ef2c0c138f8267e1bc631d3328347d354f96724b0af22f2c79516120443b7f0
+  lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
-  mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   minitest-focus (1.4.1) sha256=394517cbe2dcb2d992d8ffc41a3b2b6315777a4daa69239de4fefe7110dd810e
-  multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080
+  minitest-hooks (1.5.4) sha256=1254069f3da51fea234dc4ff974108d03d19260ad5c4b78eed9695726a5069b8
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
   os (1.1.4) sha256=57816d6a334e7bd6aed048f4b0308226c5fb027433b67d90a9ab435f35108d3f
+  parallel (1.28.0) sha256=33e6de1484baf2524792d178b0913fc8eb94c628d6cfe45599ad4458c638c970
+  parser (3.3.12.0) sha256=21a6d7f755d5a24dfbdc6e6b772e4e879a52e7631a88bc5a3a134606052c9828
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   pstore (0.2.1) sha256=03904d0f2c66579e96d1e6704cdabc0c88df7ea8ed8782d9f3569f6f6c702c1a
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
-  representable (3.2.0) sha256=cc29bf7eebc31653586849371a43ffe36c60b54b0a6365b5f7d95ec34d1ebace
-  retriable (3.8.0) sha256=9f2f1b0207594c7817f17f671587b8ec7587387ac6cebda6c941a802bb98a8e5
+  rbtree (0.4.7) sha256=1efabbcb3fd5f12249c9c8a610a765074868164eed0c50c9db2531c00ed161cb
+  regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
+  rubocop (1.88.2) sha256=8def251c90cd955feb4daa3edc0ab56893250c4ce90ef81e6c80c03f9a939bbf
+  rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   signet (0.22.0) sha256=b76d495ccb07ad35dbc89f3e920665a9d8ed717141955034005d7843dcfe4780
-  trailblazer-option (0.1.2) sha256=20e4f12ea4e1f718c8007e7944ca21a329eee4eed9e0fa5dde6e8ad8ac4344a3
-  uber (0.1.0) sha256=5beeb407ff807b5db994f82fa9ee07cfceaa561dad8af20be880bc67eba935dc
+  unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
+  unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
 
 BUNDLED WITH

--- a/google-cloud-kms/samples/Gemfile.lock
+++ b/google-cloud-kms/samples/Gemfile.lock
@@ -3,18 +3,13 @@ GEM
   specs:
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.1.2)
-    concurrent-ruby (1.3.8)
-    declarative (0.0.20)
-    digest-crc (0.7.0)
-      rake (>= 12.0.0, < 14.0.0)
     faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-follow_redirects (0.5.0)
-      faraday (>= 1, < 3)
     faraday-net_http (3.4.4)
       net-http (~> 0.5)
     faraday-retry (2.4.0)
@@ -29,47 +24,6 @@ GEM
       googleapis-common-protos-types (~> 1.15)
       googleauth (~> 1.12)
       grpc (~> 1.66)
-    google-apis-bigquery_v2 (0.106.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-<<<<<<< HEAD
-    google-apis-core (1.2.99)
-      addressable (~> 2.8, >= 2.8.7)
-=======
-    google-apis-core (1.2.5)
-      addressable (~> 2.9)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-      faraday (~> 2.13)
-      faraday-follow_redirects (~> 0.3)
-      googleauth (~> 1.14)
-      mini_mime (~> 1.1)
-      multi_json (~> 1.11)
-      representable (~> 3.0)
-<<<<<<< HEAD
-      retriable (~> 3.1)
-=======
-      retriable (>= 3.1, < 5.0)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-    google-apis-iamcredentials_v1 (0.28.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-    google-apis-storage_v1 (0.65.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-    google-cloud-asset (1.10.0)
-      google-cloud-asset-v1 (>= 0.29, < 2.a)
-      google-cloud-core (~> 1.6)
-    google-cloud-asset-v1 (1.9.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-cloud-os_config-v1 (> 0.0, < 2.a)
-      google-identity-access_context_manager-v1 (> 0.0, < 2.a)
-      grpc-google-iam-v1 (~> 1.11)
-    google-cloud-bigquery (1.64.0)
-      bigdecimal (>= 3.0, < 5)
-      concurrent-ruby (~> 1.0)
-      google-apis-bigquery_v2 (~> 0.71)
-      google-apis-core (>= 0.18, < 2)
-      google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
     google-cloud-core (1.9.0)
       google-cloud-env (>= 1.0, < 3.a)
       google-cloud-errors (~> 1.0)
@@ -77,32 +31,18 @@ GEM
       base64 (~> 0.2)
       faraday (>= 1.0, < 3.a)
     google-cloud-errors (1.7.0)
-    google-cloud-os_config-v1 (1.9.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-    google-cloud-pubsub (3.4.0)
-      concurrent-ruby (~> 1.3)
-      google-cloud-core (~> 1.8)
-      google-cloud-pubsub-v1 (~> 1.11)
-      retriable (~> 3.1)
-    google-cloud-pubsub-v1 (1.16.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-iam-v1 (~> 1.3)
-    google-cloud-storage (1.62.0)
-      addressable (~> 2.8)
-      digest-crc (~> 0.4)
-      google-apis-core (>= 0.18, < 2)
-      google-apis-iamcredentials_v1 (~> 0.18)
-      google-apis-storage_v1 (>= 0.42)
+    google-cloud-kms (2.12.0)
       google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
-    google-iam-v1 (1.7.0)
+      google-cloud-kms-v1 (>= 0.26, < 2.a)
+    google-cloud-kms-v1 (1.15.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
-      grpc-google-iam-v1 (~> 1.11)
-    google-identity-access_context_manager-v1 (0.15.0)
+      google-cloud-location (~> 1.0)
+      google-iam-v1 (~> 1.3)
+    google-cloud-location (1.5.0)
+      gapic-common (~> 1.3)
+      google-cloud-errors (~> 1.0)
+    google-iam-v1 (1.7.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
       grpc-google-iam-v1 (~> 1.11)
@@ -134,6 +74,8 @@ GEM
     google-protobuf (4.35.1-x86_64-linux-musl)
       bigdecimal
       rake (~> 13.3)
+    google-style (1.25.3)
+      rubocop (~> 1.28.2)
     googleapis-common-protos (1.9.0)
       google-protobuf (~> 4.26)
       googleapis-common-protos-types (~> 1.21)
@@ -183,28 +125,44 @@ GEM
     jwt (3.2.0)
       base64
     logger (1.7.0)
-    mini_mime (1.1.5)
     minitest (5.27.0)
     minitest-focus (1.4.1)
       minitest (> 5.0)
-    multi_json (1.21.1)
+    minitest-hooks (1.5.4)
+      minitest (> 5.3)
     net-http (0.9.1)
       uri (>= 0.11.1)
     os (1.1.4)
+    parallel (1.28.0)
+    parser (3.3.12.0)
+      ast (~> 2.4.1)
+      racc
+    prism (1.9.0)
     pstore (0.2.1)
     public_suffix (7.0.5)
+    racc (1.8.1)
+    rainbow (3.1.1)
     rake (13.4.2)
-    representable (3.2.0)
-      declarative (< 0.1.0)
-      trailblazer-option (>= 0.1.1, < 0.2.0)
-      uber (< 0.2.0)
-    retriable (3.8.0)
+    regexp_parser (2.12.0)
+    rexml (3.4.4)
+    rubocop (1.28.2)
+      parallel (~> 1.10)
+      parser (>= 3.1.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.17.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.50.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    ruby-progressbar (1.13.0)
     signet (0.22.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 4.0)
-    trailblazer-option (0.1.2)
-    uber (0.1.0)
+    unicode-display_width (2.6.0)
     uri (1.1.1)
 
 PLATFORMS
@@ -219,47 +177,30 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  google-cloud-asset
-  google-cloud-bigquery
-  google-cloud-pubsub
-  google-cloud-storage
+  google-cloud-kms
+  google-style (~> 1.25.1)
   minitest (~> 5.14)
-  minitest-focus
+  minitest-focus (~> 1.1)
+  minitest-hooks (~> 1.5)
   rake
 
 CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
-  concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
-  declarative (0.0.20) sha256=8021dd6cb17ab2b61233c56903d3f5a259c5cf43c80ff332d447d395b17d9ff9
-  digest-crc (0.7.0) sha256=64adc23a26a241044cbe6732477ca1b3c281d79e2240bcff275a37a5a0d78c07
   faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
-  faraday-follow_redirects (0.5.0) sha256=5cde93c894b30943a5d2b93c2fe9284216a6b756f7af406a1e55f211d97d10ad
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
   faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
   gapic-common (1.3.0) sha256=4e5d9be1effb7366e2cda13c0f44922285d5613ac8de8b9b18c2c835fe4faa91
-  google-apis-bigquery_v2 (0.106.0) sha256=a0f4243b634a0c79c29b7dacdd79233bd9c9ba2eda6fde9c2b19414fd165dd93
-<<<<<<< HEAD
-  google-apis-core (1.2.99)
-=======
-  google-apis-core (1.2.5) sha256=e21562b5627a0fc6a0c3165e429c3afed0f6a628eaa514e83f7204dda1adff69
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-  google-apis-iamcredentials_v1 (0.28.0) sha256=0a92ffe6cc39c569554af2a77a25dfc61519ed8bbb64ab04cffdd352dc5ef106
-  google-apis-storage_v1 (0.65.0) sha256=4247aa542931691f6988ab61e45cdea2878cbfe897a98eec4af9cdcb678eb359
-  google-cloud-asset (1.10.0) sha256=6ea6fd9e0735873884094c14d84d5a6d826b0e07aaeec245d34735ab2c5828e0
-  google-cloud-asset-v1 (1.9.0) sha256=ecfb654d0d350ed98209d46937c8095ec867c8ff6c3f7d70b8889f6fb70fd397
-  google-cloud-bigquery (1.64.0) sha256=d807363903e08958c3bc09ccc1f9d1218646c8f18176751879348a1a4a884d57
   google-cloud-core (1.9.0) sha256=ab55409f51488e8deefb6edcc1ce4771dfb5da2fe7b3bc075709a030c2b682a4
   google-cloud-env (2.4.0) sha256=01cb35ecee5d1c4d1cd4deaed8bb5bddc838e296bcc2a35c5d1ddd07ce40d28d
   google-cloud-errors (1.7.0) sha256=6e682f42d89aae08689f36f28495de629d756da076bafff0003bac7f8042ebb3
-  google-cloud-os_config-v1 (1.9.0) sha256=693c13690cfd7cf9d307c25d005ff33b823b6709791d3714c344ff1597ec3a30
-  google-cloud-pubsub (3.4.0) sha256=6a6390a6f605701945d5be233dea51e0b04009f157b5d701b092423fbc690edd
-  google-cloud-pubsub-v1 (1.16.0) sha256=ffe128821208bd3d2f27cb0d25eb6accb3893c99e0b736d1740b8b5e1570426b
-  google-cloud-storage (1.62.0) sha256=e2c3c08bf8fd40d50be92304084942203314d4fc0ee52028e99f9359c3ad1330
+  google-cloud-kms (2.12.0) sha256=c546fea8e7f0d07e09532fa0714cd783424d8dc7d859334940e7cb6e2e788d8c
+  google-cloud-kms-v1 (1.15.0) sha256=25942a07b11809bc535263bb4ce7e0d9ccef5e863463374defd7487dcd07ef97
+  google-cloud-location (1.5.0) sha256=336f94609b1fb18fce1929048fac964f4d5a87d27c1e5444bfed3605469c7532
   google-iam-v1 (1.7.0) sha256=9e3ea9dcc59cbd5f8d2f62b00da41ec57a2e427b33c0e798207fa06c8fbb8b87
-  google-identity-access_context_manager-v1 (0.15.0) sha256=8f105320bcbdc03c7fdb05369886117b4f341b792ed4ab81a144929bbcd7820b
   google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
   google-protobuf (4.35.1) sha256=a3a6471331d918f58dfa4d014a8f6286f0af2cf4840216bde52fcf2ea3fe3726
   google-protobuf (4.35.1-aarch64-linux-gnu) sha256=50ca44d0eeff3f8475e630a1accdd974256f3510694d574e2c9d6119ea8bc9e1
@@ -270,6 +211,7 @@ CHECKSUMS
   google-protobuf (4.35.1-x86_64-darwin) sha256=66b62b4df00931018a692806df66393efa960d6d2b7da69735187249f950d3ee
   google-protobuf (4.35.1-x86_64-linux-gnu) sha256=c786439087512a3fbd199e9897d265b855f951d4027e218ea55e858d45969edd
   google-protobuf (4.35.1-x86_64-linux-musl) sha256=91890eb0002934a339fdb7d77a147c46b7474b6799db27872b747b905837f744
+  google-style (1.25.3) sha256=d417fd0f6d6a9f4bb2ff69e1cfaa1c4d0e19230589cdf4383df4540082c395d4
   googleapis-common-protos (1.9.0) sha256=207be372d8d25e3876e1e1155d057e14f3c92f8f5428772864a8ce04a0b756e4
   googleapis-common-protos-types (1.23.0) sha256=992e740a523794d9fc5f29a504465d8fc737aaa16c930fe7228e3346860faf0a
   googleauth (1.17.3) sha256=9a655455885c0c17a8b70537acd2a992a7c7842c43c06c6612dfb0d93e755d58
@@ -286,20 +228,26 @@ CHECKSUMS
   json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
-  mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   minitest-focus (1.4.1) sha256=394517cbe2dcb2d992d8ffc41a3b2b6315777a4daa69239de4fefe7110dd810e
-  multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080
+  minitest-hooks (1.5.4) sha256=1254069f3da51fea234dc4ff974108d03d19260ad5c4b78eed9695726a5069b8
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
   os (1.1.4) sha256=57816d6a334e7bd6aed048f4b0308226c5fb027433b67d90a9ab435f35108d3f
+  parallel (1.28.0) sha256=33e6de1484baf2524792d178b0913fc8eb94c628d6cfe45599ad4458c638c970
+  parser (3.3.12.0) sha256=21a6d7f755d5a24dfbdc6e6b772e4e879a52e7631a88bc5a3a134606052c9828
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   pstore (0.2.1) sha256=03904d0f2c66579e96d1e6704cdabc0c88df7ea8ed8782d9f3569f6f6c702c1a
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
-  representable (3.2.0) sha256=cc29bf7eebc31653586849371a43ffe36c60b54b0a6365b5f7d95ec34d1ebace
-  retriable (3.8.0) sha256=9f2f1b0207594c7817f17f671587b8ec7587387ac6cebda6c941a802bb98a8e5
+  regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rubocop (1.28.2) sha256=0d9bf4108fd86ede43c6cf30adcb3dd2e0c6750941c5ec2a00621478157cb377
+  rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   signet (0.22.0) sha256=b76d495ccb07ad35dbc89f3e920665a9d8ed717141955034005d7843dcfe4780
-  trailblazer-option (0.1.2) sha256=20e4f12ea4e1f718c8007e7944ca21a329eee4eed9e0fa5dde6e8ad8ac4344a3
-  uber (0.1.0) sha256=5beeb407ff807b5db994f82fa9ee07cfceaa561dad8af20be880bc67eba935dc
+  unicode-display_width (2.6.0) sha256=12279874bba6d5e4d2728cef814b19197dbb10d7a7837a869bab65da943b7f5a
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
 
 BUNDLED WITH

--- a/google-cloud-logging/samples/Gemfile.lock
+++ b/google-cloud-logging/samples/Gemfile.lock
@@ -3,6 +3,7 @@ GEM
   specs:
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.1.2)
     concurrent-ruby (1.3.8)
@@ -29,47 +30,19 @@ GEM
       googleapis-common-protos-types (~> 1.15)
       googleauth (~> 1.12)
       grpc (~> 1.66)
-    google-apis-bigquery_v2 (0.106.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-<<<<<<< HEAD
-    google-apis-core (1.2.99)
-      addressable (~> 2.8, >= 2.8.7)
-=======
     google-apis-core (1.2.5)
       addressable (~> 2.9)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
       faraday (~> 2.13)
       faraday-follow_redirects (~> 0.3)
       googleauth (~> 1.14)
       mini_mime (~> 1.1)
       multi_json (~> 1.11)
       representable (~> 3.0)
-<<<<<<< HEAD
-      retriable (~> 3.1)
-=======
       retriable (>= 3.1, < 5.0)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
     google-apis-iamcredentials_v1 (0.28.0)
       google-apis-core (>= 0.15.0, < 2.a)
     google-apis-storage_v1 (0.65.0)
       google-apis-core (>= 0.15.0, < 2.a)
-    google-cloud-asset (1.10.0)
-      google-cloud-asset-v1 (>= 0.29, < 2.a)
-      google-cloud-core (~> 1.6)
-    google-cloud-asset-v1 (1.9.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-cloud-os_config-v1 (> 0.0, < 2.a)
-      google-identity-access_context_manager-v1 (> 0.0, < 2.a)
-      grpc-google-iam-v1 (~> 1.11)
-    google-cloud-bigquery (1.64.0)
-      bigdecimal (>= 3.0, < 5)
-      concurrent-ruby (~> 1.0)
-      google-apis-bigquery_v2 (~> 0.71)
-      google-apis-core (>= 0.18, < 2)
-      google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
     google-cloud-core (1.9.0)
       google-cloud-env (>= 1.0, < 3.a)
       google-cloud-errors (~> 1.0)
@@ -77,18 +50,14 @@ GEM
       base64 (~> 0.2)
       faraday (>= 1.0, < 3.a)
     google-cloud-errors (1.7.0)
-    google-cloud-os_config-v1 (1.9.0)
+    google-cloud-logging (2.7.0)
+      concurrent-ruby (~> 1.1)
+      google-cloud-core (~> 1.5)
+      google-cloud-logging-v2 (>= 0.0, < 2.a)
+      stackdriver-core (~> 1.3)
+    google-cloud-logging-v2 (1.7.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
-    google-cloud-pubsub (3.4.0)
-      concurrent-ruby (~> 1.3)
-      google-cloud-core (~> 1.8)
-      google-cloud-pubsub-v1 (~> 1.11)
-      retriable (~> 3.1)
-    google-cloud-pubsub-v1 (1.16.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-iam-v1 (~> 1.3)
     google-cloud-storage (1.62.0)
       addressable (~> 2.8)
       digest-crc (~> 0.4)
@@ -98,14 +67,6 @@ GEM
       google-cloud-core (~> 1.6)
       googleauth (~> 1.9)
       mini_mime (~> 1.0)
-    google-iam-v1 (1.7.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      grpc-google-iam-v1 (~> 1.11)
-    google-identity-access_context_manager-v1 (0.15.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      grpc-google-iam-v1 (~> 1.11)
     google-logging-utils (0.2.0)
     google-protobuf (4.35.1)
       bigdecimal
@@ -134,7 +95,9 @@ GEM
     google-protobuf (4.35.1-x86_64-linux-musl)
       bigdecimal
       rake (~> 13.3)
-    googleapis-common-protos (1.9.0)
+    google-style (1.25.3)
+      rubocop (~> 1.28.2)
+    googleapis-common-protos (1.10.0)
       google-protobuf (~> 4.26)
       googleapis-common-protos-types (~> 1.21)
       grpc (~> 1.41)
@@ -175,10 +138,6 @@ GEM
     grpc (1.83.0-x86_64-linux-musl)
       google-protobuf (>= 3.25, < 5.0)
       googleapis-common-protos-types (~> 1.0)
-    grpc-google-iam-v1 (1.12.0)
-      google-protobuf (>= 3.18, < 5.a)
-      googleapis-common-protos (~> 1.9.0)
-      grpc (~> 1.41)
     json (2.21.2)
     jwt (3.2.0)
       base64
@@ -187,24 +146,51 @@ GEM
     minitest (5.27.0)
     minitest-focus (1.4.1)
       minitest (> 5.0)
+    minitest-rg (5.4.0)
+      minitest (>= 5.0, < 7)
     multi_json (1.21.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
     os (1.1.4)
+    parallel (1.28.0)
+    parser (3.3.12.0)
+      ast (~> 2.4.1)
+      racc
+    prism (1.9.0)
     pstore (0.2.1)
     public_suffix (7.0.5)
+    racc (1.8.1)
+    rainbow (3.1.1)
     rake (13.4.2)
+    regexp_parser (2.12.0)
     representable (3.2.0)
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
-    retriable (3.8.0)
+    retriable (4.2.0)
+    rexml (3.4.4)
+    rubocop (1.28.2)
+      parallel (~> 1.10)
+      parser (>= 3.1.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.17.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.50.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    ruby-progressbar (1.13.0)
     signet (0.22.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 4.0)
+    stackdriver-core (1.8.0)
+      google-cloud-core (~> 1.2)
     trailblazer-option (0.1.2)
     uber (0.1.0)
+    unicode-display_width (2.6.0)
     uri (1.1.1)
 
 PLATFORMS
@@ -219,16 +205,17 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  google-cloud-asset
-  google-cloud-bigquery
-  google-cloud-pubsub
+  google-cloud-logging
   google-cloud-storage
+  google-style (~> 1.25.1)
   minitest (~> 5.14)
-  minitest-focus
+  minitest-focus (~> 1.1)
+  minitest-rg (~> 5.2)
   rake
 
 CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
@@ -240,26 +227,15 @@ CHECKSUMS
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
   faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
   gapic-common (1.3.0) sha256=4e5d9be1effb7366e2cda13c0f44922285d5613ac8de8b9b18c2c835fe4faa91
-  google-apis-bigquery_v2 (0.106.0) sha256=a0f4243b634a0c79c29b7dacdd79233bd9c9ba2eda6fde9c2b19414fd165dd93
-<<<<<<< HEAD
-  google-apis-core (1.2.99)
-=======
   google-apis-core (1.2.5) sha256=e21562b5627a0fc6a0c3165e429c3afed0f6a628eaa514e83f7204dda1adff69
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
   google-apis-iamcredentials_v1 (0.28.0) sha256=0a92ffe6cc39c569554af2a77a25dfc61519ed8bbb64ab04cffdd352dc5ef106
   google-apis-storage_v1 (0.65.0) sha256=4247aa542931691f6988ab61e45cdea2878cbfe897a98eec4af9cdcb678eb359
-  google-cloud-asset (1.10.0) sha256=6ea6fd9e0735873884094c14d84d5a6d826b0e07aaeec245d34735ab2c5828e0
-  google-cloud-asset-v1 (1.9.0) sha256=ecfb654d0d350ed98209d46937c8095ec867c8ff6c3f7d70b8889f6fb70fd397
-  google-cloud-bigquery (1.64.0) sha256=d807363903e08958c3bc09ccc1f9d1218646c8f18176751879348a1a4a884d57
   google-cloud-core (1.9.0) sha256=ab55409f51488e8deefb6edcc1ce4771dfb5da2fe7b3bc075709a030c2b682a4
   google-cloud-env (2.4.0) sha256=01cb35ecee5d1c4d1cd4deaed8bb5bddc838e296bcc2a35c5d1ddd07ce40d28d
   google-cloud-errors (1.7.0) sha256=6e682f42d89aae08689f36f28495de629d756da076bafff0003bac7f8042ebb3
-  google-cloud-os_config-v1 (1.9.0) sha256=693c13690cfd7cf9d307c25d005ff33b823b6709791d3714c344ff1597ec3a30
-  google-cloud-pubsub (3.4.0) sha256=6a6390a6f605701945d5be233dea51e0b04009f157b5d701b092423fbc690edd
-  google-cloud-pubsub-v1 (1.16.0) sha256=ffe128821208bd3d2f27cb0d25eb6accb3893c99e0b736d1740b8b5e1570426b
+  google-cloud-logging (2.7.0) sha256=b31e457d9773ceafcd68b146708b4e793796615880a0b7ef7d8cf841b23aff74
+  google-cloud-logging-v2 (1.7.0) sha256=5cfc51acf83825d50d724638344fb0bf00ca1b6a8d3440ede8af8f455c8cde31
   google-cloud-storage (1.62.0) sha256=e2c3c08bf8fd40d50be92304084942203314d4fc0ee52028e99f9359c3ad1330
-  google-iam-v1 (1.7.0) sha256=9e3ea9dcc59cbd5f8d2f62b00da41ec57a2e427b33c0e798207fa06c8fbb8b87
-  google-identity-access_context_manager-v1 (0.15.0) sha256=8f105320bcbdc03c7fdb05369886117b4f341b792ed4ab81a144929bbcd7820b
   google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
   google-protobuf (4.35.1) sha256=a3a6471331d918f58dfa4d014a8f6286f0af2cf4840216bde52fcf2ea3fe3726
   google-protobuf (4.35.1-aarch64-linux-gnu) sha256=50ca44d0eeff3f8475e630a1accdd974256f3510694d574e2c9d6119ea8bc9e1
@@ -270,7 +246,8 @@ CHECKSUMS
   google-protobuf (4.35.1-x86_64-darwin) sha256=66b62b4df00931018a692806df66393efa960d6d2b7da69735187249f950d3ee
   google-protobuf (4.35.1-x86_64-linux-gnu) sha256=c786439087512a3fbd199e9897d265b855f951d4027e218ea55e858d45969edd
   google-protobuf (4.35.1-x86_64-linux-musl) sha256=91890eb0002934a339fdb7d77a147c46b7474b6799db27872b747b905837f744
-  googleapis-common-protos (1.9.0) sha256=207be372d8d25e3876e1e1155d057e14f3c92f8f5428772864a8ce04a0b756e4
+  google-style (1.25.3) sha256=d417fd0f6d6a9f4bb2ff69e1cfaa1c4d0e19230589cdf4383df4540082c395d4
+  googleapis-common-protos (1.10.0) sha256=13e47ad0ce85d3d30065c03863efd302a82b0e08ba576f2a9b9dbbfeecb57ee0
   googleapis-common-protos-types (1.23.0) sha256=992e740a523794d9fc5f29a504465d8fc737aaa16c930fe7228e3346860faf0a
   googleauth (1.17.3) sha256=9a655455885c0c17a8b70537acd2a992a7c7842c43c06c6612dfb0d93e755d58
   grpc (1.83.0) sha256=38119e7f9f7cbc98e79145201da4be470a7542b0befad454651d35015ea55c59
@@ -282,24 +259,36 @@ CHECKSUMS
   grpc (1.83.0-x86_64-darwin) sha256=cfad91d559d1907159a5247fb12dc112a8ea0ebe2027ca7f5ab648d01a645716
   grpc (1.83.0-x86_64-linux-gnu) sha256=25d66bfa3cb1b05258b3f9632478c7e7ceb52cb16ccc0b4b26d7df36be7158b1
   grpc (1.83.0-x86_64-linux-musl) sha256=a5023264dbb8038c23b147bbf80adb06932ef11b5ab493412e9e37a43114fa8c
-  grpc-google-iam-v1 (1.12.0) sha256=a70ecad8987e340d5e22e7bf01be31256c84b29a3f78bebd385a4a110e1f2aef
   json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   minitest-focus (1.4.1) sha256=394517cbe2dcb2d992d8ffc41a3b2b6315777a4daa69239de4fefe7110dd810e
+  minitest-rg (5.4.0) sha256=54d42bb8ce876381245be5866f3c1dd704ef79c06ba5c9ff280c0aa28c56effb
   multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
   os (1.1.4) sha256=57816d6a334e7bd6aed048f4b0308226c5fb027433b67d90a9ab435f35108d3f
+  parallel (1.28.0) sha256=33e6de1484baf2524792d178b0913fc8eb94c628d6cfe45599ad4458c638c970
+  parser (3.3.12.0) sha256=21a6d7f755d5a24dfbdc6e6b772e4e879a52e7631a88bc5a3a134606052c9828
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   pstore (0.2.1) sha256=03904d0f2c66579e96d1e6704cdabc0c88df7ea8ed8782d9f3569f6f6c702c1a
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
+  regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
   representable (3.2.0) sha256=cc29bf7eebc31653586849371a43ffe36c60b54b0a6365b5f7d95ec34d1ebace
-  retriable (3.8.0) sha256=9f2f1b0207594c7817f17f671587b8ec7587387ac6cebda6c941a802bb98a8e5
+  retriable (4.2.0) sha256=90c3b257472a1c02f2a3dfa64dd35a420f7a624cef1a5981e20fdac5730f8cdc
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rubocop (1.28.2) sha256=0d9bf4108fd86ede43c6cf30adcb3dd2e0c6750941c5ec2a00621478157cb377
+  rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   signet (0.22.0) sha256=b76d495ccb07ad35dbc89f3e920665a9d8ed717141955034005d7843dcfe4780
+  stackdriver-core (1.8.0) sha256=3a8f35ec5bf51cd3b3e8903afb2fa1285fcd1a3c93ab39eaaa850102590843e3
   trailblazer-option (0.1.2) sha256=20e4f12ea4e1f718c8007e7944ca21a329eee4eed9e0fa5dde6e8ad8ac4344a3
   uber (0.1.0) sha256=5beeb407ff807b5db994f82fa9ee07cfceaa561dad8af20be880bc67eba935dc
+  unicode-display_width (2.6.0) sha256=12279874bba6d5e4d2728cef814b19197dbb10d7a7837a869bab65da943b7f5a
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
 
 BUNDLED WITH

--- a/google-cloud-monitoring/samples/Gemfile.lock
+++ b/google-cloud-monitoring/samples/Gemfile.lock
@@ -3,18 +3,14 @@ GEM
   specs:
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.1.2)
-    concurrent-ruby (1.3.8)
-    declarative (0.0.20)
-    digest-crc (0.7.0)
-      rake (>= 12.0.0, < 14.0.0)
+    erb (6.0.6)
     faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-follow_redirects (0.5.0)
-      faraday (>= 1, < 3)
     faraday-net_http (3.4.4)
       net-http (~> 0.5)
     faraday-retry (2.4.0)
@@ -29,47 +25,6 @@ GEM
       googleapis-common-protos-types (~> 1.15)
       googleauth (~> 1.12)
       grpc (~> 1.66)
-    google-apis-bigquery_v2 (0.106.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-<<<<<<< HEAD
-    google-apis-core (1.2.99)
-      addressable (~> 2.8, >= 2.8.7)
-=======
-    google-apis-core (1.2.5)
-      addressable (~> 2.9)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-      faraday (~> 2.13)
-      faraday-follow_redirects (~> 0.3)
-      googleauth (~> 1.14)
-      mini_mime (~> 1.1)
-      multi_json (~> 1.11)
-      representable (~> 3.0)
-<<<<<<< HEAD
-      retriable (~> 3.1)
-=======
-      retriable (>= 3.1, < 5.0)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-    google-apis-iamcredentials_v1 (0.28.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-    google-apis-storage_v1 (0.65.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-    google-cloud-asset (1.10.0)
-      google-cloud-asset-v1 (>= 0.29, < 2.a)
-      google-cloud-core (~> 1.6)
-    google-cloud-asset-v1 (1.9.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-cloud-os_config-v1 (> 0.0, < 2.a)
-      google-identity-access_context_manager-v1 (> 0.0, < 2.a)
-      grpc-google-iam-v1 (~> 1.11)
-    google-cloud-bigquery (1.64.0)
-      bigdecimal (>= 3.0, < 5)
-      concurrent-ruby (~> 1.0)
-      google-apis-bigquery_v2 (~> 0.71)
-      google-apis-core (>= 0.18, < 2)
-      google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
     google-cloud-core (1.9.0)
       google-cloud-env (>= 1.0, < 3.a)
       google-cloud-errors (~> 1.0)
@@ -77,35 +32,20 @@ GEM
       base64 (~> 0.2)
       faraday (>= 1.0, < 3.a)
     google-cloud-errors (1.7.0)
-    google-cloud-os_config-v1 (1.9.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-    google-cloud-pubsub (3.4.0)
-      concurrent-ruby (~> 1.3)
-      google-cloud-core (~> 1.8)
-      google-cloud-pubsub-v1 (~> 1.11)
-      retriable (~> 3.1)
-    google-cloud-pubsub-v1 (1.16.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-iam-v1 (~> 1.3)
-    google-cloud-storage (1.62.0)
-      addressable (~> 2.8)
-      digest-crc (~> 0.4)
-      google-apis-core (>= 0.18, < 2)
-      google-apis-iamcredentials_v1 (~> 0.18)
-      google-apis-storage_v1 (>= 0.42)
+    google-cloud-monitoring (1.11.0)
       google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
-    google-iam-v1 (1.7.0)
+      google-cloud-monitoring-dashboard-v1 (>= 0.14, < 2.a)
+      google-cloud-monitoring-metrics_scope-v1 (>= 0.5, < 2.a)
+      google-cloud-monitoring-v3 (>= 0.15, < 2.a)
+    google-cloud-monitoring-dashboard-v1 (1.7.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
-      grpc-google-iam-v1 (~> 1.11)
-    google-identity-access_context_manager-v1 (0.15.0)
+    google-cloud-monitoring-metrics_scope-v1 (1.8.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
-      grpc-google-iam-v1 (~> 1.11)
+    google-cloud-monitoring-v3 (1.10.0)
+      gapic-common (~> 1.3)
+      google-cloud-errors (~> 1.0)
     google-logging-utils (0.2.0)
     google-protobuf (4.35.1)
       bigdecimal
@@ -134,7 +74,9 @@ GEM
     google-protobuf (4.35.1-x86_64-linux-musl)
       bigdecimal
       rake (~> 13.3)
-    googleapis-common-protos (1.9.0)
+    google-style (1.25.3)
+      rubocop (~> 1.28.2)
+    googleapis-common-protos (1.10.0)
       google-protobuf (~> 4.26)
       googleapis-common-protos-types (~> 1.21)
       grpc (~> 1.41)
@@ -175,36 +117,69 @@ GEM
     grpc (1.83.0-x86_64-linux-musl)
       google-protobuf (>= 3.25, < 5.0)
       googleapis-common-protos-types (~> 1.0)
-    grpc-google-iam-v1 (1.12.0)
-      google-protobuf (>= 3.18, < 5.a)
-      googleapis-common-protos (~> 1.9.0)
-      grpc (~> 1.41)
+    io-console (0.8.2)
+    irb (1.18.0)
+      pp (>= 0.6.0)
+      prism (>= 1.3.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
     json (2.21.2)
     jwt (3.2.0)
       base64
     logger (1.7.0)
-    mini_mime (1.1.5)
     minitest (5.27.0)
     minitest-focus (1.4.1)
       minitest (> 5.0)
-    multi_json (1.21.1)
+    minitest-hooks (1.5.4)
+      minitest (> 5.3)
     net-http (0.9.1)
       uri (>= 0.11.1)
     os (1.1.4)
+    parallel (1.28.0)
+    parser (3.3.12.0)
+      ast (~> 2.4.1)
+      racc
+    pp (0.6.4)
+      prettyprint
+    prettyprint (0.2.0)
+    prism (1.9.0)
     pstore (0.2.1)
     public_suffix (7.0.5)
+    racc (1.8.1)
+    rainbow (3.1.1)
     rake (13.4.2)
-    representable (3.2.0)
-      declarative (< 0.1.0)
-      trailblazer-option (>= 0.1.1, < 0.2.0)
-      uber (< 0.2.0)
-    retriable (3.8.0)
+    rbs (4.1.2)
+      logger
+      prism (>= 1.6.0)
+      tsort
+    rdoc (8.0.0)
+      erb
+      prism (>= 1.6.0)
+      rbs (>= 4.0.0)
+      tsort
+    regexp_parser (2.12.0)
+    reline (0.6.3)
+      io-console (~> 0.5)
+    rexml (3.4.4)
+    rubocop (1.28.2)
+      parallel (~> 1.10)
+      parser (>= 3.1.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.17.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.50.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    ruby-progressbar (1.13.0)
     signet (0.22.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 4.0)
-    trailblazer-option (0.1.2)
-    uber (0.1.0)
+    tsort (0.2.0)
+    unicode-display_width (2.6.0)
     uri (1.1.1)
 
 PLATFORMS
@@ -219,47 +194,34 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  google-cloud-asset
-  google-cloud-bigquery
-  google-cloud-pubsub
-  google-cloud-storage
+  google-cloud-monitoring
+  google-cloud-monitoring-dashboard-v1
+  google-cloud-monitoring-v3
+  google-style (~> 1.25.1)
+  irb
   minitest (~> 5.14)
-  minitest-focus
-  rake
+  minitest-focus (~> 1.1)
+  minitest-hooks (~> 1.5)
+  rake (>= 12.0)
 
 CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
-  concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
-  declarative (0.0.20) sha256=8021dd6cb17ab2b61233c56903d3f5a259c5cf43c80ff332d447d395b17d9ff9
-  digest-crc (0.7.0) sha256=64adc23a26a241044cbe6732477ca1b3c281d79e2240bcff275a37a5a0d78c07
+  erb (6.0.6) sha256=a9b24986700f5bf127c4f297c5403c3ca41b83b0a316c0cd09a096b56e644ae5
   faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
-  faraday-follow_redirects (0.5.0) sha256=5cde93c894b30943a5d2b93c2fe9284216a6b756f7af406a1e55f211d97d10ad
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
   faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
   gapic-common (1.3.0) sha256=4e5d9be1effb7366e2cda13c0f44922285d5613ac8de8b9b18c2c835fe4faa91
-  google-apis-bigquery_v2 (0.106.0) sha256=a0f4243b634a0c79c29b7dacdd79233bd9c9ba2eda6fde9c2b19414fd165dd93
-<<<<<<< HEAD
-  google-apis-core (1.2.99)
-=======
-  google-apis-core (1.2.5) sha256=e21562b5627a0fc6a0c3165e429c3afed0f6a628eaa514e83f7204dda1adff69
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-  google-apis-iamcredentials_v1 (0.28.0) sha256=0a92ffe6cc39c569554af2a77a25dfc61519ed8bbb64ab04cffdd352dc5ef106
-  google-apis-storage_v1 (0.65.0) sha256=4247aa542931691f6988ab61e45cdea2878cbfe897a98eec4af9cdcb678eb359
-  google-cloud-asset (1.10.0) sha256=6ea6fd9e0735873884094c14d84d5a6d826b0e07aaeec245d34735ab2c5828e0
-  google-cloud-asset-v1 (1.9.0) sha256=ecfb654d0d350ed98209d46937c8095ec867c8ff6c3f7d70b8889f6fb70fd397
-  google-cloud-bigquery (1.64.0) sha256=d807363903e08958c3bc09ccc1f9d1218646c8f18176751879348a1a4a884d57
   google-cloud-core (1.9.0) sha256=ab55409f51488e8deefb6edcc1ce4771dfb5da2fe7b3bc075709a030c2b682a4
   google-cloud-env (2.4.0) sha256=01cb35ecee5d1c4d1cd4deaed8bb5bddc838e296bcc2a35c5d1ddd07ce40d28d
   google-cloud-errors (1.7.0) sha256=6e682f42d89aae08689f36f28495de629d756da076bafff0003bac7f8042ebb3
-  google-cloud-os_config-v1 (1.9.0) sha256=693c13690cfd7cf9d307c25d005ff33b823b6709791d3714c344ff1597ec3a30
-  google-cloud-pubsub (3.4.0) sha256=6a6390a6f605701945d5be233dea51e0b04009f157b5d701b092423fbc690edd
-  google-cloud-pubsub-v1 (1.16.0) sha256=ffe128821208bd3d2f27cb0d25eb6accb3893c99e0b736d1740b8b5e1570426b
-  google-cloud-storage (1.62.0) sha256=e2c3c08bf8fd40d50be92304084942203314d4fc0ee52028e99f9359c3ad1330
-  google-iam-v1 (1.7.0) sha256=9e3ea9dcc59cbd5f8d2f62b00da41ec57a2e427b33c0e798207fa06c8fbb8b87
-  google-identity-access_context_manager-v1 (0.15.0) sha256=8f105320bcbdc03c7fdb05369886117b4f341b792ed4ab81a144929bbcd7820b
+  google-cloud-monitoring (1.11.0) sha256=113564e0d3e64cd30b0834f2bdb5a83310769629ffba985e0b5f82f669490843
+  google-cloud-monitoring-dashboard-v1 (1.7.0) sha256=0c15903dca5376420c1dbec4d692bd49cba328ae14c7cc2cda72858a3c35e510
+  google-cloud-monitoring-metrics_scope-v1 (1.8.0) sha256=96002010c0fdd92282db93b2d8270a07018bcc4b20d5f4193e1d16b9f6c4dfa5
+  google-cloud-monitoring-v3 (1.10.0) sha256=c2645aab857071b8f46cbb9f6fcb0ac5da53ab4cd44df16514eb81d1a47e2269
   google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
   google-protobuf (4.35.1) sha256=a3a6471331d918f58dfa4d014a8f6286f0af2cf4840216bde52fcf2ea3fe3726
   google-protobuf (4.35.1-aarch64-linux-gnu) sha256=50ca44d0eeff3f8475e630a1accdd974256f3510694d574e2c9d6119ea8bc9e1
@@ -270,7 +232,8 @@ CHECKSUMS
   google-protobuf (4.35.1-x86_64-darwin) sha256=66b62b4df00931018a692806df66393efa960d6d2b7da69735187249f950d3ee
   google-protobuf (4.35.1-x86_64-linux-gnu) sha256=c786439087512a3fbd199e9897d265b855f951d4027e218ea55e858d45969edd
   google-protobuf (4.35.1-x86_64-linux-musl) sha256=91890eb0002934a339fdb7d77a147c46b7474b6799db27872b747b905837f744
-  googleapis-common-protos (1.9.0) sha256=207be372d8d25e3876e1e1155d057e14f3c92f8f5428772864a8ce04a0b756e4
+  google-style (1.25.3) sha256=d417fd0f6d6a9f4bb2ff69e1cfaa1c4d0e19230589cdf4383df4540082c395d4
+  googleapis-common-protos (1.10.0) sha256=13e47ad0ce85d3d30065c03863efd302a82b0e08ba576f2a9b9dbbfeecb57ee0
   googleapis-common-protos-types (1.23.0) sha256=992e740a523794d9fc5f29a504465d8fc737aaa16c930fe7228e3346860faf0a
   googleauth (1.17.3) sha256=9a655455885c0c17a8b70537acd2a992a7c7842c43c06c6612dfb0d93e755d58
   grpc (1.83.0) sha256=38119e7f9f7cbc98e79145201da4be470a7542b0befad454651d35015ea55c59
@@ -282,24 +245,37 @@ CHECKSUMS
   grpc (1.83.0-x86_64-darwin) sha256=cfad91d559d1907159a5247fb12dc112a8ea0ebe2027ca7f5ab648d01a645716
   grpc (1.83.0-x86_64-linux-gnu) sha256=25d66bfa3cb1b05258b3f9632478c7e7ceb52cb16ccc0b4b26d7df36be7158b1
   grpc (1.83.0-x86_64-linux-musl) sha256=a5023264dbb8038c23b147bbf80adb06932ef11b5ab493412e9e37a43114fa8c
-  grpc-google-iam-v1 (1.12.0) sha256=a70ecad8987e340d5e22e7bf01be31256c84b29a3f78bebd385a4a110e1f2aef
+  io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
+  irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
   json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
-  mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   minitest-focus (1.4.1) sha256=394517cbe2dcb2d992d8ffc41a3b2b6315777a4daa69239de4fefe7110dd810e
-  multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080
+  minitest-hooks (1.5.4) sha256=1254069f3da51fea234dc4ff974108d03d19260ad5c4b78eed9695726a5069b8
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
   os (1.1.4) sha256=57816d6a334e7bd6aed048f4b0308226c5fb027433b67d90a9ab435f35108d3f
+  parallel (1.28.0) sha256=33e6de1484baf2524792d178b0913fc8eb94c628d6cfe45599ad4458c638c970
+  parser (3.3.12.0) sha256=21a6d7f755d5a24dfbdc6e6b772e4e879a52e7631a88bc5a3a134606052c9828
+  pp (0.6.4) sha256=dfcb0fce700c41456265922884f9fe195d7fbb0674a3578e6c0f69588e82b570
+  prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   pstore (0.2.1) sha256=03904d0f2c66579e96d1e6704cdabc0c88df7ea8ed8782d9f3569f6f6c702c1a
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
-  representable (3.2.0) sha256=cc29bf7eebc31653586849371a43ffe36c60b54b0a6365b5f7d95ec34d1ebace
-  retriable (3.8.0) sha256=9f2f1b0207594c7817f17f671587b8ec7587387ac6cebda6c941a802bb98a8e5
+  rbs (4.1.2) sha256=050eb1d8b508f1233bed929c0f2c7052302f7adf295230d9cb314e9024078f48
+  rdoc (8.0.0) sha256=03bf8c08a9639658855a0cfd77c0abca8325c227693f7f33f82957811348c469
+  regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
+  reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rubocop (1.28.2) sha256=0d9bf4108fd86ede43c6cf30adcb3dd2e0c6750941c5ec2a00621478157cb377
+  rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   signet (0.22.0) sha256=b76d495ccb07ad35dbc89f3e920665a9d8ed717141955034005d7843dcfe4780
-  trailblazer-option (0.1.2) sha256=20e4f12ea4e1f718c8007e7944ca21a329eee4eed9e0fa5dde6e8ad8ac4344a3
-  uber (0.1.0) sha256=5beeb407ff807b5db994f82fa9ee07cfceaa561dad8af20be880bc67eba935dc
+  tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
+  unicode-display_width (2.6.0) sha256=12279874bba6d5e4d2728cef814b19197dbb10d7a7837a869bab65da943b7f5a
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
 
 BUNDLED WITH

--- a/google-cloud-parameter_manager/samples/Gemfile.lock
+++ b/google-cloud-parameter_manager/samples/Gemfile.lock
@@ -3,18 +3,13 @@ GEM
   specs:
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.1.2)
-    concurrent-ruby (1.3.8)
-    declarative (0.0.20)
-    digest-crc (0.7.0)
-      rake (>= 12.0.0, < 14.0.0)
     faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-follow_redirects (0.5.0)
-      faraday (>= 1, < 3)
     faraday-net_http (3.4.4)
       net-http (~> 0.5)
     faraday-retry (2.4.0)
@@ -29,47 +24,6 @@ GEM
       googleapis-common-protos-types (~> 1.15)
       googleauth (~> 1.12)
       grpc (~> 1.66)
-    google-apis-bigquery_v2 (0.106.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-<<<<<<< HEAD
-    google-apis-core (1.2.99)
-      addressable (~> 2.8, >= 2.8.7)
-=======
-    google-apis-core (1.2.5)
-      addressable (~> 2.9)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-      faraday (~> 2.13)
-      faraday-follow_redirects (~> 0.3)
-      googleauth (~> 1.14)
-      mini_mime (~> 1.1)
-      multi_json (~> 1.11)
-      representable (~> 3.0)
-<<<<<<< HEAD
-      retriable (~> 3.1)
-=======
-      retriable (>= 3.1, < 5.0)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-    google-apis-iamcredentials_v1 (0.28.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-    google-apis-storage_v1 (0.65.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-    google-cloud-asset (1.10.0)
-      google-cloud-asset-v1 (>= 0.29, < 2.a)
-      google-cloud-core (~> 1.6)
-    google-cloud-asset-v1 (1.9.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-cloud-os_config-v1 (> 0.0, < 2.a)
-      google-identity-access_context_manager-v1 (> 0.0, < 2.a)
-      grpc-google-iam-v1 (~> 1.11)
-    google-cloud-bigquery (1.64.0)
-      bigdecimal (>= 3.0, < 5)
-      concurrent-ruby (~> 1.0)
-      google-apis-bigquery_v2 (~> 0.71)
-      google-apis-core (>= 0.18, < 2)
-      google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
     google-cloud-core (1.9.0)
       google-cloud-env (>= 1.0, < 3.a)
       google-cloud-errors (~> 1.0)
@@ -77,32 +31,34 @@ GEM
       base64 (~> 0.2)
       faraday (>= 1.0, < 3.a)
     google-cloud-errors (1.7.0)
-    google-cloud-os_config-v1 (1.9.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-    google-cloud-pubsub (3.4.0)
-      concurrent-ruby (~> 1.3)
-      google-cloud-core (~> 1.8)
-      google-cloud-pubsub-v1 (~> 1.11)
-      retriable (~> 3.1)
-    google-cloud-pubsub-v1 (1.16.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-iam-v1 (~> 1.3)
-    google-cloud-storage (1.62.0)
-      addressable (~> 2.8)
-      digest-crc (~> 0.4)
-      google-apis-core (>= 0.18, < 2)
-      google-apis-iamcredentials_v1 (~> 0.18)
-      google-apis-storage_v1 (>= 0.42)
+    google-cloud-kms (2.12.0)
       google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
-    google-iam-v1 (1.7.0)
+      google-cloud-kms-v1 (>= 0.26, < 2.a)
+    google-cloud-kms-v1 (1.15.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
+      google-cloud-location (~> 1.0)
+      google-iam-v1 (~> 1.3)
+    google-cloud-location (1.5.0)
+      gapic-common (~> 1.3)
+      google-cloud-errors (~> 1.0)
+    google-cloud-parameter_manager (1.0.0)
+      google-cloud-core (~> 1.6)
+      google-cloud-parameter_manager-v1 (>= 0.0, < 2.a)
+    google-cloud-parameter_manager-v1 (1.0.0)
+      gapic-common (~> 1.3)
+      google-cloud-errors (~> 1.0)
+      google-cloud-location (~> 1.0)
       grpc-google-iam-v1 (~> 1.11)
-    google-identity-access_context_manager-v1 (0.15.0)
+    google-cloud-secret_manager (2.2.0)
+      google-cloud-core (~> 1.6)
+      google-cloud-secret_manager-v1 (~> 1.2)
+    google-cloud-secret_manager-v1 (1.9.0)
+      gapic-common (~> 1.3)
+      google-cloud-errors (~> 1.0)
+      google-cloud-location (~> 1.0)
+      grpc-google-iam-v1 (~> 1.11)
+    google-iam-v1 (1.7.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
       grpc-google-iam-v1 (~> 1.11)
@@ -134,6 +90,8 @@ GEM
     google-protobuf (4.35.1-x86_64-linux-musl)
       bigdecimal
       rake (~> 13.3)
+    google-style (1.30.1)
+      rubocop (~> 1.63)
     googleapis-common-protos (1.9.0)
       google-protobuf (~> 4.26)
       googleapis-common-protos-types (~> 1.21)
@@ -182,29 +140,50 @@ GEM
     json (2.21.2)
     jwt (3.2.0)
       base64
+    language_server-protocol (3.17.0.6)
+    lint_roller (1.1.0)
     logger (1.7.0)
-    mini_mime (1.1.5)
     minitest (5.27.0)
     minitest-focus (1.4.1)
       minitest (> 5.0)
-    multi_json (1.21.1)
+    minitest-rg (5.4.0)
+      minitest (>= 5.0, < 7)
     net-http (0.9.1)
       uri (>= 0.11.1)
     os (1.1.4)
+    parallel (1.28.0)
+    parser (3.3.12.0)
+      ast (~> 2.4.1)
+      racc
+    prism (1.9.0)
     pstore (0.2.1)
     public_suffix (7.0.5)
+    racc (1.8.1)
+    rainbow (3.1.1)
     rake (13.4.2)
-    representable (3.2.0)
-      declarative (< 0.1.0)
-      trailblazer-option (>= 0.1.1, < 0.2.0)
-      uber (< 0.2.0)
-    retriable (3.8.0)
+    regexp_parser (2.12.0)
+    rubocop (1.88.2)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (>= 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.50.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    ruby-progressbar (1.13.0)
     signet (0.22.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 4.0)
-    trailblazer-option (0.1.2)
-    uber (0.1.0)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
     uri (1.1.1)
 
 PLATFORMS
@@ -219,47 +198,36 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  google-cloud-asset
-  google-cloud-bigquery
-  google-cloud-pubsub
-  google-cloud-storage
+  google-cloud-kms
+  google-cloud-parameter_manager
+  google-cloud-secret_manager
+  google-style (~> 1.30.1)
   minitest (~> 5.14)
-  minitest-focus
+  minitest-focus (~> 1.1)
+  minitest-rg (~> 5.2)
   rake
 
 CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
-  concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
-  declarative (0.0.20) sha256=8021dd6cb17ab2b61233c56903d3f5a259c5cf43c80ff332d447d395b17d9ff9
-  digest-crc (0.7.0) sha256=64adc23a26a241044cbe6732477ca1b3c281d79e2240bcff275a37a5a0d78c07
   faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
-  faraday-follow_redirects (0.5.0) sha256=5cde93c894b30943a5d2b93c2fe9284216a6b756f7af406a1e55f211d97d10ad
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
   faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
   gapic-common (1.3.0) sha256=4e5d9be1effb7366e2cda13c0f44922285d5613ac8de8b9b18c2c835fe4faa91
-  google-apis-bigquery_v2 (0.106.0) sha256=a0f4243b634a0c79c29b7dacdd79233bd9c9ba2eda6fde9c2b19414fd165dd93
-<<<<<<< HEAD
-  google-apis-core (1.2.99)
-=======
-  google-apis-core (1.2.5) sha256=e21562b5627a0fc6a0c3165e429c3afed0f6a628eaa514e83f7204dda1adff69
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-  google-apis-iamcredentials_v1 (0.28.0) sha256=0a92ffe6cc39c569554af2a77a25dfc61519ed8bbb64ab04cffdd352dc5ef106
-  google-apis-storage_v1 (0.65.0) sha256=4247aa542931691f6988ab61e45cdea2878cbfe897a98eec4af9cdcb678eb359
-  google-cloud-asset (1.10.0) sha256=6ea6fd9e0735873884094c14d84d5a6d826b0e07aaeec245d34735ab2c5828e0
-  google-cloud-asset-v1 (1.9.0) sha256=ecfb654d0d350ed98209d46937c8095ec867c8ff6c3f7d70b8889f6fb70fd397
-  google-cloud-bigquery (1.64.0) sha256=d807363903e08958c3bc09ccc1f9d1218646c8f18176751879348a1a4a884d57
   google-cloud-core (1.9.0) sha256=ab55409f51488e8deefb6edcc1ce4771dfb5da2fe7b3bc075709a030c2b682a4
   google-cloud-env (2.4.0) sha256=01cb35ecee5d1c4d1cd4deaed8bb5bddc838e296bcc2a35c5d1ddd07ce40d28d
   google-cloud-errors (1.7.0) sha256=6e682f42d89aae08689f36f28495de629d756da076bafff0003bac7f8042ebb3
-  google-cloud-os_config-v1 (1.9.0) sha256=693c13690cfd7cf9d307c25d005ff33b823b6709791d3714c344ff1597ec3a30
-  google-cloud-pubsub (3.4.0) sha256=6a6390a6f605701945d5be233dea51e0b04009f157b5d701b092423fbc690edd
-  google-cloud-pubsub-v1 (1.16.0) sha256=ffe128821208bd3d2f27cb0d25eb6accb3893c99e0b736d1740b8b5e1570426b
-  google-cloud-storage (1.62.0) sha256=e2c3c08bf8fd40d50be92304084942203314d4fc0ee52028e99f9359c3ad1330
+  google-cloud-kms (2.12.0) sha256=c546fea8e7f0d07e09532fa0714cd783424d8dc7d859334940e7cb6e2e788d8c
+  google-cloud-kms-v1 (1.15.0) sha256=25942a07b11809bc535263bb4ce7e0d9ccef5e863463374defd7487dcd07ef97
+  google-cloud-location (1.5.0) sha256=336f94609b1fb18fce1929048fac964f4d5a87d27c1e5444bfed3605469c7532
+  google-cloud-parameter_manager (1.0.0) sha256=77330ff224a44fd0ebb525b62b1ae048e48f70a65bca0ceafe99767d24a796e5
+  google-cloud-parameter_manager-v1 (1.0.0) sha256=671faff78b7ab2e1a6928d528feef9a282d98747ecc6f3d40b876b866a7dc5d7
+  google-cloud-secret_manager (2.2.0) sha256=71a61a1427c0b9c5876ae99b4a61a92e62af8b6f0c0c9f0639dbeff8f27c3cea
+  google-cloud-secret_manager-v1 (1.9.0) sha256=f24397f11fcf6e3e17c6a8add1370f1f1ea679a2134876a35990a549ec346bc9
   google-iam-v1 (1.7.0) sha256=9e3ea9dcc59cbd5f8d2f62b00da41ec57a2e427b33c0e798207fa06c8fbb8b87
-  google-identity-access_context_manager-v1 (0.15.0) sha256=8f105320bcbdc03c7fdb05369886117b4f341b792ed4ab81a144929bbcd7820b
   google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
   google-protobuf (4.35.1) sha256=a3a6471331d918f58dfa4d014a8f6286f0af2cf4840216bde52fcf2ea3fe3726
   google-protobuf (4.35.1-aarch64-linux-gnu) sha256=50ca44d0eeff3f8475e630a1accdd974256f3510694d574e2c9d6119ea8bc9e1
@@ -270,6 +238,7 @@ CHECKSUMS
   google-protobuf (4.35.1-x86_64-darwin) sha256=66b62b4df00931018a692806df66393efa960d6d2b7da69735187249f950d3ee
   google-protobuf (4.35.1-x86_64-linux-gnu) sha256=c786439087512a3fbd199e9897d265b855f951d4027e218ea55e858d45969edd
   google-protobuf (4.35.1-x86_64-linux-musl) sha256=91890eb0002934a339fdb7d77a147c46b7474b6799db27872b747b905837f744
+  google-style (1.30.1) sha256=ae9260c1f86856d8179a17fb270ccc2137ec0c0baa2a728ab5c8e7d76ce4032a
   googleapis-common-protos (1.9.0) sha256=207be372d8d25e3876e1e1155d057e14f3c92f8f5428772864a8ce04a0b756e4
   googleapis-common-protos-types (1.23.0) sha256=992e740a523794d9fc5f29a504465d8fc737aaa16c930fe7228e3346860faf0a
   googleauth (1.17.3) sha256=9a655455885c0c17a8b70537acd2a992a7c7842c43c06c6612dfb0d93e755d58
@@ -285,21 +254,29 @@ CHECKSUMS
   grpc-google-iam-v1 (1.12.0) sha256=a70ecad8987e340d5e22e7bf01be31256c84b29a3f78bebd385a4a110e1f2aef
   json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
+  language_server-protocol (3.17.0.6) sha256=5ef2c0c138f8267e1bc631d3328347d354f96724b0af22f2c79516120443b7f0
+  lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
-  mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   minitest-focus (1.4.1) sha256=394517cbe2dcb2d992d8ffc41a3b2b6315777a4daa69239de4fefe7110dd810e
-  multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080
+  minitest-rg (5.4.0) sha256=54d42bb8ce876381245be5866f3c1dd704ef79c06ba5c9ff280c0aa28c56effb
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
   os (1.1.4) sha256=57816d6a334e7bd6aed048f4b0308226c5fb027433b67d90a9ab435f35108d3f
+  parallel (1.28.0) sha256=33e6de1484baf2524792d178b0913fc8eb94c628d6cfe45599ad4458c638c970
+  parser (3.3.12.0) sha256=21a6d7f755d5a24dfbdc6e6b772e4e879a52e7631a88bc5a3a134606052c9828
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   pstore (0.2.1) sha256=03904d0f2c66579e96d1e6704cdabc0c88df7ea8ed8782d9f3569f6f6c702c1a
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
-  representable (3.2.0) sha256=cc29bf7eebc31653586849371a43ffe36c60b54b0a6365b5f7d95ec34d1ebace
-  retriable (3.8.0) sha256=9f2f1b0207594c7817f17f671587b8ec7587387ac6cebda6c941a802bb98a8e5
+  regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
+  rubocop (1.88.2) sha256=8def251c90cd955feb4daa3edc0ab56893250c4ce90ef81e6c80c03f9a939bbf
+  rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   signet (0.22.0) sha256=b76d495ccb07ad35dbc89f3e920665a9d8ed717141955034005d7843dcfe4780
-  trailblazer-option (0.1.2) sha256=20e4f12ea4e1f718c8007e7944ca21a329eee4eed9e0fa5dde6e8ad8ac4344a3
-  uber (0.1.0) sha256=5beeb407ff807b5db994f82fa9ee07cfceaa561dad8af20be880bc67eba935dc
+  unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
+  unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
 
 BUNDLED WITH

--- a/google-cloud-pubsub/samples/Gemfile.lock
+++ b/google-cloud-pubsub/samples/Gemfile.lock
@@ -3,12 +3,13 @@ GEM
   specs:
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    ast (2.4.3)
+    avro (1.12.1)
+      multi_json (~> 1.0)
     base64 (0.3.0)
     bigdecimal (4.1.2)
     concurrent-ruby (1.3.8)
     declarative (0.0.20)
-    digest-crc (0.7.0)
-      rake (>= 12.0.0, < 14.0.0)
     faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
@@ -31,37 +32,15 @@ GEM
       grpc (~> 1.66)
     google-apis-bigquery_v2 (0.106.0)
       google-apis-core (>= 0.15.0, < 2.a)
-<<<<<<< HEAD
-    google-apis-core (1.2.99)
-      addressable (~> 2.8, >= 2.8.7)
-=======
     google-apis-core (1.2.5)
       addressable (~> 2.9)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
       faraday (~> 2.13)
       faraday-follow_redirects (~> 0.3)
       googleauth (~> 1.14)
       mini_mime (~> 1.1)
       multi_json (~> 1.11)
       representable (~> 3.0)
-<<<<<<< HEAD
-      retriable (~> 3.1)
-=======
       retriable (>= 3.1, < 5.0)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-    google-apis-iamcredentials_v1 (0.28.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-    google-apis-storage_v1 (0.65.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-    google-cloud-asset (1.10.0)
-      google-cloud-asset-v1 (>= 0.29, < 2.a)
-      google-cloud-core (~> 1.6)
-    google-cloud-asset-v1 (1.9.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-cloud-os_config-v1 (> 0.0, < 2.a)
-      google-identity-access_context_manager-v1 (> 0.0, < 2.a)
-      grpc-google-iam-v1 (~> 1.11)
     google-cloud-bigquery (1.64.0)
       bigdecimal (>= 3.0, < 5)
       concurrent-ruby (~> 1.0)
@@ -77,9 +56,6 @@ GEM
       base64 (~> 0.2)
       faraday (>= 1.0, < 3.a)
     google-cloud-errors (1.7.0)
-    google-cloud-os_config-v1 (1.9.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
     google-cloud-pubsub (3.4.0)
       concurrent-ruby (~> 1.3)
       google-cloud-core (~> 1.8)
@@ -89,20 +65,7 @@ GEM
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
       google-iam-v1 (~> 1.3)
-    google-cloud-storage (1.62.0)
-      addressable (~> 2.8)
-      digest-crc (~> 0.4)
-      google-apis-core (>= 0.18, < 2)
-      google-apis-iamcredentials_v1 (~> 0.18)
-      google-apis-storage_v1 (>= 0.42)
-      google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
     google-iam-v1 (1.7.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      grpc-google-iam-v1 (~> 1.11)
-    google-identity-access_context_manager-v1 (0.15.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
       grpc-google-iam-v1 (~> 1.11)
@@ -134,6 +97,8 @@ GEM
     google-protobuf (4.35.1-x86_64-linux-musl)
       bigdecimal
       rake (~> 13.3)
+    google-style (1.25.3)
+      rubocop (~> 1.28.2)
     googleapis-common-protos (1.9.0)
       google-protobuf (~> 4.26)
       googleapis-common-protos-types (~> 1.21)
@@ -187,24 +152,70 @@ GEM
     minitest (5.27.0)
     minitest-focus (1.4.1)
       minitest (> 5.0)
+    minitest-hooks (1.5.4)
+      minitest (> 5.3)
     multi_json (1.21.1)
+    mustermann (3.1.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
     os (1.1.4)
+    parallel (1.28.0)
+    parser (3.3.12.0)
+      ast (~> 2.4.1)
+      racc
+    prism (1.9.0)
     pstore (0.2.1)
     public_suffix (7.0.5)
+    racc (1.8.1)
+    rack (3.2.6)
+    rack-protection (4.2.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
+    rack-session (2.1.2)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
+    rack-test (2.2.0)
+      rack (>= 1.3)
+    rainbow (3.1.1)
     rake (13.4.2)
+    regexp_parser (2.12.0)
     representable (3.2.0)
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
     retriable (3.8.0)
+    rexml (3.4.4)
+    rubocop (1.28.2)
+      parallel (~> 1.10)
+      parser (>= 3.1.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.17.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.50.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    ruby-progressbar (1.13.0)
     signet (0.22.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 4.0)
+    sinatra (4.2.1)
+      logger (>= 1.6.0)
+      mustermann (~> 3.0)
+      rack (>= 3.0.0, < 4)
+      rack-protection (= 4.2.1)
+      rack-session (>= 2.0.0, < 3)
+      tilt (~> 2.0)
+    tilt (2.8.0)
+    toys-core (0.22.0)
+      logger
     trailblazer-option (0.1.2)
     uber (0.1.0)
+    unicode-display_width (2.6.0)
     uri (1.1.1)
 
 PLATFORMS
@@ -219,47 +230,42 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  google-cloud-asset
+  avro (~> 1.10)
   google-cloud-bigquery
   google-cloud-pubsub
-  google-cloud-storage
+  google-logging-utils (~> 0.2.0)
+  google-style (~> 1.25.1)
   minitest (~> 5.14)
-  minitest-focus
+  minitest-focus (~> 1.1)
+  minitest-hooks (~> 1.5)
+  rack-test
   rake
+  sinatra
+  toys-core
 
 CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
+  avro (1.12.1) sha256=e2a32e605e935f9196d590bb193d1fa13b83d169303b811ecb614e67ad59ac43
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
   concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
   declarative (0.0.20) sha256=8021dd6cb17ab2b61233c56903d3f5a259c5cf43c80ff332d447d395b17d9ff9
-  digest-crc (0.7.0) sha256=64adc23a26a241044cbe6732477ca1b3c281d79e2240bcff275a37a5a0d78c07
   faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
   faraday-follow_redirects (0.5.0) sha256=5cde93c894b30943a5d2b93c2fe9284216a6b756f7af406a1e55f211d97d10ad
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
   faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
   gapic-common (1.3.0) sha256=4e5d9be1effb7366e2cda13c0f44922285d5613ac8de8b9b18c2c835fe4faa91
   google-apis-bigquery_v2 (0.106.0) sha256=a0f4243b634a0c79c29b7dacdd79233bd9c9ba2eda6fde9c2b19414fd165dd93
-<<<<<<< HEAD
-  google-apis-core (1.2.99)
-=======
   google-apis-core (1.2.5) sha256=e21562b5627a0fc6a0c3165e429c3afed0f6a628eaa514e83f7204dda1adff69
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-  google-apis-iamcredentials_v1 (0.28.0) sha256=0a92ffe6cc39c569554af2a77a25dfc61519ed8bbb64ab04cffdd352dc5ef106
-  google-apis-storage_v1 (0.65.0) sha256=4247aa542931691f6988ab61e45cdea2878cbfe897a98eec4af9cdcb678eb359
-  google-cloud-asset (1.10.0) sha256=6ea6fd9e0735873884094c14d84d5a6d826b0e07aaeec245d34735ab2c5828e0
-  google-cloud-asset-v1 (1.9.0) sha256=ecfb654d0d350ed98209d46937c8095ec867c8ff6c3f7d70b8889f6fb70fd397
   google-cloud-bigquery (1.64.0) sha256=d807363903e08958c3bc09ccc1f9d1218646c8f18176751879348a1a4a884d57
   google-cloud-core (1.9.0) sha256=ab55409f51488e8deefb6edcc1ce4771dfb5da2fe7b3bc075709a030c2b682a4
   google-cloud-env (2.4.0) sha256=01cb35ecee5d1c4d1cd4deaed8bb5bddc838e296bcc2a35c5d1ddd07ce40d28d
   google-cloud-errors (1.7.0) sha256=6e682f42d89aae08689f36f28495de629d756da076bafff0003bac7f8042ebb3
-  google-cloud-os_config-v1 (1.9.0) sha256=693c13690cfd7cf9d307c25d005ff33b823b6709791d3714c344ff1597ec3a30
   google-cloud-pubsub (3.4.0) sha256=6a6390a6f605701945d5be233dea51e0b04009f157b5d701b092423fbc690edd
   google-cloud-pubsub-v1 (1.16.0) sha256=ffe128821208bd3d2f27cb0d25eb6accb3893c99e0b736d1740b8b5e1570426b
-  google-cloud-storage (1.62.0) sha256=e2c3c08bf8fd40d50be92304084942203314d4fc0ee52028e99f9359c3ad1330
   google-iam-v1 (1.7.0) sha256=9e3ea9dcc59cbd5f8d2f62b00da41ec57a2e427b33c0e798207fa06c8fbb8b87
-  google-identity-access_context_manager-v1 (0.15.0) sha256=8f105320bcbdc03c7fdb05369886117b4f341b792ed4ab81a144929bbcd7820b
   google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
   google-protobuf (4.35.1) sha256=a3a6471331d918f58dfa4d014a8f6286f0af2cf4840216bde52fcf2ea3fe3726
   google-protobuf (4.35.1-aarch64-linux-gnu) sha256=50ca44d0eeff3f8475e630a1accdd974256f3510694d574e2c9d6119ea8bc9e1
@@ -270,6 +276,7 @@ CHECKSUMS
   google-protobuf (4.35.1-x86_64-darwin) sha256=66b62b4df00931018a692806df66393efa960d6d2b7da69735187249f950d3ee
   google-protobuf (4.35.1-x86_64-linux-gnu) sha256=c786439087512a3fbd199e9897d265b855f951d4027e218ea55e858d45969edd
   google-protobuf (4.35.1-x86_64-linux-musl) sha256=91890eb0002934a339fdb7d77a147c46b7474b6799db27872b747b905837f744
+  google-style (1.25.3) sha256=d417fd0f6d6a9f4bb2ff69e1cfaa1c4d0e19230589cdf4383df4540082c395d4
   googleapis-common-protos (1.9.0) sha256=207be372d8d25e3876e1e1155d057e14f3c92f8f5428772864a8ce04a0b756e4
   googleapis-common-protos-types (1.23.0) sha256=992e740a523794d9fc5f29a504465d8fc737aaa16c930fe7228e3346860faf0a
   googleauth (1.17.3) sha256=9a655455885c0c17a8b70537acd2a992a7c7842c43c06c6612dfb0d93e755d58
@@ -289,17 +296,37 @@ CHECKSUMS
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   minitest-focus (1.4.1) sha256=394517cbe2dcb2d992d8ffc41a3b2b6315777a4daa69239de4fefe7110dd810e
+  minitest-hooks (1.5.4) sha256=1254069f3da51fea234dc4ff974108d03d19260ad5c4b78eed9695726a5069b8
   multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080
+  mustermann (3.1.1) sha256=4c6170c7234d5499c345562ba7c7dfe73e1754286dcc1abb053064d66a127198
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
   os (1.1.4) sha256=57816d6a334e7bd6aed048f4b0308226c5fb027433b67d90a9ab435f35108d3f
+  parallel (1.28.0) sha256=33e6de1484baf2524792d178b0913fc8eb94c628d6cfe45599ad4458c638c970
+  parser (3.3.12.0) sha256=21a6d7f755d5a24dfbdc6e6b772e4e879a52e7631a88bc5a3a134606052c9828
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   pstore (0.2.1) sha256=03904d0f2c66579e96d1e6704cdabc0c88df7ea8ed8782d9f3569f6f6c702c1a
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2
+  rack-protection (4.2.1) sha256=cf6e2842df8c55f5e4d1a4be015e603e19e9bc3a7178bae58949ccbb58558bac
+  rack-session (2.1.2) sha256=595434f8c0c3473ae7d7ac56ecda6cc6dfd9d37c0b2b5255330aa1576967ffe8
+  rack-test (2.2.0) sha256=005a36692c306ac0b4a9350355ee080fd09ddef1148a5f8b2ac636c720f5c463
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
+  regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
   representable (3.2.0) sha256=cc29bf7eebc31653586849371a43ffe36c60b54b0a6365b5f7d95ec34d1ebace
   retriable (3.8.0) sha256=9f2f1b0207594c7817f17f671587b8ec7587387ac6cebda6c941a802bb98a8e5
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rubocop (1.28.2) sha256=0d9bf4108fd86ede43c6cf30adcb3dd2e0c6750941c5ec2a00621478157cb377
+  rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   signet (0.22.0) sha256=b76d495ccb07ad35dbc89f3e920665a9d8ed717141955034005d7843dcfe4780
+  sinatra (4.2.1) sha256=b7aeb9b11d046b552972ade834f1f9be98b185fa8444480688e3627625377080
+  tilt (2.8.0) sha256=ba472eb2716fe1e04112d6d219a9dae938ec09a6a1e2ad3ecc7922e79bde3721
+  toys-core (0.22.0) sha256=fb02aa335f03d3a9a2524c61ebc4324260fd960a7d8e052bcc1d1dca5fc1a1a6
   trailblazer-option (0.1.2) sha256=20e4f12ea4e1f718c8007e7944ca21a329eee4eed9e0fa5dde6e8ad8ac4344a3
   uber (0.1.0) sha256=5beeb407ff807b5db994f82fa9ee07cfceaa561dad8af20be880bc67eba935dc
+  unicode-display_width (2.6.0) sha256=12279874bba6d5e4d2728cef814b19197dbb10d7a7837a869bab65da943b7f5a
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
 
 BUNDLED WITH

--- a/google-cloud-recaptcha_enterprise/samples/Gemfile.lock
+++ b/google-cloud-recaptcha_enterprise/samples/Gemfile.lock
@@ -3,18 +3,13 @@ GEM
   specs:
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.1.2)
-    concurrent-ruby (1.3.8)
-    declarative (0.0.20)
-    digest-crc (0.7.0)
-      rake (>= 12.0.0, < 14.0.0)
     faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-follow_redirects (0.5.0)
-      faraday (>= 1, < 3)
     faraday-net_http (3.4.4)
       net-http (~> 0.5)
     faraday-retry (2.4.0)
@@ -29,47 +24,6 @@ GEM
       googleapis-common-protos-types (~> 1.15)
       googleauth (~> 1.12)
       grpc (~> 1.66)
-    google-apis-bigquery_v2 (0.106.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-<<<<<<< HEAD
-    google-apis-core (1.2.99)
-      addressable (~> 2.8, >= 2.8.7)
-=======
-    google-apis-core (1.2.5)
-      addressable (~> 2.9)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-      faraday (~> 2.13)
-      faraday-follow_redirects (~> 0.3)
-      googleauth (~> 1.14)
-      mini_mime (~> 1.1)
-      multi_json (~> 1.11)
-      representable (~> 3.0)
-<<<<<<< HEAD
-      retriable (~> 3.1)
-=======
-      retriable (>= 3.1, < 5.0)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-    google-apis-iamcredentials_v1 (0.28.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-    google-apis-storage_v1 (0.65.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-    google-cloud-asset (1.10.0)
-      google-cloud-asset-v1 (>= 0.29, < 2.a)
-      google-cloud-core (~> 1.6)
-    google-cloud-asset-v1 (1.9.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-cloud-os_config-v1 (> 0.0, < 2.a)
-      google-identity-access_context_manager-v1 (> 0.0, < 2.a)
-      grpc-google-iam-v1 (~> 1.11)
-    google-cloud-bigquery (1.64.0)
-      bigdecimal (>= 3.0, < 5)
-      concurrent-ruby (~> 1.0)
-      google-apis-bigquery_v2 (~> 0.71)
-      google-apis-core (>= 0.18, < 2)
-      google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
     google-cloud-core (1.9.0)
       google-cloud-env (>= 1.0, < 3.a)
       google-cloud-errors (~> 1.0)
@@ -77,35 +31,12 @@ GEM
       base64 (~> 0.2)
       faraday (>= 1.0, < 3.a)
     google-cloud-errors (1.7.0)
-    google-cloud-os_config-v1 (1.9.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-    google-cloud-pubsub (3.4.0)
-      concurrent-ruby (~> 1.3)
-      google-cloud-core (~> 1.8)
-      google-cloud-pubsub-v1 (~> 1.11)
-      retriable (~> 3.1)
-    google-cloud-pubsub-v1 (1.16.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-iam-v1 (~> 1.3)
-    google-cloud-storage (1.62.0)
-      addressable (~> 2.8)
-      digest-crc (~> 0.4)
-      google-apis-core (>= 0.18, < 2)
-      google-apis-iamcredentials_v1 (~> 0.18)
-      google-apis-storage_v1 (>= 0.42)
+    google-cloud-recaptcha_enterprise (2.2.0)
       google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
-    google-iam-v1 (1.7.0)
+      google-cloud-recaptcha_enterprise-v1 (~> 1.6)
+    google-cloud-recaptcha_enterprise-v1 (1.12.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
-      grpc-google-iam-v1 (~> 1.11)
-    google-identity-access_context_manager-v1 (0.15.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      grpc-google-iam-v1 (~> 1.11)
     google-logging-utils (0.2.0)
     google-protobuf (4.35.1)
       bigdecimal
@@ -134,7 +65,9 @@ GEM
     google-protobuf (4.35.1-x86_64-linux-musl)
       bigdecimal
       rake (~> 13.3)
-    googleapis-common-protos (1.9.0)
+    google-style (1.25.3)
+      rubocop (~> 1.28.2)
+    googleapis-common-protos (1.10.0)
       google-protobuf (~> 4.26)
       googleapis-common-protos-types (~> 1.21)
       grpc (~> 1.41)
@@ -175,37 +108,58 @@ GEM
     grpc (1.83.0-x86_64-linux-musl)
       google-protobuf (>= 3.25, < 5.0)
       googleapis-common-protos-types (~> 1.0)
-    grpc-google-iam-v1 (1.12.0)
-      google-protobuf (>= 3.18, < 5.a)
-      googleapis-common-protos (~> 1.9.0)
-      grpc (~> 1.41)
     json (2.21.2)
     jwt (3.2.0)
       base64
     logger (1.7.0)
-    mini_mime (1.1.5)
     minitest (5.27.0)
     minitest-focus (1.4.1)
       minitest (> 5.0)
-    multi_json (1.21.1)
+    minitest-hooks (1.5.4)
+      minitest (> 5.3)
     net-http (0.9.1)
       uri (>= 0.11.1)
     os (1.1.4)
+    parallel (1.28.0)
+    parser (3.3.12.0)
+      ast (~> 2.4.1)
+      racc
+    prism (1.9.0)
     pstore (0.2.1)
     public_suffix (7.0.5)
+    racc (1.8.1)
+    rainbow (3.1.1)
     rake (13.4.2)
-    representable (3.2.0)
-      declarative (< 0.1.0)
-      trailblazer-option (>= 0.1.1, < 0.2.0)
-      uber (< 0.2.0)
-    retriable (3.8.0)
+    regexp_parser (2.12.0)
+    rexml (3.4.4)
+    rubocop (1.28.2)
+      parallel (~> 1.10)
+      parser (>= 3.1.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.17.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.50.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    ruby-progressbar (1.13.0)
+    rubyzip (3.4.1)
+    selenium-webdriver (4.44.0)
+      base64 (~> 0.2)
+      logger (~> 1.4)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 4.0)
+      websocket (~> 1.0)
     signet (0.22.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 4.0)
-    trailblazer-option (0.1.2)
-    uber (0.1.0)
+    unicode-display_width (2.6.0)
     uri (1.1.1)
+    webrick (1.9.2)
+    websocket (1.2.11)
 
 PLATFORMS
   aarch64-linux-gnu
@@ -219,47 +173,30 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  google-cloud-asset
-  google-cloud-bigquery
-  google-cloud-pubsub
-  google-cloud-storage
+  google-cloud-recaptcha_enterprise
+  google-style (~> 1.25.1)
   minitest (~> 5.14)
-  minitest-focus
+  minitest-focus (~> 1.1)
+  minitest-hooks (~> 1.5)
   rake
+  selenium-webdriver (~> 4.1)
+  webrick (~> 1.7)
 
 CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
-  concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
-  declarative (0.0.20) sha256=8021dd6cb17ab2b61233c56903d3f5a259c5cf43c80ff332d447d395b17d9ff9
-  digest-crc (0.7.0) sha256=64adc23a26a241044cbe6732477ca1b3c281d79e2240bcff275a37a5a0d78c07
   faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
-  faraday-follow_redirects (0.5.0) sha256=5cde93c894b30943a5d2b93c2fe9284216a6b756f7af406a1e55f211d97d10ad
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
   faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
   gapic-common (1.3.0) sha256=4e5d9be1effb7366e2cda13c0f44922285d5613ac8de8b9b18c2c835fe4faa91
-  google-apis-bigquery_v2 (0.106.0) sha256=a0f4243b634a0c79c29b7dacdd79233bd9c9ba2eda6fde9c2b19414fd165dd93
-<<<<<<< HEAD
-  google-apis-core (1.2.99)
-=======
-  google-apis-core (1.2.5) sha256=e21562b5627a0fc6a0c3165e429c3afed0f6a628eaa514e83f7204dda1adff69
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-  google-apis-iamcredentials_v1 (0.28.0) sha256=0a92ffe6cc39c569554af2a77a25dfc61519ed8bbb64ab04cffdd352dc5ef106
-  google-apis-storage_v1 (0.65.0) sha256=4247aa542931691f6988ab61e45cdea2878cbfe897a98eec4af9cdcb678eb359
-  google-cloud-asset (1.10.0) sha256=6ea6fd9e0735873884094c14d84d5a6d826b0e07aaeec245d34735ab2c5828e0
-  google-cloud-asset-v1 (1.9.0) sha256=ecfb654d0d350ed98209d46937c8095ec867c8ff6c3f7d70b8889f6fb70fd397
-  google-cloud-bigquery (1.64.0) sha256=d807363903e08958c3bc09ccc1f9d1218646c8f18176751879348a1a4a884d57
   google-cloud-core (1.9.0) sha256=ab55409f51488e8deefb6edcc1ce4771dfb5da2fe7b3bc075709a030c2b682a4
   google-cloud-env (2.4.0) sha256=01cb35ecee5d1c4d1cd4deaed8bb5bddc838e296bcc2a35c5d1ddd07ce40d28d
   google-cloud-errors (1.7.0) sha256=6e682f42d89aae08689f36f28495de629d756da076bafff0003bac7f8042ebb3
-  google-cloud-os_config-v1 (1.9.0) sha256=693c13690cfd7cf9d307c25d005ff33b823b6709791d3714c344ff1597ec3a30
-  google-cloud-pubsub (3.4.0) sha256=6a6390a6f605701945d5be233dea51e0b04009f157b5d701b092423fbc690edd
-  google-cloud-pubsub-v1 (1.16.0) sha256=ffe128821208bd3d2f27cb0d25eb6accb3893c99e0b736d1740b8b5e1570426b
-  google-cloud-storage (1.62.0) sha256=e2c3c08bf8fd40d50be92304084942203314d4fc0ee52028e99f9359c3ad1330
-  google-iam-v1 (1.7.0) sha256=9e3ea9dcc59cbd5f8d2f62b00da41ec57a2e427b33c0e798207fa06c8fbb8b87
-  google-identity-access_context_manager-v1 (0.15.0) sha256=8f105320bcbdc03c7fdb05369886117b4f341b792ed4ab81a144929bbcd7820b
+  google-cloud-recaptcha_enterprise (2.2.0) sha256=84778f7eba34aff02bb563a7a544583f2de1252172af2d410b88b9867793775b
+  google-cloud-recaptcha_enterprise-v1 (1.12.0) sha256=b1862ab8e4f442701a114f09c1d4ad35d832499a0ec2b0da50dfb5b96bd6d6bb
   google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
   google-protobuf (4.35.1) sha256=a3a6471331d918f58dfa4d014a8f6286f0af2cf4840216bde52fcf2ea3fe3726
   google-protobuf (4.35.1-aarch64-linux-gnu) sha256=50ca44d0eeff3f8475e630a1accdd974256f3510694d574e2c9d6119ea8bc9e1
@@ -270,7 +207,8 @@ CHECKSUMS
   google-protobuf (4.35.1-x86_64-darwin) sha256=66b62b4df00931018a692806df66393efa960d6d2b7da69735187249f950d3ee
   google-protobuf (4.35.1-x86_64-linux-gnu) sha256=c786439087512a3fbd199e9897d265b855f951d4027e218ea55e858d45969edd
   google-protobuf (4.35.1-x86_64-linux-musl) sha256=91890eb0002934a339fdb7d77a147c46b7474b6799db27872b747b905837f744
-  googleapis-common-protos (1.9.0) sha256=207be372d8d25e3876e1e1155d057e14f3c92f8f5428772864a8ce04a0b756e4
+  google-style (1.25.3) sha256=d417fd0f6d6a9f4bb2ff69e1cfaa1c4d0e19230589cdf4383df4540082c395d4
+  googleapis-common-protos (1.10.0) sha256=13e47ad0ce85d3d30065c03863efd302a82b0e08ba576f2a9b9dbbfeecb57ee0
   googleapis-common-protos-types (1.23.0) sha256=992e740a523794d9fc5f29a504465d8fc737aaa16c930fe7228e3346860faf0a
   googleauth (1.17.3) sha256=9a655455885c0c17a8b70537acd2a992a7c7842c43c06c6612dfb0d93e755d58
   grpc (1.83.0) sha256=38119e7f9f7cbc98e79145201da4be470a7542b0befad454651d35015ea55c59
@@ -282,25 +220,34 @@ CHECKSUMS
   grpc (1.83.0-x86_64-darwin) sha256=cfad91d559d1907159a5247fb12dc112a8ea0ebe2027ca7f5ab648d01a645716
   grpc (1.83.0-x86_64-linux-gnu) sha256=25d66bfa3cb1b05258b3f9632478c7e7ceb52cb16ccc0b4b26d7df36be7158b1
   grpc (1.83.0-x86_64-linux-musl) sha256=a5023264dbb8038c23b147bbf80adb06932ef11b5ab493412e9e37a43114fa8c
-  grpc-google-iam-v1 (1.12.0) sha256=a70ecad8987e340d5e22e7bf01be31256c84b29a3f78bebd385a4a110e1f2aef
   json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
-  mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   minitest-focus (1.4.1) sha256=394517cbe2dcb2d992d8ffc41a3b2b6315777a4daa69239de4fefe7110dd810e
-  multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080
+  minitest-hooks (1.5.4) sha256=1254069f3da51fea234dc4ff974108d03d19260ad5c4b78eed9695726a5069b8
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
   os (1.1.4) sha256=57816d6a334e7bd6aed048f4b0308226c5fb027433b67d90a9ab435f35108d3f
+  parallel (1.28.0) sha256=33e6de1484baf2524792d178b0913fc8eb94c628d6cfe45599ad4458c638c970
+  parser (3.3.12.0) sha256=21a6d7f755d5a24dfbdc6e6b772e4e879a52e7631a88bc5a3a134606052c9828
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   pstore (0.2.1) sha256=03904d0f2c66579e96d1e6704cdabc0c88df7ea8ed8782d9f3569f6f6c702c1a
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
-  representable (3.2.0) sha256=cc29bf7eebc31653586849371a43ffe36c60b54b0a6365b5f7d95ec34d1ebace
-  retriable (3.8.0) sha256=9f2f1b0207594c7817f17f671587b8ec7587387ac6cebda6c941a802bb98a8e5
+  regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rubocop (1.28.2) sha256=0d9bf4108fd86ede43c6cf30adcb3dd2e0c6750941c5ec2a00621478157cb377
+  rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
+  rubyzip (3.4.1) sha256=0a79e745b5c25872ebd148457df5665da8530ed8626c993b01457128f173ca02
+  selenium-webdriver (4.44.0) sha256=6f1df072529af369589c46f0e01132952aabb250cfd683c274d74dc1eb5d8477
   signet (0.22.0) sha256=b76d495ccb07ad35dbc89f3e920665a9d8ed717141955034005d7843dcfe4780
-  trailblazer-option (0.1.2) sha256=20e4f12ea4e1f718c8007e7944ca21a329eee4eed9e0fa5dde6e8ad8ac4344a3
-  uber (0.1.0) sha256=5beeb407ff807b5db994f82fa9ee07cfceaa561dad8af20be880bc67eba935dc
+  unicode-display_width (2.6.0) sha256=12279874bba6d5e4d2728cef814b19197dbb10d7a7837a869bab65da943b7f5a
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
+  webrick (1.9.2) sha256=beb4a15fc474defed24a3bda4ffd88a490d517c9e4e6118c3edce59e45864131
+  websocket (1.2.11) sha256=b7e7a74e2410b5e85c25858b26b3322f29161e300935f70a0e0d3c35e0462737
 
 BUNDLED WITH
   4.0.14

--- a/google-cloud-scheduler/samples/Gemfile.lock
+++ b/google-cloud-scheduler/samples/Gemfile.lock
@@ -3,18 +3,13 @@ GEM
   specs:
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.1.2)
-    concurrent-ruby (1.3.8)
-    declarative (0.0.20)
-    digest-crc (0.7.0)
-      rake (>= 12.0.0, < 14.0.0)
     faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-follow_redirects (0.5.0)
-      faraday (>= 1, < 3)
     faraday-net_http (3.4.4)
       net-http (~> 0.5)
     faraday-retry (2.4.0)
@@ -29,47 +24,6 @@ GEM
       googleapis-common-protos-types (~> 1.15)
       googleauth (~> 1.12)
       grpc (~> 1.66)
-    google-apis-bigquery_v2 (0.106.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-<<<<<<< HEAD
-    google-apis-core (1.2.99)
-      addressable (~> 2.8, >= 2.8.7)
-=======
-    google-apis-core (1.2.5)
-      addressable (~> 2.9)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-      faraday (~> 2.13)
-      faraday-follow_redirects (~> 0.3)
-      googleauth (~> 1.14)
-      mini_mime (~> 1.1)
-      multi_json (~> 1.11)
-      representable (~> 3.0)
-<<<<<<< HEAD
-      retriable (~> 3.1)
-=======
-      retriable (>= 3.1, < 5.0)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-    google-apis-iamcredentials_v1 (0.28.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-    google-apis-storage_v1 (0.65.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-    google-cloud-asset (1.10.0)
-      google-cloud-asset-v1 (>= 0.29, < 2.a)
-      google-cloud-core (~> 1.6)
-    google-cloud-asset-v1 (1.9.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-cloud-os_config-v1 (> 0.0, < 2.a)
-      google-identity-access_context_manager-v1 (> 0.0, < 2.a)
-      grpc-google-iam-v1 (~> 1.11)
-    google-cloud-bigquery (1.64.0)
-      bigdecimal (>= 3.0, < 5)
-      concurrent-ruby (~> 1.0)
-      google-apis-bigquery_v2 (~> 0.71)
-      google-apis-core (>= 0.18, < 2)
-      google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
     google-cloud-core (1.9.0)
       google-cloud-env (>= 1.0, < 3.a)
       google-cloud-errors (~> 1.0)
@@ -77,35 +31,20 @@ GEM
       base64 (~> 0.2)
       faraday (>= 1.0, < 3.a)
     google-cloud-errors (1.7.0)
-    google-cloud-os_config-v1 (1.9.0)
+    google-cloud-location (1.5.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
-    google-cloud-pubsub (3.4.0)
-      concurrent-ruby (~> 1.3)
-      google-cloud-core (~> 1.8)
-      google-cloud-pubsub-v1 (~> 1.11)
-      retriable (~> 3.1)
-    google-cloud-pubsub-v1 (1.16.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-iam-v1 (~> 1.3)
-    google-cloud-storage (1.62.0)
-      addressable (~> 2.8)
-      digest-crc (~> 0.4)
-      google-apis-core (>= 0.18, < 2)
-      google-apis-iamcredentials_v1 (~> 0.18)
-      google-apis-storage_v1 (>= 0.42)
+    google-cloud-scheduler (3.2.0)
       google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
-    google-iam-v1 (1.7.0)
+      google-cloud-scheduler-v1 (~> 1.2)
+    google-cloud-scheduler-v1 (1.7.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
-      grpc-google-iam-v1 (~> 1.11)
-    google-identity-access_context_manager-v1 (0.15.0)
+      google-cloud-location (~> 1.0)
+    google-cloud-scheduler-v1beta1 (0.18.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
-      grpc-google-iam-v1 (~> 1.11)
+      google-cloud-location (~> 1.0)
     google-logging-utils (0.2.0)
     google-protobuf (4.35.1)
       bigdecimal
@@ -134,7 +73,9 @@ GEM
     google-protobuf (4.35.1-x86_64-linux-musl)
       bigdecimal
       rake (~> 13.3)
-    googleapis-common-protos (1.9.0)
+    google-style (1.25.3)
+      rubocop (~> 1.28.2)
+    googleapis-common-protos (1.10.0)
       google-protobuf (~> 4.26)
       googleapis-common-protos-types (~> 1.21)
       grpc (~> 1.41)
@@ -175,36 +116,65 @@ GEM
     grpc (1.83.0-x86_64-linux-musl)
       google-protobuf (>= 3.25, < 5.0)
       googleapis-common-protos-types (~> 1.0)
-    grpc-google-iam-v1 (1.12.0)
-      google-protobuf (>= 3.18, < 5.a)
-      googleapis-common-protos (~> 1.9.0)
-      grpc (~> 1.41)
     json (2.21.2)
     jwt (3.2.0)
       base64
     logger (1.7.0)
-    mini_mime (1.1.5)
     minitest (5.27.0)
     minitest-focus (1.4.1)
       minitest (> 5.0)
-    multi_json (1.21.1)
+    mustermann (3.1.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
     os (1.1.4)
+    parallel (1.28.0)
+    parser (3.3.12.0)
+      ast (~> 2.4.1)
+      racc
+    prism (1.9.0)
     pstore (0.2.1)
     public_suffix (7.0.5)
+    racc (1.8.1)
+    rack (3.2.6)
+    rack-protection (4.2.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
+    rack-session (2.1.2)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
+    rack-test (2.2.0)
+      rack (>= 1.3)
+    rainbow (3.1.1)
     rake (13.4.2)
-    representable (3.2.0)
-      declarative (< 0.1.0)
-      trailblazer-option (>= 0.1.1, < 0.2.0)
-      uber (< 0.2.0)
-    retriable (3.8.0)
+    regexp_parser (2.12.0)
+    rexml (3.4.4)
+    rubocop (1.28.2)
+      parallel (~> 1.10)
+      parser (>= 3.1.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.17.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.50.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    ruby-progressbar (1.13.0)
     signet (0.22.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 4.0)
-    trailblazer-option (0.1.2)
-    uber (0.1.0)
+    sinatra (4.2.1)
+      logger (>= 1.6.0)
+      mustermann (~> 3.0)
+      rack (>= 3.0.0, < 4)
+      rack-protection (= 4.2.1)
+      rack-session (>= 2.0.0, < 3)
+      tilt (~> 2.0)
+    tilt (2.8.0)
+    unicode-display_width (2.6.0)
     uri (1.1.1)
 
 PLATFORMS
@@ -219,47 +189,33 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  google-cloud-asset
-  google-cloud-bigquery
-  google-cloud-pubsub
-  google-cloud-storage
+  google-cloud-scheduler
+  google-cloud-scheduler-v1
+  google-cloud-scheduler-v1beta1
+  google-style (~> 1.25.1)
   minitest (~> 5.14)
-  minitest-focus
+  minitest-focus (~> 1.4)
+  rack-test
   rake
+  sinatra
 
 CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
-  concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
-  declarative (0.0.20) sha256=8021dd6cb17ab2b61233c56903d3f5a259c5cf43c80ff332d447d395b17d9ff9
-  digest-crc (0.7.0) sha256=64adc23a26a241044cbe6732477ca1b3c281d79e2240bcff275a37a5a0d78c07
   faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
-  faraday-follow_redirects (0.5.0) sha256=5cde93c894b30943a5d2b93c2fe9284216a6b756f7af406a1e55f211d97d10ad
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
   faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
   gapic-common (1.3.0) sha256=4e5d9be1effb7366e2cda13c0f44922285d5613ac8de8b9b18c2c835fe4faa91
-  google-apis-bigquery_v2 (0.106.0) sha256=a0f4243b634a0c79c29b7dacdd79233bd9c9ba2eda6fde9c2b19414fd165dd93
-<<<<<<< HEAD
-  google-apis-core (1.2.99)
-=======
-  google-apis-core (1.2.5) sha256=e21562b5627a0fc6a0c3165e429c3afed0f6a628eaa514e83f7204dda1adff69
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-  google-apis-iamcredentials_v1 (0.28.0) sha256=0a92ffe6cc39c569554af2a77a25dfc61519ed8bbb64ab04cffdd352dc5ef106
-  google-apis-storage_v1 (0.65.0) sha256=4247aa542931691f6988ab61e45cdea2878cbfe897a98eec4af9cdcb678eb359
-  google-cloud-asset (1.10.0) sha256=6ea6fd9e0735873884094c14d84d5a6d826b0e07aaeec245d34735ab2c5828e0
-  google-cloud-asset-v1 (1.9.0) sha256=ecfb654d0d350ed98209d46937c8095ec867c8ff6c3f7d70b8889f6fb70fd397
-  google-cloud-bigquery (1.64.0) sha256=d807363903e08958c3bc09ccc1f9d1218646c8f18176751879348a1a4a884d57
   google-cloud-core (1.9.0) sha256=ab55409f51488e8deefb6edcc1ce4771dfb5da2fe7b3bc075709a030c2b682a4
   google-cloud-env (2.4.0) sha256=01cb35ecee5d1c4d1cd4deaed8bb5bddc838e296bcc2a35c5d1ddd07ce40d28d
   google-cloud-errors (1.7.0) sha256=6e682f42d89aae08689f36f28495de629d756da076bafff0003bac7f8042ebb3
-  google-cloud-os_config-v1 (1.9.0) sha256=693c13690cfd7cf9d307c25d005ff33b823b6709791d3714c344ff1597ec3a30
-  google-cloud-pubsub (3.4.0) sha256=6a6390a6f605701945d5be233dea51e0b04009f157b5d701b092423fbc690edd
-  google-cloud-pubsub-v1 (1.16.0) sha256=ffe128821208bd3d2f27cb0d25eb6accb3893c99e0b736d1740b8b5e1570426b
-  google-cloud-storage (1.62.0) sha256=e2c3c08bf8fd40d50be92304084942203314d4fc0ee52028e99f9359c3ad1330
-  google-iam-v1 (1.7.0) sha256=9e3ea9dcc59cbd5f8d2f62b00da41ec57a2e427b33c0e798207fa06c8fbb8b87
-  google-identity-access_context_manager-v1 (0.15.0) sha256=8f105320bcbdc03c7fdb05369886117b4f341b792ed4ab81a144929bbcd7820b
+  google-cloud-location (1.5.0) sha256=336f94609b1fb18fce1929048fac964f4d5a87d27c1e5444bfed3605469c7532
+  google-cloud-scheduler (3.2.0) sha256=97601ee4eb82fa327fd1e1cba3a8d03ecab088f464c24c552aff116388df4ea7
+  google-cloud-scheduler-v1 (1.7.0) sha256=5f3bad0ed461ca18242ee8c55a2761293e4c56007b5c782d57da21f78cd158ac
+  google-cloud-scheduler-v1beta1 (0.18.0) sha256=6140763f42a2569398c90fd6ae642b97eee408bc780d3f200b28648260725c9b
   google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
   google-protobuf (4.35.1) sha256=a3a6471331d918f58dfa4d014a8f6286f0af2cf4840216bde52fcf2ea3fe3726
   google-protobuf (4.35.1-aarch64-linux-gnu) sha256=50ca44d0eeff3f8475e630a1accdd974256f3510694d574e2c9d6119ea8bc9e1
@@ -270,7 +226,8 @@ CHECKSUMS
   google-protobuf (4.35.1-x86_64-darwin) sha256=66b62b4df00931018a692806df66393efa960d6d2b7da69735187249f950d3ee
   google-protobuf (4.35.1-x86_64-linux-gnu) sha256=c786439087512a3fbd199e9897d265b855f951d4027e218ea55e858d45969edd
   google-protobuf (4.35.1-x86_64-linux-musl) sha256=91890eb0002934a339fdb7d77a147c46b7474b6799db27872b747b905837f744
-  googleapis-common-protos (1.9.0) sha256=207be372d8d25e3876e1e1155d057e14f3c92f8f5428772864a8ce04a0b756e4
+  google-style (1.25.3) sha256=d417fd0f6d6a9f4bb2ff69e1cfaa1c4d0e19230589cdf4383df4540082c395d4
+  googleapis-common-protos (1.10.0) sha256=13e47ad0ce85d3d30065c03863efd302a82b0e08ba576f2a9b9dbbfeecb57ee0
   googleapis-common-protos-types (1.23.0) sha256=992e740a523794d9fc5f29a504465d8fc737aaa16c930fe7228e3346860faf0a
   googleauth (1.17.3) sha256=9a655455885c0c17a8b70537acd2a992a7c7842c43c06c6612dfb0d93e755d58
   grpc (1.83.0) sha256=38119e7f9f7cbc98e79145201da4be470a7542b0befad454651d35015ea55c59
@@ -282,24 +239,35 @@ CHECKSUMS
   grpc (1.83.0-x86_64-darwin) sha256=cfad91d559d1907159a5247fb12dc112a8ea0ebe2027ca7f5ab648d01a645716
   grpc (1.83.0-x86_64-linux-gnu) sha256=25d66bfa3cb1b05258b3f9632478c7e7ceb52cb16ccc0b4b26d7df36be7158b1
   grpc (1.83.0-x86_64-linux-musl) sha256=a5023264dbb8038c23b147bbf80adb06932ef11b5ab493412e9e37a43114fa8c
-  grpc-google-iam-v1 (1.12.0) sha256=a70ecad8987e340d5e22e7bf01be31256c84b29a3f78bebd385a4a110e1f2aef
   json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
-  mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   minitest-focus (1.4.1) sha256=394517cbe2dcb2d992d8ffc41a3b2b6315777a4daa69239de4fefe7110dd810e
-  multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080
+  mustermann (3.1.1) sha256=4c6170c7234d5499c345562ba7c7dfe73e1754286dcc1abb053064d66a127198
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
   os (1.1.4) sha256=57816d6a334e7bd6aed048f4b0308226c5fb027433b67d90a9ab435f35108d3f
+  parallel (1.28.0) sha256=33e6de1484baf2524792d178b0913fc8eb94c628d6cfe45599ad4458c638c970
+  parser (3.3.12.0) sha256=21a6d7f755d5a24dfbdc6e6b772e4e879a52e7631a88bc5a3a134606052c9828
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   pstore (0.2.1) sha256=03904d0f2c66579e96d1e6704cdabc0c88df7ea8ed8782d9f3569f6f6c702c1a
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2
+  rack-protection (4.2.1) sha256=cf6e2842df8c55f5e4d1a4be015e603e19e9bc3a7178bae58949ccbb58558bac
+  rack-session (2.1.2) sha256=595434f8c0c3473ae7d7ac56ecda6cc6dfd9d37c0b2b5255330aa1576967ffe8
+  rack-test (2.2.0) sha256=005a36692c306ac0b4a9350355ee080fd09ddef1148a5f8b2ac636c720f5c463
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
-  representable (3.2.0) sha256=cc29bf7eebc31653586849371a43ffe36c60b54b0a6365b5f7d95ec34d1ebace
-  retriable (3.8.0) sha256=9f2f1b0207594c7817f17f671587b8ec7587387ac6cebda6c941a802bb98a8e5
+  regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rubocop (1.28.2) sha256=0d9bf4108fd86ede43c6cf30adcb3dd2e0c6750941c5ec2a00621478157cb377
+  rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   signet (0.22.0) sha256=b76d495ccb07ad35dbc89f3e920665a9d8ed717141955034005d7843dcfe4780
-  trailblazer-option (0.1.2) sha256=20e4f12ea4e1f718c8007e7944ca21a329eee4eed9e0fa5dde6e8ad8ac4344a3
-  uber (0.1.0) sha256=5beeb407ff807b5db994f82fa9ee07cfceaa561dad8af20be880bc67eba935dc
+  sinatra (4.2.1) sha256=b7aeb9b11d046b552972ade834f1f9be98b185fa8444480688e3627625377080
+  tilt (2.8.0) sha256=ba472eb2716fe1e04112d6d219a9dae938ec09a6a1e2ad3ecc7922e79bde3721
+  unicode-display_width (2.6.0) sha256=12279874bba6d5e4d2728cef814b19197dbb10d7a7837a869bab65da943b7f5a
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
 
 BUNDLED WITH

--- a/google-cloud-secret_manager/samples/Gemfile.lock
+++ b/google-cloud-secret_manager/samples/Gemfile.lock
@@ -3,18 +3,13 @@ GEM
   specs:
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.1.2)
-    concurrent-ruby (1.3.8)
-    declarative (0.0.20)
-    digest-crc (0.7.0)
-      rake (>= 12.0.0, < 14.0.0)
     faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-follow_redirects (0.5.0)
-      faraday (>= 1, < 3)
     faraday-net_http (3.4.4)
       net-http (~> 0.5)
     faraday-retry (2.4.0)
@@ -29,47 +24,6 @@ GEM
       googleapis-common-protos-types (~> 1.15)
       googleauth (~> 1.12)
       grpc (~> 1.66)
-    google-apis-bigquery_v2 (0.106.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-<<<<<<< HEAD
-    google-apis-core (1.2.99)
-      addressable (~> 2.8, >= 2.8.7)
-=======
-    google-apis-core (1.2.5)
-      addressable (~> 2.9)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-      faraday (~> 2.13)
-      faraday-follow_redirects (~> 0.3)
-      googleauth (~> 1.14)
-      mini_mime (~> 1.1)
-      multi_json (~> 1.11)
-      representable (~> 3.0)
-<<<<<<< HEAD
-      retriable (~> 3.1)
-=======
-      retriable (>= 3.1, < 5.0)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-    google-apis-iamcredentials_v1 (0.28.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-    google-apis-storage_v1 (0.65.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-    google-cloud-asset (1.10.0)
-      google-cloud-asset-v1 (>= 0.29, < 2.a)
-      google-cloud-core (~> 1.6)
-    google-cloud-asset-v1 (1.9.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-cloud-os_config-v1 (> 0.0, < 2.a)
-      google-identity-access_context_manager-v1 (> 0.0, < 2.a)
-      grpc-google-iam-v1 (~> 1.11)
-    google-cloud-bigquery (1.64.0)
-      bigdecimal (>= 3.0, < 5)
-      concurrent-ruby (~> 1.0)
-      google-apis-bigquery_v2 (~> 0.71)
-      google-apis-core (>= 0.18, < 2)
-      google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
     google-cloud-core (1.9.0)
       google-cloud-env (>= 1.0, < 3.a)
       google-cloud-errors (~> 1.0)
@@ -77,34 +31,20 @@ GEM
       base64 (~> 0.2)
       faraday (>= 1.0, < 3.a)
     google-cloud-errors (1.7.0)
-    google-cloud-os_config-v1 (1.9.0)
+    google-cloud-location (1.5.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
-    google-cloud-pubsub (3.4.0)
-      concurrent-ruby (~> 1.3)
-      google-cloud-core (~> 1.8)
-      google-cloud-pubsub-v1 (~> 1.11)
-      retriable (~> 3.1)
-    google-cloud-pubsub-v1 (1.16.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-iam-v1 (~> 1.3)
-    google-cloud-storage (1.62.0)
-      addressable (~> 2.8)
-      digest-crc (~> 0.4)
-      google-apis-core (>= 0.18, < 2)
-      google-apis-iamcredentials_v1 (~> 0.18)
-      google-apis-storage_v1 (>= 0.42)
-      google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
-    google-iam-v1 (1.7.0)
+    google-cloud-resource_manager-v3 (1.8.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
       grpc-google-iam-v1 (~> 1.11)
-    google-identity-access_context_manager-v1 (0.15.0)
+    google-cloud-secret_manager (2.2.0)
+      google-cloud-core (~> 1.6)
+      google-cloud-secret_manager-v1 (~> 1.2)
+    google-cloud-secret_manager-v1 (1.9.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
+      google-cloud-location (~> 1.0)
       grpc-google-iam-v1 (~> 1.11)
     google-logging-utils (0.2.0)
     google-protobuf (4.35.1)
@@ -134,6 +74,8 @@ GEM
     google-protobuf (4.35.1-x86_64-linux-musl)
       bigdecimal
       rake (~> 13.3)
+    google-style (1.25.3)
+      rubocop (~> 1.28.2)
     googleapis-common-protos (1.9.0)
       google-protobuf (~> 4.26)
       googleapis-common-protos-types (~> 1.21)
@@ -183,28 +125,44 @@ GEM
     jwt (3.2.0)
       base64
     logger (1.7.0)
-    mini_mime (1.1.5)
     minitest (5.27.0)
     minitest-focus (1.4.1)
       minitest (> 5.0)
-    multi_json (1.21.1)
+    minitest-rg (5.4.0)
+      minitest (>= 5.0, < 7)
     net-http (0.9.1)
       uri (>= 0.11.1)
     os (1.1.4)
+    parallel (1.28.0)
+    parser (3.3.12.0)
+      ast (~> 2.4.1)
+      racc
+    prism (1.9.0)
     pstore (0.2.1)
     public_suffix (7.0.5)
+    racc (1.8.1)
+    rainbow (3.1.1)
     rake (13.4.2)
-    representable (3.2.0)
-      declarative (< 0.1.0)
-      trailblazer-option (>= 0.1.1, < 0.2.0)
-      uber (< 0.2.0)
-    retriable (3.8.0)
+    regexp_parser (2.12.0)
+    rexml (3.4.4)
+    rubocop (1.28.2)
+      parallel (~> 1.10)
+      parser (>= 3.1.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.17.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.50.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    ruby-progressbar (1.13.0)
     signet (0.22.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 4.0)
-    trailblazer-option (0.1.2)
-    uber (0.1.0)
+    unicode-display_width (2.6.0)
     uri (1.1.1)
 
 PLATFORMS
@@ -219,47 +177,31 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  google-cloud-asset
-  google-cloud-bigquery
-  google-cloud-pubsub
-  google-cloud-storage
+  google-cloud-resource_manager-v3 (~> 1.3)
+  google-cloud-secret_manager
+  google-style (~> 1.25.1)
   minitest (~> 5.14)
-  minitest-focus
+  minitest-focus (~> 1.1)
+  minitest-rg (~> 5.2)
   rake
 
 CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
-  concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
-  declarative (0.0.20) sha256=8021dd6cb17ab2b61233c56903d3f5a259c5cf43c80ff332d447d395b17d9ff9
-  digest-crc (0.7.0) sha256=64adc23a26a241044cbe6732477ca1b3c281d79e2240bcff275a37a5a0d78c07
   faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
-  faraday-follow_redirects (0.5.0) sha256=5cde93c894b30943a5d2b93c2fe9284216a6b756f7af406a1e55f211d97d10ad
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
   faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
   gapic-common (1.3.0) sha256=4e5d9be1effb7366e2cda13c0f44922285d5613ac8de8b9b18c2c835fe4faa91
-  google-apis-bigquery_v2 (0.106.0) sha256=a0f4243b634a0c79c29b7dacdd79233bd9c9ba2eda6fde9c2b19414fd165dd93
-<<<<<<< HEAD
-  google-apis-core (1.2.99)
-=======
-  google-apis-core (1.2.5) sha256=e21562b5627a0fc6a0c3165e429c3afed0f6a628eaa514e83f7204dda1adff69
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-  google-apis-iamcredentials_v1 (0.28.0) sha256=0a92ffe6cc39c569554af2a77a25dfc61519ed8bbb64ab04cffdd352dc5ef106
-  google-apis-storage_v1 (0.65.0) sha256=4247aa542931691f6988ab61e45cdea2878cbfe897a98eec4af9cdcb678eb359
-  google-cloud-asset (1.10.0) sha256=6ea6fd9e0735873884094c14d84d5a6d826b0e07aaeec245d34735ab2c5828e0
-  google-cloud-asset-v1 (1.9.0) sha256=ecfb654d0d350ed98209d46937c8095ec867c8ff6c3f7d70b8889f6fb70fd397
-  google-cloud-bigquery (1.64.0) sha256=d807363903e08958c3bc09ccc1f9d1218646c8f18176751879348a1a4a884d57
   google-cloud-core (1.9.0) sha256=ab55409f51488e8deefb6edcc1ce4771dfb5da2fe7b3bc075709a030c2b682a4
   google-cloud-env (2.4.0) sha256=01cb35ecee5d1c4d1cd4deaed8bb5bddc838e296bcc2a35c5d1ddd07ce40d28d
   google-cloud-errors (1.7.0) sha256=6e682f42d89aae08689f36f28495de629d756da076bafff0003bac7f8042ebb3
-  google-cloud-os_config-v1 (1.9.0) sha256=693c13690cfd7cf9d307c25d005ff33b823b6709791d3714c344ff1597ec3a30
-  google-cloud-pubsub (3.4.0) sha256=6a6390a6f605701945d5be233dea51e0b04009f157b5d701b092423fbc690edd
-  google-cloud-pubsub-v1 (1.16.0) sha256=ffe128821208bd3d2f27cb0d25eb6accb3893c99e0b736d1740b8b5e1570426b
-  google-cloud-storage (1.62.0) sha256=e2c3c08bf8fd40d50be92304084942203314d4fc0ee52028e99f9359c3ad1330
-  google-iam-v1 (1.7.0) sha256=9e3ea9dcc59cbd5f8d2f62b00da41ec57a2e427b33c0e798207fa06c8fbb8b87
-  google-identity-access_context_manager-v1 (0.15.0) sha256=8f105320bcbdc03c7fdb05369886117b4f341b792ed4ab81a144929bbcd7820b
+  google-cloud-location (1.5.0) sha256=336f94609b1fb18fce1929048fac964f4d5a87d27c1e5444bfed3605469c7532
+  google-cloud-resource_manager-v3 (1.8.0) sha256=a288663a557b72e2701cbe147a64cb2e675be5f6d872bab590a288d51e7e5c41
+  google-cloud-secret_manager (2.2.0) sha256=71a61a1427c0b9c5876ae99b4a61a92e62af8b6f0c0c9f0639dbeff8f27c3cea
+  google-cloud-secret_manager-v1 (1.9.0) sha256=f24397f11fcf6e3e17c6a8add1370f1f1ea679a2134876a35990a549ec346bc9
   google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
   google-protobuf (4.35.1) sha256=a3a6471331d918f58dfa4d014a8f6286f0af2cf4840216bde52fcf2ea3fe3726
   google-protobuf (4.35.1-aarch64-linux-gnu) sha256=50ca44d0eeff3f8475e630a1accdd974256f3510694d574e2c9d6119ea8bc9e1
@@ -270,6 +212,7 @@ CHECKSUMS
   google-protobuf (4.35.1-x86_64-darwin) sha256=66b62b4df00931018a692806df66393efa960d6d2b7da69735187249f950d3ee
   google-protobuf (4.35.1-x86_64-linux-gnu) sha256=c786439087512a3fbd199e9897d265b855f951d4027e218ea55e858d45969edd
   google-protobuf (4.35.1-x86_64-linux-musl) sha256=91890eb0002934a339fdb7d77a147c46b7474b6799db27872b747b905837f744
+  google-style (1.25.3) sha256=d417fd0f6d6a9f4bb2ff69e1cfaa1c4d0e19230589cdf4383df4540082c395d4
   googleapis-common-protos (1.9.0) sha256=207be372d8d25e3876e1e1155d057e14f3c92f8f5428772864a8ce04a0b756e4
   googleapis-common-protos-types (1.23.0) sha256=992e740a523794d9fc5f29a504465d8fc737aaa16c930fe7228e3346860faf0a
   googleauth (1.17.3) sha256=9a655455885c0c17a8b70537acd2a992a7c7842c43c06c6612dfb0d93e755d58
@@ -286,20 +229,26 @@ CHECKSUMS
   json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
-  mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   minitest-focus (1.4.1) sha256=394517cbe2dcb2d992d8ffc41a3b2b6315777a4daa69239de4fefe7110dd810e
-  multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080
+  minitest-rg (5.4.0) sha256=54d42bb8ce876381245be5866f3c1dd704ef79c06ba5c9ff280c0aa28c56effb
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
   os (1.1.4) sha256=57816d6a334e7bd6aed048f4b0308226c5fb027433b67d90a9ab435f35108d3f
+  parallel (1.28.0) sha256=33e6de1484baf2524792d178b0913fc8eb94c628d6cfe45599ad4458c638c970
+  parser (3.3.12.0) sha256=21a6d7f755d5a24dfbdc6e6b772e4e879a52e7631a88bc5a3a134606052c9828
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   pstore (0.2.1) sha256=03904d0f2c66579e96d1e6704cdabc0c88df7ea8ed8782d9f3569f6f6c702c1a
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
-  representable (3.2.0) sha256=cc29bf7eebc31653586849371a43ffe36c60b54b0a6365b5f7d95ec34d1ebace
-  retriable (3.8.0) sha256=9f2f1b0207594c7817f17f671587b8ec7587387ac6cebda6c941a802bb98a8e5
+  regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rubocop (1.28.2) sha256=0d9bf4108fd86ede43c6cf30adcb3dd2e0c6750941c5ec2a00621478157cb377
+  rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   signet (0.22.0) sha256=b76d495ccb07ad35dbc89f3e920665a9d8ed717141955034005d7843dcfe4780
-  trailblazer-option (0.1.2) sha256=20e4f12ea4e1f718c8007e7944ca21a329eee4eed9e0fa5dde6e8ad8ac4344a3
-  uber (0.1.0) sha256=5beeb407ff807b5db994f82fa9ee07cfceaa561dad8af20be880bc67eba935dc
+  unicode-display_width (2.6.0) sha256=12279874bba6d5e4d2728cef814b19197dbb10d7a7837a869bab65da943b7f5a
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
 
 BUNDLED WITH

--- a/google-cloud-security_center/samples/Gemfile.lock
+++ b/google-cloud-security_center/samples/Gemfile.lock
@@ -5,16 +5,10 @@ GEM
       public_suffix (>= 2.0.2, < 8.0)
     base64 (0.3.0)
     bigdecimal (4.1.2)
-    concurrent-ruby (1.3.8)
-    declarative (0.0.20)
-    digest-crc (0.7.0)
-      rake (>= 12.0.0, < 14.0.0)
     faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-follow_redirects (0.5.0)
-      faraday (>= 1, < 3)
     faraday-net_http (3.4.4)
       net-http (~> 0.5)
     faraday-retry (2.4.0)
@@ -29,47 +23,6 @@ GEM
       googleapis-common-protos-types (~> 1.15)
       googleauth (~> 1.12)
       grpc (~> 1.66)
-    google-apis-bigquery_v2 (0.106.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-<<<<<<< HEAD
-    google-apis-core (1.2.99)
-      addressable (~> 2.8, >= 2.8.7)
-=======
-    google-apis-core (1.2.5)
-      addressable (~> 2.9)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-      faraday (~> 2.13)
-      faraday-follow_redirects (~> 0.3)
-      googleauth (~> 1.14)
-      mini_mime (~> 1.1)
-      multi_json (~> 1.11)
-      representable (~> 3.0)
-<<<<<<< HEAD
-      retriable (~> 3.1)
-=======
-      retriable (>= 3.1, < 5.0)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-    google-apis-iamcredentials_v1 (0.28.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-    google-apis-storage_v1 (0.65.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-    google-cloud-asset (1.10.0)
-      google-cloud-asset-v1 (>= 0.29, < 2.a)
-      google-cloud-core (~> 1.6)
-    google-cloud-asset-v1 (1.9.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-cloud-os_config-v1 (> 0.0, < 2.a)
-      google-identity-access_context_manager-v1 (> 0.0, < 2.a)
-      grpc-google-iam-v1 (~> 1.11)
-    google-cloud-bigquery (1.64.0)
-      bigdecimal (>= 3.0, < 5)
-      concurrent-ruby (~> 1.0)
-      google-apis-bigquery_v2 (~> 0.71)
-      google-apis-core (>= 0.18, < 2)
-      google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
     google-cloud-core (1.9.0)
       google-cloud-env (>= 1.0, < 3.a)
       google-cloud-errors (~> 1.0)
@@ -77,32 +30,15 @@ GEM
       base64 (~> 0.2)
       faraday (>= 1.0, < 3.a)
     google-cloud-errors (1.7.0)
-    google-cloud-os_config-v1 (1.9.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-    google-cloud-pubsub (3.4.0)
-      concurrent-ruby (~> 1.3)
-      google-cloud-core (~> 1.8)
-      google-cloud-pubsub-v1 (~> 1.11)
-      retriable (~> 3.1)
-    google-cloud-pubsub-v1 (1.16.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-iam-v1 (~> 1.3)
-    google-cloud-storage (1.62.0)
-      addressable (~> 2.8)
-      digest-crc (~> 0.4)
-      google-apis-core (>= 0.18, < 2)
-      google-apis-iamcredentials_v1 (~> 0.18)
-      google-apis-storage_v1 (>= 0.42)
+    google-cloud-security_center (2.2.0)
       google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
-    google-iam-v1 (1.7.0)
+      google-cloud-security_center-v1 (~> 1.0)
+      google-cloud-security_center-v2 (~> 1.0)
+    google-cloud-security_center-v1 (1.11.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
       grpc-google-iam-v1 (~> 1.11)
-    google-identity-access_context_manager-v1 (0.15.0)
+    google-cloud-security_center-v2 (1.9.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
       grpc-google-iam-v1 (~> 1.11)
@@ -183,28 +119,17 @@ GEM
     jwt (3.2.0)
       base64
     logger (1.7.0)
-    mini_mime (1.1.5)
     minitest (5.27.0)
-    minitest-focus (1.4.1)
-      minitest (> 5.0)
-    multi_json (1.21.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
     os (1.1.4)
     pstore (0.2.1)
     public_suffix (7.0.5)
     rake (13.4.2)
-    representable (3.2.0)
-      declarative (< 0.1.0)
-      trailblazer-option (>= 0.1.1, < 0.2.0)
-      uber (< 0.2.0)
-    retriable (3.8.0)
     signet (0.22.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 4.0)
-    trailblazer-option (0.1.2)
-    uber (0.1.0)
     uri (1.1.1)
 
 PLATFORMS
@@ -219,47 +144,25 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  google-cloud-asset
-  google-cloud-bigquery
-  google-cloud-pubsub
-  google-cloud-storage
+  google-cloud-security_center
   minitest (~> 5.14)
-  minitest-focus
-  rake
+  rake (>= 12.0)
 
 CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
-  concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
-  declarative (0.0.20) sha256=8021dd6cb17ab2b61233c56903d3f5a259c5cf43c80ff332d447d395b17d9ff9
-  digest-crc (0.7.0) sha256=64adc23a26a241044cbe6732477ca1b3c281d79e2240bcff275a37a5a0d78c07
   faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
-  faraday-follow_redirects (0.5.0) sha256=5cde93c894b30943a5d2b93c2fe9284216a6b756f7af406a1e55f211d97d10ad
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
   faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
   gapic-common (1.3.0) sha256=4e5d9be1effb7366e2cda13c0f44922285d5613ac8de8b9b18c2c835fe4faa91
-  google-apis-bigquery_v2 (0.106.0) sha256=a0f4243b634a0c79c29b7dacdd79233bd9c9ba2eda6fde9c2b19414fd165dd93
-<<<<<<< HEAD
-  google-apis-core (1.2.99)
-=======
-  google-apis-core (1.2.5) sha256=e21562b5627a0fc6a0c3165e429c3afed0f6a628eaa514e83f7204dda1adff69
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-  google-apis-iamcredentials_v1 (0.28.0) sha256=0a92ffe6cc39c569554af2a77a25dfc61519ed8bbb64ab04cffdd352dc5ef106
-  google-apis-storage_v1 (0.65.0) sha256=4247aa542931691f6988ab61e45cdea2878cbfe897a98eec4af9cdcb678eb359
-  google-cloud-asset (1.10.0) sha256=6ea6fd9e0735873884094c14d84d5a6d826b0e07aaeec245d34735ab2c5828e0
-  google-cloud-asset-v1 (1.9.0) sha256=ecfb654d0d350ed98209d46937c8095ec867c8ff6c3f7d70b8889f6fb70fd397
-  google-cloud-bigquery (1.64.0) sha256=d807363903e08958c3bc09ccc1f9d1218646c8f18176751879348a1a4a884d57
   google-cloud-core (1.9.0) sha256=ab55409f51488e8deefb6edcc1ce4771dfb5da2fe7b3bc075709a030c2b682a4
   google-cloud-env (2.4.0) sha256=01cb35ecee5d1c4d1cd4deaed8bb5bddc838e296bcc2a35c5d1ddd07ce40d28d
   google-cloud-errors (1.7.0) sha256=6e682f42d89aae08689f36f28495de629d756da076bafff0003bac7f8042ebb3
-  google-cloud-os_config-v1 (1.9.0) sha256=693c13690cfd7cf9d307c25d005ff33b823b6709791d3714c344ff1597ec3a30
-  google-cloud-pubsub (3.4.0) sha256=6a6390a6f605701945d5be233dea51e0b04009f157b5d701b092423fbc690edd
-  google-cloud-pubsub-v1 (1.16.0) sha256=ffe128821208bd3d2f27cb0d25eb6accb3893c99e0b736d1740b8b5e1570426b
-  google-cloud-storage (1.62.0) sha256=e2c3c08bf8fd40d50be92304084942203314d4fc0ee52028e99f9359c3ad1330
-  google-iam-v1 (1.7.0) sha256=9e3ea9dcc59cbd5f8d2f62b00da41ec57a2e427b33c0e798207fa06c8fbb8b87
-  google-identity-access_context_manager-v1 (0.15.0) sha256=8f105320bcbdc03c7fdb05369886117b4f341b792ed4ab81a144929bbcd7820b
+  google-cloud-security_center (2.2.0) sha256=2d4045db3b0044b23188849798495c6ba62bf9b9b4d3c7314a1141f7b904fef9
+  google-cloud-security_center-v1 (1.11.0) sha256=02a3c7da363f5d1d9fcdf399fee6c1c8e743a9359ed5ed151e5aae09173b3e67
+  google-cloud-security_center-v2 (1.9.0) sha256=cac9ef86460093c94bba961861acbd1ef6e95eb51ba336934aeccdc7a9e567b7
   google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
   google-protobuf (4.35.1) sha256=a3a6471331d918f58dfa4d014a8f6286f0af2cf4840216bde52fcf2ea3fe3726
   google-protobuf (4.35.1-aarch64-linux-gnu) sha256=50ca44d0eeff3f8475e630a1accdd974256f3510694d574e2c9d6119ea8bc9e1
@@ -286,20 +189,13 @@ CHECKSUMS
   json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
-  mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
-  minitest-focus (1.4.1) sha256=394517cbe2dcb2d992d8ffc41a3b2b6315777a4daa69239de4fefe7110dd810e
-  multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
   os (1.1.4) sha256=57816d6a334e7bd6aed048f4b0308226c5fb027433b67d90a9ab435f35108d3f
   pstore (0.2.1) sha256=03904d0f2c66579e96d1e6704cdabc0c88df7ea8ed8782d9f3569f6f6c702c1a
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
-  representable (3.2.0) sha256=cc29bf7eebc31653586849371a43ffe36c60b54b0a6365b5f7d95ec34d1ebace
-  retriable (3.8.0) sha256=9f2f1b0207594c7817f17f671587b8ec7587387ac6cebda6c941a802bb98a8e5
   signet (0.22.0) sha256=b76d495ccb07ad35dbc89f3e920665a9d8ed717141955034005d7843dcfe4780
-  trailblazer-option (0.1.2) sha256=20e4f12ea4e1f718c8007e7944ca21a329eee4eed9e0fa5dde6e8ad8ac4344a3
-  uber (0.1.0) sha256=5beeb407ff807b5db994f82fa9ee07cfceaa561dad8af20be880bc67eba935dc
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
 
 BUNDLED WITH

--- a/google-cloud-service_directory/samples/Gemfile.lock
+++ b/google-cloud-service_directory/samples/Gemfile.lock
@@ -3,18 +3,13 @@ GEM
   specs:
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.1.2)
-    concurrent-ruby (1.3.8)
-    declarative (0.0.20)
-    digest-crc (0.7.0)
-      rake (>= 12.0.0, < 14.0.0)
     faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-follow_redirects (0.5.0)
-      faraday (>= 1, < 3)
     faraday-net_http (3.4.4)
       net-http (~> 0.5)
     faraday-retry (2.4.0)
@@ -29,47 +24,6 @@ GEM
       googleapis-common-protos-types (~> 1.15)
       googleauth (~> 1.12)
       grpc (~> 1.66)
-    google-apis-bigquery_v2 (0.106.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-<<<<<<< HEAD
-    google-apis-core (1.2.99)
-      addressable (~> 2.8, >= 2.8.7)
-=======
-    google-apis-core (1.2.5)
-      addressable (~> 2.9)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-      faraday (~> 2.13)
-      faraday-follow_redirects (~> 0.3)
-      googleauth (~> 1.14)
-      mini_mime (~> 1.1)
-      multi_json (~> 1.11)
-      representable (~> 3.0)
-<<<<<<< HEAD
-      retriable (~> 3.1)
-=======
-      retriable (>= 3.1, < 5.0)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-    google-apis-iamcredentials_v1 (0.28.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-    google-apis-storage_v1 (0.65.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-    google-cloud-asset (1.10.0)
-      google-cloud-asset-v1 (>= 0.29, < 2.a)
-      google-cloud-core (~> 1.6)
-    google-cloud-asset-v1 (1.9.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-cloud-os_config-v1 (> 0.0, < 2.a)
-      google-identity-access_context_manager-v1 (> 0.0, < 2.a)
-      grpc-google-iam-v1 (~> 1.11)
-    google-cloud-bigquery (1.64.0)
-      bigdecimal (>= 3.0, < 5)
-      concurrent-ruby (~> 1.0)
-      google-apis-bigquery_v2 (~> 0.71)
-      google-apis-core (>= 0.18, < 2)
-      google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
     google-cloud-core (1.9.0)
       google-cloud-env (>= 1.0, < 3.a)
       google-cloud-errors (~> 1.0)
@@ -77,34 +31,16 @@ GEM
       base64 (~> 0.2)
       faraday (>= 1.0, < 3.a)
     google-cloud-errors (1.7.0)
-    google-cloud-os_config-v1 (1.9.0)
+    google-cloud-location (1.5.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
-    google-cloud-pubsub (3.4.0)
-      concurrent-ruby (~> 1.3)
-      google-cloud-core (~> 1.8)
-      google-cloud-pubsub-v1 (~> 1.11)
-      retriable (~> 3.1)
-    google-cloud-pubsub-v1 (1.16.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-iam-v1 (~> 1.3)
-    google-cloud-storage (1.62.0)
-      addressable (~> 2.8)
-      digest-crc (~> 0.4)
-      google-apis-core (>= 0.18, < 2)
-      google-apis-iamcredentials_v1 (~> 0.18)
-      google-apis-storage_v1 (>= 0.42)
+    google-cloud-service_directory (2.2.0)
       google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
-    google-iam-v1 (1.7.0)
+      google-cloud-service_directory-v1 (~> 1.2)
+    google-cloud-service_directory-v1 (1.7.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
-      grpc-google-iam-v1 (~> 1.11)
-    google-identity-access_context_manager-v1 (0.15.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
+      google-cloud-location (~> 1.0)
       grpc-google-iam-v1 (~> 1.11)
     google-logging-utils (0.2.0)
     google-protobuf (4.35.1)
@@ -134,6 +70,8 @@ GEM
     google-protobuf (4.35.1-x86_64-linux-musl)
       bigdecimal
       rake (~> 13.3)
+    google-style (1.25.3)
+      rubocop (~> 1.28.2)
     googleapis-common-protos (1.9.0)
       google-protobuf (~> 4.26)
       googleapis-common-protos-types (~> 1.21)
@@ -183,28 +121,44 @@ GEM
     jwt (3.2.0)
       base64
     logger (1.7.0)
-    mini_mime (1.1.5)
     minitest (5.27.0)
     minitest-focus (1.4.1)
       minitest (> 5.0)
-    multi_json (1.21.1)
+    minitest-rg (5.4.0)
+      minitest (>= 5.0, < 7)
     net-http (0.9.1)
       uri (>= 0.11.1)
     os (1.1.4)
+    parallel (1.28.0)
+    parser (3.3.12.0)
+      ast (~> 2.4.1)
+      racc
+    prism (1.9.0)
     pstore (0.2.1)
     public_suffix (7.0.5)
+    racc (1.8.1)
+    rainbow (3.1.1)
     rake (13.4.2)
-    representable (3.2.0)
-      declarative (< 0.1.0)
-      trailblazer-option (>= 0.1.1, < 0.2.0)
-      uber (< 0.2.0)
-    retriable (3.8.0)
+    regexp_parser (2.12.0)
+    rexml (3.4.4)
+    rubocop (1.28.2)
+      parallel (~> 1.10)
+      parser (>= 3.1.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.17.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.50.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    ruby-progressbar (1.13.0)
     signet (0.22.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 4.0)
-    trailblazer-option (0.1.2)
-    uber (0.1.0)
+    unicode-display_width (2.6.0)
     uri (1.1.1)
 
 PLATFORMS
@@ -219,47 +173,29 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  google-cloud-asset
-  google-cloud-bigquery
-  google-cloud-pubsub
-  google-cloud-storage
+  google-cloud-service_directory
+  google-style (~> 1.25.1)
   minitest (~> 5.14)
-  minitest-focus
+  minitest-focus (~> 1.1)
+  minitest-rg (~> 5.2)
   rake
 
 CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
-  concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
-  declarative (0.0.20) sha256=8021dd6cb17ab2b61233c56903d3f5a259c5cf43c80ff332d447d395b17d9ff9
-  digest-crc (0.7.0) sha256=64adc23a26a241044cbe6732477ca1b3c281d79e2240bcff275a37a5a0d78c07
   faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
-  faraday-follow_redirects (0.5.0) sha256=5cde93c894b30943a5d2b93c2fe9284216a6b756f7af406a1e55f211d97d10ad
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
   faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
   gapic-common (1.3.0) sha256=4e5d9be1effb7366e2cda13c0f44922285d5613ac8de8b9b18c2c835fe4faa91
-  google-apis-bigquery_v2 (0.106.0) sha256=a0f4243b634a0c79c29b7dacdd79233bd9c9ba2eda6fde9c2b19414fd165dd93
-<<<<<<< HEAD
-  google-apis-core (1.2.99)
-=======
-  google-apis-core (1.2.5) sha256=e21562b5627a0fc6a0c3165e429c3afed0f6a628eaa514e83f7204dda1adff69
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-  google-apis-iamcredentials_v1 (0.28.0) sha256=0a92ffe6cc39c569554af2a77a25dfc61519ed8bbb64ab04cffdd352dc5ef106
-  google-apis-storage_v1 (0.65.0) sha256=4247aa542931691f6988ab61e45cdea2878cbfe897a98eec4af9cdcb678eb359
-  google-cloud-asset (1.10.0) sha256=6ea6fd9e0735873884094c14d84d5a6d826b0e07aaeec245d34735ab2c5828e0
-  google-cloud-asset-v1 (1.9.0) sha256=ecfb654d0d350ed98209d46937c8095ec867c8ff6c3f7d70b8889f6fb70fd397
-  google-cloud-bigquery (1.64.0) sha256=d807363903e08958c3bc09ccc1f9d1218646c8f18176751879348a1a4a884d57
   google-cloud-core (1.9.0) sha256=ab55409f51488e8deefb6edcc1ce4771dfb5da2fe7b3bc075709a030c2b682a4
   google-cloud-env (2.4.0) sha256=01cb35ecee5d1c4d1cd4deaed8bb5bddc838e296bcc2a35c5d1ddd07ce40d28d
   google-cloud-errors (1.7.0) sha256=6e682f42d89aae08689f36f28495de629d756da076bafff0003bac7f8042ebb3
-  google-cloud-os_config-v1 (1.9.0) sha256=693c13690cfd7cf9d307c25d005ff33b823b6709791d3714c344ff1597ec3a30
-  google-cloud-pubsub (3.4.0) sha256=6a6390a6f605701945d5be233dea51e0b04009f157b5d701b092423fbc690edd
-  google-cloud-pubsub-v1 (1.16.0) sha256=ffe128821208bd3d2f27cb0d25eb6accb3893c99e0b736d1740b8b5e1570426b
-  google-cloud-storage (1.62.0) sha256=e2c3c08bf8fd40d50be92304084942203314d4fc0ee52028e99f9359c3ad1330
-  google-iam-v1 (1.7.0) sha256=9e3ea9dcc59cbd5f8d2f62b00da41ec57a2e427b33c0e798207fa06c8fbb8b87
-  google-identity-access_context_manager-v1 (0.15.0) sha256=8f105320bcbdc03c7fdb05369886117b4f341b792ed4ab81a144929bbcd7820b
+  google-cloud-location (1.5.0) sha256=336f94609b1fb18fce1929048fac964f4d5a87d27c1e5444bfed3605469c7532
+  google-cloud-service_directory (2.2.0) sha256=9d5de629ea82e88aab1353bd4c4621fc99a7ee729cef8fe8573717c14a04476b
+  google-cloud-service_directory-v1 (1.7.0) sha256=7d03e6d93584a0ddc14eba4597def521ef47e11b639fdef9985379c70edcf045
   google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
   google-protobuf (4.35.1) sha256=a3a6471331d918f58dfa4d014a8f6286f0af2cf4840216bde52fcf2ea3fe3726
   google-protobuf (4.35.1-aarch64-linux-gnu) sha256=50ca44d0eeff3f8475e630a1accdd974256f3510694d574e2c9d6119ea8bc9e1
@@ -270,6 +206,7 @@ CHECKSUMS
   google-protobuf (4.35.1-x86_64-darwin) sha256=66b62b4df00931018a692806df66393efa960d6d2b7da69735187249f950d3ee
   google-protobuf (4.35.1-x86_64-linux-gnu) sha256=c786439087512a3fbd199e9897d265b855f951d4027e218ea55e858d45969edd
   google-protobuf (4.35.1-x86_64-linux-musl) sha256=91890eb0002934a339fdb7d77a147c46b7474b6799db27872b747b905837f744
+  google-style (1.25.3) sha256=d417fd0f6d6a9f4bb2ff69e1cfaa1c4d0e19230589cdf4383df4540082c395d4
   googleapis-common-protos (1.9.0) sha256=207be372d8d25e3876e1e1155d057e14f3c92f8f5428772864a8ce04a0b756e4
   googleapis-common-protos-types (1.23.0) sha256=992e740a523794d9fc5f29a504465d8fc737aaa16c930fe7228e3346860faf0a
   googleauth (1.17.3) sha256=9a655455885c0c17a8b70537acd2a992a7c7842c43c06c6612dfb0d93e755d58
@@ -286,20 +223,26 @@ CHECKSUMS
   json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
-  mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   minitest-focus (1.4.1) sha256=394517cbe2dcb2d992d8ffc41a3b2b6315777a4daa69239de4fefe7110dd810e
-  multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080
+  minitest-rg (5.4.0) sha256=54d42bb8ce876381245be5866f3c1dd704ef79c06ba5c9ff280c0aa28c56effb
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
   os (1.1.4) sha256=57816d6a334e7bd6aed048f4b0308226c5fb027433b67d90a9ab435f35108d3f
+  parallel (1.28.0) sha256=33e6de1484baf2524792d178b0913fc8eb94c628d6cfe45599ad4458c638c970
+  parser (3.3.12.0) sha256=21a6d7f755d5a24dfbdc6e6b772e4e879a52e7631a88bc5a3a134606052c9828
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   pstore (0.2.1) sha256=03904d0f2c66579e96d1e6704cdabc0c88df7ea8ed8782d9f3569f6f6c702c1a
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
-  representable (3.2.0) sha256=cc29bf7eebc31653586849371a43ffe36c60b54b0a6365b5f7d95ec34d1ebace
-  retriable (3.8.0) sha256=9f2f1b0207594c7817f17f671587b8ec7587387ac6cebda6c941a802bb98a8e5
+  regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rubocop (1.28.2) sha256=0d9bf4108fd86ede43c6cf30adcb3dd2e0c6750941c5ec2a00621478157cb377
+  rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   signet (0.22.0) sha256=b76d495ccb07ad35dbc89f3e920665a9d8ed717141955034005d7843dcfe4780
-  trailblazer-option (0.1.2) sha256=20e4f12ea4e1f718c8007e7944ca21a329eee4eed9e0fa5dde6e8ad8ac4344a3
-  uber (0.1.0) sha256=5beeb407ff807b5db994f82fa9ee07cfceaa561dad8af20be880bc67eba935dc
+  unicode-display_width (2.6.0) sha256=12279874bba6d5e4d2728cef814b19197dbb10d7a7837a869bab65da943b7f5a
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
 
 BUNDLED WITH

--- a/google-cloud-storage-control/samples/Gemfile.lock
+++ b/google-cloud-storage-control/samples/Gemfile.lock
@@ -3,9 +3,9 @@ GEM
   specs:
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.1.2)
-    concurrent-ruby (1.3.8)
     declarative (0.0.20)
     digest-crc (0.7.0)
       rake (>= 12.0.0, < 14.0.0)
@@ -29,47 +29,19 @@ GEM
       googleapis-common-protos-types (~> 1.15)
       googleauth (~> 1.12)
       grpc (~> 1.66)
-    google-apis-bigquery_v2 (0.106.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-<<<<<<< HEAD
-    google-apis-core (1.2.99)
-      addressable (~> 2.8, >= 2.8.7)
-=======
     google-apis-core (1.2.5)
       addressable (~> 2.9)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
       faraday (~> 2.13)
       faraday-follow_redirects (~> 0.3)
       googleauth (~> 1.14)
       mini_mime (~> 1.1)
       multi_json (~> 1.11)
       representable (~> 3.0)
-<<<<<<< HEAD
-      retriable (~> 3.1)
-=======
       retriable (>= 3.1, < 5.0)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
     google-apis-iamcredentials_v1 (0.28.0)
       google-apis-core (>= 0.15.0, < 2.a)
     google-apis-storage_v1 (0.65.0)
       google-apis-core (>= 0.15.0, < 2.a)
-    google-cloud-asset (1.10.0)
-      google-cloud-asset-v1 (>= 0.29, < 2.a)
-      google-cloud-core (~> 1.6)
-    google-cloud-asset-v1 (1.9.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-cloud-os_config-v1 (> 0.0, < 2.a)
-      google-identity-access_context_manager-v1 (> 0.0, < 2.a)
-      grpc-google-iam-v1 (~> 1.11)
-    google-cloud-bigquery (1.64.0)
-      bigdecimal (>= 3.0, < 5)
-      concurrent-ruby (~> 1.0)
-      google-apis-bigquery_v2 (~> 0.71)
-      google-apis-core (>= 0.18, < 2)
-      google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
     google-cloud-core (1.9.0)
       google-cloud-env (>= 1.0, < 3.a)
       google-cloud-errors (~> 1.0)
@@ -77,18 +49,6 @@ GEM
       base64 (~> 0.2)
       faraday (>= 1.0, < 3.a)
     google-cloud-errors (1.7.0)
-    google-cloud-os_config-v1 (1.9.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-    google-cloud-pubsub (3.4.0)
-      concurrent-ruby (~> 1.3)
-      google-cloud-core (~> 1.8)
-      google-cloud-pubsub-v1 (~> 1.11)
-      retriable (~> 3.1)
-    google-cloud-pubsub-v1 (1.16.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-iam-v1 (~> 1.3)
     google-cloud-storage (1.62.0)
       addressable (~> 2.8)
       digest-crc (~> 0.4)
@@ -98,11 +58,10 @@ GEM
       google-cloud-core (~> 1.6)
       googleauth (~> 1.9)
       mini_mime (~> 1.0)
-    google-iam-v1 (1.7.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      grpc-google-iam-v1 (~> 1.11)
-    google-identity-access_context_manager-v1 (0.15.0)
+    google-cloud-storage-control (1.4.0)
+      google-cloud-core (~> 1.6)
+      google-cloud-storage-control-v2 (>= 0.0, < 2.a)
+    google-cloud-storage-control-v2 (1.13.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
       grpc-google-iam-v1 (~> 1.11)
@@ -134,6 +93,8 @@ GEM
     google-protobuf (4.35.1-x86_64-linux-musl)
       bigdecimal
       rake (~> 13.3)
+    google-style (1.27.1)
+      rubocop (~> 1.56)
     googleapis-common-protos (1.9.0)
       google-protobuf (~> 4.26)
       googleapis-common-protos-types (~> 1.21)
@@ -182,29 +143,59 @@ GEM
     json (2.21.2)
     jwt (3.2.0)
       base64
+    language_server-protocol (3.17.0.6)
+    lint_roller (1.1.0)
     logger (1.7.0)
     mini_mime (1.1.5)
     minitest (5.27.0)
     minitest-focus (1.4.1)
       minitest (> 5.0)
+    minitest-hooks (1.5.4)
+      minitest (> 5.3)
     multi_json (1.21.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
     os (1.1.4)
+    parallel (1.28.0)
+    parser (3.3.12.0)
+      ast (~> 2.4.1)
+      racc
+    prism (1.9.0)
     pstore (0.2.1)
     public_suffix (7.0.5)
+    racc (1.8.1)
+    rainbow (3.1.1)
     rake (13.4.2)
+    regexp_parser (2.12.0)
     representable (3.2.0)
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
-    retriable (3.8.0)
+    retriable (4.2.0)
+    rubocop (1.88.2)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (>= 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.50.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    ruby-progressbar (1.13.0)
     signet (0.22.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 4.0)
     trailblazer-option (0.1.2)
     uber (0.1.0)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
     uri (1.1.1)
 
 PLATFORMS
@@ -219,20 +210,20 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  google-cloud-asset
-  google-cloud-bigquery
-  google-cloud-pubsub
   google-cloud-storage
+  google-cloud-storage-control
+  google-style (~> 1.27.1)
   minitest (~> 5.14)
-  minitest-focus
+  minitest-focus (~> 1.1)
+  minitest-hooks (~> 1.5)
   rake
 
 CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
-  concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
   declarative (0.0.20) sha256=8021dd6cb17ab2b61233c56903d3f5a259c5cf43c80ff332d447d395b17d9ff9
   digest-crc (0.7.0) sha256=64adc23a26a241044cbe6732477ca1b3c281d79e2240bcff275a37a5a0d78c07
   faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
@@ -240,26 +231,15 @@ CHECKSUMS
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
   faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
   gapic-common (1.3.0) sha256=4e5d9be1effb7366e2cda13c0f44922285d5613ac8de8b9b18c2c835fe4faa91
-  google-apis-bigquery_v2 (0.106.0) sha256=a0f4243b634a0c79c29b7dacdd79233bd9c9ba2eda6fde9c2b19414fd165dd93
-<<<<<<< HEAD
-  google-apis-core (1.2.99)
-=======
   google-apis-core (1.2.5) sha256=e21562b5627a0fc6a0c3165e429c3afed0f6a628eaa514e83f7204dda1adff69
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
   google-apis-iamcredentials_v1 (0.28.0) sha256=0a92ffe6cc39c569554af2a77a25dfc61519ed8bbb64ab04cffdd352dc5ef106
   google-apis-storage_v1 (0.65.0) sha256=4247aa542931691f6988ab61e45cdea2878cbfe897a98eec4af9cdcb678eb359
-  google-cloud-asset (1.10.0) sha256=6ea6fd9e0735873884094c14d84d5a6d826b0e07aaeec245d34735ab2c5828e0
-  google-cloud-asset-v1 (1.9.0) sha256=ecfb654d0d350ed98209d46937c8095ec867c8ff6c3f7d70b8889f6fb70fd397
-  google-cloud-bigquery (1.64.0) sha256=d807363903e08958c3bc09ccc1f9d1218646c8f18176751879348a1a4a884d57
   google-cloud-core (1.9.0) sha256=ab55409f51488e8deefb6edcc1ce4771dfb5da2fe7b3bc075709a030c2b682a4
   google-cloud-env (2.4.0) sha256=01cb35ecee5d1c4d1cd4deaed8bb5bddc838e296bcc2a35c5d1ddd07ce40d28d
   google-cloud-errors (1.7.0) sha256=6e682f42d89aae08689f36f28495de629d756da076bafff0003bac7f8042ebb3
-  google-cloud-os_config-v1 (1.9.0) sha256=693c13690cfd7cf9d307c25d005ff33b823b6709791d3714c344ff1597ec3a30
-  google-cloud-pubsub (3.4.0) sha256=6a6390a6f605701945d5be233dea51e0b04009f157b5d701b092423fbc690edd
-  google-cloud-pubsub-v1 (1.16.0) sha256=ffe128821208bd3d2f27cb0d25eb6accb3893c99e0b736d1740b8b5e1570426b
   google-cloud-storage (1.62.0) sha256=e2c3c08bf8fd40d50be92304084942203314d4fc0ee52028e99f9359c3ad1330
-  google-iam-v1 (1.7.0) sha256=9e3ea9dcc59cbd5f8d2f62b00da41ec57a2e427b33c0e798207fa06c8fbb8b87
-  google-identity-access_context_manager-v1 (0.15.0) sha256=8f105320bcbdc03c7fdb05369886117b4f341b792ed4ab81a144929bbcd7820b
+  google-cloud-storage-control (1.4.0) sha256=f43ef850840e907a701fc95492a9cd7f95e7c7a7283ae7b456714b4ed1080ed4
+  google-cloud-storage-control-v2 (1.13.0) sha256=7e4192323c3afcf77ad06c8708ec28e97ed1294d6fc372c308681594f347c42f
   google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
   google-protobuf (4.35.1) sha256=a3a6471331d918f58dfa4d014a8f6286f0af2cf4840216bde52fcf2ea3fe3726
   google-protobuf (4.35.1-aarch64-linux-gnu) sha256=50ca44d0eeff3f8475e630a1accdd974256f3510694d574e2c9d6119ea8bc9e1
@@ -270,6 +250,7 @@ CHECKSUMS
   google-protobuf (4.35.1-x86_64-darwin) sha256=66b62b4df00931018a692806df66393efa960d6d2b7da69735187249f950d3ee
   google-protobuf (4.35.1-x86_64-linux-gnu) sha256=c786439087512a3fbd199e9897d265b855f951d4027e218ea55e858d45969edd
   google-protobuf (4.35.1-x86_64-linux-musl) sha256=91890eb0002934a339fdb7d77a147c46b7474b6799db27872b747b905837f744
+  google-style (1.27.1) sha256=aa5ff9756673a4365f31589e8359b22f0c7b52f191ca87608bc0045b0fa1f1c0
   googleapis-common-protos (1.9.0) sha256=207be372d8d25e3876e1e1155d057e14f3c92f8f5428772864a8ce04a0b756e4
   googleapis-common-protos-types (1.23.0) sha256=992e740a523794d9fc5f29a504465d8fc737aaa16c930fe7228e3346860faf0a
   googleauth (1.17.3) sha256=9a655455885c0c17a8b70537acd2a992a7c7842c43c06c6612dfb0d93e755d58
@@ -285,21 +266,35 @@ CHECKSUMS
   grpc-google-iam-v1 (1.12.0) sha256=a70ecad8987e340d5e22e7bf01be31256c84b29a3f78bebd385a4a110e1f2aef
   json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
+  language_server-protocol (3.17.0.6) sha256=5ef2c0c138f8267e1bc631d3328347d354f96724b0af22f2c79516120443b7f0
+  lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   minitest-focus (1.4.1) sha256=394517cbe2dcb2d992d8ffc41a3b2b6315777a4daa69239de4fefe7110dd810e
+  minitest-hooks (1.5.4) sha256=1254069f3da51fea234dc4ff974108d03d19260ad5c4b78eed9695726a5069b8
   multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
   os (1.1.4) sha256=57816d6a334e7bd6aed048f4b0308226c5fb027433b67d90a9ab435f35108d3f
+  parallel (1.28.0) sha256=33e6de1484baf2524792d178b0913fc8eb94c628d6cfe45599ad4458c638c970
+  parser (3.3.12.0) sha256=21a6d7f755d5a24dfbdc6e6b772e4e879a52e7631a88bc5a3a134606052c9828
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   pstore (0.2.1) sha256=03904d0f2c66579e96d1e6704cdabc0c88df7ea8ed8782d9f3569f6f6c702c1a
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
+  regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
   representable (3.2.0) sha256=cc29bf7eebc31653586849371a43ffe36c60b54b0a6365b5f7d95ec34d1ebace
-  retriable (3.8.0) sha256=9f2f1b0207594c7817f17f671587b8ec7587387ac6cebda6c941a802bb98a8e5
+  retriable (4.2.0) sha256=90c3b257472a1c02f2a3dfa64dd35a420f7a624cef1a5981e20fdac5730f8cdc
+  rubocop (1.88.2) sha256=8def251c90cd955feb4daa3edc0ab56893250c4ce90ef81e6c80c03f9a939bbf
+  rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   signet (0.22.0) sha256=b76d495ccb07ad35dbc89f3e920665a9d8ed717141955034005d7843dcfe4780
   trailblazer-option (0.1.2) sha256=20e4f12ea4e1f718c8007e7944ca21a329eee4eed9e0fa5dde6e8ad8ac4344a3
   uber (0.1.0) sha256=5beeb407ff807b5db994f82fa9ee07cfceaa561dad8af20be880bc67eba935dc
+  unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
+  unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
 
 BUNDLED WITH

--- a/google-cloud-storage/samples/Gemfile.lock
+++ b/google-cloud-storage/samples/Gemfile.lock
@@ -3,12 +3,15 @@ GEM
   specs:
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.1.2)
+    cgi (0.5.2)
     concurrent-ruby (1.3.8)
     declarative (0.0.20)
     digest-crc (0.7.0)
       rake (>= 12.0.0, < 14.0.0)
+    erb (6.0.6)
     faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
@@ -29,47 +32,19 @@ GEM
       googleapis-common-protos-types (~> 1.15)
       googleauth (~> 1.12)
       grpc (~> 1.66)
-    google-apis-bigquery_v2 (0.106.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-<<<<<<< HEAD
-    google-apis-core (1.2.99)
-      addressable (~> 2.8, >= 2.8.7)
-=======
     google-apis-core (1.2.5)
       addressable (~> 2.9)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
       faraday (~> 2.13)
       faraday-follow_redirects (~> 0.3)
       googleauth (~> 1.14)
       mini_mime (~> 1.1)
       multi_json (~> 1.11)
       representable (~> 3.0)
-<<<<<<< HEAD
-      retriable (~> 3.1)
-=======
       retriable (>= 3.1, < 5.0)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
     google-apis-iamcredentials_v1 (0.28.0)
       google-apis-core (>= 0.15.0, < 2.a)
     google-apis-storage_v1 (0.65.0)
       google-apis-core (>= 0.15.0, < 2.a)
-    google-cloud-asset (1.10.0)
-      google-cloud-asset-v1 (>= 0.29, < 2.a)
-      google-cloud-core (~> 1.6)
-    google-cloud-asset-v1 (1.9.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-cloud-os_config-v1 (> 0.0, < 2.a)
-      google-identity-access_context_manager-v1 (> 0.0, < 2.a)
-      grpc-google-iam-v1 (~> 1.11)
-    google-cloud-bigquery (1.64.0)
-      bigdecimal (>= 3.0, < 5)
-      concurrent-ruby (~> 1.0)
-      google-apis-bigquery_v2 (~> 0.71)
-      google-apis-core (>= 0.18, < 2)
-      google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
     google-cloud-core (1.9.0)
       google-cloud-env (>= 1.0, < 3.a)
       google-cloud-errors (~> 1.0)
@@ -77,7 +52,15 @@ GEM
       base64 (~> 0.2)
       faraday (>= 1.0, < 3.a)
     google-cloud-errors (1.7.0)
-    google-cloud-os_config-v1 (1.9.0)
+    google-cloud-kms (2.12.0)
+      google-cloud-core (~> 1.6)
+      google-cloud-kms-v1 (>= 0.26, < 2.a)
+    google-cloud-kms-v1 (1.15.0)
+      gapic-common (~> 1.3)
+      google-cloud-errors (~> 1.0)
+      google-cloud-location (~> 1.0)
+      google-iam-v1 (~> 1.3)
+    google-cloud-location (1.5.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
     google-cloud-pubsub (3.4.0)
@@ -99,10 +82,6 @@ GEM
       googleauth (~> 1.9)
       mini_mime (~> 1.0)
     google-iam-v1 (1.7.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      grpc-google-iam-v1 (~> 1.11)
-    google-identity-access_context_manager-v1 (0.15.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
       grpc-google-iam-v1 (~> 1.11)
@@ -134,6 +113,8 @@ GEM
     google-protobuf (4.35.1-x86_64-linux-musl)
       bigdecimal
       rake (~> 13.3)
+    google-style (1.30.1)
+      rubocop (~> 1.63)
     googleapis-common-protos (1.9.0)
       google-protobuf (~> 4.26)
       googleapis-common-protos-types (~> 1.21)
@@ -179,32 +160,84 @@ GEM
       google-protobuf (>= 3.18, < 5.a)
       googleapis-common-protos (~> 1.9.0)
       grpc (~> 1.41)
+    io-console (0.8.2)
+    irb (1.18.0)
+      pp (>= 0.6.0)
+      prism (>= 1.3.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
     json (2.21.2)
     jwt (3.2.0)
       base64
+    language_server-protocol (3.17.0.6)
+    lint_roller (1.1.0)
     logger (1.7.0)
     mini_mime (1.1.5)
     minitest (5.27.0)
     minitest-focus (1.4.1)
       minitest (> 5.0)
+    minitest-hooks (1.5.4)
+      minitest (> 5.3)
     multi_json (1.21.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
     os (1.1.4)
+    ostruct (0.6.3)
+    parallel (1.28.0)
+    parser (3.3.12.0)
+      ast (~> 2.4.1)
+      racc
+    pp (0.6.4)
+      prettyprint
+    prettyprint (0.2.0)
+    prism (1.9.0)
     pstore (0.2.1)
     public_suffix (7.0.5)
+    racc (1.8.1)
+    rainbow (3.1.1)
     rake (13.4.2)
+    rbs (4.1.2)
+      logger
+      prism (>= 1.6.0)
+      tsort
+    rdoc (8.0.0)
+      erb
+      prism (>= 1.6.0)
+      rbs (>= 4.0.0)
+      tsort
+    regexp_parser (2.12.0)
+    reline (0.6.3)
+      io-console (~> 0.5)
     representable (3.2.0)
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
     retriable (3.8.0)
+    rubocop (1.88.2)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (>= 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.50.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    ruby-progressbar (1.13.0)
     signet (0.22.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 4.0)
     trailblazer-option (0.1.2)
+    tsort (0.2.0)
     uber (0.1.0)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
     uri (1.1.1)
 
 PLATFORMS
@@ -219,47 +252,47 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  google-cloud-asset
-  google-cloud-bigquery
+  cgi
+  google-cloud-kms
   google-cloud-pubsub
   google-cloud-storage
+  google-style (~> 1.30.0)
+  irb
   minitest (~> 5.14)
-  minitest-focus
+  minitest-focus (~> 1.1)
+  minitest-hooks (~> 1.5)
+  ostruct
   rake
 
 CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
+  cgi (0.5.2) sha256=61ca30298171190fd4fa0d8018e57ada456eae9b7a2b78526debf7f0a0e6f8bb
   concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
   declarative (0.0.20) sha256=8021dd6cb17ab2b61233c56903d3f5a259c5cf43c80ff332d447d395b17d9ff9
   digest-crc (0.7.0) sha256=64adc23a26a241044cbe6732477ca1b3c281d79e2240bcff275a37a5a0d78c07
+  erb (6.0.6) sha256=a9b24986700f5bf127c4f297c5403c3ca41b83b0a316c0cd09a096b56e644ae5
   faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
   faraday-follow_redirects (0.5.0) sha256=5cde93c894b30943a5d2b93c2fe9284216a6b756f7af406a1e55f211d97d10ad
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
   faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
   gapic-common (1.3.0) sha256=4e5d9be1effb7366e2cda13c0f44922285d5613ac8de8b9b18c2c835fe4faa91
-  google-apis-bigquery_v2 (0.106.0) sha256=a0f4243b634a0c79c29b7dacdd79233bd9c9ba2eda6fde9c2b19414fd165dd93
-<<<<<<< HEAD
-  google-apis-core (1.2.99)
-=======
   google-apis-core (1.2.5) sha256=e21562b5627a0fc6a0c3165e429c3afed0f6a628eaa514e83f7204dda1adff69
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
   google-apis-iamcredentials_v1 (0.28.0) sha256=0a92ffe6cc39c569554af2a77a25dfc61519ed8bbb64ab04cffdd352dc5ef106
   google-apis-storage_v1 (0.65.0) sha256=4247aa542931691f6988ab61e45cdea2878cbfe897a98eec4af9cdcb678eb359
-  google-cloud-asset (1.10.0) sha256=6ea6fd9e0735873884094c14d84d5a6d826b0e07aaeec245d34735ab2c5828e0
-  google-cloud-asset-v1 (1.9.0) sha256=ecfb654d0d350ed98209d46937c8095ec867c8ff6c3f7d70b8889f6fb70fd397
-  google-cloud-bigquery (1.64.0) sha256=d807363903e08958c3bc09ccc1f9d1218646c8f18176751879348a1a4a884d57
   google-cloud-core (1.9.0) sha256=ab55409f51488e8deefb6edcc1ce4771dfb5da2fe7b3bc075709a030c2b682a4
   google-cloud-env (2.4.0) sha256=01cb35ecee5d1c4d1cd4deaed8bb5bddc838e296bcc2a35c5d1ddd07ce40d28d
   google-cloud-errors (1.7.0) sha256=6e682f42d89aae08689f36f28495de629d756da076bafff0003bac7f8042ebb3
-  google-cloud-os_config-v1 (1.9.0) sha256=693c13690cfd7cf9d307c25d005ff33b823b6709791d3714c344ff1597ec3a30
+  google-cloud-kms (2.12.0) sha256=c546fea8e7f0d07e09532fa0714cd783424d8dc7d859334940e7cb6e2e788d8c
+  google-cloud-kms-v1 (1.15.0) sha256=25942a07b11809bc535263bb4ce7e0d9ccef5e863463374defd7487dcd07ef97
+  google-cloud-location (1.5.0) sha256=336f94609b1fb18fce1929048fac964f4d5a87d27c1e5444bfed3605469c7532
   google-cloud-pubsub (3.4.0) sha256=6a6390a6f605701945d5be233dea51e0b04009f157b5d701b092423fbc690edd
   google-cloud-pubsub-v1 (1.16.0) sha256=ffe128821208bd3d2f27cb0d25eb6accb3893c99e0b736d1740b8b5e1570426b
   google-cloud-storage (1.62.0) sha256=e2c3c08bf8fd40d50be92304084942203314d4fc0ee52028e99f9359c3ad1330
   google-iam-v1 (1.7.0) sha256=9e3ea9dcc59cbd5f8d2f62b00da41ec57a2e427b33c0e798207fa06c8fbb8b87
-  google-identity-access_context_manager-v1 (0.15.0) sha256=8f105320bcbdc03c7fdb05369886117b4f341b792ed4ab81a144929bbcd7820b
   google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
   google-protobuf (4.35.1) sha256=a3a6471331d918f58dfa4d014a8f6286f0af2cf4840216bde52fcf2ea3fe3726
   google-protobuf (4.35.1-aarch64-linux-gnu) sha256=50ca44d0eeff3f8475e630a1accdd974256f3510694d574e2c9d6119ea8bc9e1
@@ -270,6 +303,7 @@ CHECKSUMS
   google-protobuf (4.35.1-x86_64-darwin) sha256=66b62b4df00931018a692806df66393efa960d6d2b7da69735187249f950d3ee
   google-protobuf (4.35.1-x86_64-linux-gnu) sha256=c786439087512a3fbd199e9897d265b855f951d4027e218ea55e858d45969edd
   google-protobuf (4.35.1-x86_64-linux-musl) sha256=91890eb0002934a339fdb7d77a147c46b7474b6799db27872b747b905837f744
+  google-style (1.30.1) sha256=ae9260c1f86856d8179a17fb270ccc2137ec0c0baa2a728ab5c8e7d76ce4032a
   googleapis-common-protos (1.9.0) sha256=207be372d8d25e3876e1e1155d057e14f3c92f8f5428772864a8ce04a0b756e4
   googleapis-common-protos-types (1.23.0) sha256=992e740a523794d9fc5f29a504465d8fc737aaa16c930fe7228e3346860faf0a
   googleauth (1.17.3) sha256=9a655455885c0c17a8b70537acd2a992a7c7842c43c06c6612dfb0d93e755d58
@@ -283,23 +317,46 @@ CHECKSUMS
   grpc (1.83.0-x86_64-linux-gnu) sha256=25d66bfa3cb1b05258b3f9632478c7e7ceb52cb16ccc0b4b26d7df36be7158b1
   grpc (1.83.0-x86_64-linux-musl) sha256=a5023264dbb8038c23b147bbf80adb06932ef11b5ab493412e9e37a43114fa8c
   grpc-google-iam-v1 (1.12.0) sha256=a70ecad8987e340d5e22e7bf01be31256c84b29a3f78bebd385a4a110e1f2aef
+  io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
+  irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
   json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
+  language_server-protocol (3.17.0.6) sha256=5ef2c0c138f8267e1bc631d3328347d354f96724b0af22f2c79516120443b7f0
+  lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   minitest-focus (1.4.1) sha256=394517cbe2dcb2d992d8ffc41a3b2b6315777a4daa69239de4fefe7110dd810e
+  minitest-hooks (1.5.4) sha256=1254069f3da51fea234dc4ff974108d03d19260ad5c4b78eed9695726a5069b8
   multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
   os (1.1.4) sha256=57816d6a334e7bd6aed048f4b0308226c5fb027433b67d90a9ab435f35108d3f
+  ostruct (0.6.3) sha256=95a2ed4a4bd1d190784e666b47b2d3f078e4a9efda2fccf18f84ddc6538ed912
+  parallel (1.28.0) sha256=33e6de1484baf2524792d178b0913fc8eb94c628d6cfe45599ad4458c638c970
+  parser (3.3.12.0) sha256=21a6d7f755d5a24dfbdc6e6b772e4e879a52e7631a88bc5a3a134606052c9828
+  pp (0.6.4) sha256=dfcb0fce700c41456265922884f9fe195d7fbb0674a3578e6c0f69588e82b570
+  prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   pstore (0.2.1) sha256=03904d0f2c66579e96d1e6704cdabc0c88df7ea8ed8782d9f3569f6f6c702c1a
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
+  rbs (4.1.2) sha256=050eb1d8b508f1233bed929c0f2c7052302f7adf295230d9cb314e9024078f48
+  rdoc (8.0.0) sha256=03bf8c08a9639658855a0cfd77c0abca8325c227693f7f33f82957811348c469
+  regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
+  reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
   representable (3.2.0) sha256=cc29bf7eebc31653586849371a43ffe36c60b54b0a6365b5f7d95ec34d1ebace
   retriable (3.8.0) sha256=9f2f1b0207594c7817f17f671587b8ec7587387ac6cebda6c941a802bb98a8e5
+  rubocop (1.88.2) sha256=8def251c90cd955feb4daa3edc0ab56893250c4ce90ef81e6c80c03f9a939bbf
+  rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   signet (0.22.0) sha256=b76d495ccb07ad35dbc89f3e920665a9d8ed717141955034005d7843dcfe4780
   trailblazer-option (0.1.2) sha256=20e4f12ea4e1f718c8007e7944ca21a329eee4eed9e0fa5dde6e8ad8ac4344a3
+  tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
   uber (0.1.0) sha256=5beeb407ff807b5db994f82fa9ee07cfceaa561dad8af20be880bc67eba935dc
+  unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
+  unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
 
 BUNDLED WITH

--- a/google-cloud-storage_batch_operations/samples/Gemfile.lock
+++ b/google-cloud-storage_batch_operations/samples/Gemfile.lock
@@ -3,9 +3,9 @@ GEM
   specs:
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.1.2)
-    concurrent-ruby (1.3.8)
     declarative (0.0.20)
     digest-crc (0.7.0)
       rake (>= 12.0.0, < 14.0.0)
@@ -29,47 +29,19 @@ GEM
       googleapis-common-protos-types (~> 1.15)
       googleauth (~> 1.12)
       grpc (~> 1.66)
-    google-apis-bigquery_v2 (0.106.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-<<<<<<< HEAD
-    google-apis-core (1.2.99)
-      addressable (~> 2.8, >= 2.8.7)
-=======
     google-apis-core (1.2.5)
       addressable (~> 2.9)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
       faraday (~> 2.13)
       faraday-follow_redirects (~> 0.3)
       googleauth (~> 1.14)
       mini_mime (~> 1.1)
       multi_json (~> 1.11)
       representable (~> 3.0)
-<<<<<<< HEAD
-      retriable (~> 3.1)
-=======
       retriable (>= 3.1, < 5.0)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
     google-apis-iamcredentials_v1 (0.28.0)
       google-apis-core (>= 0.15.0, < 2.a)
     google-apis-storage_v1 (0.65.0)
       google-apis-core (>= 0.15.0, < 2.a)
-    google-cloud-asset (1.10.0)
-      google-cloud-asset-v1 (>= 0.29, < 2.a)
-      google-cloud-core (~> 1.6)
-    google-cloud-asset-v1 (1.9.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-cloud-os_config-v1 (> 0.0, < 2.a)
-      google-identity-access_context_manager-v1 (> 0.0, < 2.a)
-      grpc-google-iam-v1 (~> 1.11)
-    google-cloud-bigquery (1.64.0)
-      bigdecimal (>= 3.0, < 5)
-      concurrent-ruby (~> 1.0)
-      google-apis-bigquery_v2 (~> 0.71)
-      google-apis-core (>= 0.18, < 2)
-      google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
     google-cloud-core (1.9.0)
       google-cloud-env (>= 1.0, < 3.a)
       google-cloud-errors (~> 1.0)
@@ -77,18 +49,9 @@ GEM
       base64 (~> 0.2)
       faraday (>= 1.0, < 3.a)
     google-cloud-errors (1.7.0)
-    google-cloud-os_config-v1 (1.9.0)
+    google-cloud-location (1.5.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
-    google-cloud-pubsub (3.4.0)
-      concurrent-ruby (~> 1.3)
-      google-cloud-core (~> 1.8)
-      google-cloud-pubsub-v1 (~> 1.11)
-      retriable (~> 3.1)
-    google-cloud-pubsub-v1 (1.16.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-iam-v1 (~> 1.3)
     google-cloud-storage (1.62.0)
       addressable (~> 2.8)
       digest-crc (~> 0.4)
@@ -98,14 +61,13 @@ GEM
       google-cloud-core (~> 1.6)
       googleauth (~> 1.9)
       mini_mime (~> 1.0)
-    google-iam-v1 (1.7.0)
+    google-cloud-storage_batch_operations (1.0.0)
+      google-cloud-core (~> 1.6)
+      google-cloud-storage_batch_operations-v1 (>= 0.0, < 2.a)
+    google-cloud-storage_batch_operations-v1 (1.0.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
-      grpc-google-iam-v1 (~> 1.11)
-    google-identity-access_context_manager-v1 (0.15.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      grpc-google-iam-v1 (~> 1.11)
+      google-cloud-location (~> 1.0)
     google-logging-utils (0.2.0)
     google-protobuf (4.35.1)
       bigdecimal
@@ -134,7 +96,9 @@ GEM
     google-protobuf (4.35.1-x86_64-linux-musl)
       bigdecimal
       rake (~> 13.3)
-    googleapis-common-protos (1.9.0)
+    google-style (1.30.1)
+      rubocop (~> 1.63)
+    googleapis-common-protos (1.10.0)
       google-protobuf (~> 4.26)
       googleapis-common-protos-types (~> 1.21)
       grpc (~> 1.41)
@@ -175,36 +139,62 @@ GEM
     grpc (1.83.0-x86_64-linux-musl)
       google-protobuf (>= 3.25, < 5.0)
       googleapis-common-protos-types (~> 1.0)
-    grpc-google-iam-v1 (1.12.0)
-      google-protobuf (>= 3.18, < 5.a)
-      googleapis-common-protos (~> 1.9.0)
-      grpc (~> 1.41)
     json (2.21.2)
     jwt (3.2.0)
       base64
+    language_server-protocol (3.17.0.6)
+    lint_roller (1.1.0)
     logger (1.7.0)
     mini_mime (1.1.5)
     minitest (5.27.0)
     minitest-focus (1.4.1)
       minitest (> 5.0)
+    minitest-hooks (1.5.4)
+      minitest (> 5.3)
     multi_json (1.21.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
     os (1.1.4)
+    parallel (1.28.0)
+    parser (3.3.12.0)
+      ast (~> 2.4.1)
+      racc
+    prism (1.9.0)
     pstore (0.2.1)
     public_suffix (7.0.5)
+    racc (1.8.1)
+    rainbow (3.1.1)
     rake (13.4.2)
+    regexp_parser (2.12.0)
     representable (3.2.0)
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
-    retriable (3.8.0)
+    retriable (4.2.0)
+    rubocop (1.88.2)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (>= 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.50.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    ruby-progressbar (1.13.0)
     signet (0.22.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 4.0)
     trailblazer-option (0.1.2)
     uber (0.1.0)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
     uri (1.1.1)
 
 PLATFORMS
@@ -219,20 +209,20 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  google-cloud-asset
-  google-cloud-bigquery
-  google-cloud-pubsub
   google-cloud-storage
+  google-cloud-storage_batch_operations
+  google-style (~> 1.30.0)
   minitest (~> 5.14)
-  minitest-focus
+  minitest-focus (~> 1.1)
+  minitest-hooks (~> 1.5)
   rake
 
 CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
-  concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
   declarative (0.0.20) sha256=8021dd6cb17ab2b61233c56903d3f5a259c5cf43c80ff332d447d395b17d9ff9
   digest-crc (0.7.0) sha256=64adc23a26a241044cbe6732477ca1b3c281d79e2240bcff275a37a5a0d78c07
   faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
@@ -240,26 +230,16 @@ CHECKSUMS
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
   faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
   gapic-common (1.3.0) sha256=4e5d9be1effb7366e2cda13c0f44922285d5613ac8de8b9b18c2c835fe4faa91
-  google-apis-bigquery_v2 (0.106.0) sha256=a0f4243b634a0c79c29b7dacdd79233bd9c9ba2eda6fde9c2b19414fd165dd93
-<<<<<<< HEAD
-  google-apis-core (1.2.99)
-=======
   google-apis-core (1.2.5) sha256=e21562b5627a0fc6a0c3165e429c3afed0f6a628eaa514e83f7204dda1adff69
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
   google-apis-iamcredentials_v1 (0.28.0) sha256=0a92ffe6cc39c569554af2a77a25dfc61519ed8bbb64ab04cffdd352dc5ef106
   google-apis-storage_v1 (0.65.0) sha256=4247aa542931691f6988ab61e45cdea2878cbfe897a98eec4af9cdcb678eb359
-  google-cloud-asset (1.10.0) sha256=6ea6fd9e0735873884094c14d84d5a6d826b0e07aaeec245d34735ab2c5828e0
-  google-cloud-asset-v1 (1.9.0) sha256=ecfb654d0d350ed98209d46937c8095ec867c8ff6c3f7d70b8889f6fb70fd397
-  google-cloud-bigquery (1.64.0) sha256=d807363903e08958c3bc09ccc1f9d1218646c8f18176751879348a1a4a884d57
   google-cloud-core (1.9.0) sha256=ab55409f51488e8deefb6edcc1ce4771dfb5da2fe7b3bc075709a030c2b682a4
   google-cloud-env (2.4.0) sha256=01cb35ecee5d1c4d1cd4deaed8bb5bddc838e296bcc2a35c5d1ddd07ce40d28d
   google-cloud-errors (1.7.0) sha256=6e682f42d89aae08689f36f28495de629d756da076bafff0003bac7f8042ebb3
-  google-cloud-os_config-v1 (1.9.0) sha256=693c13690cfd7cf9d307c25d005ff33b823b6709791d3714c344ff1597ec3a30
-  google-cloud-pubsub (3.4.0) sha256=6a6390a6f605701945d5be233dea51e0b04009f157b5d701b092423fbc690edd
-  google-cloud-pubsub-v1 (1.16.0) sha256=ffe128821208bd3d2f27cb0d25eb6accb3893c99e0b736d1740b8b5e1570426b
+  google-cloud-location (1.5.0) sha256=336f94609b1fb18fce1929048fac964f4d5a87d27c1e5444bfed3605469c7532
   google-cloud-storage (1.62.0) sha256=e2c3c08bf8fd40d50be92304084942203314d4fc0ee52028e99f9359c3ad1330
-  google-iam-v1 (1.7.0) sha256=9e3ea9dcc59cbd5f8d2f62b00da41ec57a2e427b33c0e798207fa06c8fbb8b87
-  google-identity-access_context_manager-v1 (0.15.0) sha256=8f105320bcbdc03c7fdb05369886117b4f341b792ed4ab81a144929bbcd7820b
+  google-cloud-storage_batch_operations (1.0.0) sha256=e442daba628ab5e3cb7c6e3bf8e4e10e35a8c2205ae49b2a5ade3bde1fd08c1e
+  google-cloud-storage_batch_operations-v1 (1.0.0) sha256=9044ff0be110a68a5efeff816dd50fbb2906e25829964893244d4ae6e0bc8f57
   google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
   google-protobuf (4.35.1) sha256=a3a6471331d918f58dfa4d014a8f6286f0af2cf4840216bde52fcf2ea3fe3726
   google-protobuf (4.35.1-aarch64-linux-gnu) sha256=50ca44d0eeff3f8475e630a1accdd974256f3510694d574e2c9d6119ea8bc9e1
@@ -270,7 +250,8 @@ CHECKSUMS
   google-protobuf (4.35.1-x86_64-darwin) sha256=66b62b4df00931018a692806df66393efa960d6d2b7da69735187249f950d3ee
   google-protobuf (4.35.1-x86_64-linux-gnu) sha256=c786439087512a3fbd199e9897d265b855f951d4027e218ea55e858d45969edd
   google-protobuf (4.35.1-x86_64-linux-musl) sha256=91890eb0002934a339fdb7d77a147c46b7474b6799db27872b747b905837f744
-  googleapis-common-protos (1.9.0) sha256=207be372d8d25e3876e1e1155d057e14f3c92f8f5428772864a8ce04a0b756e4
+  google-style (1.30.1) sha256=ae9260c1f86856d8179a17fb270ccc2137ec0c0baa2a728ab5c8e7d76ce4032a
+  googleapis-common-protos (1.10.0) sha256=13e47ad0ce85d3d30065c03863efd302a82b0e08ba576f2a9b9dbbfeecb57ee0
   googleapis-common-protos-types (1.23.0) sha256=992e740a523794d9fc5f29a504465d8fc737aaa16c930fe7228e3346860faf0a
   googleauth (1.17.3) sha256=9a655455885c0c17a8b70537acd2a992a7c7842c43c06c6612dfb0d93e755d58
   grpc (1.83.0) sha256=38119e7f9f7cbc98e79145201da4be470a7542b0befad454651d35015ea55c59
@@ -282,24 +263,37 @@ CHECKSUMS
   grpc (1.83.0-x86_64-darwin) sha256=cfad91d559d1907159a5247fb12dc112a8ea0ebe2027ca7f5ab648d01a645716
   grpc (1.83.0-x86_64-linux-gnu) sha256=25d66bfa3cb1b05258b3f9632478c7e7ceb52cb16ccc0b4b26d7df36be7158b1
   grpc (1.83.0-x86_64-linux-musl) sha256=a5023264dbb8038c23b147bbf80adb06932ef11b5ab493412e9e37a43114fa8c
-  grpc-google-iam-v1 (1.12.0) sha256=a70ecad8987e340d5e22e7bf01be31256c84b29a3f78bebd385a4a110e1f2aef
   json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
+  language_server-protocol (3.17.0.6) sha256=5ef2c0c138f8267e1bc631d3328347d354f96724b0af22f2c79516120443b7f0
+  lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   minitest-focus (1.4.1) sha256=394517cbe2dcb2d992d8ffc41a3b2b6315777a4daa69239de4fefe7110dd810e
+  minitest-hooks (1.5.4) sha256=1254069f3da51fea234dc4ff974108d03d19260ad5c4b78eed9695726a5069b8
   multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
   os (1.1.4) sha256=57816d6a334e7bd6aed048f4b0308226c5fb027433b67d90a9ab435f35108d3f
+  parallel (1.28.0) sha256=33e6de1484baf2524792d178b0913fc8eb94c628d6cfe45599ad4458c638c970
+  parser (3.3.12.0) sha256=21a6d7f755d5a24dfbdc6e6b772e4e879a52e7631a88bc5a3a134606052c9828
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   pstore (0.2.1) sha256=03904d0f2c66579e96d1e6704cdabc0c88df7ea8ed8782d9f3569f6f6c702c1a
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
+  regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
   representable (3.2.0) sha256=cc29bf7eebc31653586849371a43ffe36c60b54b0a6365b5f7d95ec34d1ebace
-  retriable (3.8.0) sha256=9f2f1b0207594c7817f17f671587b8ec7587387ac6cebda6c941a802bb98a8e5
+  retriable (4.2.0) sha256=90c3b257472a1c02f2a3dfa64dd35a420f7a624cef1a5981e20fdac5730f8cdc
+  rubocop (1.88.2) sha256=8def251c90cd955feb4daa3edc0ab56893250c4ce90ef81e6c80c03f9a939bbf
+  rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   signet (0.22.0) sha256=b76d495ccb07ad35dbc89f3e920665a9d8ed717141955034005d7843dcfe4780
   trailblazer-option (0.1.2) sha256=20e4f12ea4e1f718c8007e7944ca21a329eee4eed9e0fa5dde6e8ad8ac4344a3
   uber (0.1.0) sha256=5beeb407ff807b5db994f82fa9ee07cfceaa561dad8af20be880bc67eba935dc
+  unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
+  unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
 
 BUNDLED WITH

--- a/google-cloud-storage_transfer/samples/Gemfile.lock
+++ b/google-cloud-storage_transfer/samples/Gemfile.lock
@@ -3,9 +3,11 @@ GEM
   specs:
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.1.2)
     concurrent-ruby (1.3.8)
+    csv (3.3.6)
     declarative (0.0.20)
     digest-crc (0.7.0)
       rake (>= 12.0.0, < 14.0.0)
@@ -29,47 +31,19 @@ GEM
       googleapis-common-protos-types (~> 1.15)
       googleauth (~> 1.12)
       grpc (~> 1.66)
-    google-apis-bigquery_v2 (0.106.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-<<<<<<< HEAD
-    google-apis-core (1.2.99)
-      addressable (~> 2.8, >= 2.8.7)
-=======
     google-apis-core (1.2.5)
       addressable (~> 2.9)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
       faraday (~> 2.13)
       faraday-follow_redirects (~> 0.3)
       googleauth (~> 1.14)
       mini_mime (~> 1.1)
       multi_json (~> 1.11)
       representable (~> 3.0)
-<<<<<<< HEAD
-      retriable (~> 3.1)
-=======
       retriable (>= 3.1, < 5.0)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
     google-apis-iamcredentials_v1 (0.28.0)
       google-apis-core (>= 0.15.0, < 2.a)
     google-apis-storage_v1 (0.65.0)
       google-apis-core (>= 0.15.0, < 2.a)
-    google-cloud-asset (1.10.0)
-      google-cloud-asset-v1 (>= 0.29, < 2.a)
-      google-cloud-core (~> 1.6)
-    google-cloud-asset-v1 (1.9.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-cloud-os_config-v1 (> 0.0, < 2.a)
-      google-identity-access_context_manager-v1 (> 0.0, < 2.a)
-      grpc-google-iam-v1 (~> 1.11)
-    google-cloud-bigquery (1.64.0)
-      bigdecimal (>= 3.0, < 5)
-      concurrent-ruby (~> 1.0)
-      google-apis-bigquery_v2 (~> 0.71)
-      google-apis-core (>= 0.18, < 2)
-      google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
     google-cloud-core (1.9.0)
       google-cloud-env (>= 1.0, < 3.a)
       google-cloud-errors (~> 1.0)
@@ -77,9 +51,6 @@ GEM
       base64 (~> 0.2)
       faraday (>= 1.0, < 3.a)
     google-cloud-errors (1.7.0)
-    google-cloud-os_config-v1 (1.9.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
     google-cloud-pubsub (3.4.0)
       concurrent-ruby (~> 1.3)
       google-cloud-core (~> 1.8)
@@ -98,11 +69,13 @@ GEM
       google-cloud-core (~> 1.6)
       googleauth (~> 1.9)
       mini_mime (~> 1.0)
-    google-iam-v1 (1.7.0)
+    google-cloud-storage_transfer (1.7.0)
+      google-cloud-core (~> 1.6)
+      google-cloud-storage_transfer-v1 (>= 0.9, < 2.a)
+    google-cloud-storage_transfer-v1 (1.11.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
-      grpc-google-iam-v1 (~> 1.11)
-    google-identity-access_context_manager-v1 (0.15.0)
+    google-iam-v1 (1.7.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
       grpc-google-iam-v1 (~> 1.11)
@@ -134,6 +107,8 @@ GEM
     google-protobuf (4.35.1-x86_64-linux-musl)
       bigdecimal
       rake (~> 13.3)
+    google-style (1.25.3)
+      rubocop (~> 1.28.2)
     googleapis-common-protos (1.9.0)
       google-protobuf (~> 4.26)
       googleapis-common-protos-types (~> 1.21)
@@ -187,24 +162,49 @@ GEM
     minitest (5.27.0)
     minitest-focus (1.4.1)
       minitest (> 5.0)
+    minitest-hooks (1.5.4)
+      minitest (> 5.3)
     multi_json (1.21.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
     os (1.1.4)
+    parallel (1.28.0)
+    parser (3.3.12.0)
+      ast (~> 2.4.1)
+      racc
+    prism (1.9.0)
     pstore (0.2.1)
     public_suffix (7.0.5)
+    racc (1.8.1)
+    rainbow (3.1.1)
     rake (13.4.2)
+    regexp_parser (2.12.0)
     representable (3.2.0)
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
     retriable (3.8.0)
+    rexml (3.4.4)
+    rubocop (1.28.2)
+      parallel (~> 1.10)
+      parser (>= 3.1.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.17.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.50.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    ruby-progressbar (1.13.0)
     signet (0.22.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 4.0)
     trailblazer-option (0.1.2)
     uber (0.1.0)
+    unicode-display_width (2.6.0)
     uri (1.1.1)
 
 PLATFORMS
@@ -219,20 +219,24 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  google-cloud-asset
-  google-cloud-bigquery
+  csv
   google-cloud-pubsub
   google-cloud-storage
+  google-cloud-storage_transfer
+  google-style (~> 1.25.1)
   minitest (~> 5.14)
-  minitest-focus
+  minitest-focus (~> 1.1)
+  minitest-hooks (~> 1.5)
   rake
 
 CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
   concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
+  csv (3.3.6) sha256=aba61e7e507a66f03d45cb1f3c4b6359861c3504038b422962875dce099e4456
   declarative (0.0.20) sha256=8021dd6cb17ab2b61233c56903d3f5a259c5cf43c80ff332d447d395b17d9ff9
   digest-crc (0.7.0) sha256=64adc23a26a241044cbe6732477ca1b3c281d79e2240bcff275a37a5a0d78c07
   faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
@@ -240,26 +244,18 @@ CHECKSUMS
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
   faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
   gapic-common (1.3.0) sha256=4e5d9be1effb7366e2cda13c0f44922285d5613ac8de8b9b18c2c835fe4faa91
-  google-apis-bigquery_v2 (0.106.0) sha256=a0f4243b634a0c79c29b7dacdd79233bd9c9ba2eda6fde9c2b19414fd165dd93
-<<<<<<< HEAD
-  google-apis-core (1.2.99)
-=======
   google-apis-core (1.2.5) sha256=e21562b5627a0fc6a0c3165e429c3afed0f6a628eaa514e83f7204dda1adff69
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
   google-apis-iamcredentials_v1 (0.28.0) sha256=0a92ffe6cc39c569554af2a77a25dfc61519ed8bbb64ab04cffdd352dc5ef106
   google-apis-storage_v1 (0.65.0) sha256=4247aa542931691f6988ab61e45cdea2878cbfe897a98eec4af9cdcb678eb359
-  google-cloud-asset (1.10.0) sha256=6ea6fd9e0735873884094c14d84d5a6d826b0e07aaeec245d34735ab2c5828e0
-  google-cloud-asset-v1 (1.9.0) sha256=ecfb654d0d350ed98209d46937c8095ec867c8ff6c3f7d70b8889f6fb70fd397
-  google-cloud-bigquery (1.64.0) sha256=d807363903e08958c3bc09ccc1f9d1218646c8f18176751879348a1a4a884d57
   google-cloud-core (1.9.0) sha256=ab55409f51488e8deefb6edcc1ce4771dfb5da2fe7b3bc075709a030c2b682a4
   google-cloud-env (2.4.0) sha256=01cb35ecee5d1c4d1cd4deaed8bb5bddc838e296bcc2a35c5d1ddd07ce40d28d
   google-cloud-errors (1.7.0) sha256=6e682f42d89aae08689f36f28495de629d756da076bafff0003bac7f8042ebb3
-  google-cloud-os_config-v1 (1.9.0) sha256=693c13690cfd7cf9d307c25d005ff33b823b6709791d3714c344ff1597ec3a30
   google-cloud-pubsub (3.4.0) sha256=6a6390a6f605701945d5be233dea51e0b04009f157b5d701b092423fbc690edd
   google-cloud-pubsub-v1 (1.16.0) sha256=ffe128821208bd3d2f27cb0d25eb6accb3893c99e0b736d1740b8b5e1570426b
   google-cloud-storage (1.62.0) sha256=e2c3c08bf8fd40d50be92304084942203314d4fc0ee52028e99f9359c3ad1330
+  google-cloud-storage_transfer (1.7.0) sha256=0d884a4b6344be417bf190689a313fe4c5eb29f42c090a969896dc01f495bdb0
+  google-cloud-storage_transfer-v1 (1.11.0) sha256=17e52ae72399bd27d49b2cd6ee682f4e9a30b52f4342564e0bd853281aaa5aa1
   google-iam-v1 (1.7.0) sha256=9e3ea9dcc59cbd5f8d2f62b00da41ec57a2e427b33c0e798207fa06c8fbb8b87
-  google-identity-access_context_manager-v1 (0.15.0) sha256=8f105320bcbdc03c7fdb05369886117b4f341b792ed4ab81a144929bbcd7820b
   google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
   google-protobuf (4.35.1) sha256=a3a6471331d918f58dfa4d014a8f6286f0af2cf4840216bde52fcf2ea3fe3726
   google-protobuf (4.35.1-aarch64-linux-gnu) sha256=50ca44d0eeff3f8475e630a1accdd974256f3510694d574e2c9d6119ea8bc9e1
@@ -270,6 +266,7 @@ CHECKSUMS
   google-protobuf (4.35.1-x86_64-darwin) sha256=66b62b4df00931018a692806df66393efa960d6d2b7da69735187249f950d3ee
   google-protobuf (4.35.1-x86_64-linux-gnu) sha256=c786439087512a3fbd199e9897d265b855f951d4027e218ea55e858d45969edd
   google-protobuf (4.35.1-x86_64-linux-musl) sha256=91890eb0002934a339fdb7d77a147c46b7474b6799db27872b747b905837f744
+  google-style (1.25.3) sha256=d417fd0f6d6a9f4bb2ff69e1cfaa1c4d0e19230589cdf4383df4540082c395d4
   googleapis-common-protos (1.9.0) sha256=207be372d8d25e3876e1e1155d057e14f3c92f8f5428772864a8ce04a0b756e4
   googleapis-common-protos-types (1.23.0) sha256=992e740a523794d9fc5f29a504465d8fc737aaa16c930fe7228e3346860faf0a
   googleauth (1.17.3) sha256=9a655455885c0c17a8b70537acd2a992a7c7842c43c06c6612dfb0d93e755d58
@@ -289,17 +286,29 @@ CHECKSUMS
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   minitest-focus (1.4.1) sha256=394517cbe2dcb2d992d8ffc41a3b2b6315777a4daa69239de4fefe7110dd810e
+  minitest-hooks (1.5.4) sha256=1254069f3da51fea234dc4ff974108d03d19260ad5c4b78eed9695726a5069b8
   multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
   os (1.1.4) sha256=57816d6a334e7bd6aed048f4b0308226c5fb027433b67d90a9ab435f35108d3f
+  parallel (1.28.0) sha256=33e6de1484baf2524792d178b0913fc8eb94c628d6cfe45599ad4458c638c970
+  parser (3.3.12.0) sha256=21a6d7f755d5a24dfbdc6e6b772e4e879a52e7631a88bc5a3a134606052c9828
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   pstore (0.2.1) sha256=03904d0f2c66579e96d1e6704cdabc0c88df7ea8ed8782d9f3569f6f6c702c1a
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
+  regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
   representable (3.2.0) sha256=cc29bf7eebc31653586849371a43ffe36c60b54b0a6365b5f7d95ec34d1ebace
   retriable (3.8.0) sha256=9f2f1b0207594c7817f17f671587b8ec7587387ac6cebda6c941a802bb98a8e5
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rubocop (1.28.2) sha256=0d9bf4108fd86ede43c6cf30adcb3dd2e0c6750941c5ec2a00621478157cb377
+  rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   signet (0.22.0) sha256=b76d495ccb07ad35dbc89f3e920665a9d8ed717141955034005d7843dcfe4780
   trailblazer-option (0.1.2) sha256=20e4f12ea4e1f718c8007e7944ca21a329eee4eed9e0fa5dde6e8ad8ac4344a3
   uber (0.1.0) sha256=5beeb407ff807b5db994f82fa9ee07cfceaa561dad8af20be880bc67eba935dc
+  unicode-display_width (2.6.0) sha256=12279874bba6d5e4d2728cef814b19197dbb10d7a7837a869bab65da943b7f5a
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
 
 BUNDLED WITH

--- a/google-cloud-tasks/samples/Gemfile.lock
+++ b/google-cloud-tasks/samples/Gemfile.lock
@@ -5,16 +5,10 @@ GEM
       public_suffix (>= 2.0.2, < 8.0)
     base64 (0.3.0)
     bigdecimal (4.1.2)
-    concurrent-ruby (1.3.8)
-    declarative (0.0.20)
-    digest-crc (0.7.0)
-      rake (>= 12.0.0, < 14.0.0)
     faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-follow_redirects (0.5.0)
-      faraday (>= 1, < 3)
     faraday-net_http (3.4.4)
       net-http (~> 0.5)
     faraday-retry (2.4.0)
@@ -29,47 +23,6 @@ GEM
       googleapis-common-protos-types (~> 1.15)
       googleauth (~> 1.12)
       grpc (~> 1.66)
-    google-apis-bigquery_v2 (0.106.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-<<<<<<< HEAD
-    google-apis-core (1.2.99)
-      addressable (~> 2.8, >= 2.8.7)
-=======
-    google-apis-core (1.2.5)
-      addressable (~> 2.9)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-      faraday (~> 2.13)
-      faraday-follow_redirects (~> 0.3)
-      googleauth (~> 1.14)
-      mini_mime (~> 1.1)
-      multi_json (~> 1.11)
-      representable (~> 3.0)
-<<<<<<< HEAD
-      retriable (~> 3.1)
-=======
-      retriable (>= 3.1, < 5.0)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-    google-apis-iamcredentials_v1 (0.28.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-    google-apis-storage_v1 (0.65.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-    google-cloud-asset (1.10.0)
-      google-cloud-asset-v1 (>= 0.29, < 2.a)
-      google-cloud-core (~> 1.6)
-    google-cloud-asset-v1 (1.9.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-cloud-os_config-v1 (> 0.0, < 2.a)
-      google-identity-access_context_manager-v1 (> 0.0, < 2.a)
-      grpc-google-iam-v1 (~> 1.11)
-    google-cloud-bigquery (1.64.0)
-      bigdecimal (>= 3.0, < 5)
-      concurrent-ruby (~> 1.0)
-      google-apis-bigquery_v2 (~> 0.71)
-      google-apis-core (>= 0.18, < 2)
-      google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
     google-cloud-core (1.9.0)
       google-cloud-env (>= 1.0, < 3.a)
       google-cloud-errors (~> 1.0)
@@ -77,34 +30,26 @@ GEM
       base64 (~> 0.2)
       faraday (>= 1.0, < 3.a)
     google-cloud-errors (1.7.0)
-    google-cloud-os_config-v1 (1.9.0)
+    google-cloud-location (1.5.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
-    google-cloud-pubsub (3.4.0)
-      concurrent-ruby (~> 1.3)
-      google-cloud-core (~> 1.8)
-      google-cloud-pubsub-v1 (~> 1.11)
-      retriable (~> 3.1)
-    google-cloud-pubsub-v1 (1.16.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-iam-v1 (~> 1.3)
-    google-cloud-storage (1.62.0)
-      addressable (~> 2.8)
-      digest-crc (~> 0.4)
-      google-apis-core (>= 0.18, < 2)
-      google-apis-iamcredentials_v1 (~> 0.18)
-      google-apis-storage_v1 (>= 0.42)
+    google-cloud-tasks (3.2.0)
       google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
-    google-iam-v1 (1.7.0)
+      google-cloud-tasks-v2 (~> 1.2)
+    google-cloud-tasks-v2 (1.6.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
+      google-cloud-location (~> 1.0)
       grpc-google-iam-v1 (~> 1.11)
-    google-identity-access_context_manager-v1 (0.15.0)
+    google-cloud-tasks-v2beta2 (0.18.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
+      google-cloud-location (~> 1.0)
+      grpc-google-iam-v1 (~> 1.11)
+    google-cloud-tasks-v2beta3 (0.20.0)
+      gapic-common (~> 1.3)
+      google-cloud-errors (~> 1.0)
+      google-cloud-location (~> 1.0)
       grpc-google-iam-v1 (~> 1.11)
     google-logging-utils (0.2.0)
     google-protobuf (4.35.1)
@@ -183,28 +128,20 @@ GEM
     jwt (3.2.0)
       base64
     logger (1.7.0)
-    mini_mime (1.1.5)
     minitest (5.27.0)
-    minitest-focus (1.4.1)
-      minitest (> 5.0)
-    multi_json (1.21.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
     os (1.1.4)
     pstore (0.2.1)
     public_suffix (7.0.5)
+    rack (3.2.6)
+    rack-test (2.2.0)
+      rack (>= 1.3)
     rake (13.4.2)
-    representable (3.2.0)
-      declarative (< 0.1.0)
-      trailblazer-option (>= 0.1.1, < 0.2.0)
-      uber (< 0.2.0)
-    retriable (3.8.0)
     signet (0.22.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 4.0)
-    trailblazer-option (0.1.2)
-    uber (0.1.0)
     uri (1.1.1)
 
 PLATFORMS
@@ -219,12 +156,12 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  google-cloud-asset
-  google-cloud-bigquery
-  google-cloud-pubsub
-  google-cloud-storage
-  minitest (~> 5.14)
-  minitest-focus
+  google-cloud-tasks
+  google-cloud-tasks-v2
+  google-cloud-tasks-v2beta2
+  google-cloud-tasks-v2beta3
+  minitest (~> 5.13)
+  rack-test
   rake
 
 CHECKSUMS
@@ -232,34 +169,18 @@ CHECKSUMS
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
-  concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
-  declarative (0.0.20) sha256=8021dd6cb17ab2b61233c56903d3f5a259c5cf43c80ff332d447d395b17d9ff9
-  digest-crc (0.7.0) sha256=64adc23a26a241044cbe6732477ca1b3c281d79e2240bcff275a37a5a0d78c07
   faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
-  faraday-follow_redirects (0.5.0) sha256=5cde93c894b30943a5d2b93c2fe9284216a6b756f7af406a1e55f211d97d10ad
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
   faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
   gapic-common (1.3.0) sha256=4e5d9be1effb7366e2cda13c0f44922285d5613ac8de8b9b18c2c835fe4faa91
-  google-apis-bigquery_v2 (0.106.0) sha256=a0f4243b634a0c79c29b7dacdd79233bd9c9ba2eda6fde9c2b19414fd165dd93
-<<<<<<< HEAD
-  google-apis-core (1.2.99)
-=======
-  google-apis-core (1.2.5) sha256=e21562b5627a0fc6a0c3165e429c3afed0f6a628eaa514e83f7204dda1adff69
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-  google-apis-iamcredentials_v1 (0.28.0) sha256=0a92ffe6cc39c569554af2a77a25dfc61519ed8bbb64ab04cffdd352dc5ef106
-  google-apis-storage_v1 (0.65.0) sha256=4247aa542931691f6988ab61e45cdea2878cbfe897a98eec4af9cdcb678eb359
-  google-cloud-asset (1.10.0) sha256=6ea6fd9e0735873884094c14d84d5a6d826b0e07aaeec245d34735ab2c5828e0
-  google-cloud-asset-v1 (1.9.0) sha256=ecfb654d0d350ed98209d46937c8095ec867c8ff6c3f7d70b8889f6fb70fd397
-  google-cloud-bigquery (1.64.0) sha256=d807363903e08958c3bc09ccc1f9d1218646c8f18176751879348a1a4a884d57
   google-cloud-core (1.9.0) sha256=ab55409f51488e8deefb6edcc1ce4771dfb5da2fe7b3bc075709a030c2b682a4
   google-cloud-env (2.4.0) sha256=01cb35ecee5d1c4d1cd4deaed8bb5bddc838e296bcc2a35c5d1ddd07ce40d28d
   google-cloud-errors (1.7.0) sha256=6e682f42d89aae08689f36f28495de629d756da076bafff0003bac7f8042ebb3
-  google-cloud-os_config-v1 (1.9.0) sha256=693c13690cfd7cf9d307c25d005ff33b823b6709791d3714c344ff1597ec3a30
-  google-cloud-pubsub (3.4.0) sha256=6a6390a6f605701945d5be233dea51e0b04009f157b5d701b092423fbc690edd
-  google-cloud-pubsub-v1 (1.16.0) sha256=ffe128821208bd3d2f27cb0d25eb6accb3893c99e0b736d1740b8b5e1570426b
-  google-cloud-storage (1.62.0) sha256=e2c3c08bf8fd40d50be92304084942203314d4fc0ee52028e99f9359c3ad1330
-  google-iam-v1 (1.7.0) sha256=9e3ea9dcc59cbd5f8d2f62b00da41ec57a2e427b33c0e798207fa06c8fbb8b87
-  google-identity-access_context_manager-v1 (0.15.0) sha256=8f105320bcbdc03c7fdb05369886117b4f341b792ed4ab81a144929bbcd7820b
+  google-cloud-location (1.5.0) sha256=336f94609b1fb18fce1929048fac964f4d5a87d27c1e5444bfed3605469c7532
+  google-cloud-tasks (3.2.0) sha256=1bc1a375f9684acae814460aeb6eaced39ddae797ee2faca73e75aebc37a2455
+  google-cloud-tasks-v2 (1.6.0) sha256=b096e2686af967a055ec223b354054cf599e7a72754e1c6c8f01b8056187af3f
+  google-cloud-tasks-v2beta2 (0.18.0) sha256=4a2856912c96f1a3c47df5922c296074f58d7e561b08203a90c65d857708ec01
+  google-cloud-tasks-v2beta3 (0.20.0) sha256=c0b8d58771e5e2b058649bc0ca93ccb5c516ef6a53438baa3c33a716a00e1658
   google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
   google-protobuf (4.35.1) sha256=a3a6471331d918f58dfa4d014a8f6286f0af2cf4840216bde52fcf2ea3fe3726
   google-protobuf (4.35.1-aarch64-linux-gnu) sha256=50ca44d0eeff3f8475e630a1accdd974256f3510694d574e2c9d6119ea8bc9e1
@@ -286,20 +207,15 @@ CHECKSUMS
   json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
-  mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
-  minitest-focus (1.4.1) sha256=394517cbe2dcb2d992d8ffc41a3b2b6315777a4daa69239de4fefe7110dd810e
-  multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
   os (1.1.4) sha256=57816d6a334e7bd6aed048f4b0308226c5fb027433b67d90a9ab435f35108d3f
   pstore (0.2.1) sha256=03904d0f2c66579e96d1e6704cdabc0c88df7ea8ed8782d9f3569f6f6c702c1a
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2
+  rack-test (2.2.0) sha256=005a36692c306ac0b4a9350355ee080fd09ddef1148a5f8b2ac636c720f5c463
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
-  representable (3.2.0) sha256=cc29bf7eebc31653586849371a43ffe36c60b54b0a6365b5f7d95ec34d1ebace
-  retriable (3.8.0) sha256=9f2f1b0207594c7817f17f671587b8ec7587387ac6cebda6c941a802bb98a8e5
   signet (0.22.0) sha256=b76d495ccb07ad35dbc89f3e920665a9d8ed717141955034005d7843dcfe4780
-  trailblazer-option (0.1.2) sha256=20e4f12ea4e1f718c8007e7944ca21a329eee4eed9e0fa5dde6e8ad8ac4344a3
-  uber (0.1.0) sha256=5beeb407ff807b5db994f82fa9ee07cfceaa561dad8af20be880bc67eba935dc
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
 
 BUNDLED WITH

--- a/google-cloud-video-live_stream/samples/Gemfile.lock
+++ b/google-cloud-video-live_stream/samples/Gemfile.lock
@@ -3,18 +3,13 @@ GEM
   specs:
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.1.2)
-    concurrent-ruby (1.3.8)
-    declarative (0.0.20)
-    digest-crc (0.7.0)
-      rake (>= 12.0.0, < 14.0.0)
     faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-follow_redirects (0.5.0)
-      faraday (>= 1, < 3)
     faraday-net_http (3.4.4)
       net-http (~> 0.5)
     faraday-retry (2.4.0)
@@ -29,47 +24,6 @@ GEM
       googleapis-common-protos-types (~> 1.15)
       googleauth (~> 1.12)
       grpc (~> 1.66)
-    google-apis-bigquery_v2 (0.106.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-<<<<<<< HEAD
-    google-apis-core (1.2.99)
-      addressable (~> 2.8, >= 2.8.7)
-=======
-    google-apis-core (1.2.5)
-      addressable (~> 2.9)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-      faraday (~> 2.13)
-      faraday-follow_redirects (~> 0.3)
-      googleauth (~> 1.14)
-      mini_mime (~> 1.1)
-      multi_json (~> 1.11)
-      representable (~> 3.0)
-<<<<<<< HEAD
-      retriable (~> 3.1)
-=======
-      retriable (>= 3.1, < 5.0)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-    google-apis-iamcredentials_v1 (0.28.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-    google-apis-storage_v1 (0.65.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-    google-cloud-asset (1.10.0)
-      google-cloud-asset-v1 (>= 0.29, < 2.a)
-      google-cloud-core (~> 1.6)
-    google-cloud-asset-v1 (1.9.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-cloud-os_config-v1 (> 0.0, < 2.a)
-      google-identity-access_context_manager-v1 (> 0.0, < 2.a)
-      grpc-google-iam-v1 (~> 1.11)
-    google-cloud-bigquery (1.64.0)
-      bigdecimal (>= 3.0, < 5)
-      concurrent-ruby (~> 1.0)
-      google-apis-bigquery_v2 (~> 0.71)
-      google-apis-core (>= 0.18, < 2)
-      google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
     google-cloud-core (1.9.0)
       google-cloud-env (>= 1.0, < 3.a)
       google-cloud-errors (~> 1.0)
@@ -77,35 +31,16 @@ GEM
       base64 (~> 0.2)
       faraday (>= 1.0, < 3.a)
     google-cloud-errors (1.7.0)
-    google-cloud-os_config-v1 (1.9.0)
+    google-cloud-location (1.5.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
-    google-cloud-pubsub (3.4.0)
-      concurrent-ruby (~> 1.3)
-      google-cloud-core (~> 1.8)
-      google-cloud-pubsub-v1 (~> 1.11)
-      retriable (~> 3.1)
-    google-cloud-pubsub-v1 (1.16.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-iam-v1 (~> 1.3)
-    google-cloud-storage (1.62.0)
-      addressable (~> 2.8)
-      digest-crc (~> 0.4)
-      google-apis-core (>= 0.18, < 2)
-      google-apis-iamcredentials_v1 (~> 0.18)
-      google-apis-storage_v1 (>= 0.42)
+    google-cloud-video-live_stream (2.2.0)
       google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
-    google-iam-v1 (1.7.0)
+      google-cloud-video-live_stream-v1 (~> 2.0)
+    google-cloud-video-live_stream-v1 (2.7.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
-      grpc-google-iam-v1 (~> 1.11)
-    google-identity-access_context_manager-v1 (0.15.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      grpc-google-iam-v1 (~> 1.11)
+      google-cloud-location (~> 1.0)
     google-logging-utils (0.2.0)
     google-protobuf (4.35.1)
       bigdecimal
@@ -134,7 +69,9 @@ GEM
     google-protobuf (4.35.1-x86_64-linux-musl)
       bigdecimal
       rake (~> 13.3)
-    googleapis-common-protos (1.9.0)
+    google-style (1.25.3)
+      rubocop (~> 1.28.2)
+    googleapis-common-protos (1.10.0)
       google-protobuf (~> 4.26)
       googleapis-common-protos-types (~> 1.21)
       grpc (~> 1.41)
@@ -175,36 +112,48 @@ GEM
     grpc (1.83.0-x86_64-linux-musl)
       google-protobuf (>= 3.25, < 5.0)
       googleapis-common-protos-types (~> 1.0)
-    grpc-google-iam-v1 (1.12.0)
-      google-protobuf (>= 3.18, < 5.a)
-      googleapis-common-protos (~> 1.9.0)
-      grpc (~> 1.41)
     json (2.21.2)
     jwt (3.2.0)
       base64
     logger (1.7.0)
-    mini_mime (1.1.5)
     minitest (5.27.0)
     minitest-focus (1.4.1)
       minitest (> 5.0)
-    multi_json (1.21.1)
+    minitest-rg (5.4.0)
+      minitest (>= 5.0, < 7)
     net-http (0.9.1)
       uri (>= 0.11.1)
     os (1.1.4)
+    parallel (1.28.0)
+    parser (3.3.12.0)
+      ast (~> 2.4.1)
+      racc
+    prism (1.9.0)
     pstore (0.2.1)
     public_suffix (7.0.5)
+    racc (1.8.1)
+    rainbow (3.1.1)
     rake (13.4.2)
-    representable (3.2.0)
-      declarative (< 0.1.0)
-      trailblazer-option (>= 0.1.1, < 0.2.0)
-      uber (< 0.2.0)
-    retriable (3.8.0)
+    regexp_parser (2.12.0)
+    rexml (3.4.4)
+    rubocop (1.28.2)
+      parallel (~> 1.10)
+      parser (>= 3.1.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.17.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.50.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    ruby-progressbar (1.13.0)
     signet (0.22.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 4.0)
-    trailblazer-option (0.1.2)
-    uber (0.1.0)
+    unicode-display_width (2.6.0)
     uri (1.1.1)
 
 PLATFORMS
@@ -219,47 +168,29 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  google-cloud-asset
-  google-cloud-bigquery
-  google-cloud-pubsub
-  google-cloud-storage
+  google-cloud-video-live_stream
+  google-style (~> 1.25.1)
   minitest (~> 5.14)
-  minitest-focus
+  minitest-focus (~> 1.1)
+  minitest-rg (~> 5.2)
   rake
 
 CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
-  concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
-  declarative (0.0.20) sha256=8021dd6cb17ab2b61233c56903d3f5a259c5cf43c80ff332d447d395b17d9ff9
-  digest-crc (0.7.0) sha256=64adc23a26a241044cbe6732477ca1b3c281d79e2240bcff275a37a5a0d78c07
   faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
-  faraday-follow_redirects (0.5.0) sha256=5cde93c894b30943a5d2b93c2fe9284216a6b756f7af406a1e55f211d97d10ad
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
   faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
   gapic-common (1.3.0) sha256=4e5d9be1effb7366e2cda13c0f44922285d5613ac8de8b9b18c2c835fe4faa91
-  google-apis-bigquery_v2 (0.106.0) sha256=a0f4243b634a0c79c29b7dacdd79233bd9c9ba2eda6fde9c2b19414fd165dd93
-<<<<<<< HEAD
-  google-apis-core (1.2.99)
-=======
-  google-apis-core (1.2.5) sha256=e21562b5627a0fc6a0c3165e429c3afed0f6a628eaa514e83f7204dda1adff69
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-  google-apis-iamcredentials_v1 (0.28.0) sha256=0a92ffe6cc39c569554af2a77a25dfc61519ed8bbb64ab04cffdd352dc5ef106
-  google-apis-storage_v1 (0.65.0) sha256=4247aa542931691f6988ab61e45cdea2878cbfe897a98eec4af9cdcb678eb359
-  google-cloud-asset (1.10.0) sha256=6ea6fd9e0735873884094c14d84d5a6d826b0e07aaeec245d34735ab2c5828e0
-  google-cloud-asset-v1 (1.9.0) sha256=ecfb654d0d350ed98209d46937c8095ec867c8ff6c3f7d70b8889f6fb70fd397
-  google-cloud-bigquery (1.64.0) sha256=d807363903e08958c3bc09ccc1f9d1218646c8f18176751879348a1a4a884d57
   google-cloud-core (1.9.0) sha256=ab55409f51488e8deefb6edcc1ce4771dfb5da2fe7b3bc075709a030c2b682a4
   google-cloud-env (2.4.0) sha256=01cb35ecee5d1c4d1cd4deaed8bb5bddc838e296bcc2a35c5d1ddd07ce40d28d
   google-cloud-errors (1.7.0) sha256=6e682f42d89aae08689f36f28495de629d756da076bafff0003bac7f8042ebb3
-  google-cloud-os_config-v1 (1.9.0) sha256=693c13690cfd7cf9d307c25d005ff33b823b6709791d3714c344ff1597ec3a30
-  google-cloud-pubsub (3.4.0) sha256=6a6390a6f605701945d5be233dea51e0b04009f157b5d701b092423fbc690edd
-  google-cloud-pubsub-v1 (1.16.0) sha256=ffe128821208bd3d2f27cb0d25eb6accb3893c99e0b736d1740b8b5e1570426b
-  google-cloud-storage (1.62.0) sha256=e2c3c08bf8fd40d50be92304084942203314d4fc0ee52028e99f9359c3ad1330
-  google-iam-v1 (1.7.0) sha256=9e3ea9dcc59cbd5f8d2f62b00da41ec57a2e427b33c0e798207fa06c8fbb8b87
-  google-identity-access_context_manager-v1 (0.15.0) sha256=8f105320bcbdc03c7fdb05369886117b4f341b792ed4ab81a144929bbcd7820b
+  google-cloud-location (1.5.0) sha256=336f94609b1fb18fce1929048fac964f4d5a87d27c1e5444bfed3605469c7532
+  google-cloud-video-live_stream (2.2.0) sha256=1d564caadb6cee3736cc011e8dc4926eba5a23908603c616a16b42f5108309a7
+  google-cloud-video-live_stream-v1 (2.7.0) sha256=31d478d0fe7a838c5ce3236bfbb00491c00fb45d54078b1d4b443df82f2cf1c8
   google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
   google-protobuf (4.35.1) sha256=a3a6471331d918f58dfa4d014a8f6286f0af2cf4840216bde52fcf2ea3fe3726
   google-protobuf (4.35.1-aarch64-linux-gnu) sha256=50ca44d0eeff3f8475e630a1accdd974256f3510694d574e2c9d6119ea8bc9e1
@@ -270,7 +201,8 @@ CHECKSUMS
   google-protobuf (4.35.1-x86_64-darwin) sha256=66b62b4df00931018a692806df66393efa960d6d2b7da69735187249f950d3ee
   google-protobuf (4.35.1-x86_64-linux-gnu) sha256=c786439087512a3fbd199e9897d265b855f951d4027e218ea55e858d45969edd
   google-protobuf (4.35.1-x86_64-linux-musl) sha256=91890eb0002934a339fdb7d77a147c46b7474b6799db27872b747b905837f744
-  googleapis-common-protos (1.9.0) sha256=207be372d8d25e3876e1e1155d057e14f3c92f8f5428772864a8ce04a0b756e4
+  google-style (1.25.3) sha256=d417fd0f6d6a9f4bb2ff69e1cfaa1c4d0e19230589cdf4383df4540082c395d4
+  googleapis-common-protos (1.10.0) sha256=13e47ad0ce85d3d30065c03863efd302a82b0e08ba576f2a9b9dbbfeecb57ee0
   googleapis-common-protos-types (1.23.0) sha256=992e740a523794d9fc5f29a504465d8fc737aaa16c930fe7228e3346860faf0a
   googleauth (1.17.3) sha256=9a655455885c0c17a8b70537acd2a992a7c7842c43c06c6612dfb0d93e755d58
   grpc (1.83.0) sha256=38119e7f9f7cbc98e79145201da4be470a7542b0befad454651d35015ea55c59
@@ -282,24 +214,29 @@ CHECKSUMS
   grpc (1.83.0-x86_64-darwin) sha256=cfad91d559d1907159a5247fb12dc112a8ea0ebe2027ca7f5ab648d01a645716
   grpc (1.83.0-x86_64-linux-gnu) sha256=25d66bfa3cb1b05258b3f9632478c7e7ceb52cb16ccc0b4b26d7df36be7158b1
   grpc (1.83.0-x86_64-linux-musl) sha256=a5023264dbb8038c23b147bbf80adb06932ef11b5ab493412e9e37a43114fa8c
-  grpc-google-iam-v1 (1.12.0) sha256=a70ecad8987e340d5e22e7bf01be31256c84b29a3f78bebd385a4a110e1f2aef
   json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
-  mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   minitest-focus (1.4.1) sha256=394517cbe2dcb2d992d8ffc41a3b2b6315777a4daa69239de4fefe7110dd810e
-  multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080
+  minitest-rg (5.4.0) sha256=54d42bb8ce876381245be5866f3c1dd704ef79c06ba5c9ff280c0aa28c56effb
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
   os (1.1.4) sha256=57816d6a334e7bd6aed048f4b0308226c5fb027433b67d90a9ab435f35108d3f
+  parallel (1.28.0) sha256=33e6de1484baf2524792d178b0913fc8eb94c628d6cfe45599ad4458c638c970
+  parser (3.3.12.0) sha256=21a6d7f755d5a24dfbdc6e6b772e4e879a52e7631a88bc5a3a134606052c9828
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   pstore (0.2.1) sha256=03904d0f2c66579e96d1e6704cdabc0c88df7ea8ed8782d9f3569f6f6c702c1a
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
-  representable (3.2.0) sha256=cc29bf7eebc31653586849371a43ffe36c60b54b0a6365b5f7d95ec34d1ebace
-  retriable (3.8.0) sha256=9f2f1b0207594c7817f17f671587b8ec7587387ac6cebda6c941a802bb98a8e5
+  regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rubocop (1.28.2) sha256=0d9bf4108fd86ede43c6cf30adcb3dd2e0c6750941c5ec2a00621478157cb377
+  rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   signet (0.22.0) sha256=b76d495ccb07ad35dbc89f3e920665a9d8ed717141955034005d7843dcfe4780
-  trailblazer-option (0.1.2) sha256=20e4f12ea4e1f718c8007e7944ca21a329eee4eed9e0fa5dde6e8ad8ac4344a3
-  uber (0.1.0) sha256=5beeb407ff807b5db994f82fa9ee07cfceaa561dad8af20be880bc67eba935dc
+  unicode-display_width (2.6.0) sha256=12279874bba6d5e4d2728cef814b19197dbb10d7a7837a869bab65da943b7f5a
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
 
 BUNDLED WITH

--- a/google-cloud-video-stitcher/samples/Gemfile.lock
+++ b/google-cloud-video-stitcher/samples/Gemfile.lock
@@ -3,18 +3,13 @@ GEM
   specs:
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.1.2)
-    concurrent-ruby (1.3.8)
-    declarative (0.0.20)
-    digest-crc (0.7.0)
-      rake (>= 12.0.0, < 14.0.0)
     faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-follow_redirects (0.5.0)
-      faraday (>= 1, < 3)
     faraday-net_http (3.4.4)
       net-http (~> 0.5)
     faraday-retry (2.4.0)
@@ -29,47 +24,6 @@ GEM
       googleapis-common-protos-types (~> 1.15)
       googleauth (~> 1.12)
       grpc (~> 1.66)
-    google-apis-bigquery_v2 (0.106.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-<<<<<<< HEAD
-    google-apis-core (1.2.99)
-      addressable (~> 2.8, >= 2.8.7)
-=======
-    google-apis-core (1.2.5)
-      addressable (~> 2.9)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-      faraday (~> 2.13)
-      faraday-follow_redirects (~> 0.3)
-      googleauth (~> 1.14)
-      mini_mime (~> 1.1)
-      multi_json (~> 1.11)
-      representable (~> 3.0)
-<<<<<<< HEAD
-      retriable (~> 3.1)
-=======
-      retriable (>= 3.1, < 5.0)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-    google-apis-iamcredentials_v1 (0.28.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-    google-apis-storage_v1 (0.65.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-    google-cloud-asset (1.10.0)
-      google-cloud-asset-v1 (>= 0.29, < 2.a)
-      google-cloud-core (~> 1.6)
-    google-cloud-asset-v1 (1.9.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-cloud-os_config-v1 (> 0.0, < 2.a)
-      google-identity-access_context_manager-v1 (> 0.0, < 2.a)
-      grpc-google-iam-v1 (~> 1.11)
-    google-cloud-bigquery (1.64.0)
-      bigdecimal (>= 3.0, < 5)
-      concurrent-ruby (~> 1.0)
-      google-apis-bigquery_v2 (~> 0.71)
-      google-apis-core (>= 0.18, < 2)
-      google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
     google-cloud-core (1.9.0)
       google-cloud-env (>= 1.0, < 3.a)
       google-cloud-errors (~> 1.0)
@@ -77,35 +31,12 @@ GEM
       base64 (~> 0.2)
       faraday (>= 1.0, < 3.a)
     google-cloud-errors (1.7.0)
-    google-cloud-os_config-v1 (1.9.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-    google-cloud-pubsub (3.4.0)
-      concurrent-ruby (~> 1.3)
-      google-cloud-core (~> 1.8)
-      google-cloud-pubsub-v1 (~> 1.11)
-      retriable (~> 3.1)
-    google-cloud-pubsub-v1 (1.16.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-iam-v1 (~> 1.3)
-    google-cloud-storage (1.62.0)
-      addressable (~> 2.8)
-      digest-crc (~> 0.4)
-      google-apis-core (>= 0.18, < 2)
-      google-apis-iamcredentials_v1 (~> 0.18)
-      google-apis-storage_v1 (>= 0.42)
+    google-cloud-video-stitcher (1.3.0)
       google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
-    google-iam-v1 (1.7.0)
+      google-cloud-video-stitcher-v1 (>= 0.8, < 2.a)
+    google-cloud-video-stitcher-v1 (1.7.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
-      grpc-google-iam-v1 (~> 1.11)
-    google-identity-access_context_manager-v1 (0.15.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      grpc-google-iam-v1 (~> 1.11)
     google-logging-utils (0.2.0)
     google-protobuf (4.35.1)
       bigdecimal
@@ -134,7 +65,9 @@ GEM
     google-protobuf (4.35.1-x86_64-linux-musl)
       bigdecimal
       rake (~> 13.3)
-    googleapis-common-protos (1.9.0)
+    google-style (1.26.4)
+      rubocop (~> 1.57.2)
+    googleapis-common-protos (1.10.0)
       google-protobuf (~> 4.26)
       googleapis-common-protos-types (~> 1.21)
       grpc (~> 1.41)
@@ -175,36 +108,51 @@ GEM
     grpc (1.83.0-x86_64-linux-musl)
       google-protobuf (>= 3.25, < 5.0)
       googleapis-common-protos-types (~> 1.0)
-    grpc-google-iam-v1 (1.12.0)
-      google-protobuf (>= 3.18, < 5.a)
-      googleapis-common-protos (~> 1.9.0)
-      grpc (~> 1.41)
     json (2.21.2)
     jwt (3.2.0)
       base64
+    language_server-protocol (3.17.0.6)
     logger (1.7.0)
-    mini_mime (1.1.5)
     minitest (5.27.0)
     minitest-focus (1.4.1)
       minitest (> 5.0)
-    multi_json (1.21.1)
+    minitest-rg (5.4.0)
+      minitest (>= 5.0, < 7)
     net-http (0.9.1)
       uri (>= 0.11.1)
     os (1.1.4)
+    parallel (1.28.0)
+    parser (3.3.12.0)
+      ast (~> 2.4.1)
+      racc
+    prism (1.9.0)
     pstore (0.2.1)
     public_suffix (7.0.5)
+    racc (1.8.1)
+    rainbow (3.1.1)
     rake (13.4.2)
-    representable (3.2.0)
-      declarative (< 0.1.0)
-      trailblazer-option (>= 0.1.1, < 0.2.0)
-      uber (< 0.2.0)
-    retriable (3.8.0)
+    regexp_parser (2.12.0)
+    rexml (3.4.4)
+    rubocop (1.57.2)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.2.2.4)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.28.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.50.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    ruby-progressbar (1.13.0)
     signet (0.22.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 4.0)
-    trailblazer-option (0.1.2)
-    uber (0.1.0)
+    unicode-display_width (2.6.0)
     uri (1.1.1)
 
 PLATFORMS
@@ -219,47 +167,30 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  google-cloud-asset
-  google-cloud-bigquery
-  google-cloud-pubsub
-  google-cloud-storage
-  minitest (~> 5.14)
-  minitest-focus
+  google-cloud-video-stitcher
+  google-cloud-video-stitcher-v1
+  google-style (~> 1.26.1)
+  grpc (~> 1.65)
+  minitest (~> 5.16)
+  minitest-focus (~> 1.1)
+  minitest-rg (~> 5.2)
   rake
 
 CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
-  concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
-  declarative (0.0.20) sha256=8021dd6cb17ab2b61233c56903d3f5a259c5cf43c80ff332d447d395b17d9ff9
-  digest-crc (0.7.0) sha256=64adc23a26a241044cbe6732477ca1b3c281d79e2240bcff275a37a5a0d78c07
   faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
-  faraday-follow_redirects (0.5.0) sha256=5cde93c894b30943a5d2b93c2fe9284216a6b756f7af406a1e55f211d97d10ad
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
   faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
   gapic-common (1.3.0) sha256=4e5d9be1effb7366e2cda13c0f44922285d5613ac8de8b9b18c2c835fe4faa91
-  google-apis-bigquery_v2 (0.106.0) sha256=a0f4243b634a0c79c29b7dacdd79233bd9c9ba2eda6fde9c2b19414fd165dd93
-<<<<<<< HEAD
-  google-apis-core (1.2.99)
-=======
-  google-apis-core (1.2.5) sha256=e21562b5627a0fc6a0c3165e429c3afed0f6a628eaa514e83f7204dda1adff69
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
-  google-apis-iamcredentials_v1 (0.28.0) sha256=0a92ffe6cc39c569554af2a77a25dfc61519ed8bbb64ab04cffdd352dc5ef106
-  google-apis-storage_v1 (0.65.0) sha256=4247aa542931691f6988ab61e45cdea2878cbfe897a98eec4af9cdcb678eb359
-  google-cloud-asset (1.10.0) sha256=6ea6fd9e0735873884094c14d84d5a6d826b0e07aaeec245d34735ab2c5828e0
-  google-cloud-asset-v1 (1.9.0) sha256=ecfb654d0d350ed98209d46937c8095ec867c8ff6c3f7d70b8889f6fb70fd397
-  google-cloud-bigquery (1.64.0) sha256=d807363903e08958c3bc09ccc1f9d1218646c8f18176751879348a1a4a884d57
   google-cloud-core (1.9.0) sha256=ab55409f51488e8deefb6edcc1ce4771dfb5da2fe7b3bc075709a030c2b682a4
   google-cloud-env (2.4.0) sha256=01cb35ecee5d1c4d1cd4deaed8bb5bddc838e296bcc2a35c5d1ddd07ce40d28d
   google-cloud-errors (1.7.0) sha256=6e682f42d89aae08689f36f28495de629d756da076bafff0003bac7f8042ebb3
-  google-cloud-os_config-v1 (1.9.0) sha256=693c13690cfd7cf9d307c25d005ff33b823b6709791d3714c344ff1597ec3a30
-  google-cloud-pubsub (3.4.0) sha256=6a6390a6f605701945d5be233dea51e0b04009f157b5d701b092423fbc690edd
-  google-cloud-pubsub-v1 (1.16.0) sha256=ffe128821208bd3d2f27cb0d25eb6accb3893c99e0b736d1740b8b5e1570426b
-  google-cloud-storage (1.62.0) sha256=e2c3c08bf8fd40d50be92304084942203314d4fc0ee52028e99f9359c3ad1330
-  google-iam-v1 (1.7.0) sha256=9e3ea9dcc59cbd5f8d2f62b00da41ec57a2e427b33c0e798207fa06c8fbb8b87
-  google-identity-access_context_manager-v1 (0.15.0) sha256=8f105320bcbdc03c7fdb05369886117b4f341b792ed4ab81a144929bbcd7820b
+  google-cloud-video-stitcher (1.3.0) sha256=82105a4135435d457b93b76955ee4f4b1dc00c7005161eefb3c75188a8df5cf0
+  google-cloud-video-stitcher-v1 (1.7.0) sha256=a175bee3d8184289d097e63380dc30e2d75459cb57e407edcd872ec0f6aa16f2
   google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
   google-protobuf (4.35.1) sha256=a3a6471331d918f58dfa4d014a8f6286f0af2cf4840216bde52fcf2ea3fe3726
   google-protobuf (4.35.1-aarch64-linux-gnu) sha256=50ca44d0eeff3f8475e630a1accdd974256f3510694d574e2c9d6119ea8bc9e1
@@ -270,7 +201,8 @@ CHECKSUMS
   google-protobuf (4.35.1-x86_64-darwin) sha256=66b62b4df00931018a692806df66393efa960d6d2b7da69735187249f950d3ee
   google-protobuf (4.35.1-x86_64-linux-gnu) sha256=c786439087512a3fbd199e9897d265b855f951d4027e218ea55e858d45969edd
   google-protobuf (4.35.1-x86_64-linux-musl) sha256=91890eb0002934a339fdb7d77a147c46b7474b6799db27872b747b905837f744
-  googleapis-common-protos (1.9.0) sha256=207be372d8d25e3876e1e1155d057e14f3c92f8f5428772864a8ce04a0b756e4
+  google-style (1.26.4) sha256=a8a24a5a020bd608d55a32462caaef7b02ae9b9d4dd36ea3945f80fdbaa11846
+  googleapis-common-protos (1.10.0) sha256=13e47ad0ce85d3d30065c03863efd302a82b0e08ba576f2a9b9dbbfeecb57ee0
   googleapis-common-protos-types (1.23.0) sha256=992e740a523794d9fc5f29a504465d8fc737aaa16c930fe7228e3346860faf0a
   googleauth (1.17.3) sha256=9a655455885c0c17a8b70537acd2a992a7c7842c43c06c6612dfb0d93e755d58
   grpc (1.83.0) sha256=38119e7f9f7cbc98e79145201da4be470a7542b0befad454651d35015ea55c59
@@ -282,24 +214,30 @@ CHECKSUMS
   grpc (1.83.0-x86_64-darwin) sha256=cfad91d559d1907159a5247fb12dc112a8ea0ebe2027ca7f5ab648d01a645716
   grpc (1.83.0-x86_64-linux-gnu) sha256=25d66bfa3cb1b05258b3f9632478c7e7ceb52cb16ccc0b4b26d7df36be7158b1
   grpc (1.83.0-x86_64-linux-musl) sha256=a5023264dbb8038c23b147bbf80adb06932ef11b5ab493412e9e37a43114fa8c
-  grpc-google-iam-v1 (1.12.0) sha256=a70ecad8987e340d5e22e7bf01be31256c84b29a3f78bebd385a4a110e1f2aef
   json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
+  language_server-protocol (3.17.0.6) sha256=5ef2c0c138f8267e1bc631d3328347d354f96724b0af22f2c79516120443b7f0
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
-  mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   minitest-focus (1.4.1) sha256=394517cbe2dcb2d992d8ffc41a3b2b6315777a4daa69239de4fefe7110dd810e
-  multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080
+  minitest-rg (5.4.0) sha256=54d42bb8ce876381245be5866f3c1dd704ef79c06ba5c9ff280c0aa28c56effb
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
   os (1.1.4) sha256=57816d6a334e7bd6aed048f4b0308226c5fb027433b67d90a9ab435f35108d3f
+  parallel (1.28.0) sha256=33e6de1484baf2524792d178b0913fc8eb94c628d6cfe45599ad4458c638c970
+  parser (3.3.12.0) sha256=21a6d7f755d5a24dfbdc6e6b772e4e879a52e7631a88bc5a3a134606052c9828
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   pstore (0.2.1) sha256=03904d0f2c66579e96d1e6704cdabc0c88df7ea8ed8782d9f3569f6f6c702c1a
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
-  representable (3.2.0) sha256=cc29bf7eebc31653586849371a43ffe36c60b54b0a6365b5f7d95ec34d1ebace
-  retriable (3.8.0) sha256=9f2f1b0207594c7817f17f671587b8ec7587387ac6cebda6c941a802bb98a8e5
+  regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rubocop (1.57.2) sha256=8f679dfe42d7821dc61dafb17d14b1294343157a197b9f8a23720ca17fb9161b
+  rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   signet (0.22.0) sha256=b76d495ccb07ad35dbc89f3e920665a9d8ed717141955034005d7843dcfe4780
-  trailblazer-option (0.1.2) sha256=20e4f12ea4e1f718c8007e7944ca21a329eee4eed9e0fa5dde6e8ad8ac4344a3
-  uber (0.1.0) sha256=5beeb407ff807b5db994f82fa9ee07cfceaa561dad8af20be880bc67eba935dc
+  unicode-display_width (2.6.0) sha256=12279874bba6d5e4d2728cef814b19197dbb10d7a7837a869bab65da943b7f5a
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
 
 BUNDLED WITH

--- a/google-cloud-video-transcoder/samples/Gemfile.lock
+++ b/google-cloud-video-transcoder/samples/Gemfile.lock
@@ -3,9 +3,9 @@ GEM
   specs:
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.1.2)
-    concurrent-ruby (1.3.8)
     declarative (0.0.20)
     digest-crc (0.7.0)
       rake (>= 12.0.0, < 14.0.0)
@@ -29,47 +29,19 @@ GEM
       googleapis-common-protos-types (~> 1.15)
       googleauth (~> 1.12)
       grpc (~> 1.66)
-    google-apis-bigquery_v2 (0.106.0)
-      google-apis-core (>= 0.15.0, < 2.a)
-<<<<<<< HEAD
-    google-apis-core (1.2.99)
-      addressable (~> 2.8, >= 2.8.7)
-=======
     google-apis-core (1.2.5)
       addressable (~> 2.9)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
       faraday (~> 2.13)
       faraday-follow_redirects (~> 0.3)
       googleauth (~> 1.14)
       mini_mime (~> 1.1)
       multi_json (~> 1.11)
       representable (~> 3.0)
-<<<<<<< HEAD
-      retriable (~> 3.1)
-=======
       retriable (>= 3.1, < 5.0)
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
     google-apis-iamcredentials_v1 (0.28.0)
       google-apis-core (>= 0.15.0, < 2.a)
     google-apis-storage_v1 (0.65.0)
       google-apis-core (>= 0.15.0, < 2.a)
-    google-cloud-asset (1.10.0)
-      google-cloud-asset-v1 (>= 0.29, < 2.a)
-      google-cloud-core (~> 1.6)
-    google-cloud-asset-v1 (1.9.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-cloud-os_config-v1 (> 0.0, < 2.a)
-      google-identity-access_context_manager-v1 (> 0.0, < 2.a)
-      grpc-google-iam-v1 (~> 1.11)
-    google-cloud-bigquery (1.64.0)
-      bigdecimal (>= 3.0, < 5)
-      concurrent-ruby (~> 1.0)
-      google-apis-bigquery_v2 (~> 0.71)
-      google-apis-core (>= 0.18, < 2)
-      google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
     google-cloud-core (1.9.0)
       google-cloud-env (>= 1.0, < 3.a)
       google-cloud-errors (~> 1.0)
@@ -77,18 +49,6 @@ GEM
       base64 (~> 0.2)
       faraday (>= 1.0, < 3.a)
     google-cloud-errors (1.7.0)
-    google-cloud-os_config-v1 (1.9.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-    google-cloud-pubsub (3.4.0)
-      concurrent-ruby (~> 1.3)
-      google-cloud-core (~> 1.8)
-      google-cloud-pubsub-v1 (~> 1.11)
-      retriable (~> 3.1)
-    google-cloud-pubsub-v1 (1.16.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      google-iam-v1 (~> 1.3)
     google-cloud-storage (1.62.0)
       addressable (~> 2.8)
       digest-crc (~> 0.4)
@@ -98,14 +58,12 @@ GEM
       google-cloud-core (~> 1.6)
       googleauth (~> 1.9)
       mini_mime (~> 1.0)
-    google-iam-v1 (1.7.0)
+    google-cloud-video-transcoder (2.2.0)
+      google-cloud-core (~> 1.6)
+      google-cloud-video-transcoder-v1 (~> 2.0)
+    google-cloud-video-transcoder-v1 (2.6.0)
       gapic-common (~> 1.3)
       google-cloud-errors (~> 1.0)
-      grpc-google-iam-v1 (~> 1.11)
-    google-identity-access_context_manager-v1 (0.15.0)
-      gapic-common (~> 1.3)
-      google-cloud-errors (~> 1.0)
-      grpc-google-iam-v1 (~> 1.11)
     google-logging-utils (0.2.0)
     google-protobuf (4.35.1)
       bigdecimal
@@ -134,7 +92,9 @@ GEM
     google-protobuf (4.35.1-x86_64-linux-musl)
       bigdecimal
       rake (~> 13.3)
-    googleapis-common-protos (1.9.0)
+    google-style (1.25.3)
+      rubocop (~> 1.28.2)
+    googleapis-common-protos (1.10.0)
       google-protobuf (~> 4.26)
       googleapis-common-protos-types (~> 1.21)
       grpc (~> 1.41)
@@ -175,10 +135,6 @@ GEM
     grpc (1.83.0-x86_64-linux-musl)
       google-protobuf (>= 3.25, < 5.0)
       googleapis-common-protos-types (~> 1.0)
-    grpc-google-iam-v1 (1.12.0)
-      google-protobuf (>= 3.18, < 5.a)
-      googleapis-common-protos (~> 1.9.0)
-      grpc (~> 1.41)
     json (2.21.2)
     jwt (3.2.0)
       base64
@@ -187,24 +143,49 @@ GEM
     minitest (5.27.0)
     minitest-focus (1.4.1)
       minitest (> 5.0)
+    minitest-rg (5.4.0)
+      minitest (>= 5.0, < 7)
     multi_json (1.21.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
     os (1.1.4)
+    parallel (1.28.0)
+    parser (3.3.12.0)
+      ast (~> 2.4.1)
+      racc
+    prism (1.9.0)
     pstore (0.2.1)
     public_suffix (7.0.5)
+    racc (1.8.1)
+    rainbow (3.1.1)
     rake (13.4.2)
+    regexp_parser (2.12.0)
     representable (3.2.0)
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
-    retriable (3.8.0)
+    retriable (4.2.0)
+    rexml (3.4.4)
+    rubocop (1.28.2)
+      parallel (~> 1.10)
+      parser (>= 3.1.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.17.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.50.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    ruby-progressbar (1.13.0)
     signet (0.22.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 4.0)
     trailblazer-option (0.1.2)
     uber (0.1.0)
+    unicode-display_width (2.6.0)
     uri (1.1.1)
 
 PLATFORMS
@@ -219,20 +200,20 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  google-cloud-asset
-  google-cloud-bigquery
-  google-cloud-pubsub
   google-cloud-storage
+  google-cloud-video-transcoder
+  google-style (~> 1.25.1)
   minitest (~> 5.14)
-  minitest-focus
+  minitest-focus (~> 1.1)
+  minitest-rg (~> 5.2)
   rake
 
 CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
-  concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
   declarative (0.0.20) sha256=8021dd6cb17ab2b61233c56903d3f5a259c5cf43c80ff332d447d395b17d9ff9
   digest-crc (0.7.0) sha256=64adc23a26a241044cbe6732477ca1b3c281d79e2240bcff275a37a5a0d78c07
   faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
@@ -240,26 +221,15 @@ CHECKSUMS
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
   faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
   gapic-common (1.3.0) sha256=4e5d9be1effb7366e2cda13c0f44922285d5613ac8de8b9b18c2c835fe4faa91
-  google-apis-bigquery_v2 (0.106.0) sha256=a0f4243b634a0c79c29b7dacdd79233bd9c9ba2eda6fde9c2b19414fd165dd93
-<<<<<<< HEAD
-  google-apis-core (1.2.99)
-=======
   google-apis-core (1.2.5) sha256=e21562b5627a0fc6a0c3165e429c3afed0f6a628eaa514e83f7204dda1adff69
->>>>>>> 66e8161415 (chore(deps): seed reproducible Gemfile.lock across 29 samples directories)
   google-apis-iamcredentials_v1 (0.28.0) sha256=0a92ffe6cc39c569554af2a77a25dfc61519ed8bbb64ab04cffdd352dc5ef106
   google-apis-storage_v1 (0.65.0) sha256=4247aa542931691f6988ab61e45cdea2878cbfe897a98eec4af9cdcb678eb359
-  google-cloud-asset (1.10.0) sha256=6ea6fd9e0735873884094c14d84d5a6d826b0e07aaeec245d34735ab2c5828e0
-  google-cloud-asset-v1 (1.9.0) sha256=ecfb654d0d350ed98209d46937c8095ec867c8ff6c3f7d70b8889f6fb70fd397
-  google-cloud-bigquery (1.64.0) sha256=d807363903e08958c3bc09ccc1f9d1218646c8f18176751879348a1a4a884d57
   google-cloud-core (1.9.0) sha256=ab55409f51488e8deefb6edcc1ce4771dfb5da2fe7b3bc075709a030c2b682a4
   google-cloud-env (2.4.0) sha256=01cb35ecee5d1c4d1cd4deaed8bb5bddc838e296bcc2a35c5d1ddd07ce40d28d
   google-cloud-errors (1.7.0) sha256=6e682f42d89aae08689f36f28495de629d756da076bafff0003bac7f8042ebb3
-  google-cloud-os_config-v1 (1.9.0) sha256=693c13690cfd7cf9d307c25d005ff33b823b6709791d3714c344ff1597ec3a30
-  google-cloud-pubsub (3.4.0) sha256=6a6390a6f605701945d5be233dea51e0b04009f157b5d701b092423fbc690edd
-  google-cloud-pubsub-v1 (1.16.0) sha256=ffe128821208bd3d2f27cb0d25eb6accb3893c99e0b736d1740b8b5e1570426b
   google-cloud-storage (1.62.0) sha256=e2c3c08bf8fd40d50be92304084942203314d4fc0ee52028e99f9359c3ad1330
-  google-iam-v1 (1.7.0) sha256=9e3ea9dcc59cbd5f8d2f62b00da41ec57a2e427b33c0e798207fa06c8fbb8b87
-  google-identity-access_context_manager-v1 (0.15.0) sha256=8f105320bcbdc03c7fdb05369886117b4f341b792ed4ab81a144929bbcd7820b
+  google-cloud-video-transcoder (2.2.0) sha256=7f2f58077f5b2ee0e67c0f62dda7994897d8a299dccd2a76570fcbc90555a259
+  google-cloud-video-transcoder-v1 (2.6.0) sha256=4502076541e557a044112a01a0663b07b2e70e5f9998c306ad51e601db89bb6d
   google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
   google-protobuf (4.35.1) sha256=a3a6471331d918f58dfa4d014a8f6286f0af2cf4840216bde52fcf2ea3fe3726
   google-protobuf (4.35.1-aarch64-linux-gnu) sha256=50ca44d0eeff3f8475e630a1accdd974256f3510694d574e2c9d6119ea8bc9e1
@@ -270,7 +240,8 @@ CHECKSUMS
   google-protobuf (4.35.1-x86_64-darwin) sha256=66b62b4df00931018a692806df66393efa960d6d2b7da69735187249f950d3ee
   google-protobuf (4.35.1-x86_64-linux-gnu) sha256=c786439087512a3fbd199e9897d265b855f951d4027e218ea55e858d45969edd
   google-protobuf (4.35.1-x86_64-linux-musl) sha256=91890eb0002934a339fdb7d77a147c46b7474b6799db27872b747b905837f744
-  googleapis-common-protos (1.9.0) sha256=207be372d8d25e3876e1e1155d057e14f3c92f8f5428772864a8ce04a0b756e4
+  google-style (1.25.3) sha256=d417fd0f6d6a9f4bb2ff69e1cfaa1c4d0e19230589cdf4383df4540082c395d4
+  googleapis-common-protos (1.10.0) sha256=13e47ad0ce85d3d30065c03863efd302a82b0e08ba576f2a9b9dbbfeecb57ee0
   googleapis-common-protos-types (1.23.0) sha256=992e740a523794d9fc5f29a504465d8fc737aaa16c930fe7228e3346860faf0a
   googleauth (1.17.3) sha256=9a655455885c0c17a8b70537acd2a992a7c7842c43c06c6612dfb0d93e755d58
   grpc (1.83.0) sha256=38119e7f9f7cbc98e79145201da4be470a7542b0befad454651d35015ea55c59
@@ -282,24 +253,35 @@ CHECKSUMS
   grpc (1.83.0-x86_64-darwin) sha256=cfad91d559d1907159a5247fb12dc112a8ea0ebe2027ca7f5ab648d01a645716
   grpc (1.83.0-x86_64-linux-gnu) sha256=25d66bfa3cb1b05258b3f9632478c7e7ceb52cb16ccc0b4b26d7df36be7158b1
   grpc (1.83.0-x86_64-linux-musl) sha256=a5023264dbb8038c23b147bbf80adb06932ef11b5ab493412e9e37a43114fa8c
-  grpc-google-iam-v1 (1.12.0) sha256=a70ecad8987e340d5e22e7bf01be31256c84b29a3f78bebd385a4a110e1f2aef
   json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   minitest-focus (1.4.1) sha256=394517cbe2dcb2d992d8ffc41a3b2b6315777a4daa69239de4fefe7110dd810e
+  minitest-rg (5.4.0) sha256=54d42bb8ce876381245be5866f3c1dd704ef79c06ba5c9ff280c0aa28c56effb
   multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
   os (1.1.4) sha256=57816d6a334e7bd6aed048f4b0308226c5fb027433b67d90a9ab435f35108d3f
+  parallel (1.28.0) sha256=33e6de1484baf2524792d178b0913fc8eb94c628d6cfe45599ad4458c638c970
+  parser (3.3.12.0) sha256=21a6d7f755d5a24dfbdc6e6b772e4e879a52e7631a88bc5a3a134606052c9828
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   pstore (0.2.1) sha256=03904d0f2c66579e96d1e6704cdabc0c88df7ea8ed8782d9f3569f6f6c702c1a
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
+  regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
   representable (3.2.0) sha256=cc29bf7eebc31653586849371a43ffe36c60b54b0a6365b5f7d95ec34d1ebace
-  retriable (3.8.0) sha256=9f2f1b0207594c7817f17f671587b8ec7587387ac6cebda6c941a802bb98a8e5
+  retriable (4.2.0) sha256=90c3b257472a1c02f2a3dfa64dd35a420f7a624cef1a5981e20fdac5730f8cdc
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rubocop (1.28.2) sha256=0d9bf4108fd86ede43c6cf30adcb3dd2e0c6750941c5ec2a00621478157cb377
+  rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   signet (0.22.0) sha256=b76d495ccb07ad35dbc89f3e920665a9d8ed717141955034005d7843dcfe4780
   trailblazer-option (0.1.2) sha256=20e4f12ea4e1f718c8007e7944ca21a329eee4eed9e0fa5dde6e8ad8ac4344a3
   uber (0.1.0) sha256=5beeb407ff807b5db994f82fa9ee07cfceaa561dad8af20be880bc67eba935dc
+  unicode-display_width (2.6.0) sha256=12279874bba6d5e4d2728cef814b19197dbb10d7a7837a869bab65da943b7f5a
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
 
 BUNDLED WITH


### PR DESCRIPTION
 Checks in Gemfile.lock generated under Ruby 3.2.11 29 client library samples/ directories.

 When CI/CD acceptance and quickstart tests execute inside samples/ subdirectories, dependencies are installed against samples/Gemfile. We therefore must pin reproducible lockfiles in these directories to ensure deterministic test execution and fulfill P1 Supply Chain Security Compliance.

closes: #509981628