### PR TITLE
chore: populate version in librarian.yaml from .release-please-manifest.json

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -227,6 +227,7 @@ libraries:
             ruby-cloud-gem-namespace: Google::Cloud::AIPlatform::V1
             ruby-cloud-service-override: AiPlatform=AIPlatform
   - name: google-cloud-alloy_db
+    version: 2.3.1
     apis:
       - path: google/cloud/alloydb/v1
         ruby:
@@ -238,6 +239,7 @@ libraries:
       wrapper_of:
         - v1:1.0
   - name: google-cloud-alloy_db-v1
+    version: 1.10.1
     apis:
       - path: google/cloud/alloydb/v1
         ruby:
@@ -264,6 +266,7 @@ libraries:
             ruby-cloud-service-override: AlloyDBCSQLAdmin=AlloyDBCloudSQLAdmin
     skip_generate: true
   - name: google-cloud-api_gateway
+    version: 2.2.1
     apis:
       - path: google/cloud/apigateway/v1
         ruby:
@@ -274,6 +277,7 @@ libraries:
       wrapper_of:
         - v1:2.0
   - name: google-cloud-api_gateway-v1
+    version: 2.6.1
     apis:
       - path: google/cloud/apigateway/v1
         ruby:
@@ -281,6 +285,7 @@ libraries:
             ruby-cloud-env-prefix: API_GATEWAY
     skip_generate: true
   - name: google-cloud-api_hub
+    version: 1.0.1
     apis:
       - path: google/cloud/apihub/v1
     skip_generate: true
@@ -293,6 +298,7 @@ libraries:
       - path: google/cloud/apihub/v1
     skip_generate: true
   - name: google-cloud-api_keys
+    version: 1.5.1
     apis:
       - path: google/api/apikeys/v2
     skip_generate: true
@@ -300,10 +306,12 @@ libraries:
       wrapper_of:
         - v2:0.5
   - name: google-cloud-api_keys-v2
+    version: 0.14.1
     apis:
       - path: google/api/apikeys/v2
     skip_generate: true
   - name: google-cloud-api_registry
+    version: 0.3.1
     apis:
       - path: google/cloud/apiregistry/v1beta
     skip_generate: true
@@ -316,6 +324,7 @@ libraries:
       - path: google/cloud/apiregistry/v1beta
     skip_generate: true
   - name: google-cloud-apigee_connect
+    version: 1.7.1
     apis:
       - path: google/cloud/apigeeconnect/v1
         ruby:
@@ -326,6 +335,7 @@ libraries:
       wrapper_of:
         - v1:0.6
   - name: google-cloud-apigee_connect-v1
+    version: 1.7.1
     apis:
       - path: google/cloud/apigeeconnect/v1
         ruby:
@@ -341,6 +351,7 @@ libraries:
       - path: google/cloud/apigeeregistry/v1
     skip_generate: true
   - name: google-cloud-app_engine
+    version: 1.7.1
     apis:
       - path: google/appengine/v1
         ruby:
@@ -359,6 +370,7 @@ libraries:
             ruby-cloud-env-prefix: APP_ENGINE
     skip_generate: true
   - name: google-cloud-app_hub
+    version: 2.2.1
     apis:
       - path: google/cloud/apphub/v1
     skip_generate: true
@@ -371,6 +383,7 @@ libraries:
       - path: google/cloud/apphub/v1
     skip_generate: true
   - name: google-cloud-app_optimize
+    version: 1.0.1
     apis:
       - path: google/cloud/appoptimize/v1beta
     skip_generate: true
@@ -378,10 +391,12 @@ libraries:
       wrapper_of:
         - v1beta:0.0
   - name: google-cloud-app_optimize-v1beta
+    version: 1.0.1
     apis:
       - path: google/cloud/appoptimize/v1beta
     skip_generate: true
   - name: google-cloud-artifact_registry
+    version: 2.2.1
     apis:
       - path: google/devtools/artifactregistry/v1
         ruby:
@@ -400,6 +415,7 @@ libraries:
             ruby-cloud-env-prefix: ARTIFACT_REGISTRY
     skip_generate: true
   - name: google-cloud-artifact_registry-v1beta2
+    version: 0.20.1
     apis:
       - path: google/devtools/artifactregistry/v1beta2
         ruby:
@@ -431,6 +447,7 @@ libraries:
       - lib/google/cloud/asset/v1/asset_service/helpers.rb
       - test/google/cloud/asset/v1/additional_paths_test.rb
   - name: google-cloud-assured_workloads
+    version: 2.2.1
     apis:
       - path: google/cloud/assuredworkloads/v1
         ruby:
@@ -449,6 +466,7 @@ libraries:
             ruby-cloud-env-prefix: ASSURED_WORKLOADS
     skip_generate: true
   - name: google-cloud-assured_workloads-v1beta1
+    version: 0.26.1
     apis:
       - path: google/cloud/assuredworkloads/v1beta1
         ruby:
@@ -469,6 +487,7 @@ libraries:
       - path: google/cloud/auditmanager/v1
     skip_generate: true
   - name: google-cloud-automl
+    version: 2.2.1
     apis:
       - path: google/cloud/automl/v1
         ruby:
@@ -487,6 +506,7 @@ libraries:
       wrapper_of:
         - v1:1.2
   - name: google-cloud-automl-v1
+    version: 1.8.1
     apis:
       - path: google/cloud/automl/v1
         ruby:
@@ -499,6 +519,7 @@ libraries:
       - lib/google/cloud/automl/v1/_helpers.rb
     skip_generate: true
   - name: google-cloud-automl-v1beta1
+    version: 0.19.1
     apis:
       - path: google/cloud/automl/v1beta1
         ruby:
@@ -510,6 +531,7 @@ libraries:
       - lib/google/cloud/automl/v1beta1/_helpers.rb
     skip_generate: true
   - name: google-cloud-backupdr
+    version: 2.3.1
     apis:
       - path: google/cloud/backupdr/v1
         ruby:
@@ -521,6 +543,7 @@ libraries:
       wrapper_of:
         - v1:1.0
   - name: google-cloud-backupdr-v1
+    version: 1.11.2
     apis:
       - path: google/cloud/backupdr/v1
         ruby:
@@ -529,6 +552,7 @@ libraries:
             ruby-cloud-path-override: backup_dr=backupdr
     skip_generate: true
   - name: google-cloud-bare_metal_solution
+    version: 2.2.1
     apis:
       - path: google/cloud/baremetalsolution/v2
     skip_generate: true
@@ -541,6 +565,7 @@ libraries:
       - path: google/cloud/baremetalsolution/v2
     skip_generate: true
   - name: google-cloud-batch
+    version: 2.2.1
     apis:
       - path: google/cloud/batch/v1
     skip_generate: true
@@ -548,10 +573,12 @@ libraries:
       wrapper_of:
         - v1:1.0
   - name: google-cloud-batch-v1
+    version: 1.8.2
     apis:
       - path: google/cloud/batch/v1
     skip_generate: true
   - name: google-cloud-beyond_corp
+    version: 1.6.1
     apis:
       - path: google/cloud/beyondcorp/appconnections/v1
     skip_generate: true
@@ -591,6 +618,7 @@ libraries:
             ruby-cloud-wrapper-gem-override: google-cloud-beyond_corp
     skip_generate: true
   - name: google-cloud-bigquery-analytics_hub
+    version: 1.5.1
     apis:
       - path: google/cloud/bigquery/analyticshub/v1
     skip_generate: true
@@ -603,6 +631,7 @@ libraries:
       - path: google/cloud/bigquery/analyticshub/v1
     skip_generate: true
   - name: google-cloud-bigquery-connection
+    version: 1.8.1
     apis:
       - path: google/cloud/bigquery/connection/v1
         ruby:
@@ -613,6 +642,7 @@ libraries:
       wrapper_of:
         - v1:0.17
   - name: google-cloud-bigquery-connection-v1
+    version: 1.7.1
     apis:
       - path: google/cloud/bigquery/connection/v1
         ruby:
@@ -620,6 +650,7 @@ libraries:
             ruby-cloud-env-prefix: BIGQUERY_CONNECTION
     skip_generate: true
   - name: google-cloud-bigquery-data_exchange
+    version: 0.7.1
     apis:
       - path: google/cloud/bigquery/dataexchange/v1beta1
     skip_generate: true
@@ -632,6 +663,7 @@ libraries:
       - path: google/cloud/bigquery/dataexchange/v1beta1
     skip_generate: true
   - name: google-cloud-bigquery-data_policies
+    version: 2.2.1
     apis:
       - path: google/cloud/bigquery/datapolicies/v1
     skip_generate: true
@@ -649,6 +681,7 @@ libraries:
       - path: google/cloud/bigquery/datapolicies/v1beta1
     skip_generate: true
   - name: google-cloud-bigquery-data_transfer
+    version: 1.9.1
     apis:
       - path: google/cloud/bigquery/datatransfer/v1
         ruby:
@@ -679,6 +712,7 @@ libraries:
             ruby-cloud-yard-strict: "false"
     skip_generate: true
   - name: google-cloud-bigquery-migration
+    version: 1.5.1
     apis:
       - path: google/cloud/bigquery/migration/v2
     skip_generate: true
@@ -691,6 +725,7 @@ libraries:
       - path: google/cloud/bigquery/migration/v2
     skip_generate: true
   - name: google-cloud-bigquery-reservation
+    version: 1.8.1
     apis:
       - path: google/cloud/bigquery/reservation/v1
         ruby:
@@ -709,6 +744,7 @@ libraries:
             ruby-cloud-env-prefix: BIGQUERY_RESERVATION
     skip_generate: true
   - name: google-cloud-bigquery-storage
+    version: 1.8.1
     apis:
       - path: google/cloud/bigquery/storage/v1
         ruby:
@@ -751,6 +787,7 @@ libraries:
       - test/google/cloud/bigtable/v2/bigtable/helpers_test.rb
     skip_generate: true
   - name: google-cloud-billing
+    version: 1.8.1
     apis:
       - path: google/cloud/billing/v1
         ruby:
@@ -762,6 +799,7 @@ libraries:
       wrapper_of:
         - v1:0.17
   - name: google-cloud-billing-budgets
+    version: 3.2.1
     apis:
       - path: google/cloud/billing/budgets/v1
         ruby:
@@ -788,6 +826,7 @@ libraries:
             ruby-cloud-env-prefix: BILLING_BUDGETS
     skip_generate: true
   - name: google-cloud-billing-v1
+    version: 1.7.1
     apis:
       - path: google/cloud/billing/v1
         ruby:
@@ -795,6 +834,7 @@ libraries:
             ruby-cloud-env-prefix: BILLING
     skip_generate: true
   - name: google-cloud-binary_authorization
+    version: 2.2.1
     apis:
       - path: google/cloud/binaryauthorization/v1
         ruby:
@@ -826,6 +866,7 @@ libraries:
             ruby-cloud-service-override: BinauthzManagementServiceV1Beta1=BinauthzManagementService;SystemPolicyV1Beta1=SystemPolicy
     skip_generate: true
   - name: google-cloud-build
+    version: 1.8.1
     apis:
       - path: google/devtools/cloudbuild/v1
         ruby:
@@ -844,6 +885,7 @@ libraries:
             ruby-cloud-env-prefix: CLOUD_BUILD
     skip_generate: true
   - name: google-cloud-build-v2
+    version: 0.14.1
     apis:
       - path: google/devtools/cloudbuild/v2
         ruby:
@@ -851,6 +893,7 @@ libraries:
             ruby-cloud-env-prefix: CLOUD_BUILD
     skip_generate: true
   - name: google-cloud-capacity_planner
+    version: 0.4.1
     apis:
       - path: google/cloud/capacityplanner/v1beta
     skip_generate: true
@@ -863,6 +906,7 @@ libraries:
       - path: google/cloud/capacityplanner/v1beta
     skip_generate: true
   - name: google-cloud-certificate_manager
+    version: 2.2.1
     apis:
       - path: google/cloud/certificatemanager/v1
     skip_generate: true
