### PR TITLE
fix(pubsub): Propagate logger to v1 admin and schema clients

### DIFF
--- a/google-cloud-pubsub/lib/google/cloud/pubsub.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub.rb
@@ -122,7 +122,6 @@ module Google
         project_id = project_id.to_s # Always cast to a string
         raise ArgumentError, "project_id is missing" if project_id.empty?
 
-        logger = Google::Cloud::PubSub::InternalLogger.new logger
         service = PubSub::Service.new project_id, credentials,
                                       host: endpoint,
                                       timeout: timeout,

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/async_publisher.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/async_publisher.rb
@@ -379,7 +379,7 @@ module Google
               grpc = @service.publish topic_name,
                                       items.map(&:msg),
                                       compress: compress && batch.total_message_bytes >= compression_bytes_threshold
-              service.logger.log_batch "publish-batch", reason, "publish", items.count, items.sum(&:bytesize)
+              service.internal_logger.log_batch "publish-batch", reason, "publish", items.count, items.sum(&:bytesize)
               items.zip Array(grpc.message_ids) do |item, id|
                 @flow_controller.release item.bytesize
                 next unless item.callback

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/batch_publisher.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/batch_publisher.rb
@@ -122,7 +122,7 @@ module Google
           grpc = service.publish topic_name,
                                  messages,
                                  compress: compress && total_message_bytes >= compression_bytes_threshold
-          service.logger.log_batch "publish-batch", reason, "publish", messages.count, @total_message_bytes
+          service.internal_logger.log_batch "publish-batch", reason, "publish", messages.count, @total_message_bytes
           to_gcloud_messages Array(grpc.message_ids)
         end
       end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/internal_logger.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/internal_logger.rb
@@ -31,7 +31,7 @@ module Google
         def log level, subtag, &message_block
           return unless VALID_LOG_LEVELS.include?(level) && block_given?
           # Only log if the logger is explicitly tagged for 'pubsub'.
-          return unless @logger && @logger.progname == LOG_NAME
+          return unless @logger.respond_to?(:progname) && @logger.progname == LOG_NAME
 
           @logger.public_send(level, "#{LOG_NAME}:#{subtag}", &message_block)
         end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/message_listener/inventory.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/message_listener/inventory.rb
@@ -86,7 +86,7 @@ module Google
               extension_time = Time.new - extension
               expired, keep = @inventory.partition { |_ack_id, item| item.pulled_at < extension_time }
               @inventory = keep.to_h
-              stream.subscriber.service.logger.log_expiry expired
+              stream.subscriber.service.internal_logger.log_expiry expired
               @wait_cond.broadcast
             end
           end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/message_listener/stream.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/message_listener/stream.rb
@@ -115,7 +115,7 @@ module Google
             synchronize do
               break if @stopped
 
-              subscriber.service.logger.log :info, "subscriber-streams" do
+              subscriber.service.internal_logger.log :info, "subscriber-streams" do
                 "stopping stream for subscription #{@subscriber.subscription_name}"
               end
               # Close the stream by pushing the sentinel value.
@@ -185,13 +185,13 @@ module Google
           end
 
           def log_info msg
-            subscriber.service.logger.log :info, "subscriber-streams" do
+            subscriber.service.internal_logger.log :info, "subscriber-streams" do
               msg
             end
           end
 
           def log_error msg
-            subscriber.service.logger.log :error, "subscriber-streams" do
+            subscriber.service.internal_logger.log :error, "subscriber-streams" do
               msg
             end
           end
@@ -289,7 +289,7 @@ module Google
             synchronize do
               # Don't allow a stream to restart if already stopped
               if @stopped
-                subscriber.service.logger.log :debug, "subscriber-streams" do
+                subscriber.service.internal_logger.log :debug, "subscriber-streams" do
                   "not filling stream for subscription #{@subscriber.subscription_name} because stream is already" \
                   " stopped"
                 end
