### PR TITLE
chore(ci): enable automated doctest execution across gem CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           - os: ubuntu-latest
             ruby: "4.0"
             # (b/515549177): Disabled linkinator globally due to broken external doc links.
-            task: "--rubocop-toplevel --rubocop --build --yard"
+            task: "--rubocop-toplevel --rubocop --build --yard --doctest"
           - os: macos-latest
             ruby: "4.0"
             task: "--test"

--- a/.toys/.lib/sample_loader.rb
+++ b/.toys/.lib/sample_loader.rb
@@ -214,7 +214,7 @@ module SampleLoader
     private
 
     def camelize name
-      ::File.basename(name, ".rb").split("_").map(&:capitalize).join
+      ::File.basename(name, ".rb").split(/[_-]/).map(&:capitalize).join
     end
 
     def traverse_name mod, name, type

--- a/.toys/ci.rb
+++ b/.toys/ci.rb
@@ -19,14 +19,15 @@ TASKS = [
   "rubocop",
   "build",
   "yard",
+  "doctest",
   "linkinator",
   "acceptance",
   "conformance",
   "samples-main",
   "samples-latest",
 ].freeze
-OPTIONAL_TASKS = ["conformance"].freeze
-ISSUE_TASKS = ["bundle", "test", "rubocop", "build", "yard", "linkinator"].freeze
+OPTIONAL_TASKS = ["conformance", "doctest"].freeze
+ISSUE_TASKS = ["bundle", "test", "rubocop", "build", "yard", "doctest", "linkinator"].freeze
 FAILURES_REPORT_PATH = "tmp/ci-failures.json"
 
 desc "Run CI tasks."

--- a/.toys/doctest.rb
+++ b/.toys/doctest.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+desc "Run YARD doctests for this gem"
+
+include :exec, e: true
+
+def run
+  require "bundler"
+  gem_dir = Dir.pwd
+  unless File.file?(File.join(gem_dir, "Gemfile")) && File.file?(File.join(gem_dir, "support/doctest_helper.rb"))
+    puts "No doctests configured for #{File.basename gem_dir}."
+    exit 0
+  end
+  Bundler.with_unbundled_env do
+    exec ["bundle", "exec", "yard", "--plugin", "doctest", "doctest"]
+  end
+end

--- a/google-cloud-bigquery/support/doctest_helper.rb
+++ b/google-cloud-bigquery/support/doctest_helper.rb
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 require "minitest/focus"
+require "minitest/mock"
+require "ostruct"
 
 require "google/cloud/bigquery"
 require "google/cloud/storage"

--- a/google-cloud-bigtable/support/doctest_helper.rb
+++ b/google-cloud-bigtable/support/doctest_helper.rb
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 require "minitest/focus"
+require "minitest/mock"
+require "ostruct"
 
 require "google/cloud/bigtable"
 require "grpc/errors"

--- a/google-cloud-datastore/support/doctest_helper.rb
+++ b/google-cloud-datastore/support/doctest_helper.rb
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 require "minitest/focus"
+require "minitest/mock"
+require "ostruct"
 
 require "grpc"
 require "google/cloud/datastore"

--- a/google-cloud-dns/support/doctest_helper.rb
+++ b/google-cloud-dns/support/doctest_helper.rb
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 require "minitest/focus"
+require "minitest/mock"
+require "ostruct"
 
 require "google/cloud/dns"
 

--- a/google-cloud-error_reporting/support/doctest_helper.rb
+++ b/google-cloud-error_reporting/support/doctest_helper.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 require "minitest/focus"
+require "minitest/mock"
 require "ostruct"
 
 require "google/cloud/error_reporting"

--- a/google-cloud-firestore/support/doctest_helper.rb
+++ b/google-cloud-firestore/support/doctest_helper.rb
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 require "minitest/focus"
+require "minitest/mock"
+require "ostruct"
 
 require "google/cloud/firestore"
 