@@ -875,6 +919,7 @@ libraries:
       - path: google/cloud/certificatemanager/v1
     skip_generate: true
   - name: google-cloud-ces
+    version: 1.0.1
     apis:
       - path: google/cloud/ces/v1
     skip_generate: true
@@ -882,14 +927,17 @@ libraries:
       wrapper_of:
         - v1:0.0
   - name: google-cloud-ces-v1
+    version: 1.0.1
     apis:
       - path: google/cloud/ces/v1
     skip_generate: true
   - name: google-cloud-ces-v1beta
+    version: 1.0.1
     apis:
       - path: google/cloud/ces/v1beta
     skip_generate: true
   - name: google-cloud-channel
+    version: 2.2.1
     apis:
       - path: google/cloud/channel/v1
         ruby:
@@ -900,6 +948,7 @@ libraries:
       wrapper_of:
         - v1:2.0
   - name: google-cloud-channel-v1
+    version: 2.6.1
     apis:
       - path: google/cloud/channel/v1
         ruby:
@@ -907,6 +956,7 @@ libraries:
             ruby-cloud-env-prefix: CHANNEL
     skip_generate: true
   - name: google-cloud-chronicle
+    version: 1.0.1
     apis:
       - path: google/cloud/chronicle/v1
     skip_generate: true
@@ -914,10 +964,12 @@ libraries:
       wrapper_of:
         - v1:0.0
   - name: google-cloud-chronicle-v1
+    version: 1.0.1
     apis:
       - path: google/cloud/chronicle/v1
     skip_generate: true
   - name: google-cloud-cloud_controls_partner
+    version: 2.2.1
     apis:
       - path: google/cloud/cloudcontrolspartner/v1
     skip_generate: true
@@ -935,6 +987,7 @@ libraries:
       - path: google/cloud/cloudcontrolspartner/v1beta
     skip_generate: true
   - name: google-cloud-cloud_dms
+    version: 1.6.1
     apis:
       - path: google/cloud/clouddms/v1
         ruby:
@@ -946,6 +999,7 @@ libraries:
       wrapper_of:
         - v1:0.7
   - name: google-cloud-cloud_dms-v1
+    version: 1.8.1
     apis:
       - path: google/cloud/clouddms/v1
         ruby:
@@ -955,6 +1009,7 @@ libraries:
             ruby-cloud-namespace-override: CloudDms=CloudDMS
     skip_generate: true
   - name: google-cloud-cloud_quotas
+    version: 2.3.1
     apis:
       - path: google/api/cloudquotas/v1
     skip_generate: true
@@ -962,14 +1017,17 @@ libraries:
       wrapper_of:
         - v1:2.0
   - name: google-cloud-cloud_quotas-v1
+    version: 2.6.1
     apis:
       - path: google/api/cloudquotas/v1
     skip_generate: true
   - name: google-cloud-cloud_quotas-v1beta
+    version: 0.10.1
     apis:
       - path: google/api/cloudquotas/v1beta
     skip_generate: true
   - name: google-cloud-cloud_security_compliance
+    version: 1.0.1
     apis:
       - path: google/cloud/cloudsecuritycompliance/v1
     skip_generate: true
@@ -982,6 +1040,7 @@ libraries:
       - path: google/cloud/cloudsecuritycompliance/v1
     skip_generate: true
   - name: google-cloud-commerce-consumer-procurement
+    version: 1.4.1
     apis:
       - path: google/cloud/commerce/consumer/procurement/v1
     skip_generate: true
@@ -994,6 +1053,7 @@ libraries:
       - path: google/cloud/commerce/consumer/procurement/v1
     skip_generate: true
   - name: google-cloud-commerce_producer
+    version: 0.1.1
     apis:
       - path: google/cloud/commerceproducer/v1beta
     skip_generate: true
@@ -1123,6 +1183,7 @@ libraries:
       - samples/quickstart.rb
     skip_generate: true
   - name: google-cloud-confidential_computing
+    version: 1.3.1
     apis:
       - path: google/cloud/confidentialcomputing/v1
     skip_generate: true
@@ -1130,10 +1191,12 @@ libraries:
       wrapper_of:
         - v1:0.7
   - name: google-cloud-confidential_computing-v1
+    version: 2.4.1
     apis:
       - path: google/cloud/confidentialcomputing/v1
     skip_generate: true
   - name: google-cloud-config_delivery
+    version: 1.0.1
     apis:
       - path: google/cloud/configdelivery/v1alpha
     skip_generate: true
@@ -1141,10 +1204,12 @@ libraries:
       wrapper_of:
         - v1:0.0
   - name: google-cloud-config_delivery-v1
+    version: 1.0.1
     apis:
       - path: google/cloud/configdelivery/v1
     skip_generate: true
   - name: google-cloud-config_service
+    version: 2.2.1
     apis:
       - path: google/cloud/config/v1
     skip_generate: true
@@ -1152,10 +1217,12 @@ libraries:
       wrapper_of:
         - v1:2.0
   - name: google-cloud-config_service-v1
+    version: 2.10.1
     apis:
       - path: google/cloud/config/v1
     skip_generate: true
   - name: google-cloud-connectors
+    version: 2.2.1
     apis:
       - path: google/cloud/connectors/v1
     skip_generate: true
@@ -1163,10 +1230,12 @@ libraries:
       wrapper_of:
         - v1:1.0
   - name: google-cloud-connectors-v1
+    version: 1.6.1
     apis:
       - path: google/cloud/connectors/v1
     skip_generate: true
   - name: google-cloud-contact_center_insights
+    version: 1.7.1
     apis:
       - path: google/cloud/contactcenterinsights/v1
     skip_generate: true
@@ -1179,6 +1248,7 @@ libraries:
       - path: google/cloud/contactcenterinsights/v1
     skip_generate: true
   - name: google-cloud-container
+    version: 2.2.1
     apis:
       - path: google/container/v1
         ruby:
@@ -1192,6 +1262,7 @@ libraries:
       wrapper_of:
         - v1:1.6
   - name: google-cloud-container-v1
+    version: 1.17.1
     apis:
       - path: google/container/v1
         ruby:
@@ -1199,6 +1270,7 @@ libraries:
             ruby-cloud-env-prefix: CONTAINER
     skip_generate: true
   - name: google-cloud-container-v1beta1
+    version: 0.57.1
     apis:
       - path: google/container/v1beta1
         ruby:
@@ -1206,6 +1278,7 @@ libraries:
             ruby-cloud-env-prefix: CONTAINER
     skip_generate: true
   - name: google-cloud-container_analysis
+    version: 1.7.1
     apis:
       - path: google/devtools/containeranalysis/v1
         ruby:
@@ -1226,6 +1299,7 @@ libraries:
       wrapper_of:
         - v1:0.9
   - name: google-cloud-container_analysis-v1
+    version: 1.8.1
     apis:
       - path: google/devtools/containeranalysis/v1
         ruby:
@@ -1237,6 +1311,7 @@ libraries:
       - test/google/cloud/container_analysis/v1/grafeas_client_test.rb
     skip_generate: true
   - name: google-cloud-data_catalog
+    version: 2.3.1
     apis:
       - path: google/cloud/datacatalog/v1
         ruby:
@@ -1273,6 +1348,7 @@ libraries:
       - path: google/cloud/datacatalog/lineage/v1
     skip_generate: true
   - name: google-cloud-data_catalog-v1
+    version: 2.8.1
     apis:
       - path: google/cloud/datacatalog/v1
         ruby:
@@ -1280,10 +1356,12 @@ libraries:
             ruby-cloud-env-prefix: DATA_CATALOG
     skip_generate: true
   - name: google-cloud-data_catalog-v1beta1
+    version: 0.13.1
     apis:
       - path: google/cloud/datacatalog/v1beta1
     skip_generate: true
   - name: google-cloud-data_fusion
+    version: 2.2.1
     apis:
       - path: google/cloud/datafusion/v1
     skip_generate: true
@@ -1291,10 +1369,12 @@ libraries:
       wrapper_of:
         - v1:2.0
   - name: google-cloud-data_fusion-v1
+    version: 2.6.1
     apis:
       - path: google/cloud/datafusion/v1
     skip_generate: true
   - name: google-cloud-data_labeling
+    version: 0.8.1
     apis:
       - path: google/cloud/datalabeling/v1beta1
         ruby:
@@ -1313,6 +1393,7 @@ libraries:
             ruby-cloud-env-prefix: DATA_LABELING
     skip_generate: true
   - name: google-cloud-database_center
+    version: 0.3.1
     apis:
       - path: google/cloud/databasecenter/v1beta
     skip_generate: true
@@ -1320,10 +1401,12 @@ libraries:
       wrapper_of:
         - v1beta:0.0
   - name: google-cloud-database_center-v1beta
+    version: 0.8.1
     apis:
       - path: google/cloud/databasecenter/v1beta
     skip_generate: true
   - name: google-cloud-dataflow
+    version: 0.9.1
     apis:
       - path: google/dataflow/v1beta3
         ruby:
@@ -1335,6 +1418,7 @@ libraries:
       wrapper_of:
         - v1beta3:0.8
   - name: google-cloud-dataflow-v1beta3
+    version: 0.17.1
     apis:
       - path: google/dataflow/v1beta3
         ruby:
@@ -1343,6 +1427,7 @@ libraries:
             ruby-cloud-service-override: JobsV1Beta3=Jobs;MessagesV1Beta3=Messages;MetricsV1Beta3=Metrics;SnapshotsV1Beta3=Snapshots
     skip_generate: true
   - name: google-cloud-dataform
+    version: 1.0.1
     apis:
       - path: google/cloud/dataform/v1beta1
     skip_generate: true
@@ -1363,6 +1448,7 @@ libraries:
             ruby-cloud-extra-dependencies: google-cloud-common=~>1.9
     skip_generate: true
   - name: google-cloud-dataplex
+    version: 2.4.1
     apis:
       - path: google/cloud/dataplex/v1
     skip_generate: true
@@ -1370,10 +1456,12 @@ libraries:
       wrapper_of:
         - v1:2.0
   - name: google-cloud-dataplex-v1
+    version: 2.10.1
     apis:
       - path: google/cloud/dataplex/v1
     skip_generate: true
   - name: google-cloud-dataproc
+    version: 2.9.1
     apis:
       - path: google/cloud/dataproc/v1
         ruby:
@@ -1388,6 +1476,7 @@ libraries:
       wrapper_of:
         - v1:0.24
   - name: google-cloud-dataproc-v1
+    version: 1.17.1
     apis:
       - path: google/cloud/dataproc/v1
         ruby:
@@ -1395,6 +1484,7 @@ libraries:
             ruby-cloud-env-prefix: DATAPROC
     skip_generate: true
   - name: google-cloud-dataqna
+    version: 0.8.1
     apis:
       - path: google/cloud/dataqna/v1alpha
         ruby:
@@ -1407,6 +1497,7 @@ libraries:
       wrapper_of:
         - v1alpha:0.6
   - name: google-cloud-dataqna-v1alpha
+    version: 0.13.1
     apis:
       - path: google/cloud/dataqna/v1alpha
         ruby:
@@ -1416,6 +1507,7 @@ libraries:
             ruby-cloud-path-override: data_qn_a=dataqna
     skip_generate: true
   - name: google-cloud-datastore-admin
+    version: 0.7.1
     apis:
       - path: google/datastore/admin/v1
         ruby:
@@ -1426,6 +1518,7 @@ libraries:
       wrapper_of:
         - v1:0.11
   - name: google-cloud-datastore-admin-v1
+    version: 1.7.1
     apis:
       - path: google/datastore/admin/v1
         ruby:
@@ -1442,6 +1535,7 @@ libraries:
       - samples/snippets.rb
     skip_generate: true
   - name: google-cloud-datastore-v1
+    version: 1.8.1
     apis:
       - path: google/datastore/v1
         ruby:
@@ -1449,6 +1543,7 @@ libraries:
             ruby-cloud-env-prefix: DATASTORE
     skip_generate: true
   - name: google-cloud-datastream
