### PR TITLE
chore(ci): address zizmor findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       with:
         ruby-version: "${{ matrix.ruby }}"
     - name: Install NodeJS 18.x
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: "18.x || 24.x"
     - name: Install tools

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,9 +70,12 @@ jobs:
       # zizmor: ignore[template-injection]
       run: "gem install --no-document toys && npm install linkinator"
     - name: Test ${{ matrix.task }}
-      # zizmor: ignore[template-injection]
+      env:
+        GITHUB_EVENT_NAME: ${{ github.event_name }}
+        GITHUB_EVENT_PATH: ${{ github.event_path }}
+        GITHUB_EVENT_INPUTS_FLAGS: ${{ github.event.inputs.flags }}
       run: |
-        toys ci -v ${{ matrix.task }} --github-event-name=${{ github.event_name }} --github-event-payload=${{ github.event_path }} ${{ github.event.inputs.flags }}
+        toys ci -v ${{ matrix.task }} --github-event-name=${GITHUB_EVENT_NAME} --github-event-payload=${GITHUB_EVENT_PATH} ${GITHUB_EVENT_INPUTS_FLAGS}
     - name: Open Issues
       if: ${{ failure() }}
       env:


### PR DESCRIPTION
### 📚 PR Stack Navigation
1. 👉 **[PR #1: Zizmor Security Audit Fixes](https://github.com/googleapis/google-cloud-ruby/pull/36206)** *(Base - You are here)*
2. **[PR #2: Doctest Prefactoring (Sample Loader & 11-Gem Mocks)](https://github.com/googleapis/google-cloud-ruby/pull/36295)**
3. **[PR #3: Doctest CI Matrix Switch](https://github.com/googleapis/google-cloud-ruby/pull/36296)** *(Top of Stack)*

---
Addresses ad-hoc package errors and unpinned actions flagged by zizmor.

**Context:**
This acts as a "prefactoring" step to unblock the upcoming Doctests PR (#36296). Because the doctest PR modifies `.github/workflows/ci.yml`, it awakened the repository's Zizmor security scanner (which triggers exclusively on modifications strictly within `.github/workflows/`). That scan surfaced a backlog of accumulated technical debt and unpinned action tags across the workflow files. 

By splitting these fixes into this isolated PR, we can cleanly address the baseline workflow debt without polluting the core doctest implementation.