@@ -319,7 +319,7 @@ module Google
               @stream_open = false
             end
             enum = @subscriber.service.streaming_pull @request_queue.each, options
-            subscriber.service.logger.log :info, "subscriber-streams" do
+            subscriber.service.internal_logger.log :info, "subscriber-streams" do
               "rpc: streamingPull, subscription: #{@subscriber.subscription_name}, stream opened"
             end
 
@@ -396,7 +396,7 @@ module Google
                  GRPC::ResourceExhausted, GRPC::Unauthenticated,
                  GRPC::Unavailable => e
             status_code = e.respond_to?(:code) ? e.code : e.class.name
-            subscriber.service.logger.log :error, "subscriber-streams" do
+            subscriber.service.internal_logger.log :error, "subscriber-streams" do
               "Subscriber stream for subscription #{@subscriber.subscription_name} has ended with status " \
               "#{status_code}; will be retried."
             end
@@ -404,13 +404,13 @@ module Google
             backoff_and_wait!
             retry
           rescue RestartStream
-            subscriber.service.logger.log :info, "subscriber-streams" do
+            subscriber.service.internal_logger.log :info, "subscriber-streams" do
               "Subscriber stream for subscription #{@subscriber.subscription_name} has ended; will be retried."
             end
             backoff_and_wait!
             retry
           rescue StandardError => e
-            subscriber.service.logger.log :error, "subscriber-streams" do
+            subscriber.service.internal_logger.log :error, "subscriber-streams" do
               "error on stream for subscription #{@subscriber.subscription_name}: #{e.inspect}"
             end
             @subscriber.error! e
@@ -463,12 +463,12 @@ module Google
           end
 
           def perform_callback_sync rec_msg
-            subscriber.service.logger.log :info, "callback-delivery" do
+            subscriber.service.internal_logger.log :info, "callback-delivery" do
               "message (ID #{rec_msg.message_id}, ackID #{rec_msg.ack_id}) delivery to user callbacks"
             end
             @subscriber.callback.call rec_msg unless stopped?
           rescue StandardError => e
-            subscriber.service.logger.log :info, "callback-exceptions" do
+            subscriber.service.internal_logger.log :info, "callback-exceptions" do
               "message (ID #{rec_msg.message_id}, ackID #{rec_msg.ack_id}) caused a user callback exception: " \
                 "#{e.inspect}"
             end
@@ -498,7 +498,7 @@ module Google
             return unless pause_streaming?
 
             @paused = true
-            subscriber.service.logger.log :info, "subscriber-flow-control" do
+            subscriber.service.internal_logger.log :info, "subscriber-flow-control" do
               "subscriber for #{@subscriber.subscription_name} is client-side flow control blocked"
             end
           end
@@ -519,7 +519,7 @@ module Google
               # leaving last_pong_at stale. Updating timestamp guarantees the monitor thread will not trigger an immediate
               # false-positive restart while the reader thread wakes up to drain buffered frames.
               @keepalive_monitor.record_pong!
-              subscriber.service.logger.log :info, "subscriber-flow-control" do
+              subscriber.service.internal_logger.log :info, "subscriber-flow-control" do
                 "subscriber for #{@subscriber.subscription_name} is unblocking client-side flow control"
               end
               # Signal to the background thread that we are unpaused

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/message_listener/timed_unary_buffer.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/message_listener/timed_unary_buffer.rb
@@ -320,7 +320,9 @@ module Google
                              reason
                            end
               requests[:acknowledge].each do |req|
-                @subscriber.service.logger.log_batch "ack-batch", new_reason, "ack", req.ack_ids.length, req.to_proto.bytesize
+                @subscriber.service.internal_logger.log_batch(
+                  "ack-batch", new_reason, "ack", req.ack_ids.length, req.to_proto.bytesize
+                )
               end
             end
             requests[:modify_ack_deadline] =