@@ -64,8 +66,40 @@ module Google
         def last_error
         end
       end
-      DocumentListener = StubbedListener
-      QueryListener = StubbedListener
+
+      class DocumentReference
+        def listen &callback
+          StubbedListener.new.start
+        end
+        alias on_snapshot listen
+      end
+
+      class Query
+        def listen &callback
+          StubbedListener.new.start
+        end
+        alias on_snapshot listen
+      end
+
+      # StubbedBulkWriter stubs out ThreadPoolExecutor and batch scheduler loops
+      # on Client#bulk_writer to prevent worker thread pools from hanging CI.
+      class StubbedBulkWriter
+        def create *args; OpenStruct.new; end
+        def set *args; OpenStruct.new; end
+        def update *args; OpenStruct.new; end
+        def delete *args; OpenStruct.new; end
+        def flush; nil; end
+        def close; nil; end
+        def on_batch_success &block; end
+        def on_batch_error &block; end
+      end
+
+      class Client
+        def bulk_writer *args
+          StubbedBulkWriter.new
+        end
+      end
+
     end
   end
 end

--- a/google-cloud-logging/support/doctest_helper.rb
+++ b/google-cloud-logging/support/doctest_helper.rb
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 require "minitest/focus"
+require "minitest/mock"
+require "ostruct"
 
 require "google/cloud/storage"
 require "google/cloud/logging"

--- a/google-cloud-pubsub/support/doctest_helper.rb
+++ b/google-cloud-pubsub/support/doctest_helper.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 require "minitest/focus"
+require "minitest/mock"
 require "ostruct"
 
 require "google/cloud/pubsub"
@@ -67,7 +68,7 @@ end
 def mock_pubsub
   Google::Cloud::PubSub.stub_new do |*args|
     credentials = OpenStruct.new(client: OpenStruct.new(updater_proc: Proc.new {}))
-    pubsub = Google::Cloud::PubSub::Project.new(Google::Cloud::PubSub::Service.new("my-project", credentials))
+    pubsub = Google::Cloud::PubSub::Project.new(Google::Cloud::PubSub::Service.new("my-project", credentials, logger: Google::Cloud::PubSub::InternalLogger.new(nil)))
 
     pubsub.service.mocked_topic_admin = Minitest::Mock.new
     pubsub.service.mocked_subscription_admin = Minitest::Mock.new
@@ -94,14 +95,14 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud" do
     mock_pubsub do |mock_topic_admin, mock_subscription_admin|
-      mock_topic_admin.expect :publish, OpenStruct.new(message_ids: ["1"]), [Hash]
+      mock_topic_admin.expect :publish_internal, OpenStruct.new(message_ids: ["1"]), [Hash]
       mock_topic_admin.expect :get_topic, topic_resp, topic: topic_path("my-topic")
     end
   end
 
   doctest.before "Google::Cloud::PubSub" do
     mock_pubsub do |mock_topic_admin, mock_subscription_admin|
-      mock_topic_admin.expect :publish, OpenStruct.new(message_ids: ["1"]), [Hash]
+      mock_topic_admin.expect :publish_internal, OpenStruct.new(message_ids: ["1"]), [Hash]
       mock_topic_admin.expect :get_topic, topic_resp, topic: topic_path("my-topic")
     end
   end
@@ -110,7 +111,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::PubSub::Message" do
     mock_pubsub do |mock_topic_admin, mock_subscription_admin|
-      mock_topic_admin.expect :publish, OpenStruct.new(message_ids: ["1"]), [Hash]
+      mock_topic_admin.expect :publish_internal, OpenStruct.new(message_ids: ["1"]), [Hash]
       mock_topic_admin.expect :get_topic, topic_resp, topic: topic_path("my-topic")
       mock_subscription_admin.expect :get_subscription, subscription_resp, subscription: subscription_path("my-topic-sub")
       mock_subscription_admin.expect :streaming_pull, [OpenStruct.new(received_messages: [Google::Cloud::PubSub::V1::ReceivedMessage.new(ack_id: "2", message: pubsub_message)])].to_enum, [Enumerator, Hash]
