### PR TITLE
chore: remove duplicate version fields in librarian.yaml

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1262,14 +1262,13 @@ libraries:
       wrapper_of:
         - v1:1.6
   - name: google-cloud-container-v1
-    version: 1.17.1
+    version: 1.18.0
     apis:
       - path: google/container/v1
         ruby:
           ruby_cloud_opts:
             ruby-cloud-env-prefix: CONTAINER
     skip_generate: true
-    version: 1.18.0
   - name: google-cloud-container-v1beta1
     version: 0.57.1
     apis:
@@ -4645,11 +4644,10 @@ libraries:
       wrapper_of:
         - v1:0.0
   - name: google-developers-developer_knowledge-v1
-    version: 0.2.2
+    version: 0.3.0
     apis:
       - path: google/developers/knowledge/v1
     skip_generate: true
-    version: 0.3.0
   - name: google-iam-client
     version: 1.3.1
     apis:


### PR DESCRIPTION
Removes duplicate version fields for `google-cloud-container-v1` and `google-developers-developer_knowledge-v1` that resulted from concurrent release PRs and ran `librarian tidy`.

google-cloud-container-v1 having duplicate version field was probably due to https://github.com/googleapis/google-cloud-ruby/pull/36303 and https://github.com/googleapis/google-cloud-ruby/pull/36308 being merged almost the same time.