@@ -329,7 +331,9 @@ module Google
                 type = mod_deadline.zero? ? "nack" : "modack"
                 new_reason = mod_ack_reqs.length > 1 ? "#{reason} and partitioned for exceeding max bytes" : reason
                 mod_ack_reqs.each do |req|
-                  @subscriber.service.logger.log_batch "ack-batch", new_reason, type, req.ack_ids.length, req.to_proto.bytesize
+                  @subscriber.service.internal_logger.log_batch(
+                    "ack-batch", new_reason, type, req.ack_ids.length, req.to_proto.bytesize
+                  )
                 end
                 mod_ack_reqs
               end.flatten

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
@@ -43,7 +43,7 @@ module Google
 
         ##
         # @private The InternalLogger object.
-        attr_reader :logger
+        attr_reader :internal_logger
 
         ##
         # Creates a new Service instance.
@@ -55,6 +55,7 @@ module Google
           @client_id = SecureRandom.uuid.freeze
           @universe_domain = universe_domain || ENV["GOOGLE_CLOUD_UNIVERSE_DOMAIN"] || "googleapis.com"
           @logger = logger
+          @internal_logger = InternalLogger.new logger
         end
 
         def subscription_admin
@@ -67,6 +68,7 @@ module Google
             config.lib_name = "gccl"
             config.lib_version = Google::Cloud::PubSub::VERSION
             config.metadata = { "google-cloud-resource-prefix": "projects/#{@project}" }
+            config.logger = @logger if @logger
           end
         end
         attr_accessor :mocked_subscription_admin
@@ -81,6 +83,7 @@ module Google
             config.lib_name = "gccl"
             config.lib_version = Google::Cloud::PubSub::VERSION
             config.metadata = { "google-cloud-resource-prefix": "projects/#{@project}" }
+            config.logger = @logger if @logger
           end
         end
         attr_accessor :mocked_topic_admin
@@ -94,6 +97,7 @@ module Google
               config.lib_name = "gccl"
               config.lib_version = Google::Cloud::PubSub::VERSION
               config.metadata = { "google-cloud-resource-prefix": "projects/#{@project}" }
+              config.logger = @logger if @logger
             end
             iam
           end
@@ -110,6 +114,7 @@ module Google
             config.lib_name = "gccl"
             config.lib_version = Google::Cloud::PubSub::VERSION
             config.metadata = { "google-cloud-resource-prefix": "projects/#{@project}" }
+            config.logger = @logger if @logger
           end
         end
         attr_accessor :mocked_schemas
@@ -147,7 +152,7 @@ module Google
         ##
         # Acknowledges receipt of a message.
         def acknowledge subscription, *ack_ids
-          logger.log_ack_nack ack_ids, "ack"
+          internal_logger.log_ack_nack ack_ids, "ack"
           subscription_admin.acknowledge_internal subscription: subscription_path(subscription),
                                                   ack_ids: ack_ids
         end
@@ -156,7 +161,7 @@ module Google
         # Modifies the ack deadline for a specific message.
         def modify_ack_deadline subscription, ids, deadline
           if deadline.zero?
-            logger.log_ack_nack Array(ids), "nack"
+            internal_logger.log_ack_nack Array(ids), "nack"
           end
           subscription_admin.modify_ack_deadline_internal subscription: subscription_path(subscription),
                                                           ack_ids: Array(ids),
@@ -203,7 +208,6 @@ module Google
             rpc.timeout = timeout if rpc.respond_to? :timeout=
           end
         end
-
       end
     end
     Pubsub = PubSub unless const_defined? :Pubsub

--- a/google-cloud-pubsub/test/google/cloud/pubsub/internal_logger_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/internal_logger_test.rb
@@ -48,4 +48,13 @@ describe Google::Cloud::PubSub::InternalLogger do
 
     _(output.string).must_be_empty
   end