@@ -125,7 +126,7 @@ YARD::Doctest.configure do |doctest|
 
   doctest.before "Google::Cloud::PubSub::Project" do
     mock_pubsub do |mock_topic_admin, mock_subscription_admin|
-      mock_topic_admin.expect :publish, OpenStruct.new(message_ids: ["1"]), [Hash]
+      mock_topic_admin.expect :publish_internal, OpenStruct.new(message_ids: ["1"]), [Hash]
       mock_topic_admin.expect :get_topic, topic_resp, topic: topic_path("my-topic")
     end
   end
@@ -140,7 +141,7 @@ YARD::Doctest.configure do |doctest|
       mock_subscription_admin.expect :streaming_pull, [].to_enum, [Enumerator, Hash]
       mock_subscription_admin.expect :streaming_pull, [].to_enum, [Enumerator, Hash]
       mock_subscription_admin.expect :streaming_pull, [].to_enum, [Enumerator, Hash]
-      mock_subscription_admin.expect :acknowledge, nil, ["projects/my-project/subscriptions/my-sub", ["2"], Hash]
+      mock_subscription_admin.expect :acknowledge_internal, nil, ["projects/my-project/subscriptions/my-sub", ["2"], Hash]
     end
   end
 
@@ -165,14 +166,14 @@ YARD::Doctest.configure do |doctest|
       mock_subscription_admin.expect :streaming_pull, [].to_enum, [Enumerator, Hash]
       mock_subscription_admin.expect :streaming_pull, [].to_enum, [Enumerator, Hash]
       mock_subscription_admin.expect :streaming_pull, [].to_enum, [Enumerator, Hash]
-      mock_subscription_admin.expect :modify_ack_deadline, nil, [Hash]
+      mock_subscription_admin.expect :modify_ack_deadline_internal, nil, [Hash]
     end
   end
 
   doctest.before "Google::Cloud::PubSub::ReceivedMessage#reject!" do
     mock_pubsub do |mock_topic_admin, mock_subscription_admin|
       mock_subscription_admin.expect :get_subscription, subscription_resp, subscription: subscription_path("my-topic-sub")
-      mock_subscription_admin.expect :pull, OpenStruct.new(received_messages: [Google::Cloud::PubSub::V1::ReceivedMessage.new(ack_id: "2", message: pubsub_message)]), [Hash]
+      mock_subscription_admin.expect :pull_internal, OpenStruct.new(received_messages: [Google::Cloud::PubSub::V1::ReceivedMessage.new(ack_id: "2", message: pubsub_message)]), [Hash]
       mock_subscription_admin.expect :streaming_pull, [OpenStruct.new(received_messages: [Google::Cloud::PubSub::V1::ReceivedMessage.new(ack_id: "2", message: pubsub_message)])].to_enum, [Enumerator, Hash]
       mock_subscription_admin.expect :streaming_pull, [].to_enum, [Enumerator, Hash]
       mock_subscription_admin.expect :streaming_pull, [].to_enum, [Enumerator, Hash]
@@ -190,16 +191,16 @@ YARD::Doctest.configure do |doctest|
       mock_subscription_admin.expect :streaming_pull, [].to_enum, [Enumerator, Hash]
       mock_subscription_admin.expect :streaming_pull, [].to_enum, [Enumerator, Hash]
       mock_subscription_admin.expect :streaming_pull, [].to_enum, [Enumerator, Hash]
-      mock_subscription_admin.expect :acknowledge, nil, [Hash]
+      mock_subscription_admin.expect :acknowledge_internal, nil, [Hash]
     end
   end
 
   doctest.before "Google::Cloud::PubSub::Subscriber#wait_for_messages" do
     mock_pubsub do |mock_topic_admin, mock_subscription_admin|
       mock_subscription_admin.expect :get_subscription, subscription_resp("my-topic-sub"), subscription: subscription_path("my-topic-sub")