+    version: 2.2.1
     apis:
       - path: google/cloud/datastream/v1
     skip_generate: true
@@ -1456,14 +1551,17 @@ libraries:
       wrapper_of:
         - v1:1.0
   - name: google-cloud-datastream-v1
+    version: 1.7.1
     apis:
       - path: google/cloud/datastream/v1
     skip_generate: true
   - name: google-cloud-datastream-v1alpha1
+    version: 0.15.1
     apis:
       - path: google/cloud/datastream/v1alpha1
     skip_generate: true
   - name: google-cloud-deploy
+    version: 2.2.1
     apis:
       - path: google/cloud/deploy/v1
     skip_generate: true
@@ -1471,6 +1569,7 @@ libraries:
       wrapper_of:
         - v1:2.0
   - name: google-cloud-deploy-v1
+    version: 2.6.1
     apis:
       - path: google/cloud/deploy/v1
         ruby:
@@ -1478,6 +1577,7 @@ libraries:
             ruby-cloud-yard-strict: "false"
     skip_generate: true
   - name: google-cloud-developer_connect
+    version: 2.4.1
     apis:
       - path: google/cloud/developerconnect/v1
     skip_generate: true
@@ -1485,10 +1585,12 @@ libraries:
       wrapper_of:
         - v1:1.0
   - name: google-cloud-developer_connect-v1
+    version: 1.7.1
     apis:
       - path: google/cloud/developerconnect/v1
     skip_generate: true
   - name: google-cloud-device_streaming
+    version: 1.0.1
     apis:
       - path: google/cloud/devicestreaming/v1
     skip_generate: true
@@ -1496,10 +1598,12 @@ libraries:
       wrapper_of:
         - v1:0.0
   - name: google-cloud-device_streaming-v1
+    version: 1.0.1
     apis:
       - path: google/cloud/devicestreaming/v1
     skip_generate: true
   - name: google-cloud-dialogflow
+    version: 1.15.1
     apis:
       - path: google/cloud/dialogflow/v2
         ruby:
@@ -1515,6 +1619,7 @@ libraries:
       wrapper_of:
         - v2:0.32
   - name: google-cloud-dialogflow-cx
+    version: 1.5.1
     apis:
       - path: google/cloud/dialogflow/cx/v3
         ruby:
@@ -1526,6 +1631,7 @@ libraries:
       wrapper_of:
         - v3:0.24
   - name: google-cloud-dialogflow-cx-v3
+    version: 1.12.2
     apis:
       - path: google/cloud/dialogflow/cx/v3
         ruby:
@@ -1534,6 +1640,7 @@ libraries:
             ruby-cloud-namespace-override: Cx=CX
     skip_generate: true
   - name: google-cloud-dialogflow-v2
+    version: 1.17.1
     apis:
       - path: google/cloud/dialogflow/v2
         ruby:
@@ -1541,6 +1648,7 @@ libraries:
             ruby-cloud-env-prefix: DIALOGFLOW
     skip_generate: true
   - name: google-cloud-discovery_engine
+    version: 2.5.1
     apis:
       - path: google/cloud/discoveryengine/v1
     skip_generate: true
@@ -1548,14 +1656,17 @@ libraries:
       wrapper_of:
         - v1:2.0
   - name: google-cloud-discovery_engine-v1
+    version: 2.10.1
     apis:
       - path: google/cloud/discoveryengine/v1
     skip_generate: true
   - name: google-cloud-discovery_engine-v1beta
+    version: 0.28.1
     apis:
       - path: google/cloud/discoveryengine/v1beta
     skip_generate: true
   - name: google-cloud-dlp
+    version: 1.10.1
     apis:
       - path: google/privacy/dlp/v2
         ruby:
@@ -1578,6 +1689,7 @@ libraries:
       wrapper_of:
         - v2:0.20
   - name: google-cloud-dlp-v2
+    version: 1.18.1
     apis:
       - path: google/privacy/dlp/v2
         ruby:
@@ -1585,6 +1697,7 @@ libraries:
             ruby-cloud-env-prefix: DLP
     skip_generate: true
   - name: google-cloud-document_ai
+    version: 2.2.1
     apis:
       - path: google/cloud/documentai/v1
         ruby:
@@ -1603,6 +1716,7 @@ libraries:
       wrapper_of:
         - v1:1.4
   - name: google-cloud-document_ai-v1
+    version: 1.13.1
     apis:
       - path: google/cloud/documentai/v1
         ruby:
@@ -1611,6 +1725,7 @@ libraries:
             ruby-cloud-namespace-override: DocumentAi=DocumentAI
     skip_generate: true
   - name: google-cloud-document_ai-v1beta3
+    version: 0.49.1
     apis:
       - path: google/cloud/documentai/v1beta3
         ruby:
@@ -1619,6 +1734,7 @@ libraries:
             ruby-cloud-namespace-override: DocumentAi=DocumentAI
     skip_generate: true
   - name: google-cloud-domains
+    version: 2.2.1
     apis:
       - path: google/cloud/domains/v1beta1
         ruby:
@@ -1629,6 +1745,7 @@ libraries:
       wrapper_of:
         - v1:1.0
   - name: google-cloud-domains-v1
+    version: 1.5.1
     apis:
       - path: google/cloud/domains/v1
         ruby:
@@ -1636,6 +1753,7 @@ libraries:
             ruby-cloud-env-prefix: DOMAINS
     skip_generate: true
   - name: google-cloud-domains-v1beta1
+    version: 0.16.1
     apis:
       - path: google/cloud/domains/v1beta1
         ruby:
@@ -1643,6 +1761,7 @@ libraries:
             ruby-cloud-env-prefix: DOMAINS
     skip_generate: true
   - name: google-cloud-edge_container
+    version: 2.2.1
     apis:
       - path: google/cloud/edgecontainer/v1
     skip_generate: true
@@ -1650,10 +1769,12 @@ libraries:
       wrapper_of:
         - v1:1.0
   - name: google-cloud-edge_container-v1
+    version: 1.5.1
     apis:
       - path: google/cloud/edgecontainer/v1
     skip_generate: true
   - name: google-cloud-edge_network
+    version: 2.2.1
     apis:
       - path: google/cloud/edgenetwork/v1
     skip_generate: true
@@ -1661,10 +1782,12 @@ libraries:
       wrapper_of:
         - v1:2.0
   - name: google-cloud-edge_network-v1
+    version: 2.6.1
     apis:
       - path: google/cloud/edgenetwork/v1
     skip_generate: true
   - name: google-cloud-error_reporting-v1beta1
+    version: 0.17.1
     apis:
       - path: google/devtools/clouderrorreporting/v1beta1
         ruby:
@@ -1672,6 +1795,7 @@ libraries:
             ruby-cloud-env-prefix: ERROR_REPORTING
     skip_generate: true
   - name: google-cloud-essential_contacts
+    version: 1.7.1
     apis:
       - path: google/cloud/essentialcontacts/v1
         ruby:
@@ -1682,6 +1806,7 @@ libraries:
       wrapper_of:
         - v1:0.6
   - name: google-cloud-essential_contacts-v1
+    version: 1.7.1
     apis:
       - path: google/cloud/essentialcontacts/v1
         ruby:
@@ -1689,6 +1814,7 @@ libraries:
             ruby-cloud-env-prefix: ESSENTIAL_CONTACTS
     skip_generate: true
   - name: google-cloud-eventarc
+    version: 2.2.1
     apis:
       - path: google/cloud/eventarc/v1
         ruby:
@@ -1699,6 +1825,7 @@ libraries:
       wrapper_of:
         - v1:2.0
   - name: google-cloud-eventarc-publishing
+    version: 1.5.1
     apis:
       - path: google/cloud/eventarc/publishing/v1
         ruby:
@@ -1709,6 +1836,7 @@ libraries:
       wrapper_of:
         - v1:0.8
   - name: google-cloud-eventarc-publishing-v1
+    version: 1.8.1
     apis:
       - path: google/cloud/eventarc/publishing/v1
         ruby:
@@ -1716,6 +1844,7 @@ libraries:
             ruby-cloud-env-prefix: EVENTARC
     skip_generate: true
   - name: google-cloud-eventarc-v1
+    version: 2.8.1
     apis:
       - path: google/cloud/eventarc/v1
         ruby:
@@ -1723,6 +1852,7 @@ libraries:
             ruby-cloud-env-prefix: EVENTARC
     skip_generate: true
   - name: google-cloud-filestore
+    version: 2.2.1
     apis:
       - path: google/cloud/filestore/v1
     skip_generate: true
@@ -1730,6 +1860,7 @@ libraries:
       wrapper_of:
         - v1:2.0
   - name: google-cloud-filestore-v1
+    version: 2.7.1
     apis:
       - path: google/cloud/filestore/v1
         ruby:
@@ -1737,6 +1868,7 @@ libraries:
             ruby-cloud-extra-dependencies: google-cloud-common=~>1.0
     skip_generate: true
   - name: google-cloud-financial_services
+    version: 1.0.1
     apis:
       - path: google/cloud/financialservices/v1
     skip_generate: true
@@ -1749,6 +1881,7 @@ libraries:
       - path: google/cloud/financialservices/v1
     skip_generate: true
   - name: google-cloud-firestore-admin
+    version: 0.7.1
     apis:
       - path: google/firestore/admin/v1
         ruby:
@@ -1767,6 +1900,7 @@ libraries:
             ruby-cloud-env-prefix: FIRESTORE
     skip_generate: true
   - name: google-cloud-firestore-v1
+    version: 2.5.0
     apis:
       - path: google/firestore/v1
         ruby:
@@ -1774,6 +1908,7 @@ libraries:
             ruby-cloud-env-prefix: FIRESTORE
     skip_generate: true
   - name: google-cloud-functions
+    version: 2.2.1
     apis:
       - path: google/cloud/functions/v2
         ruby:
@@ -1784,6 +1919,7 @@ libraries:
       wrapper_of:
         - v2:1.0
   - name: google-cloud-functions-v1
+    version: 2.6.1
     apis:
       - path: google/cloud/functions/v1
         ruby:
@@ -1791,6 +1927,7 @@ libraries:
             ruby-cloud-env-prefix: FUNCTIONS
     skip_generate: true
   - name: google-cloud-functions-v2
+    version: 1.6.1
     apis:
       - path: google/cloud/functions/v2
         ruby:
@@ -1837,6 +1974,7 @@ libraries:
       - path: google/cloud/geminidataanalytics/v1beta
     skip_generate: true
   - name: google-cloud-gke_backup
+    version: 2.2.1
     apis:
       - path: google/cloud/gkebackup/v1
     skip_generate: true
@@ -1873,6 +2011,7 @@ libraries:
             ruby-cloud-env-prefix: GKE_CONNECT_GATEWAY
     skip_generate: true
   - name: google-cloud-gke_hub
+    version: 2.2.1
     apis:
       - path: google/cloud/gkehub/v1
         ruby:
@@ -1914,6 +2053,7 @@ libraries:
       - path: google/cloud/gkemulticloud/v1
     skip_generate: true
   - name: google-cloud-gke_recommender
+    version: 1.0.1
     apis:
       - path: google/cloud/gkerecommender/v1
     skip_generate: true
@@ -1950,6 +2090,7 @@ libraries:
             ruby-cloud-path-override: g_suite_add_ons=gsuite_add_ons
     skip_generate: true
   - name: google-cloud-hypercompute_cluster
+    version: 1.0.1
     apis:
       - path: google/cloud/hypercomputecluster/v1beta
     skip_generate: true
@@ -1962,6 +2103,7 @@ libraries:
       - path: google/cloud/hypercomputecluster/v1beta
     skip_generate: true
   - name: google-cloud-iap
+    version: 1.7.1
     apis:
       - path: google/cloud/iap/v1
         ruby:
@@ -1972,6 +2114,7 @@ libraries:
       wrapper_of:
         - v1:0.11
   - name: google-cloud-iap-v1
+    version: 1.8.1
     apis:
       - path: google/cloud/iap/v1
         ruby:
@@ -1979,6 +2122,7 @@ libraries:
             ruby-cloud-env-prefix: IAP
     skip_generate: true
   - name: google-cloud-ids
+    version: 2.2.1
     apis:
       - path: google/cloud/ids/v1
         ruby:
@@ -1989,6 +2133,7 @@ libraries:
       wrapper_of:
         - v1:2.0
   - name: google-cloud-ids-v1
+    version: 2.6.1
     apis:
       - path: google/cloud/ids/v1
         ruby:
@@ -1996,6 +2141,7 @@ libraries:
             ruby-cloud-namespace-override: Ids=IDS
     skip_generate: true
   - name: google-cloud-kms
+    version: 2.12.1
     apis:
       - path: google/cloud/kms/v1
         ruby:
@@ -2018,6 +2164,7 @@ libraries:
       wrapper_of:
         - v1:0.26
   - name: google-cloud-kms-inventory
+    version: 1.5.1
     apis:
       - path: google/cloud/kms/inventory/v1
     skip_generate: true
@@ -2047,6 +2194,7 @@ libraries:
       - test/google/cloud/kms/v1/iam_policy_test.rb
     skip_generate: true
   - name: google-cloud-language
+    version: 2.2.1
     apis:
       - path: google/cloud/language/v2
         ruby:
@@ -2082,6 +2230,7 @@ libraries:
       - path: google/cloud/language/v2
     skip_generate: true
   - name: google-cloud-license_manager
+    version: 1.0.1
     apis:
       - path: google/cloud/licensemanager/v1
     skip_generate: true
@@ -2094,6 +2243,7 @@ libraries:
       - path: google/cloud/licensemanager/v1
     skip_generate: true
   - name: google-cloud-life_sciences
+    version: 0.8.1
     apis:
       - path: google/cloud/lifesciences/v2beta
         ruby:
@@ -2114,11 +2264,13 @@ libraries:
             ruby-cloud-service-override: WorkflowsServiceV2Beta=WorkflowsService
     skip_generate: true
   - name: google-cloud-location
+    version: 1.5.1
     keep:
       - README.md
       - .repo-metadata.json
     skip_generate: true
   - name: google-cloud-location_finder
+    version: 1.0.1
     apis:
       - path: google/cloud/locationfinder/v1
     skip_generate: true
@@ -2131,6 +2283,7 @@ libraries:
       - path: google/cloud/locationfinder/v1
     skip_generate: true
   - name: google-cloud-logging-v2
+    version: 1.7.1
     apis:
       - path: google/logging/v2
         ruby:
@@ -2140,6 +2293,7 @@ libraries:
             ruby-cloud-yard-strict: "false"
     skip_generate: true
   - name: google-cloud-lustre
+    version: 1.0.1
     apis:
       - path: google/cloud/lustre/v1
     skip_generate: true
@@ -2147,10 +2301,12 @@ libraries:
       wrapper_of:
         - v1:0.0
   - name: google-cloud-lustre-v1
+    version: 1.0.1
     apis:
       - path: google/cloud/lustre/v1
     skip_generate: true
   - name: google-cloud-maintenance-api
+    version: 1.0.1
     apis:
       - path: google/cloud/maintenance/api/v1beta
     skip_generate: true
@@ -2158,14 +2314,17 @@ libraries:
       wrapper_of:
         - v1beta:0.0
   - name: google-cloud-maintenance-api-v1
+    version: 1.0.1
     apis:
       - path: google/cloud/maintenance/api/v1
     skip_generate: true
   - name: google-cloud-maintenance-api-v1beta
+    version: 1.0.1
     apis:
       - path: google/cloud/maintenance/api/v1beta
     skip_generate: true
   - name: google-cloud-managed_identities
+    version: 1.6.1
     apis:
       - path: google/cloud/managedidentities/v1
         ruby:
@@ -2176,6 +2335,7 @@ libraries:
       wrapper_of:
         - v1:0.7
   - name: google-cloud-managed_identities-v1
+    version: 1.8.1
     apis:
       - path: google/cloud/managedidentities/v1
         ruby:
@@ -2183,6 +2343,7 @@ libraries:
             ruby-cloud-env-prefix: MANAGED_IDENTITIES
     skip_generate: true
   - name: google-cloud-managed_kafka
+    version: 2.3.1
     apis:
       - path: google/cloud/managedkafka/v1
     skip_generate: true
@@ -2203,10 +2364,12 @@ libraries:
       - path: google/cloud/managedkafka/schemaregistry/v1
     skip_generate: true
   - name: google-cloud-managed_kafka-v1
+    version: 1.9.1
     apis:
       - path: google/cloud/managedkafka/v1
     skip_generate: true
   - name: google-cloud-media_translation
+    version: 0.8.1
     apis:
       - path: google/cloud/mediatranslation/v1beta1
         ruby:
@@ -2217,6 +2380,7 @@ libraries:
       wrapper_of:
         - v1beta1:0.8
   - name: google-cloud-media_translation-v1beta1
+    version: 0.16.1
     apis:
       - path: google/cloud/mediatranslation/v1beta1
         ruby:
@@ -2224,6 +2388,7 @@ libraries:
             ruby-cloud-env-prefix: MEDIA_TRANSLATION
     skip_generate: true
   - name: google-cloud-memcache
+    version: 2.2.1
     apis:
       - path: google/cloud/memcache/v1beta2
         ruby:
@@ -2234,6 +2399,7 @@ libraries:
       wrapper_of:
         - v1:2.0
   - name: google-cloud-memcache-v1
+    version: 2.6.1
     apis:
       - path: google/cloud/memcache/v1
         ruby:
@@ -2241,6 +2407,7 @@ libraries:
             ruby-cloud-env-prefix: MEMCACHE
     skip_generate: true
   - name: google-cloud-memcache-v1beta2
+    version: 0.18.1
     apis:
       - path: google/cloud/memcache/v1beta2
         ruby:
@@ -2248,6 +2415,7 @@ libraries:
             ruby-cloud-env-prefix: MEMCACHE
     skip_generate: true
   - name: google-cloud-memorystore
+    version: 1.2.1
     apis:
       - path: google/cloud/memorystore/v1
     skip_generate: true
@@ -2255,14 +2423,17 @@ libraries:
       wrapper_of:
         - v1:1.0
   - name: google-cloud-memorystore-v1
+    version: 1.11.1
     apis:
       - path: google/cloud/memorystore/v1
     skip_generate: true
   - name: google-cloud-memorystore-v1beta
+    version: 0.14.1
     apis:
       - path: google/cloud/memorystore/v1beta
     skip_generate: true
   - name: google-cloud-metastore
+    version: 2.2.1
     apis:
       - path: google/cloud/metastore/v1
         ruby:
@@ -2273,6 +2444,7 @@ libraries:
       wrapper_of:
         - v1:2.0
   - name: google-cloud-metastore-v1
+    version: 2.6.1
     apis:
       - path: google/cloud/metastore/v1
         ruby:
@@ -2280,6 +2452,7 @@ libraries:
             ruby-cloud-env-prefix: METASTORE
     skip_generate: true
   - name: google-cloud-metastore-v1beta
+    version: 0.22.1
     apis:
       - path: google/cloud/metastore/v1beta
         ruby:
@@ -2287,6 +2460,7 @@ libraries:
             ruby-cloud-env-prefix: METASTORE
     skip_generate: true
   - name: google-cloud-migration_center
+    version: 2.2.1
     apis:
       - path: google/cloud/migrationcenter/v1
     skip_generate: true
@@ -2294,10 +2468,12 @@ libraries:
       wrapper_of:
         - v1:2.0
   - name: google-cloud-migration_center-v1
+    version: 2.6.1
     apis:
       - path: google/cloud/migrationcenter/v1
     skip_generate: true
   - name: google-cloud-monitoring
+    version: 1.11.1
     apis:
       - path: google/monitoring/v3
         ruby:
@@ -2339,6 +2515,7 @@ libraries:
             ruby-cloud-wrapper-gem-override: google-cloud-monitoring
     skip_generate: true
   - name: google-cloud-monitoring-v3
+    version: 1.10.1
     apis:
       - path: google/monitoring/v3
         ruby:
@@ -2346,6 +2523,7 @@ libraries:
             ruby-cloud-env-prefix: MONITORING
     skip_generate: true
   - name: google-cloud-netapp
+    version: 2.2.1
     apis:
       - path: google/cloud/netapp/v1
         ruby:
@@ -2357,6 +2535,7 @@ libraries:
       wrapper_of:
         - v1:2.0
   - name: google-cloud-netapp-v1
+    version: 2.12.1
     apis:
       - path: google/cloud/netapp/v1
         ruby:
@@ -2365,6 +2544,7 @@ libraries:
             ruby-cloud-path-override: net_app=netapp
     skip_generate: true
   - name: google-cloud-network_connectivity
+    version: 2.5.1
     apis:
       - path: google/cloud/networkconnectivity/v1
         ruby:
@@ -2375,6 +2555,7 @@ libraries:
       wrapper_of:
         - v1:1.3
   - name: google-cloud-network_connectivity-v1
+    version: 1.15.1
     apis:
       - path: google/cloud/networkconnectivity/v1
         ruby:
@@ -2382,6 +2563,7 @@ libraries:
             ruby-cloud-env-prefix: NETWORK_CONNECTIVITY
     skip_generate: true
   - name: google-cloud-network_connectivity-v1alpha1
+    version: 0.17.1
     apis:
       - path: google/cloud/networkconnectivity/v1alpha1
         ruby:
@@ -2389,10 +2571,12 @@ libraries:
             ruby-cloud-env-prefix: NETWORK_CONNECTIVITY
     skip_generate: true
   - name: google-cloud-network_connectivity-v1beta
+    version: 0.3.1
     apis:
       - path: google/cloud/networkconnectivity/v1beta
     skip_generate: true
   - name: google-cloud-network_management
+    version: 2.3.1
     apis:
       - path: google/cloud/networkmanagement/v1
     skip_generate: true
@@ -2400,10 +2584,12 @@ libraries:
       wrapper_of:
         - v1:2.0
   - name: google-cloud-network_management-v1
+    version: 2.12.1
     apis:
       - path: google/cloud/networkmanagement/v1
     skip_generate: true
   - name: google-cloud-network_security
+    version: 1.4.1
     apis:
       - path: google/cloud/networksecurity/v1beta1
     skip_generate: true
@@ -2411,14 +2597,17 @@ libraries:
       wrapper_of:
         - v1beta1:0.7
   - name: google-cloud-network_security-v1
+    version: 0.1.1
     apis:
       - path: google/cloud/networksecurity/v1
     skip_generate: true
   - name: google-cloud-network_security-v1beta1
+    version: 0.17.1
     apis:
       - path: google/cloud/networksecurity/v1beta1
     skip_generate: true
   - name: google-cloud-network_services
+    version: 2.2.1
     apis:
       - path: google/cloud/networkservices/v1
     skip_generate: true
@@ -2426,6 +2615,7 @@ libraries:
       wrapper_of:
         - v1:2.0
   - name: google-cloud-network_services-v1
+    version: 2.12.1
     apis:
       - path: google/cloud/networkservices/v1
     skip_generate: true
@@ -2442,6 +2632,7 @@ libraries:
         - v1:1.0
         - v2:1.0
   - name: google-cloud-notebooks-v1
+    version: 1.6.1
     apis:
       - path: google/cloud/notebooks/v1
         ruby:
@@ -2449,6 +2640,7 @@ libraries:
             ruby-cloud-env-prefix: NOTEBOOKS
     skip_generate: true
   - name: google-cloud-notebooks-v1beta1
+    version: 0.18.1
     apis:
       - path: google/cloud/notebooks/v1beta1
         ruby:
@@ -2456,10 +2648,12 @@ libraries:
             ruby-cloud-env-prefix: NOTEBOOKS
     skip_generate: true
   - name: google-cloud-notebooks-v2
