### PR TITLE
fix: prepare release google-cloud-storage-control-v2

### DIFF
--- a/google-cloud-storage-control-v2/CHANGELOG.md
+++ b/google-cloud-storage-control-v2/CHANGELOG.md
@@ -151,3 +151,5 @@
 * Initial release of generated google-cloud-storage-control-v2 client ([#25743](https://github.com/googleapis/google-cloud-ruby/issues/25743)) 
 
 ## Release History
+
+


### PR DESCRIPTION
This commit is a dummy commit to force Release Please to make a release pull request for google-cloud-storage-control-v2 Gem.
This Gem had a change in the previous Librarian migration pull request https://github.com/googleapis/google-cloud-ruby/pull/36465 but we merged the pull request with "chore:".

For https://github.com/googleapis/librarian/issues/7386