-      mock_subscription_admin.expect :pull, OpenStruct.new(received_messages: [Google::Cloud::PubSub::V1::ReceivedMessage.new(ack_id: "2", message: pubsub_message)]),
+      mock_subscription_admin.expect :pull_internal, OpenStruct.new(received_messages: [Google::Cloud::PubSub::V1::ReceivedMessage.new(ack_id: "2", message: pubsub_message)]),
                              subscription: subscription_path("my-topic-sub"), max_messages: 100, return_immediately: false
-      mock_subscription_admin.expect :acknowledge, nil, subscription: subscription_path("my-topic-sub"), ack_ids: ["2"]
+      mock_subscription_admin.expect :acknowledge_internal, nil, subscription: subscription_path("my-topic-sub"), ack_ids: ["2"]
     end
   end
 
@@ -213,27 +214,27 @@ YARD::Doctest.configure do |doctest|
   doctest.before "Google::Cloud::PubSub::Subscriber#pull@The `immediate: false` option is now recommended to avoid adverse impacts on pull operations:" do
      mock_pubsub do |mock_topic_admin, mock_subscription_admin|
      mock_subscription_admin.expect :get_subscription, subscription_resp("my-topic-sub"), subscription: subscription_path("my-topic-sub")
-     mock_subscription_admin.expect :pull, OpenStruct.new(received_messages: [Google::Cloud::PubSub::V1::ReceivedMessage.new(ack_id: "2", message: pubsub_message)]),
+     mock_subscription_admin.expect :pull_internal, OpenStruct.new(received_messages: [Google::Cloud::PubSub::V1::ReceivedMessage.new(ack_id: "2", message: pubsub_message)]),
                              subscription: subscription_path("my-topic-sub"), max_messages: 100, return_immediately: false
-     mock_subscription_admin.expect :acknowledge, nil, subscription: subscription_path("my-topic-sub"), ack_ids: ["2"]
+     mock_subscription_admin.expect :acknowledge_internal, nil, subscription: subscription_path("my-topic-sub"), ack_ids: ["2"]
     end
   end
 
   doctest.before "Google::Cloud::PubSub::Subscriber#pull@A maximum number of messages returned can also be specified:" do
     mock_pubsub do |mock_topic_admin, mock_subscription_admin|
       mock_subscription_admin.expect :get_subscription, subscription_resp("my-topic-sub"), subscription: subscription_path("my-topic-sub")
-      mock_subscription_admin.expect :pull, OpenStruct.new(received_messages: [Google::Cloud::PubSub::V1::ReceivedMessage.new(ack_id: "2", message: pubsub_message)]),
+      mock_subscription_admin.expect :pull_internal, OpenStruct.new(received_messages: [Google::Cloud::PubSub::V1::ReceivedMessage.new(ack_id: "2", message: pubsub_message)]),
                              subscription: subscription_path("my-topic-sub"), max_messages: 10, return_immediately: false
-      mock_subscription_admin.expect :acknowledge, nil, subscription: subscription_path("my-topic-sub"), ack_ids: ["2"]
+      mock_subscription_admin.expect :acknowledge_internal, nil, subscription: subscription_path("my-topic-sub"), ack_ids: ["2"]
     end
   end
 
   doctest.before "Google::Cloud::PubSub::Subscriber#modify_ack_deadline" do
     mock_pubsub do |mock_topic_admin, mock_subscription_admin|
       mock_subscription_admin.expect :get_subscription, subscription_resp, subscription: subscription_path("my-topic-sub")