+    version: 1.6.1
     apis:
       - path: google/cloud/notebooks/v2
     skip_generate: true
   - name: google-cloud-optimization
+    version: 1.5.1
     apis:
       - path: google/cloud/optimization/v1
     skip_generate: true
@@ -2467,6 +2661,7 @@ libraries:
       wrapper_of:
         - v1:0.8
   - name: google-cloud-optimization-v1
+    version: 0.17.1
     apis:
       - path: google/cloud/optimization/v1
     skip_generate: true
@@ -2497,6 +2692,7 @@ libraries:
       - path: google/cloud/orchestration/airflow/service/v1
     skip_generate: true
   - name: google-cloud-org_policy
+    version: 1.7.1
     apis:
       - path: google/cloud/orgpolicy/v2
         ruby:
@@ -2507,6 +2703,7 @@ libraries:
       wrapper_of:
         - v2:0.9
   - name: google-cloud-org_policy-v2
+    version: 1.9.1
     apis:
       - path: google/cloud/orgpolicy/v2
         ruby:
@@ -2514,6 +2711,7 @@ libraries:
             ruby-cloud-env-prefix: ORG_POLICY
     skip_generate: true
   - name: google-cloud-os_config
+    version: 1.9.1
     apis:
       - path: google/cloud/osconfig/v1
         ruby:
@@ -2524,6 +2722,7 @@ libraries:
       wrapper_of:
         - v1:0.15
   - name: google-cloud-os_config-v1
+    version: 1.9.1
     apis:
       - path: google/cloud/osconfig/v1
         ruby:
@@ -2531,6 +2730,7 @@ libraries:
             ruby-cloud-env-prefix: OS_CONFIG
     skip_generate: true
   - name: google-cloud-os_config-v1alpha
+    version: 0.17.1
     apis:
       - path: google/cloud/osconfig/v1alpha
         ruby:
@@ -2538,6 +2738,7 @@ libraries:
             ruby-cloud-env-prefix: OS_CONFIG
     skip_generate: true
   - name: google-cloud-os_login
+    version: 2.2.1
     apis:
       - path: google/cloud/oslogin/v1
         ruby:
@@ -2550,6 +2751,7 @@ libraries:
       wrapper_of:
         - v1:1.2
   - name: google-cloud-os_login-v1
+    version: 1.7.1
     apis:
       - path: google/cloud/oslogin/v1
         ruby:
@@ -2557,6 +2759,7 @@ libraries:
             ruby-cloud-env-prefix: OS_LOGIN
     skip_generate: true
   - name: google-cloud-os_login-v1beta
+    version: 0.22.1
     apis:
       - path: google/cloud/oslogin/v1beta
         ruby:
@@ -2564,6 +2767,7 @@ libraries:
             ruby-cloud-env-prefix: OS_LOGIN
     skip_generate: true
   - name: google-cloud-parallelstore
+    version: 2.2.1
     apis:
       - path: google/cloud/parallelstore/v1
     skip_generate: true
@@ -2571,10 +2775,12 @@ libraries:
       wrapper_of:
         - v1:1.0
   - name: google-cloud-parallelstore-v1
+    version: 1.8.1
     apis:
       - path: google/cloud/parallelstore/v1
     skip_generate: true
   - name: google-cloud-parallelstore-v1beta
+    version: 0.14.1
     apis:
       - path: google/cloud/parallelstore/v1beta
     skip_generate: true
@@ -2671,6 +2877,7 @@ libraries:
       - path: google/cloud/parametermanager/v1
     skip_generate: true
   - name: google-cloud-phishing_protection
+    version: 0.18.1
     apis:
       - path: google/cloud/phishingprotection/v1beta1
         ruby:
@@ -2685,6 +2892,7 @@ libraries:
       wrapper_of:
         - v1beta1:0.8
   - name: google-cloud-phishing_protection-v1beta1
+    version: 0.16.1
     apis:
       - path: google/cloud/phishingprotection/v1beta1
         ruby:
@@ -2693,6 +2901,7 @@ libraries:
             ruby-cloud-service-override: PhishingProtectionServiceV1Beta1=PhishingProtectionService
     skip_generate: true
   - name: google-cloud-policy_simulator
+    version: 1.5.1
     apis:
       - path: google/cloud/policysimulator/v1
     skip_generate: true
@@ -2700,6 +2909,7 @@ libraries:
       wrapper_of:
         - v1:0.3
   - name: google-cloud-policy_simulator-v1
+    version: 1.9.1
     apis:
       - path: google/cloud/policysimulator/v1
         ruby:
@@ -2707,6 +2917,7 @@ libraries:
             ruby-cloud-extra-dependencies: google-cloud-org_policy-v2=~>1.0
     skip_generate: true
   - name: google-cloud-policy_troubleshooter
+    version: 1.9.1
     apis:
       - path: google/cloud/policytroubleshooter/v1
         ruby:
@@ -2725,6 +2936,7 @@ libraries:
             ruby-cloud-extra-dependencies: google-iam-v1=>0.5+<2.a;google-iam-v2=>0.3+<2.a
     skip_generate: true
   - name: google-cloud-policy_troubleshooter-v1
+    version: 1.7.1
     apis:
       - path: google/cloud/policytroubleshooter/v1
         ruby:
@@ -2732,6 +2944,7 @@ libraries:
             ruby-cloud-env-prefix: POLICY_TROUBLESHOOTER
     skip_generate: true
   - name: google-cloud-private_catalog
+    version: 0.8.1
     apis:
       - path: google/cloud/privatecatalog/v1beta1
         ruby:
@@ -2742,6 +2955,7 @@ libraries:
       wrapper_of:
         - v1beta1:0.6
   - name: google-cloud-private_catalog-v1beta1
+    version: 0.15.1
     apis:
       - path: google/cloud/privatecatalog/v1beta1
         ruby:
@@ -2750,6 +2964,7 @@ libraries:
             ruby-cloud-yard-strict: "false"
     skip_generate: true
   - name: google-cloud-privileged_access_manager
+    version: 1.2.1
     apis:
       - path: google/cloud/privilegedaccessmanager/v1
     skip_generate: true
@@ -2762,6 +2977,7 @@ libraries:
       - path: google/cloud/privilegedaccessmanager/v1
     skip_generate: true
   - name: google-cloud-product_registry
+    version: 0.1.1
     apis:
       - path: google/cloud/productregistry/v1
     skip_generate: true
@@ -2769,10 +2985,12 @@ libraries:
       wrapper_of:
         - v1:0.0
   - name: google-cloud-product_registry-v1
+    version: 0.1.1
     apis:
       - path: google/cloud/productregistry/v1
     skip_generate: true
   - name: google-cloud-profiler
+    version: 1.7.1
     apis:
       - path: google/devtools/cloudprofiler/v2
         ruby:
@@ -2783,6 +3001,7 @@ libraries:
       wrapper_of:
         - v2:0.9
   - name: google-cloud-profiler-v2
+    version: 1.7.1
     apis:
       - path: google/devtools/cloudprofiler/v2
         ruby:
@@ -2815,6 +3034,7 @@ libraries:
       - test/google/cloud/pubsub/v1/topic_admin/helpers_test.rb
     skip_generate: true
   - name: google-cloud-rapid_migration_assessment
+    version: 2.2.1
     apis:
       - path: google/cloud/rapidmigrationassessment/v1
     skip_generate: true
@@ -2872,6 +3092,7 @@ libraries:
             ruby-cloud-service-override: RecaptchaEnterpriseServiceV1Beta1=RecaptchaEnterpriseService
     skip_generate: true
   - name: google-cloud-recommendation_engine
+    version: 0.9.1
     apis:
       - path: google/cloud/recommendationengine/v1beta1
         ruby:
@@ -2882,6 +3103,7 @@ libraries:
       wrapper_of:
         - v1beta1:0.8
   - name: google-cloud-recommendation_engine-v1beta1
+    version: 0.18.1
     apis:
       - path: google/cloud/recommendationengine/v1beta1
         ruby:
@@ -2889,6 +3111,7 @@ libraries:
             ruby-cloud-env-prefix: RECOMMENDATION_ENGINE
     skip_generate: true
   - name: google-cloud-recommender
+    version: 1.8.1
     apis:
       - path: google/cloud/recommender/v1
         ruby:
@@ -2900,6 +3123,7 @@ libraries:
       wrapper_of:
         - v1:0.17
   - name: google-cloud-recommender-v1
+    version: 1.8.1
     apis:
       - path: google/cloud/recommender/v1
         ruby:
@@ -2921,6 +3145,7 @@ libraries:
       wrapper_of:
         - v1:2.0
   - name: google-cloud-redis-cluster
+    version: 2.2.1
     apis:
       - path: google/cloud/redis/cluster/v1
     skip_generate: true
@@ -2928,10 +3153,12 @@ libraries:
       wrapper_of:
         - v1:1.0
   - name: google-cloud-redis-cluster-v1
+    version: 1.8.1
     apis:
       - path: google/cloud/redis/cluster/v1
     skip_generate: true
   - name: google-cloud-redis-cluster-v1beta1
+    version: 0.12.1
     apis:
       - path: google/cloud/redis/cluster/v1beta1
     skip_generate: true
@@ -2952,6 +3179,7 @@ libraries:
             ruby-cloud-env-prefix: REDIS
     skip_generate: true
   - name: google-cloud-resource_manager
+    version: 1.2.1
     apis:
       - path: google/cloud/resourcemanager/v3
         ruby:
@@ -2964,6 +3192,7 @@ libraries:
       wrapper_of:
         - v3:1.2
   - name: google-cloud-resource_manager-v3
+    version: 1.8.1
     apis:
       - path: google/cloud/resourcemanager/v3
         ruby:
@@ -2971,6 +3200,7 @@ libraries:
             ruby-cloud-env-prefix: RESOURCE_MANAGER
     skip_generate: true
   - name: google-cloud-retail
+    version: 2.3.1
     apis:
       - path: google/cloud/retail/v2
         ruby:
@@ -2989,6 +3219,7 @@ libraries:
             ruby-cloud-env-prefix: RETAIL
     skip_generate: true
   - name: google-cloud-run-client
+    version: 1.8.1
     apis:
       - path: google/cloud/run/v2
     keep:
@@ -2998,6 +3229,7 @@ libraries:
       wrapper_of:
         - v2:0.17
   - name: google-cloud-run-v2
+    version: 0.29.1
     apis:
       - path: google/cloud/run/v2
         ruby:
@@ -3018,6 +3250,7 @@ libraries:
       - path: google/cloud/saasplatform/saasservicemgmt/v1beta1
     skip_generate: true
   - name: google-cloud-scheduler
+    version: 3.2.1
     apis:
       - path: google/cloud/scheduler/v1
         ruby:
@@ -3040,6 +3273,7 @@ libraries:
       wrapper_of:
         - v1:1.2
   - name: google-cloud-scheduler-v1
+    version: 1.7.1
     apis:
       - path: google/cloud/scheduler/v1
         ruby:
@@ -3047,6 +3281,7 @@ libraries:
             ruby-cloud-env-prefix: SCHEDULER
     skip_generate: true
   - name: google-cloud-scheduler-v1beta1
+    version: 0.18.1
     apis:
       - path: google/cloud/scheduler/v1beta1
         ruby:
@@ -3054,6 +3289,7 @@ libraries:
             ruby-cloud-env-prefix: SCHEDULER
     skip_generate: true
   - name: google-cloud-secret_manager
+    version: 2.2.1
     apis:
       - path: google/cloud/secretmanager/v1
         ruby:
@@ -3214,6 +3450,7 @@ libraries:
             ruby-cloud-env-prefix: SECRET_MANAGER
     skip_generate: true
   - name: google-cloud-secure_source_manager
+    version: 2.3.1
     apis:
       - path: google/cloud/securesourcemanager/v1
     skip_generate: true
@@ -3226,6 +3463,7 @@ libraries:
       - path: google/cloud/securesourcemanager/v1
     skip_generate: true
   - name: google-cloud-security-private_ca
+    version: 2.2.1
     apis:
       - path: google/cloud/security/privateca/v1
         ruby:
@@ -3255,6 +3493,7 @@ libraries:
             ruby-cloud-gem-namespace: Google::Cloud::Security::PrivateCA::V1beta1
     skip_generate: true
   - name: google-cloud-security-public_ca
+    version: 2.2.1
     apis:
       - path: google/cloud/security/publicca/v1
         ruby:
@@ -3265,6 +3504,7 @@ libraries:
       wrapper_of:
         - v1:1.0
   - name: google-cloud-security-public_ca-v1
+    version: 1.5.1
     apis:
       - path: google/cloud/security/publicca/v1
         ruby:
@@ -3280,6 +3520,7 @@ libraries:
             ruby-cloud-gem-namespace: Google::Cloud::Security::PublicCA::V1beta1
     skip_generate: true
   - name: google-cloud-security_center
+    version: 2.2.1
     apis:
       - path: google/cloud/securitycenter/v2
         ruby:
@@ -3322,6 +3563,7 @@ libraries:
             ruby-cloud-env-prefix: SECURITY_CENTER
     skip_generate: true
   - name: google-cloud-security_center_management
+    version: 1.4.1
     apis:
       - path: google/cloud/securitycentermanagement/v1
     skip_generate: true
@@ -3334,6 +3576,7 @@ libraries:
       - path: google/cloud/securitycentermanagement/v1
     skip_generate: true
   - name: google-cloud-service_control
+    version: 1.7.1
     apis:
       - path: google/api/servicecontrol/v1
         ruby:
@@ -3352,6 +3595,7 @@ libraries:
             ruby-cloud-env-prefix: SERVICE_CONTROL
     skip_generate: true
   - name: google-cloud-service_directory
+    version: 2.2.1
     apis:
       - path: google/cloud/servicedirectory/v1
         ruby:
@@ -3387,6 +3631,7 @@ libraries:
             ruby-cloud-env-prefix: SERVICE_DIRECTORY
     skip_generate: true
   - name: google-cloud-service_health
+    version: 2.2.1
     apis:
       - path: google/cloud/servicehealth/v1
     skip_generate: true
@@ -3394,10 +3639,12 @@ libraries:
       wrapper_of:
         - v1:2.0
   - name: google-cloud-service_health-v1
+    version: 2.5.1
     apis:
       - path: google/cloud/servicehealth/v1
     skip_generate: true
   - name: google-cloud-service_management
+    version: 1.7.1
     apis:
       - path: google/api/servicemanagement/v1
         ruby:
@@ -3408,6 +3655,7 @@ libraries:
       wrapper_of:
         - v1:0.10
   - name: google-cloud-service_management-v1
+    version: 1.8.1
     apis:
       - path: google/api/servicemanagement/v1
         ruby:
@@ -3415,6 +3663,7 @@ libraries:
             ruby-cloud-env-prefix: SERVICE_MANAGEMENT
     skip_generate: true
   - name: google-cloud-service_usage
+    version: 1.6.1
     apis:
       - path: google/api/serviceusage/v1
         ruby:
@@ -3425,6 +3674,7 @@ libraries:
       wrapper_of:
         - v1:0.6
   - name: google-cloud-service_usage-v1
+    version: 1.8.1
     apis:
       - path: google/api/serviceusage/v1
         ruby:
@@ -3432,6 +3682,7 @@ libraries:
             ruby-cloud-env-prefix: SERVICE_USAGE
     skip_generate: true
   - name: google-cloud-shell
+    version: 1.7.1
     apis:
       - path: google/cloud/shell/v1
         ruby:
@@ -3442,6 +3693,7 @@ libraries:
       wrapper_of:
         - v1:0.7
   - name: google-cloud-shell-v1
+    version: 1.8.1
     apis:
       - path: google/cloud/shell/v1
         ruby:
@@ -3458,6 +3710,7 @@ libraries:
             ruby-cloud-wrapper-gem-override: google-cloud-spanner
     skip_generate: true
   - name: google-cloud-spanner-admin-instance-v1
+    version: 2.8.1
     apis:
       - path: google/spanner/admin/instance/v1
         ruby:
@@ -3466,6 +3719,7 @@ libraries:
             ruby-cloud-wrapper-gem-override: google-cloud-spanner
     skip_generate: true
   - name: google-cloud-spanner-v1
+    version: 1.19.1
     apis:
       - path: google/spanner/v1
         ruby:
@@ -3473,6 +3727,7 @@ libraries:
             ruby-cloud-env-prefix: SPANNER
     skip_generate: true
   - name: google-cloud-speech
+    version: 2.2.1
     apis:
       - path: google/cloud/speech/v2
         ruby:
@@ -3489,6 +3744,7 @@ libraries:
         - v2:1.0
         - v1:1.2
   - name: google-cloud-speech-v1
+    version: 1.8.1
     apis:
       - path: google/cloud/speech/v1
         ruby:
@@ -3510,6 +3766,7 @@ libraries:
       - acceptance/google/cloud/speech/v1p1beta1/speech_smoke_test.rb
     skip_generate: true
   - name: google-cloud-speech-v2
+    version: 1.8.1
     apis:
       - path: google/cloud/speech/v2
         ruby:
@@ -3522,10 +3779,12 @@ libraries:
       - path: google/cloud/sql/v1
     skip_generate: true
   - name: google-cloud-sql-v1beta4
+    version: 0.1.1
     apis:
       - path: google/cloud/sql/v1beta4
     skip_generate: true
   - name: google-cloud-storage-control
+    version: 1.4.1
     apis:
       - path: google/storage/control/v2
     keep:
@@ -3588,6 +3847,7 @@ libraries:
       - path: google/cloud/storagebatchoperations/v1
     skip_generate: true
   - name: google-cloud-storage_insights
+    version: 2.2.1
     apis:
       - path: google/cloud/storageinsights/v1
     skip_generate: true
@@ -3595,10 +3855,12 @@ libraries:
       wrapper_of:
         - v1:1.0
   - name: google-cloud-storage_insights-v1
+    version: 1.7.1
     apis:
       - path: google/cloud/storageinsights/v1
     skip_generate: true
   - name: google-cloud-storage_transfer
+    version: 1.7.1
     apis:
       - path: google/storagetransfer/v1
     keep:
@@ -3631,6 +3893,7 @@ libraries:
       - path: google/storagetransfer/v1
     skip_generate: true
   - name: google-cloud-support
+    version: 1.4.1
     apis:
       - path: google/cloud/support/v2
     skip_generate: true
@@ -3648,6 +3911,7 @@ libraries:
       - path: google/cloud/support/v2beta
     skip_generate: true
   - name: google-cloud-talent
+    version: 2.2.1
     apis:
       - path: google/cloud/talent/v4
         ruby:
@@ -3670,6 +3934,7 @@ libraries:
             ruby-cloud-env-prefix: TALENT
     skip_generate: true
   - name: google-cloud-talent-v4beta1
+    version: 0.19.1
     apis:
       - path: google/cloud/talent/v4beta1
         ruby:
@@ -3677,6 +3942,7 @@ libraries:
             ruby-cloud-env-prefix: TALENT
     skip_generate: true
   - name: google-cloud-tasks
+    version: 3.2.1
     apis:
       - path: google/cloud/tasks/v2
         ruby:
@@ -3702,6 +3968,7 @@ libraries:
             ruby-cloud-env-prefix: TASKS
     skip_generate: true
   - name: google-cloud-tasks-v2beta2
+    version: 0.18.1
     apis:
       - path: google/cloud/tasks/v2beta2
         ruby:
@@ -3709,6 +3976,7 @@ libraries:
             ruby-cloud-env-prefix: TASKS
     skip_generate: true
   - name: google-cloud-tasks-v2beta3
+    version: 0.20.1
     apis:
       - path: google/cloud/tasks/v2beta3
         ruby:
@@ -3716,6 +3984,7 @@ libraries:
             ruby-cloud-env-prefix: TASKS
     skip_generate: true
   - name: google-cloud-telco_automation
+    version: 2.2.1
     apis:
       - path: google/cloud/telcoautomation/v1
     skip_generate: true
@@ -3723,10 +3992,12 @@ libraries:
       wrapper_of:
         - v1:2.0
   - name: google-cloud-telco_automation-v1
+    version: 2.5.1
     apis:
       - path: google/cloud/telcoautomation/v1
     skip_generate: true
   - name: google-cloud-text_to_speech
+    version: 2.2.1
     apis:
       - path: google/cloud/texttospeech/v1
         ruby:
@@ -3741,6 +4012,7 @@ libraries:
       wrapper_of:
         - v1:1.7
   - name: google-cloud-text_to_speech-v1
+    version: 1.19.1
     apis:
       - path: google/cloud/texttospeech/v1
         ruby:
@@ -3756,6 +4028,7 @@ libraries:
             ruby-cloud-env-prefix: TEXTTOSPEECH
     skip_generate: true
   - name: google-cloud-tpu
+    version: 1.6.1
     apis:
       - path: google/cloud/tpu/v1
         ruby:
@@ -3766,6 +4039,7 @@ libraries:
       wrapper_of:
         - v1:0.6
   - name: google-cloud-tpu-v1
+    version: 1.7.1
     apis:
       - path: google/cloud/tpu/v1
         ruby:
@@ -3773,6 +4047,7 @@ libraries:
             ruby-cloud-env-prefix: CLOUD_TPU
     skip_generate: true
   - name: google-cloud-trace-v1
+    version: 1.6.1
     apis:
       - path: google/devtools/cloudtrace/v1
         ruby:
@@ -3780,6 +4055,7 @@ libraries:
             ruby-cloud-env-prefix: TRACE
     skip_generate: true
   - name: google-cloud-trace-v2
+    version: 1.5.1
     apis:
       - path: google/devtools/cloudtrace/v2
         ruby:
@@ -3787,6 +4063,7 @@ libraries:
             ruby-cloud-env-prefix: TRACE
     skip_generate: true
   - name: google-cloud-translate
+    version: 3.9.1
     apis:
       - path: google/cloud/translate/v3
         ruby:
@@ -3808,6 +4085,7 @@ libraries:
         - v3:0.11
         - v2:0.0
   - name: google-cloud-translate-v3
+    version: 1.10.1
     apis:
       - path: google/cloud/translate/v3
         ruby:
@@ -3815,6 +4093,7 @@ libraries:
             ruby-cloud-env-prefix: TRANSLATE
     skip_generate: true
   - name: google-cloud-vector_search
+    version: 0.1.1
     apis:
       - path: google/cloud/vectorsearch/v1
     skip_generate: true
@@ -3894,6 +4173,7 @@ libraries:
       - path: google/cloud/video/livestream/v1
     skip_generate: true
   - name: google-cloud-video-stitcher
+    version: 1.3.1
     apis:
       - path: google/cloud/video/stitcher/v1
     keep:
@@ -3972,6 +4252,7 @@ libraries:
       - path: google/cloud/video/stitcher/v1
     skip_generate: true
   - name: google-cloud-video-transcoder
+    version: 2.2.1
     apis:
       - path: google/cloud/video/transcoder/v1
         ruby:
@@ -4017,6 +4298,7 @@ libraries:
             ruby-cloud-env-prefix: TRANSCODER
     skip_generate: true
   - name: google-cloud-video_intelligence
+    version: 4.2.1
     apis:
       - path: google/cloud/videointelligence/v1
         ruby:
@@ -4030,6 +4312,7 @@ libraries:
       wrapper_of:
         - v1:1.2
   - name: google-cloud-video_intelligence-v1
+    version: 1.7.1
     apis:
       - path: google/cloud/videointelligence/v1
         ruby:
@@ -4037,6 +4320,7 @@ libraries:
             ruby-cloud-env-prefix: VIDEO_INTELLIGENCE
     skip_generate: true
   - name: google-cloud-video_intelligence-v1beta2
+    version: 0.17.1
     apis:
       - path: google/cloud/videointelligence/v1beta2
         ruby:
@@ -4044,6 +4328,7 @@ libraries:
             ruby-cloud-env-prefix: VIDEO_INTELLIGENCE
     skip_generate: true
   - name: google-cloud-video_intelligence-v1p1beta1
+    version: 0.17.1
     apis:
       - path: google/cloud/videointelligence/v1p1beta1
         ruby:
@@ -4051,6 +4336,7 @@ libraries:
             ruby-cloud-env-prefix: VIDEO_INTELLIGENCE
     skip_generate: true
   - name: google-cloud-video_intelligence-v1p2beta1
+    version: 0.18.1
     apis:
       - path: google/cloud/videointelligence/v1p2beta1
         ruby:
@@ -4058,6 +4344,7 @@ libraries:
             ruby-cloud-env-prefix: VIDEO_INTELLIGENCE
     skip_generate: true
   - name: google-cloud-video_intelligence-v1p3beta1
+    version: 0.14.1
     apis:
       - path: google/cloud/videointelligence/v1p3beta1
         ruby:
@@ -4065,6 +4352,7 @@ libraries:
             ruby-cloud-env-prefix: VIDEO_INTELLIGENCE
     skip_generate: true
   - name: google-cloud-vision
+    version: 2.2.1
     apis:
       - path: google/cloud/vision/v1
         ruby:
@@ -4115,6 +4403,7 @@ libraries:
       - test/google/cloud/vision/v1p3beta1/image_annotator_helpers_test.rb
     skip_generate: true
   - name: google-cloud-vision-v1p4beta1
+    version: 0.16.1
     apis:
       - path: google/cloud/vision/v1p4beta1
         ruby:
@@ -4131,6 +4420,7 @@ libraries:
       - test/google/cloud/vision/v1p4beta1/image_annotator_helpers_test.rb
     skip_generate: true
   - name: google-cloud-vision_ai
+    version: 1.2.1
     apis:
       - path: google/cloud/visionai/v1
         ruby:
@@ -4141,6 +4431,7 @@ libraries:
       wrapper_of:
         - v1:1.0
   - name: google-cloud-vision_ai-v1
+    version: 1.5.1
     apis:
       - path: google/cloud/visionai/v1
         ruby:
@@ -4148,6 +4439,7 @@ libraries:
             ruby-cloud-gem-namespace: Google::Cloud::VisionAI::V1
     skip_generate: true
   - name: google-cloud-vm_migration
+    version: 2.2.1
     apis:
       - path: google/cloud/vmmigration/v1
         ruby:
@@ -4158,6 +4450,7 @@ libraries:
       wrapper_of:
         - v1:2.0
   - name: google-cloud-vm_migration-v1
+    version: 2.9.1
     apis:
       - path: google/cloud/vmmigration/v1
         ruby:
@@ -4165,6 +4458,7 @@ libraries:
             ruby-cloud-namespace-override: VmMigration=VMMigration
     skip_generate: true
   - name: google-cloud-vmware_engine
+    version: 2.2.1
     apis:
       - path: google/cloud/vmwareengine/v1
     skip_generate: true
@@ -4172,10 +4466,12 @@ libraries:
       wrapper_of:
         - v1:1.0
   - name: google-cloud-vmware_engine-v1
+    version: 1.5.1
     apis:
       - path: google/cloud/vmwareengine/v1
     skip_generate: true
   - name: google-cloud-vpc_access
+    version: 1.7.1
     apis:
       - path: google/cloud/vpcaccess/v1
         ruby:
@@ -4186,6 +4482,7 @@ libraries:
       wrapper_of:
         - v1:0.7
   - name: google-cloud-vpc_access-v1
+    version: 1.7.1
     apis:
       - path: google/cloud/vpcaccess/v1
         ruby:
@@ -4193,6 +4490,7 @@ libraries:
             ruby-cloud-env-prefix: VPC_ACCESS
     skip_generate: true
   - name: google-cloud-web_risk
+    version: 2.2.1
     apis:
       - path: google/cloud/webrisk/v1
         ruby:
@@ -4205,6 +4503,7 @@ libraries:
       wrapper_of:
         - v1:1.2
   - name: google-cloud-web_risk-v1
+    version: 1.8.1
     apis:
       - path: google/cloud/webrisk/v1
         ruby:
@@ -4212,6 +4511,7 @@ libraries:
             ruby-cloud-env-prefix: WEBRISK
     skip_generate: true
   - name: google-cloud-web_risk-v1beta1
+    version: 0.16.1
     apis:
       - path: google/cloud/webrisk/v1beta1
         ruby:
@@ -4220,6 +4520,7 @@ libraries:
             ruby-cloud-service-override: WebRiskServiceV1Beta1=WebRiskService
     skip_generate: true
   - name: google-cloud-web_security_scanner
+    version: 2.2.1
     apis:
       - path: google/cloud/websecurityscanner/v1
         ruby:
@@ -4246,6 +4547,7 @@ libraries:
             ruby-cloud-env-prefix: WEB_SECURITY_SCANNER
     skip_generate: true
   - name: google-cloud-workflows
+    version: 3.2.1
     apis:
       - path: google/cloud/workflows/v1
         ruby:
@@ -4256,6 +4558,7 @@ libraries:
       wrapper_of:
         - v1:2.0
   - name: google-cloud-workflows-executions-v1
+    version: 1.6.1
     apis:
       - path: google/cloud/workflows/executions/v1
         ruby:
@@ -4264,6 +4567,7 @@ libraries:
             ruby-cloud-wrapper-gem-override: google-cloud-workflows
     skip_generate: true
   - name: google-cloud-workflows-executions-v1beta
+    version: 0.14.1
     apis:
       - path: google/cloud/workflows/executions/v1beta
         ruby:
@@ -4272,6 +4576,7 @@ libraries:
             ruby-cloud-wrapper-gem-override: google-cloud-workflows
     skip_generate: true
   - name: google-cloud-workflows-v1
+    version: 2.6.1
     apis:
       - path: google/cloud/workflows/v1
         ruby:
@@ -4279,6 +4584,7 @@ libraries:
             ruby-cloud-env-prefix: WORKFLOWS
     skip_generate: true
   - name: google-cloud-workflows-v1beta
+    version: 0.17.1
     apis:
       - path: google/cloud/workflows/v1beta
         ruby:
@@ -4286,6 +4592,7 @@ libraries:
             ruby-cloud-env-prefix: WORKFLOWS
     skip_generate: true
   - name: google-cloud-workload_manager
+    version: 0.2.1
     apis:
       - path: google/cloud/workloadmanager/v1
     skip_generate: true
@@ -4293,10 +4600,12 @@ libraries:
       wrapper_of:
         - v1:0.0
   - name: google-cloud-workload_manager-v1
+    version: 0.2.1
     apis:
       - path: google/cloud/workloadmanager/v1
     skip_generate: true
   - name: google-cloud-workstations
+    version: 2.2.1
     apis:
       - path: google/cloud/workstations/v1
     skip_generate: true
@@ -4304,14 +4613,17 @@ libraries:
       wrapper_of:
         - v1:1.0
   - name: google-cloud-workstations-v1
+    version: 1.6.1
     apis:
       - path: google/cloud/workstations/v1
     skip_generate: true
   - name: google-cloud-workstations-v1beta
+    version: 0.10.1
     apis:
       - path: google/cloud/workstations/v1beta
     skip_generate: true
   - name: google-developers-developer_knowledge
+    version: 0.2.1
     apis:
       - path: google/developers/knowledge/v1
     skip_generate: true
@@ -4319,10 +4631,12 @@ libraries:
       wrapper_of:
         - v1:0.0
   - name: google-developers-developer_knowledge-v1
+    version: 0.2.2
     apis:
       - path: google/developers/knowledge/v1
     skip_generate: true
   - name: google-iam-client
+    version: 1.3.1
     apis:
       - path: google/iam/v2
     keep:
@@ -4332,6 +4646,7 @@ libraries:
       wrapper_of:
         - v2:0.5
   - name: google-iam-credentials
+    version: 1.7.1
     apis:
       - path: google/iam/credentials/v1
         ruby:
@@ -4342,6 +4657,7 @@ libraries:
       wrapper_of:
         - v1:0.8
   - name: google-iam-credentials-v1
+    version: 1.6.1
     apis:
       - path: google/iam/credentials/v1
         ruby:
@@ -4349,12 +4665,14 @@ libraries:
             ruby-cloud-env-prefix: IAM_CREDENTIALS
     skip_generate: true
   - name: google-iam-v1
+    version: 1.7.1
     apis:
       - path: google/iam/v1
     keep:
       - README.md
     skip_generate: true
   - name: google-iam-v1beta
+    version: 0.15.1
     apis:
       - path: google/iam/v1beta
         ruby:
@@ -4362,6 +4680,7 @@ libraries:
             ruby-cloud-env-prefix: IAM
     skip_generate: true
   - name: google-iam-v2
+    version: 0.13.1
     apis:
       - path: google/iam/v2
         ruby:
@@ -4369,14 +4688,17 @@ libraries:
             ruby-cloud-wrapper-gem-override: google-iam-client
     skip_generate: true
   - name: google-iam-v3
+    version: 0.6.0
     apis:
       - path: google/iam/v3
     skip_generate: true
   - name: google-iam-v3beta
+    version: 0.7.1
     apis:
       - path: google/iam/v3beta
     skip_generate: true
   - name: google-identity-access_context_manager
+    version: 1.7.1
     apis:
       - path: google/identity/accesscontextmanager/v1
     skip_generate: true
@@ -4389,6 +4711,7 @@ libraries:
       - path: google/identity/accesscontextmanager/v1
     skip_generate: true
   - name: google-maps-fleet_engine
+    version: 1.3.1
     apis:
       - path: google/maps/fleetengine/v1
     skip_generate: true
@@ -4396,6 +4719,7 @@ libraries:
       wrapper_of:
         - v1:0.0
   - name: google-maps-fleet_engine-delivery
+    version: 1.3.1
     apis:
       - path: google/maps/fleetengine/delivery/v1
     skip_generate: true
@@ -4403,6 +4727,7 @@ libraries:
       wrapper_of:
         - v1:0.0
   - name: google-maps-fleet_engine-delivery-v1
+    version: 0.10.1
     apis:
       - path: google/maps/fleetengine/delivery/v1
         ruby:
@@ -4410,6 +4735,7 @@ libraries:
             ruby-cloud-extra-dependencies: google-geo-type=>0.0+<2.a
     skip_generate: true
   - name: google-maps-fleet_engine-v1
+    version: 0.10.1
     apis:
       - path: google/maps/fleetengine/v1
         ruby:
@@ -4417,6 +4743,7 @@ libraries:
             ruby-cloud-extra-dependencies: google-geo-type=>0.0+<2.a
     skip_generate: true
   - name: google-maps-isochrones
+    version: 0.1.1
     apis:
       - path: google/maps/isochrones/v1
     skip_generate: true
@@ -4424,6 +4751,7 @@ libraries:
       wrapper_of:
         - v1:0.0
   - name: google-maps-isochrones-v1
+    version: 0.1.1
     apis:
       - path: google/maps/isochrones/v1
     skip_generate: true
@@ -4441,6 +4769,7 @@ libraries:
       - path: google/maps/routeoptimization/v1
     copyright_year: "2026"
   - name: google-shopping-css
+    version: 1.4.1
     apis:
       - path: google/shopping/css/v1
     skip_generate: true
@@ -4448,6 +4777,7 @@ libraries:
       wrapper_of:
         - v1:0.0
   - name: google-shopping-css-v1
+    version: 0.10.1
     apis:
       - path: google/shopping/css/v1
         ruby:
@@ -4455,6 +4785,7 @@ libraries:
             ruby-cloud-extra-dependencies: google-shopping-type=>0.0+<2.a
     skip_generate: true
   - name: google-shopping-merchant-accounts
+    version: 0.8.1
     apis:
       - path: google/shopping/merchant/accounts/v1beta
     skip_generate: true
@@ -4462,6 +4793,7 @@ libraries:
       wrapper_of:
         - v1beta:0.2
   - name: google-shopping-merchant-accounts-v1
