### PR TITLE
chore: update release-please strategy

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -4,4 +4,4 @@ manifest: true
 monorepoTags: true
 onDemand: true
 primaryBranch: main
-releaseType: ruby-yoshi
+releaseType: ruby-librarian

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,7 @@
   "include-component-in-tag": true,
   "include-v-in-tag": true,
   "prerelease": false,
-  "release-type": "ruby-yoshi",
+  "release-type": "ruby-librarian",
   "skip-github-release": false,
   "separate-pull-requests": true,
   "tag-separator": "/",


### PR DESCRIPTION
Update release strategy to `ruby-librarian`. 

See [milestone 1](https://docs.google.com/document/d/17ejQey_fzKfnSUWocmlMlJh1TYaavIxRe_-dqQ48foA/edit?resourcekey=0-oqhz5UToZVoA4NMHrBQHMQ&tab=t.2qgt77kdbk4q#bookmark=id.8co1dwrlis1m) of migration plan for more details.