-      mock_subscription_admin.expect :pull, OpenStruct.new(received_messages: [Google::Cloud::PubSub::V1::ReceivedMessage.new(ack_id: "2", message: pubsub_message)]),
+      mock_subscription_admin.expect :pull_internal, OpenStruct.new(received_messages: [Google::Cloud::PubSub::V1::ReceivedMessage.new(ack_id: "2", message: pubsub_message)]),
                              subscription: subscription_path("my-sub"), max_messages: 100, return_immediately: false
-      mock_subscription_admin.expect :modify_ack_deadline, nil, subscription: subscription_path("my-sub"), ack_ids: ["2"], ack_deadline_seconds: 120
+      mock_subscription_admin.expect :modify_ack_deadline_internal, nil, subscription: subscription_path("my-sub"), ack_ids: ["2"], ack_deadline_seconds: 120
 
 
     end
@@ -262,7 +263,7 @@ YARD::Doctest.configure do |doctest|
       mock_subscription_admin.expect :streaming_pull, [].to_enum, [Enumerator, Hash]
       mock_subscription_admin.expect :streaming_pull, [].to_enum, [Enumerator, Hash]
       mock_subscription_admin.expect :streaming_pull, [].to_enum, [Enumerator, Hash]
-      mock_subscription_admin.expect :acknowledge, nil, ["projects/my-project/subscriptions/my-ordered-topic-sub", ["2"], Hash]
+      mock_subscription_admin.expect :acknowledge_internal, nil, ["projects/my-project/subscriptions/my-ordered-topic-sub", ["2"], Hash]
     end
   end
 
@@ -276,7 +277,7 @@ YARD::Doctest.configure do |doctest|
       mock_subscription_admin.expect :streaming_pull, [].to_enum, [Enumerator, Hash]
       mock_subscription_admin.expect :streaming_pull, [].to_enum, [Enumerator, Hash]
       mock_subscription_admin.expect :streaming_pull, [].to_enum, [Enumerator, Hash]
-      mock_subscription_admin.expect :acknowledge, nil, [Hash]
+      mock_subscription_admin.expect :acknowledge_internal, nil, [Hash]
     end
   end
 
@@ -286,28 +287,34 @@ YARD::Doctest.configure do |doctest|
   doctest.before "Google::Cloud::PubSub::Publisher" do
     mock_pubsub do |mock_topic_admin, mock_subscription_admin|
       mock_topic_admin.expect :get_topic, topic_resp, topic: topic_path("my-topic-only")
-      mock_topic_admin.expect :publish, OpenStruct.new(message_ids: ["1"]), [Hash]
+      mock_topic_admin.expect :publish_internal, OpenStruct.new(message_ids: ["1"]), [Hash]
+    end
+  end
+
+  doctest.before "Google::Cloud::PubSub::Publisher#reload!" do
+    mock_pubsub do |mock_topic_admin, mock_subscription_admin|
+      mock_topic_admin.expect :get_topic, topic_resp, topic: topic_path("my-topic")
     end
   end
 
   doctest.before "Google::Cloud::PubSub::Publisher#async_publisher" do
     mock_pubsub do |mock_topic_admin, mock_subscription_admin|
       mock_topic_admin.expect :get_topic, topic_resp, topic: topic_path("my-topic")
-      mock_topic_admin.expect :publish, OpenStruct.new(message_ids: ["1"]), [Hash]
+      mock_topic_admin.expect :publish_internal, OpenStruct.new(message_ids: ["1"]), [Hash]
     end
   end
 
   doctest.before "Google::Cloud::PubSub::Publisher#publish" do
     mock_pubsub do |mock_topic_admin, mock_subscription_admin|
       mock_topic_admin.expect :get_topic, topic_resp, topic: topic_path("my-topic")
-      mock_topic_admin.expect :publish, OpenStruct.new(message_ids: ["1"]), [Hash]
+      mock_topic_admin.expect :publish_internal, OpenStruct.new(message_ids: ["1"]), [Hash]
     end
   end
 
   doctest.before "Google::Cloud::PubSub::Publisher#publish@Additionally, a message can be published with attributes:" do
     mock_pubsub do |mock_topic_admin, mock_subscription_admin|
       mock_topic_admin.expect :get_topic, topic_resp, topic: topic_path("my-topic")