+    version: 0.7.1
     apis:
       - path: google/shopping/merchant/accounts/v1
         ruby:
@@ -4469,6 +4801,7 @@ libraries:
             ruby-cloud-extra-dependencies: google-shopping-type=~>1.0
     skip_generate: true
   - name: google-shopping-merchant-accounts-v1beta
+    version: 0.14.1
     apis:
       - path: google/shopping/merchant/accounts/v1beta
         ruby:
@@ -4476,6 +4809,7 @@ libraries:
             ruby-cloud-extra-dependencies: google-shopping-type=>0.0+<2.a
     skip_generate: true
   - name: google-shopping-merchant-conversions
+    version: 0.4.1
     apis:
       - path: google/shopping/merchant/conversions/v1beta
     skip_generate: true
@@ -4483,14 +4817,17 @@ libraries:
       wrapper_of:
         - v1beta:0.0
   - name: google-shopping-merchant-conversions-v1
+    version: 0.4.1
     apis:
       - path: google/shopping/merchant/conversions/v1
     skip_generate: true
   - name: google-shopping-merchant-conversions-v1beta
+    version: 0.7.1
     apis:
       - path: google/shopping/merchant/conversions/v1beta
     skip_generate: true
   - name: google-shopping-merchant-data_sources
+    version: 0.5.1
     apis:
       - path: google/shopping/merchant/datasources/v1beta
     skip_generate: true
@@ -4498,6 +4835,7 @@ libraries:
       wrapper_of:
         - v1beta:0.2
   - name: google-shopping-merchant-data_sources-v1
+    version: 0.5.0
     apis:
       - path: google/shopping/merchant/datasources/v1
         ruby:
@@ -4505,6 +4843,7 @@ libraries:
             ruby-cloud-extra-dependencies: google-shopping-type=~>1.0
     skip_generate: true
   - name: google-shopping-merchant-data_sources-v1beta
+    version: 0.9.0
     apis:
       - path: google/shopping/merchant/datasources/v1beta
         ruby:
@@ -4512,6 +4851,7 @@ libraries:
             ruby-cloud-extra-dependencies: google-shopping-type=>0.0+<2.a
     skip_generate: true
   - name: google-shopping-merchant-inventories
+    version: 0.7.1
     apis:
       - path: google/shopping/merchant/inventories/v1beta
     skip_generate: true
@@ -4519,6 +4859,7 @@ libraries:
       wrapper_of:
         - v1beta:0.2
   - name: google-shopping-merchant-inventories-v1
+    version: 0.6.0
     apis:
       - path: google/shopping/merchant/inventories/v1
         ruby:
@@ -4526,6 +4867,7 @@ libraries:
             ruby-cloud-extra-dependencies: google-shopping-type=~>1.0
     skip_generate: true
   - name: google-shopping-merchant-inventories-v1beta
+    version: 0.11.0
     apis:
       - path: google/shopping/merchant/inventories/v1beta
         ruby:
@@ -4533,6 +4875,7 @@ libraries:
             ruby-cloud-extra-dependencies: google-shopping-type=>0.0+<2.a
     skip_generate: true
   - name: google-shopping-merchant-issue_resolution
+    version: 0.4.1
     apis:
       - path: google/shopping/merchant/issueresolution/v1beta
     skip_generate: true
@@ -4540,6 +4883,7 @@ libraries:
       wrapper_of:
         - v1beta:0.0
   - name: google-shopping-merchant-issue_resolution-v1
+    version: 0.5.0
     apis:
       - path: google/shopping/merchant/issueresolution/v1
         ruby:
@@ -4547,6 +4891,7 @@ libraries:
             ruby-cloud-extra-dependencies: google-shopping-type=~>1.0
     skip_generate: true
   - name: google-shopping-merchant-issue_resolution-v1beta
+    version: 0.6.0
     apis:
       - path: google/shopping/merchant/issueresolution/v1beta
         ruby:
@@ -4554,6 +4899,7 @@ libraries:
             ruby-cloud-extra-dependencies: google-shopping-type=~>1.0
     skip_generate: true
   - name: google-shopping-merchant-lfp
+    version: 0.5.1
     apis:
       - path: google/shopping/merchant/lfp/v1beta
     skip_generate: true
@@ -4561,6 +4907,7 @@ libraries:
       wrapper_of:
         - v1beta:0.0
   - name: google-shopping-merchant-lfp-v1
+    version: 0.4.0
     apis:
       - path: google/shopping/merchant/lfp/v1
         ruby:
@@ -4568,6 +4915,7 @@ libraries:
             ruby-cloud-extra-dependencies: google-shopping-type=~>1.0
     skip_generate: true
   - name: google-shopping-merchant-lfp-v1beta
+    version: 0.8.0
     apis:
       - path: google/shopping/merchant/lfp/v1beta
         ruby:
@@ -4575,6 +4923,7 @@ libraries:
             ruby-cloud-extra-dependencies: google-shopping-type=>0.0+<2.a
     skip_generate: true
   - name: google-shopping-merchant-notifications
+    version: 0.4.1
     apis:
       - path: google/shopping/merchant/notifications/v1beta
     skip_generate: true
@@ -4582,10 +4931,12 @@ libraries:
       wrapper_of:
         - v1beta:0.0
   - name: google-shopping-merchant-notifications-v1
+    version: 0.4.0
     apis:
       - path: google/shopping/merchant/notifications/v1
     skip_generate: true
   - name: google-shopping-merchant-notifications-v1beta
+    version: 0.7.0
     apis:
       - path: google/shopping/merchant/notifications/v1beta
         ruby:
@@ -4593,6 +4944,7 @@ libraries:
             ruby-cloud-extra-dependencies: google-shopping-type=>0.0+<2.a
     skip_generate: true
   - name: google-shopping-merchant-order_tracking
+    version: 0.3.1
     apis:
       - path: google/shopping/merchant/ordertracking/v1beta
     skip_generate: true
@@ -4600,6 +4952,7 @@ libraries:
       wrapper_of:
         - v1beta:0.0
   - name: google-shopping-merchant-order_tracking-v1
+    version: 0.4.0
     apis:
       - path: google/shopping/merchant/ordertracking/v1
         ruby:
@@ -4607,6 +4960,7 @@ libraries:
             ruby-cloud-extra-dependencies: google-shopping-type=~>1.0
     skip_generate: true
   - name: google-shopping-merchant-order_tracking-v1beta
+    version: 0.4.0
     apis:
       - path: google/shopping/merchant/ordertracking/v1beta
         ruby:
@@ -4614,6 +4968,7 @@ libraries:
             ruby-cloud-extra-dependencies: google-shopping-type=>0.0+<2.a
     skip_generate: true
   - name: google-shopping-merchant-products
+    version: 0.5.1
     apis:
       - path: google/shopping/merchant/products/v1beta
     skip_generate: true
@@ -4621,6 +4976,7 @@ libraries:
       wrapper_of:
         - v1beta:0.0
   - name: google-shopping-merchant-products-v1
+    version: 0.9.0
     apis:
       - path: google/shopping/merchant/products/v1
         ruby:
@@ -4628,6 +4984,7 @@ libraries:
             ruby-cloud-extra-dependencies: google-shopping-type=~>1.0
     skip_generate: true
   - name: google-shopping-merchant-products-v1beta
+    version: 0.11.0
     apis:
       - path: google/shopping/merchant/products/v1beta
         ruby:
@@ -4635,6 +4992,7 @@ libraries:
             ruby-cloud-extra-dependencies: google-shopping-type=>0.0+<2.a
     skip_generate: true
   - name: google-shopping-merchant-promotions
+    version: 0.4.1
     apis:
       - path: google/shopping/merchant/promotions/v1beta
     skip_generate: true
@@ -4642,6 +5000,7 @@ libraries:
       wrapper_of:
         - v1beta:0.0
   - name: google-shopping-merchant-promotions-v1
+    version: 0.4.0
     apis:
       - path: google/shopping/merchant/promotions/v1
         ruby:
@@ -4649,6 +5008,7 @@ libraries:
             ruby-cloud-extra-dependencies: google-shopping-type=~>1.0
     skip_generate: true
   - name: google-shopping-merchant-promotions-v1beta
+    version: 0.7.0
     apis:
       - path: google/shopping/merchant/promotions/v1beta
         ruby:
@@ -4656,6 +5016,7 @@ libraries:
             ruby-cloud-extra-dependencies: google-shopping-type=>0.0+<2.a
     skip_generate: true
   - name: google-shopping-merchant-quota
+    version: 0.4.1
     apis:
       - path: google/shopping/merchant/quota/v1beta
     skip_generate: true
@@ -4663,14 +5024,17 @@ libraries:
       wrapper_of:
         - v1beta:0.0
   - name: google-shopping-merchant-quota-v1
+    version: 0.5.0
     apis:
       - path: google/shopping/merchant/quota/v1
     skip_generate: true
   - name: google-shopping-merchant-quota-v1beta
+    version: 0.7.0
     apis:
       - path: google/shopping/merchant/quota/v1beta
     skip_generate: true
   - name: google-shopping-merchant-reports
+    version: 0.6.1
     apis:
       - path: google/shopping/merchant/reports/v1beta
     skip_generate: true
@@ -4678,6 +5042,7 @@ libraries:
       wrapper_of:
         - v1beta:0.3
   - name: google-shopping-merchant-reports-v1
+    version: 0.5.0
     apis:
       - path: google/shopping/merchant/reports/v1
         ruby:
@@ -4685,6 +5050,7 @@ libraries:
             ruby-cloud-extra-dependencies: google-shopping-type=~>1.0
     skip_generate: true
   - name: google-shopping-merchant-reports-v1beta
+    version: 0.12.0
     apis:
       - path: google/shopping/merchant/reports/v1beta
         ruby:
@@ -4692,6 +5058,7 @@ libraries:
             ruby-cloud-extra-dependencies: google-shopping-type=>0.0+<2.a
     skip_generate: true
   - name: google-shopping-merchant-reviews
+    version: 0.4.1
     apis:
       - path: google/shopping/merchant/reviews/v1beta
     skip_generate: true
@@ -4699,6 +5066,7 @@ libraries:
       wrapper_of:
         - v1beta:0.0
   - name: google-shopping-merchant-reviews-v1beta
+    version: 0.9.0
     apis:
       - path: google/shopping/merchant/reviews/v1beta
         ruby:
@@ -4706,6 +5074,7 @@ libraries:
             ruby-cloud-extra-dependencies: google-shopping-type=>0.0+<2.a
     skip_generate: true
   - name: grafeas
+    version: 1.8.1
     apis:
       - path: grafeas/v1
         ruby:
@@ -4719,6 +5088,7 @@ libraries:
       wrapper_of:
         - v1:0.14
   - name: grafeas-v1
+    version: 1.10.0
     apis:
       - path: grafeas/v1
         ruby:


### PR DESCRIPTION
Populate missing `version:` fields for 370 library entries in `librarian.yaml` from `.release-please-manifest.json`.

Without pre-populated `version:` fields, when libraries are released by `release-please`, `version:` is appended to the bottom of the YAML mapping, causing field-ordering issues until `librarian tidy` is run (as seen in PR #36305 and PR #36299).

After populating the fields, `go run github.com/googleapis/librarian/cmd/librarian@v0.38.0 tidy` was executed to format and validate `librarian.yaml`.

### Script used to populate versions:

```python
import json

with open(".release-please-manifest.json", "r") as f:
    manifest = json.load(f)

with open("librarian.yaml", "r") as f:
    lines = f.readlines()

new_lines = []
for i, line in enumerate(lines):
    new_lines.append(line)
    if line.startswith("  - name: "):
        lib_name = line[len("  - name: "):].strip()
        next_line = lines[i + 1] if i + 1 < len(lines) else ""
        if not next_line.startswith("    version:"):
            if lib_name in manifest:
                ver = manifest[lib_name]
                new_lines.append(f"    version: {ver}\n")

with open("librarian.yaml", "w") as f:
    f.writelines(new_lines)
```