+
+  it "does not raise an error when a custom logger without progname is passed" do
+    custom_mock = Object.new
+    logging = Google::Cloud::PubSub::InternalLogger.new custom_mock
+
+    logging.log :info, "test-tag" do
+      "test message"
+    end
+  end
 end

--- a/google-cloud-pubsub/test/google/cloud/pubsub/message_listener/inventory_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/message_listener/inventory_test.rb
@@ -221,7 +221,7 @@ describe Google::Cloud::PubSub::MessageListener, :inventory, :mock_pubsub do
   it "removes expired items" do
     logging_mock = Minitest::Mock.new
     logging_mock.expect :log_expiry, nil, [Array]
-    service_mock = OpenStruct.new logger: logging_mock
+    service_mock = OpenStruct.new internal_logger: logging_mock
     listener_mock = OpenStruct.new service: service_mock
     stream_mock = OpenStruct.new subscriber: listener_mock
 

--- a/google-cloud-pubsub/test/google/cloud/pubsub/service_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/service_test.rb
@@ -218,6 +218,30 @@ describe Google::Cloud::PubSub::Service do
     end
   end
 
+  it "configures the V1::SubscriptionAdmin::Client with logger" do
+    custom_logger = Logger.new $stdout
+    service = Google::Cloud::PubSub::Service.new project, credentials, logger: custom_logger
+    _(service.subscription_admin.configure.logger).must_equal custom_logger
+  end
+
+  it "configures the V1::TopicAdmin::Client with logger" do
+    custom_logger = Logger.new $stdout
+    service = Google::Cloud::PubSub::Service.new project, credentials, logger: custom_logger
+    _(service.topic_admin.configure.logger).must_equal custom_logger
+  end
+
+  it "configures the V1::SchemaService::Client with logger" do
+    custom_logger = Logger.new $stdout
+    service = Google::Cloud::PubSub::Service.new project, credentials, logger: custom_logger
+    _(service.schemas.configure.logger).must_equal custom_logger
+  end
+
+  it "configures the IAMPolicy client with logger" do
+    custom_logger = Logger.new $stdout
+    service = Google::Cloud::PubSub::Service.new project, credentials, logger: custom_logger
+    _(service.iam.configure.logger).must_equal custom_logger
+  end
+
   it "should raise errors other than grpc on ack" do
     service = Google::Cloud::PubSub::Service.new project, nil, logger: mock_logging
     mocked_subscription_admin = Minitest::Mock.new

--- a/google-cloud-pubsub/test/google/cloud/pubsub_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub_test.rb
@@ -103,7 +103,7 @@ describe Google::Cloud do
         _(timeout).must_be :nil?
         _(host).must_be :nil?
         _(universe_domain).must_be :nil?
-        _(logger).must_be_kind_of Google::Cloud::PubSub::InternalLogger
+        _(logger).must_be_kind_of Logger
         OpenStruct.new project: project
       }
 
@@ -159,7 +159,7 @@ describe Google::Cloud do
         _(timeout).must_be :nil?
         _(host).must_be :nil?
         _(universe_domain).must_be :nil?
-        _(logger).must_be_kind_of Google::Cloud::PubSub::InternalLogger
+        _(logger).must_be_kind_of Logger
         OpenStruct.new project: project
       }
 
@@ -192,7 +192,7 @@ describe Google::Cloud do
         _(timeout).must_be :nil?
         _(host).must_be :nil?
         _(universe_domain).must_be :nil?
-        _(logger).must_be_kind_of Google::Cloud::PubSub::InternalLogger
+        _(logger).must_be_kind_of Logger
         OpenStruct.new project: project
       }
 
@@ -240,7 +240,7 @@ describe Google::Cloud do
         _(timeout).must_equal timeout
         _(host).must_be :nil?
         _(universe_domain).must_be :nil?
-        _(logger).must_be_kind_of Google::Cloud::PubSub::InternalLogger
+        _(logger).must_be_kind_of Logger
       }
 
       # Clear all environment variables