-      mock_topic_admin.expect :publish, OpenStruct.new(message_ids: ["1"]), [Hash]
+      mock_topic_admin.expect :publish_internal, OpenStruct.new(message_ids: ["1"]), [Hash]
     end
   end
 
@@ -319,14 +326,14 @@ YARD::Doctest.configure do |doctest|
         pubsub_message("task 2 completed", { "foo" => "baz" }),
         pubsub_message("task 3 completed", { "foo" => "bif" })
       ]
-      mock_topic_admin.expect :publish, OpenStruct.new(message_ids: ["1", "2", "3"]), [Hash]
+      mock_topic_admin.expect :publish_internal, OpenStruct.new(message_ids: ["1", "2", "3"]), [Hash]
     end
   end
 
   doctest.before "Google::Cloud::PubSub::Publisher#publish@Ordered messages are supported using ordering_key:" do
     mock_pubsub do |mock_topic_admin, mock_subscription_admin|
       mock_topic_admin.expect :get_topic, topic_resp, topic: topic_path("my-ordered-topic")
-      mock_topic_admin.expect :publish, OpenStruct.new(message_ids: ["1"]), [Hash]
+      mock_topic_admin.expect :publish_internal, OpenStruct.new(message_ids: ["1"]), [Hash]
     end
   end
 
@@ -347,7 +354,7 @@ YARD::Doctest.configure do |doctest|
         pubsub_message("task 2 completed", { "foo" => "baz" }),
         pubsub_message("task 3 completed", { "foo" => "bif" })
       ]
-      mock_topic_admin.expect :publish, OpenStruct.new(message_ids: ["1", "2", "3"]), [Hash]
+      mock_topic_admin.expect :publish_internal, OpenStruct.new(message_ids: ["1", "2", "3"]), [Hash]
     end
   end
 end

--- a/google-cloud-storage/support/doctest_helper.rb
+++ b/google-cloud-storage/support/doctest_helper.rb
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 require "minitest/focus"
+require "minitest/mock"
+require "ostruct"
 
 require "google/cloud/storage"
 require "google/cloud/pubsub"

--- a/google-cloud-trace/support/doctest_helper.rb
+++ b/google-cloud-trace/support/doctest_helper.rb
@@ -16,6 +16,8 @@
 require "google/cloud/trace"
 require "minitest/rg"
 require "minitest/focus"
+require "minitest/mock"
+require "ostruct"
 require "active_record"
 
 module Google

--- a/google-cloud-translate-v2/support/doctest_helper.rb
+++ b/google-cloud-translate-v2/support/doctest_helper.rb
@@ -1,3 +1,5 @@
+require "ostruct"
+require "minitest/mock"
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -55,7 +57,7 @@ YARD::Doctest.configure do |doctest|
   doctest.before "Google::Cloud::Translate::V2.new" do
     mock_translate do |mock|
       res_attrs = { detectedSourceLanguage: "en", translatedText: "Salve mundi!" }
-      mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: nil, format: nil, model: nil, cid: nil]
+      mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"]], to: "la", from: nil, format: nil, model: nil, cid: nil
     end
   end
 
@@ -64,7 +66,7 @@ YARD::Doctest.configure do |doctest|
   doctest.before "Google::Cloud::Translate::V2::Api" do
     mock_translate do |mock|
       res_attrs = { detectedSourceLanguage: "en", translatedText: "Salve mundi!" }
-      mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: nil, format: nil, model: nil, cid: nil]
+      mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"]], to: "la", from: nil, format: nil, model: nil, cid: nil
     end
   end
 
@@ -82,21 +84,21 @@ YARD::Doctest.configure do |doctest|
   doctest.before "Google::Cloud::Translate::V2::Api#translate" do
     mock_translate do |mock|
       res_attrs = { detectedSourceLanguage: "en", translatedText: "Salve mundi!", model: "base" }
