### PR TITLE
chore(storage): fix test failures for universe domain and requester pays

### DIFF
--- a/.kokoro/continuous/acceptance.cfg
+++ b/.kokoro/continuous/acceptance.cfg
@@ -29,7 +29,13 @@ env_vars: {
 
 env_vars: {
   key: "SECRET_MANAGER_KEYS"
-  value: "ruby-main-ci-service-account,ruby-firestore-ci-service-account"
+  value:
+    "client-library-test-universe-domain,"
+    "client-library-test-universe-domain-credential,"
+    "client-library-test-universe-project-id,"
+    "client-library-test-universe-storage-location,"
+    "ruby-firestore-ci-service-account,"
+    "ruby-main-ci-service-account"
 }
 
 env_vars: {

--- a/.kokoro/nightly/acceptance-newest.cfg
+++ b/.kokoro/nightly/acceptance-newest.cfg
@@ -29,7 +29,13 @@ env_vars: {
 
 env_vars: {
   key: "SECRET_MANAGER_KEYS"
-  value: "ruby-main-ci-service-account,ruby-firestore-ci-service-account"
+  value:
+    "client-library-test-universe-domain,"
+    "client-library-test-universe-domain-credential,"
+    "client-library-test-universe-project-id,"
+    "client-library-test-universe-storage-location,"
+    "ruby-firestore-ci-service-account,"
+    "ruby-main-ci-service-account"
 }
 
 env_vars: {

--- a/.kokoro/nightly/acceptance-oldest.cfg
+++ b/.kokoro/nightly/acceptance-oldest.cfg
@@ -29,7 +29,13 @@ env_vars: {
 
 env_vars: {
   key: "SECRET_MANAGER_KEYS"
-  value: "ruby-main-ci-service-account,ruby-firestore-ci-service-account"
+  value:
+    "client-library-test-universe-domain,"
+    "client-library-test-universe-domain-credential,"
+    "client-library-test-universe-project-id,"
+    "client-library-test-universe-storage-location,"
+    "ruby-firestore-ci-service-account,"
+    "ruby-main-ci-service-account"
 }
 
 env_vars: {

--- a/.kokoro/presubmit/acceptance.cfg
+++ b/.kokoro/presubmit/acceptance.cfg
@@ -29,7 +29,13 @@ env_vars: {
 
 env_vars: {
   key: "SECRET_MANAGER_KEYS"
-  value: "client-library-test-universe-domain, client-library-test-universe-project-id, client-library-test-universe-storage-location, client-library-test-universe-domain-credential,ruby-main-ci-service-account,ruby-firestore-ci-service-account"
+  value:
+    "client-library-test-universe-domain,"
+    "client-library-test-universe-domain-credential,"
+    "client-library-test-universe-project-id,"
+    "client-library-test-universe-storage-location,"
+    "ruby-firestore-ci-service-account,"
+    "ruby-main-ci-service-account"
 }
 
 env_vars: {

--- a/google-cloud-storage/acceptance/storage/universe_domain_test.rb
+++ b/google-cloud-storage/acceptance/storage/universe_domain_test.rb
@@ -16,11 +16,16 @@ require "storage_helper"
 
 describe Google::Cloud::Storage, :universe_domain do
   if ENV["KOKORO_GFILE_DIR"]
-    # Fetch secret values from the secret_manager path
-    TEST_UNIVERSE_PROJECT_ID = File.read(File.realpath(File.join(ENV["KOKORO_GFILE_DIR"], "secret_manager", "client-library-test-universe-project-id")))
-    TEST_UNIVERSE_LOCATION = File.read(File.realpath(File.join(ENV["KOKORO_GFILE_DIR"], "secret_manager", "client-library-test-universe-storage-location")))
-    TEST_UNIVERSE_DOMAIN = File.read(File.realpath(File.join( ENV["KOKORO_GFILE_DIR"], "secret_manager", "client-library-test-universe-domain")))
-    TEST_UNIVERSE_DOMAIN_CREDENTIAL = File.realpath(File.join( ENV["KOKORO_GFILE_DIR"], "secret_manager", "client-library-test-universe-domain-credential"))
+    begin
+      # Fetch secret values from the secret_manager path
+      TEST_UNIVERSE_PROJECT_ID = File.read(File.realpath(File.join(ENV["KOKORO_GFILE_DIR"], "secret_manager", "client-library-test-universe-project-id")))
+      TEST_UNIVERSE_LOCATION = File.read(File.realpath(File.join(ENV["KOKORO_GFILE_DIR"], "secret_manager", "client-library-test-universe-storage-location")))
+      TEST_UNIVERSE_DOMAIN = File.read(File.realpath(File.join( ENV["KOKORO_GFILE_DIR"], "secret_manager", "client-library-test-universe-domain")))
+      TEST_UNIVERSE_DOMAIN_CREDENTIAL = File.realpath(File.join( ENV["KOKORO_GFILE_DIR"], "secret_manager", "client-library-test-universe-domain-credential"))
+    rescue StandardError => e
+      puts "Unable to load universe domain secrets: #{e.message}"
+      next
+    end
 
     let :ud_storage do
       Google::Cloud::Storage.new(


### PR DESCRIPTION
Nightly acceptance crashed the `google-cloud-storage` suite due to missing secrets (failing to load).

This unblocks CI by:
1. Adding universe domain secrets to nightly/continuous Kokoro configs, matching [presubmit](https://github.com/googleapis/google-cloud-ruby/blob/main/.kokoro/presubmit/acceptance.cfg#L32).
2. Rescuing missing secret errors in `universe_domain_test.rb` to log and skip instead of crashing.


Follow-up PRs will address individual failing tests once nightly runs again. Bug: 552162906

Example Logs:
```
[acceptance/storage/universe_domain_test.rb:20](https://cs.corp.google.com/piper///depot/google3/acceptance/storage/universe_domain_test.rb?l=20):in 'File.realpath': No such file or directory @ rb_check_realpath_internal - /secrets/gfile/secret_manager/client-library-test-universe-project-id (Errno::ENOENT)
	from [acceptance/storage/universe_domain_test.rb:20](https://cs.corp.google.com/piper///depot/google3/acceptance/storage/universe_domain_test.rb?l=20):in 'block in <top (required)>'
	from /[h/.gem/gems/minitest-5.27.0/lib/minitest/spec.rb:99](https://cs.corp.google.com/piper///depot/google3/h/.gem/gems/minitest-5.27.0/lib/minitest/spec.rb?l=99):in 'Module#class_eval'
	from /[h/.gem/gems/minitest-5.27.0/lib/minitest/spec.rb:99](https://cs.corp.google.com/piper///depot/google3/h/.gem/gems/minitest-5.27.0/lib/minitest/spec.rb?l=99):in 'Kernel#describe'
	from [acceptance/storage/universe_domain_test.rb:17](https://cs.corp.google.com/piper///depot/google3/acceptance/storage/universe_domain_test.rb?l=17):in '<top (required)>'
	from /[tmp/toys-minitest-script-20260828-4032-vsb1ak.rb:28](https://cs.corp.google.com/piper///depot/google3/tmp/toys-minitest-script-20260828-4032-vsb1ak.rb?l=28):in 'Kernel#load'
	from /[tmp/toys-minitest-script-20260828-4032-vsb1ak.rb:28](https://cs.corp.google.com/piper///depot/google3/tmp/toys-minitest-script-20260828-4032-vsb1ak.rb?l=28):in '<main>'
[2026-08-28 08:04:03 ERROR]  Minitest failed!
```