@@ -265,7 +265,7 @@ describe Google::Cloud do
         _(timeout).must_be :nil?
         _(host).must_equal endpoint
         _(universe_domain).must_be :nil?
-        _(logger).must_be_kind_of Google::Cloud::PubSub::InternalLogger
+        _(logger).must_be_kind_of Logger
         OpenStruct.new project: project, credentials: credentials
       }
 
@@ -294,7 +294,7 @@ describe Google::Cloud do
         _(timeout).must_be :nil?
         _(host).must_be :nil?
         _(universe_domain).must_equal actual_universe_domain
-        _(logger).must_be_kind_of Google::Cloud::PubSub::InternalLogger
+        _(logger).must_be_kind_of Logger
         OpenStruct.new project: project, credentials: credentials
       }
 
@@ -344,7 +344,7 @@ describe Google::Cloud do
         _(timeout).must_be :nil?
         _(host).must_be :nil?
         _(universe_domain).must_be :nil?
-        _(kwargs[:logger]).must_be_kind_of Google::Cloud::PubSub::InternalLogger
+        _(kwargs[:logger]).must_be_kind_of Logger
         OpenStruct.new project: project
       }
       empty_env = OpenStruct.new
@@ -388,7 +388,7 @@ describe Google::Cloud do
         _(timeout).must_be :nil?
         _(host).must_be :nil?
         _(universe_domain).must_be :nil?
-        _(kwargs[:logger]).must_be_kind_of Google::Cloud::PubSub::InternalLogger
+        _(kwargs[:logger]).must_be_kind_of Logger
         OpenStruct.new project: project
       }
 
@@ -427,7 +427,7 @@ describe Google::Cloud do
         _(timeout).must_be :nil?
         _(host).must_be :nil?
         _(universe_domain).must_be :nil?
-        _(kwargs[:logger]).must_be_kind_of Google::Cloud::PubSub::InternalLogger
+        _(kwargs[:logger]).must_be_kind_of Logger
         OpenStruct.new project: project
       }
 
@@ -464,7 +464,7 @@ describe Google::Cloud do
         _(project).must_equal "project-id"
         _(credentials).must_equal "pubsub-credentials"
         _(timeout).must_equal 42.0
-        _(kwargs[:logger]).must_be_kind_of Google::Cloud::PubSub::InternalLogger
+        _(kwargs[:logger]).must_be_kind_of Logger
         OpenStruct.new project: project
       }
 
@@ -502,7 +502,7 @@ describe Google::Cloud do
         _(project).must_equal "project-id"
         _(credentials).must_equal "pubsub-credentials"
         _(timeout).must_equal 42.0
-        _(kwargs[:logger]).must_be_kind_of Google::Cloud::PubSub::InternalLogger
+        _(kwargs[:logger]).must_be_kind_of Logger
         OpenStruct.new project: project
       }
 
@@ -537,7 +537,7 @@ describe Google::Cloud do
       stubbed_service = ->(project, credentials, timeout: nil, host: nil, universe_domain: nil, **kwargs) {
         _(host).must_equal actual_endpoint
         _(universe_domain).must_equal actual_universe_domain
-        _(kwargs[:logger]).must_be_kind_of Google::Cloud::PubSub::InternalLogger
+        _(kwargs[:logger]).must_be_kind_of Logger
         OpenStruct.new project: project
       }
 


### PR DESCRIPTION
Ensure configured logger is passed down to underlying GAPIC clients (`TopicAdmin`, `SubscriptionAdmin`, `SchemaService`, and `IAMPolicy`).

Previously, `Service` did not set `config.logger` on underlying GAPIC clients, ignoring any custom logger passed to `Google::Cloud::PubSub.new`.

This change passes the `Logger` directly to GAPIC configs while keeping `InternalLogger` for internal stream and batch diagnostics. This is non-breaking as `Service` and `InternalLogger` are private internals.

Fixes #32440