-      mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: nil, format: nil, model: nil, cid: nil]
+      mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"]], to: "la", from: nil, format: nil, model: nil, cid: nil
     end
   end
 
   doctest.before "Google::Cloud::Translate::V2::Api#translate@Using the neural machine translation model:" do
     mock_translate do |mock|
       res_attrs = { detectedSourceLanguage: "en", translatedText: "Salve mundi!", model: "nmt" }
-      mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: nil, format: nil, model: "nmt", cid: nil]
+      mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"]], to: "la", from: nil, format: nil, model: "nmt", cid: nil
     end
   end
 
   doctest.before "Google::Cloud::Translate::V2::Api#translate@Setting the `from` language." do
     mock_translate do |mock|
       res_attrs = { detectedSourceLanguage: nil, translatedText: "Salve mundi!" }
-      mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: "en", format: nil, model: nil, cid: nil]
+      mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"]], to: "la", from: "en", format: nil, model: nil, cid: nil
     end
   end
 
@@ -104,14 +106,14 @@ YARD::Doctest.configure do |doctest|
     mock_translate do |mock|
       res_attrs_1 = { detectedSourceLanguage: nil, translatedText: "Salve amice." }
       res_attrs_2 = { detectedSourceLanguage: nil, translatedText: "Vide te mox." }
-      mock.expect :translate, list_translations_response([res_attrs_1, res_attrs_2]), [["Hello my friend.", "See you soon."], to: "la", from: "en", format: nil, model: nil, cid: nil]
+      mock.expect :translate, list_translations_response([res_attrs_1, res_attrs_2]), [["Hello my friend.", "See you soon."]], to: "la", from: "en", format: nil, model: nil, cid: nil
     end
   end
 
   doctest.before "Google::Cloud::Translate::V2::Api#translate@Preserving HTML tags." do
     mock_translate do |mock|
       res_attrs = { detectedSourceLanguage: nil, translatedText: "<strong>Salve</strong> mundi!" }
-      mock.expect :translate, list_translations_response([res_attrs]), [["<strong>Hello</strong> world!"], to: "la", from: nil, format: nil, model: nil, cid: nil]
+      mock.expect :translate, list_translations_response([res_attrs]), [["<strong>Hello</strong> world!"]], to: "la", from: nil, format: nil, model: nil, cid: nil
     end
   end
 
@@ -162,7 +164,7 @@ YARD::Doctest.configure do |doctest|
   doctest.before "Google::Cloud::Translate::V2::Translation" do
     mock_translate do |mock|
       res_attrs = { detectedSourceLanguage: "en", translatedText: "Salve mundi!" }
-      mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"], to: "la", from: nil, format: nil, model: nil, cid: nil]
+      mock.expect :translate, list_translations_response([res_attrs]), [["Hello world!"]], to: "la", from: nil, format: nil, model: nil, cid: nil
     end
   end
 end


### PR DESCRIPTION
## Description

This PR implements and fully enables automated `yard-doctest` validation across all client libraries in the `google-cloud-ruby` repository within GitHub Actions. 

**Summary of Changes:**
1. **CI Engine Activation:** Defines a global `toys doctest` tool in `.toys/doctest.rb` to dynamically invoke `yard --plugin doctest` correctly via isolated bundle environments. 
2. **Matrix Enablement:** Modifies `.github/workflows/ci.yml` and `.toys/ci.rb` to run the `--doctest` flag natively in the testing matrix.
3. **Mocks & Compatibility Prefactoring:** Updates `sample_loader.rb` to support parsing hyphenated filenames, and modifies `doctest_helper.rb` mocks across 11 gems (e.g. `google-cloud-firestore`, `pubsub`, `storage`, etc.) to prevent hanging threads and Minitest 6 kwarg crashes in Ruby 3.x CI pipelines.