### PR TITLE
chore(renovate): restrict update schedule to weekends and group minor and patch dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,9 +2,11 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     // Use pre-determined best practices, including monorepo groupings & GitHub Action digest pinning
-    "config:best-practices",
-    // Create version bump PRs globally on a monthly basis (first day of the month)
-    "schedule:monthly"
+    "config:best-practices"
+  ],
+  // Restrict Renovate's execution to weekend window
+  "schedule": [
+    "after 8pm on Friday and before 6am on Monday"
   ],
   "semanticCommits": "enabled",
   "semanticCommitType": "chore",
@@ -16,15 +18,16 @@
     "enabled": true,
     "groupName": "maintain Gemfile.lock files",
     "automerge": false
-    // Inherits "schedule:monthly" from extends preset
+    // Inherits weekend schedule from root config
   },
   "packageRules": [
-    // Group all patch updates across all dependencies into a single PR
+    // Group all minor and patch updates across all dependencies into a single collective PR
     {
       "matchUpdateTypes": [
+        "minor",
         "patch"
       ],
-      "groupName": "all patch updates"
+      "groupName": "all minor and patch dependencies"
     },
 
     // Disable proactive rubygems version bumps across Phase 1 while keeping lockFileMaintenance enabled.


### PR DESCRIPTION
This PR optimizes `.github/renovate.json5` configuration to throttle and group dependency updates as requested in b/525027506:

1. **Weekend Schedule Window**: Restricts Renovate execution schedule to `"after 8pm on Friday and before 6am on Monday"` (replacing `"schedule:monthly"` in `extends`), ensuring updates are generated on weekends.
2. **Dependency Grouping**: Groups all minor and patch updates together into a single collective `"all minor and patch dependencies"` PR.
3. **Lockfile Maintenance**: Keeps automated `Gemfile.lock` maintenance enabled across all monorepo gems (`lockFileMaintenance`), which inherits the root weekend schedule.

Fixes b/525027506