### PR TITLE
chore: update owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,7 @@
 # explicitly taken by someone else.
 *                                    @googleapis/cloud-sdk-ruby-team @yoshi-approver
 
-/librarian.yaml                      @googleapis/cloud-sdk-librarian-team
+/librarian.yaml                      @googleapis/cloud-sdk-ruby-team @googleapis/cloud-sdk-librarian-team
 /google-cloud-bigquery*/.            @googleapis/cloud-sdk-ruby-team @yoshi-approver @googleapis/bigquery-team
 /google-cloud-bigtable*/.            @googleapis/cloud-sdk-ruby-team @yoshi-approver @googleapis/bigtable-team
 /google-cloud-datastore*/.           @googleapis/cloud-sdk-ruby-team @yoshi-approver


### PR DESCRIPTION
Update the owner of `librarian.yaml` to include the ruby team.