### PR TITLE
chore(ci): enable automated doctest execution across gem CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           - os: ubuntu-latest
             ruby: "4.0"
             # (b/515549177): Disabled linkinator globally due to broken external doc links.
-            task: "--rubocop-toplevel --rubocop --build --yard"
+            task: "--rubocop-toplevel --rubocop --build --yard --doctest"
           - os: macos-latest
             ruby: "4.0"
             task: "--test"

--- a/.toys/ci.rb
+++ b/.toys/ci.rb
@@ -19,14 +19,15 @@ TASKS = [
   "rubocop",
   "build",
   "yard",
+  "doctest",
   "linkinator",
   "acceptance",
   "conformance",
   "samples-main",
   "samples-latest",
 ].freeze
-OPTIONAL_TASKS = ["conformance"].freeze
-ISSUE_TASKS = ["bundle", "test", "rubocop", "build", "yard", "linkinator"].freeze
+OPTIONAL_TASKS = ["conformance", "doctest"].freeze
+ISSUE_TASKS = ["bundle", "test", "rubocop", "build", "yard", "doctest", "linkinator"].freeze
 FAILURES_REPORT_PATH = "tmp/ci-failures.json"
 
 desc "Run CI tasks."

--- a/.toys/doctest.rb
+++ b/.toys/doctest.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+desc "Run YARD doctests for this gem"
+
+include :exec, e: true
+
+def run
+  require "bundler"
+  gem_dir = Dir.pwd
+  unless File.file?(File.join(gem_dir, "Gemfile")) && File.file?(File.join(gem_dir, "support/doctest_helper.rb"))
+    puts "No doctests configured for #{File.basename(gem_dir)}."
+    exit 0
+  end
+  Bundler.with_unbundled_env do
+    exec ["bundle", "exec", "yard", "--plugin", "doctest", "doctest"]
+  end
+end


### PR DESCRIPTION
### 📚 PR Stack Navigation
1. **[PR #1: Zizmor Security Audit Fixes](https://github.com/googleapis/google-cloud-ruby/pull/36206)** *(Base)*
2. **[PR #2: Doctest Prefactoring (Sample Loader & 11-Gem Mocks)](https://github.com/googleapis/google-cloud-ruby/pull/36295)**
3. 👉 **[PR #3: Doctest CI Matrix Switch](https://github.com/googleapis/google-cloud-ruby/pull/36296)** *(Top of Stack - You are here)*

---
Enables automated YARD doctest execution in the Ubuntu Ruby 4.0 CI matrix.

Stack:
1. #36206 (Zizmor security fixes)
2. #36295 (Prefactoring: sample loader & doctest helper mocks across 11 gems)
3. This PR: Enables CI matrix switch in `ci.yml` & `ci.rb` (2-line diff)

Fixes: b/434017709
