### PR TITLE
chore: preview YARD formatting fixes from gapic-generator-ruby #1337

### DIFF
--- a/google-apps-chat-v1/proto_docs/google/apps/card/v1/card.rb
+++ b/google-apps-chat-v1/proto_docs/google/apps/card/v1/card.rb
@@ -897,7 +897,7 @@ module Google
         # For example, the following JSON creates a divider:
         #
         # ```
-        # "divider": {}
+        # "divider": \\{}
         # ```
         class Divider
           include ::Google::Protobuf::MessageExts
@@ -1751,7 +1751,7 @@ module Google
         #     settings under **Customize**.
         # @!attribute [rw] weight
         #   @return [::Integer]
-        #     The stroke weight of the icon. Choose from {100, 200, 300, 400,
+        #     The stroke weight of the icon. Choose from \\{100, 200, 300, 400,
         #     500, 600, 700}. If absent, default value is 400. If any other value is
         #     specified, the default value is used.
         #

--- a/google-apps-chat-v1/proto_docs/google/chat/v1/annotation.rb
+++ b/google-apps-chat-v1/proto_docs/google/chat/v1/annotation.rb
@@ -29,7 +29,7 @@ module Google
         #
         # Example plain-text message body:
         # ```
-        # Hello @FooBot how are you!"
+        # Hello `@FooBot` how are you!"
         # ```
         #
         # The corresponding annotations metadata:

--- a/google-apps-chat-v1/proto_docs/google/chat/v1/space.rb
+++ b/google-apps-chat-v1/proto_docs/google/chat/v1/space.rb
@@ -338,7 +338,7 @@ module Google
           #     Optional. Setting for toggling space history on and off.
           # @!attribute [rw] use_at_mention_all
           #   @return [::Google::Apps::Chat::V1::Space::PermissionSetting]
-          #     Optional. Setting for using @all in a space.
+          #     Optional. Setting for using `@all` in a space.
           # @!attribute [rw] manage_apps
           #   @return [::Google::Apps::Chat::V1::Space::PermissionSetting]
           #     Optional. Setting for managing apps in a space.

--- a/google-apps-chat-v1/proto_docs/google/chat/v1/space_notification_setting.rb
+++ b/google-apps-chat-v1/proto_docs/google/chat/v1/space_notification_setting.rb
@@ -42,16 +42,16 @@ module Google
             # Reserved.
             NOTIFICATION_SETTING_UNSPECIFIED = 0
 
-            # Notifications are triggered by @mentions, followed threads, first
+            # Notifications are triggered by `@mentions`, followed threads, first
             # message of new threads. All new threads are automatically followed,
             # unless manually unfollowed by the user.
             ALL = 1
 
-            # The notification is triggered by @mentions, followed threads, first
+            # The notification is triggered by `@mentions`, followed threads, first
             # message of new threads. Not available for 1:1 direct messages.
             MAIN_CONVERSATIONS = 2
 
-            # The notification is triggered by @mentions, followed threads. Not
+            # The notification is triggered by `@mentions`, followed threads. Not
             # available for 1:1 direct messages.
             FOR_YOU = 3
 

--- a/google-cloud-agent_registry-v1/proto_docs/google/cloud/agentregistry/v1/agent.rb
+++ b/google-cloud-agent_registry-v1/proto_docs/google/cloud/agentregistry/v1/agent.rb
@@ -67,10 +67,10 @@ module Google
         #     Output only. Attributes of the Agent.
         #     Valid values:
         #
-        #      * `agentregistry.googleapis.com/system/Framework`: {"framework":
+        #      * `agentregistry.googleapis.com/system/Framework`: \\{"framework":
         #      "google-adk"} - the agent framework used to develop the Agent. Example
         #      values: "google-adk", "langchain", "custom".
-        #      * `agentregistry.googleapis.com/system/RuntimeIdentity`: {"principal":
+        #      * `agentregistry.googleapis.com/system/RuntimeIdentity`: \\{"principal":
         #      "principal://..."} - the runtime identity associated with the Agent.
         #      * `agentregistry.googleapis.com/system/RuntimeReference`: \\{"uri": "//..."}
         #      - the URI of the underlying resource hosting the Agent, for

--- a/google-cloud-agent_registry-v1/proto_docs/google/cloud/agentregistry/v1/mcp_server.rb
+++ b/google-cloud-agent_registry-v1/proto_docs/google/cloud/agentregistry/v1/mcp_server.rb
@@ -52,7 +52,7 @@ module Google
         #     Output only. Attributes of the MCP Server.
         #     Valid values:
         #
-        #      * `agentregistry.googleapis.com/system/RuntimeIdentity`: {"principal":
+        #      * `agentregistry.googleapis.com/system/RuntimeIdentity`: \\{"principal":
         #      "principal://..."} - the runtime identity associated with the MCP Server.
         #      * `agentregistry.googleapis.com/system/RuntimeReference`: \\{"uri": "//..."}
         #      - the URI of the underlying resource hosting the MCP Server, for

--- a/google-cloud-ai_platform-v1/lib/google/cloud/ai_platform/v1/featurestore_online_serving_service/client.rb
+++ b/google-cloud-ai_platform-v1/lib/google/cloud/ai_platform/v1/featurestore_online_serving_service/client.rb
@@ -439,7 +439,7 @@ module Google
             #   @param entity_type [::String]
             #     Required. The resource name of the EntityType for the entities being
             #     written. Value format:
-            #     `projects/{project}/locations/{location}/featurestores/
+            #     `projects/\\{project}/locations/\\{location}/featurestores/
             #     \\{featurestore}/entityTypes/\\{entityType}`. For example,
             #     for a machine learning model predicting user clicks on a website, an
             #     EntityType ID could be `user`.

--- a/google-cloud-ai_platform-v1/lib/google/cloud/ai_platform/v1/featurestore_online_serving_service/rest/client.rb
+++ b/google-cloud-ai_platform-v1/lib/google/cloud/ai_platform/v1/featurestore_online_serving_service/rest/client.rb
@@ -422,7 +422,7 @@ module Google
               #   @param entity_type [::String]
               #     Required. The resource name of the EntityType for the entities being
               #     written. Value format:
-              #     `projects/{project}/locations/{location}/featurestores/
+              #     `projects/\\{project}/locations/\\{location}/featurestores/
               #     \\{featurestore}/entityTypes/\\{entityType}`. For example,
               #     for a machine learning model predicting user clicks on a website, an
               #     EntityType ID could be `user`.

--- a/google-cloud-ai_platform-v1/proto_docs/google/cloud/aiplatform/v1/evaluation_service.rb
+++ b/google-cloud-ai_platform-v1/proto_docs/google/cloud/aiplatform/v1/evaluation_service.rb
@@ -556,7 +556,7 @@ module Google
         #     Required. The type of the computation based metric.
         # @!attribute [rw] parameters
         #   @return [::Google::Protobuf::Struct]
-        #     Optional. A map of parameters for the metric, e.g. {"rouge_type":
+        #     Optional. A map of parameters for the metric, e.g. \\{"rouge_type":
         #     "rougeL"}.
         class ComputationBasedMetricSpec
           include ::Google::Protobuf::MessageExts

--- a/google-cloud-ai_platform-v1/proto_docs/google/cloud/aiplatform/v1/featurestore_online_service.rb
+++ b/google-cloud-ai_platform-v1/proto_docs/google/cloud/aiplatform/v1/featurestore_online_service.rb
@@ -27,7 +27,7 @@ module Google
         #   @return [::String]
         #     Required. The resource name of the EntityType for the entities being
         #     written. Value format:
-        #     `projects/{project}/locations/{location}/featurestores/
+        #     `projects/\\{project}/locations/\\{location}/featurestores/
         #     \\{featurestore}/entityTypes/\\{entityType}`. For example,
         #     for a machine learning model predicting user clicks on a website, an
         #     EntityType ID could be `user`.

--- a/google-cloud-ai_platform-v1/proto_docs/google/cloud/aiplatform/v1/tuning_job.rb
+++ b/google-cloud-ai_platform-v1/proto_docs/google/cloud/aiplatform/v1/tuning_job.rb
@@ -148,7 +148,7 @@ module Google
         #     parent model with version 1. Otherwise the version id will be incremented
         #     by 1 from the last version ID in the parent model. E.g.,
         #
-        #     `projects/{project}/locations/{location}/models/{model}@{last_version_id +
+        #     `projects/\\{project}/locations/\\{location}/models/\\{model}@\\{last_version_id +
         #     1}`
         # @!attribute [r] endpoint
         #   @return [::String]

--- a/google-cloud-bigtable-admin-v2/proto_docs/google/bigtable/admin/v2/table.rb
+++ b/google-cloud-bigtable-admin-v2/proto_docs/google/bigtable/admin/v2/table.rb
@@ -540,7 +540,7 @@ module Google
           #   @return [::String]
           #     A globally unique identifier for the backup which cannot be
           #     changed. Values are of the form
-          #     `projects/{project}/instances/{instance}/clusters/{cluster}/
+          #     `projects/\\{project}/instances/\\{instance}/clusters/\\{cluster}/
           #        backups/[_a-zA-Z0-9][-_.a-zA-Z0-9]*`
           #     The final segment of the name must be between 1 and 50 characters
           #     in length.

--- a/google-cloud-bigtable-v2/lib/google/cloud/bigtable/v2/bigtable/client.rb
+++ b/google-cloud-bigtable-v2/lib/google/cloud/bigtable/v2/bigtable/client.rb
@@ -1333,7 +1333,7 @@ module Google
             #     `@` character followed by the parameter name (for example, `@firstName`) in
             #     the query string.
             #
-            #     For example, if param_types["firstName"] = Bytes then @firstName will be a
+            #     For example, if param_types["firstName"] = Bytes then `@firstName` will be a
             #     query parameter of type Bytes. The specific `Value` to be used for the
             #     query execution must be sent in `ExecuteQueryRequest` in the `params` map.
             #

--- a/google-cloud-bigtable-v2/lib/google/cloud/bigtable/v2/bigtable/rest/client.rb
+++ b/google-cloud-bigtable-v2/lib/google/cloud/bigtable/v2/bigtable/rest/client.rb
@@ -1197,7 +1197,7 @@ module Google
               #     `@` character followed by the parameter name (for example, `@firstName`) in
               #     the query string.
               #
-              #     For example, if param_types["firstName"] = Bytes then @firstName will be a
+              #     For example, if param_types["firstName"] = Bytes then `@firstName` will be a
               #     query parameter of type Bytes. The specific `Value` to be used for the
               #     query execution must be sent in `ExecuteQueryRequest` in the `params` map.
               # @yield [result, operation] Access the result along with the TransportOperation object

--- a/google-cloud-bigtable-v2/proto_docs/google/bigtable/v2/bigtable.rb
+++ b/google-cloud-bigtable-v2/proto_docs/google/bigtable/v2/bigtable.rb
@@ -926,7 +926,7 @@ module Google
         #     `@` character followed by the parameter name (for example, `@firstName`) in
         #     the query string.
         #
-        #     For example, if param_types["firstName"] = Bytes then @firstName will be a
+        #     For example, if param_types["firstName"] = Bytes then `@firstName` will be a
         #     query parameter of type Bytes. The specific `Value` to be used for the
         #     query execution must be sent in `ExecuteQueryRequest` in the `params` map.
         class PrepareQueryRequest

--- a/google-cloud-compute-v1/Gemfile.lock
+++ b/google-cloud-compute-v1/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    google-cloud-compute-v1 (3.9.0)
+    google-cloud-compute-v1 (3.10.0)
       gapic-common (~> 1.3)
       google-cloud-common (~> 1.0)
       google-cloud-errors (~> 1.0)
@@ -235,7 +235,7 @@ CHECKSUMS
   faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
   gapic-common (1.3.0) sha256=4e5d9be1effb7366e2cda13c0f44922285d5613ac8de8b9b18c2c835fe4faa91
   google-cloud-common (1.10.0) sha256=f8036aa5a5f6a32d9ccab652f0f52a996ac02f5be83f403075465e8ba99238ee
-  google-cloud-compute-v1 (3.9.0)
+  google-cloud-compute-v1 (3.10.0)
   google-cloud-env (2.4.0) sha256=01cb35ecee5d1c4d1cd4deaed8bb5bddc838e296bcc2a35c5d1ddd07ce40d28d
   google-cloud-errors (1.7.0) sha256=6e682f42d89aae08689f36f28495de629d756da076bafff0003bac7f8042ebb3
   google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b

--- a/google-cloud-config_delivery-v1/proto_docs/google/cloud/configdelivery/v1/config_delivery.rb
+++ b/google-cloud-config_delivery-v1/proto_docs/google/cloud/configdelivery/v1/config_delivery.rb
@@ -25,7 +25,7 @@ module Google
         # @!attribute [rw] name
         #   @return [::String]
         #     Identifier. Name of the `ResourceBundle`. Format is
-        #     `projects/{project}/locations/{location}/resourceBundle
+        #     `projects/\\{project}/locations/\\{location}/resourceBundle
         #     /[a-z][a-z0-9\-]\\{0,62}`.
         # @!attribute [r] create_time
         #   @return [::Google::Protobuf::Timestamp]

--- a/google-cloud-config_service-v1/proto_docs/google/cloud/config/v1/config.rb
+++ b/google-cloud-config_service-v1/proto_docs/google/cloud/config/v1/config.rb
@@ -46,7 +46,7 @@ module Google
         # @!attribute [r] latest_revision
         #   @return [::String]
         #     Output only. Revision name that was most recently applied.
-        #     Format: `projects/{project}/locations/{location}/deployments/{deployment}/
+        #     Format: `projects/\\{project}/locations/\\{location}/deployments/\\{deployment}/
         #     revisions/\\{revision}`
         # @!attribute [r] state_detail
         #   @return [::String]
@@ -793,7 +793,7 @@ module Google
         # @!attribute [rw] name
         #   @return [::String]
         #     Revision name. Format:
-        #     `projects/{project}/locations/{location}/deployments/{deployment}/
+        #     `projects/\\{project}/locations/\\{location}/deployments/\\{deployment}/
         #     revisions/\\{revision}`
         # @!attribute [r] create_time
         #   @return [::Google::Protobuf::Timestamp]

--- a/google-cloud-data_catalog-lineage-v1/proto_docs/google/cloud/datacatalog/lineage/v1/lineage.rb
+++ b/google-cloud-data_catalog-lineage-v1/proto_docs/google/cloud/datacatalog/lineage/v1/lineage.rb
@@ -800,7 +800,7 @@ module Google
           #     location parts of the resource name must match the project and location of
           #     the lineage resource being created. Examples:
           #
-          #     - `{source_type: COMPOSER, name:
+          #     - `\\{source_type: COMPOSER, name:
           #       "projects/foo/locations/us/environments/bar"}`
           #     - `{source_type: BIGQUERY, name: "projects/foo/locations/eu"}`
           #     - `{source_type: CUSTOM,   name: "myCustomIntegration"}`

--- a/google-cloud-data_catalog-v1/lib/google/cloud/data_catalog/v1/data_catalog/client.rb
+++ b/google-cloud-data_catalog-v1/lib/google/cloud/data_catalog/v1/data_catalog/client.rb
@@ -1338,7 +1338,7 @@ module Google
             #     Examples:
             #
             #     * `pubsub.topic.{PROJECT_ID}.{TOPIC_ID}`
-            #     * `pubsub.topic.{PROJECT_ID}.`\``{TOPIC.ID.SEPARATED.WITH.DOTS}`\`
+            #     * `pubsub.topic.{PROJECT_ID}.`\``\\{TOPIC.ID.SEPARATED.WITH.DOTS}`\`
             #     * `bigquery.table.{PROJECT_ID}.{DATASET_ID}.{TABLE_ID}`
             #     * `bigquery.dataset.{PROJECT_ID}.{DATASET_ID}`
             #     * `datacatalog.entry.{PROJECT_ID}.{LOCATION_ID}.{ENTRY_GROUP_ID}.{ENTRY_ID}`

--- a/google-cloud-data_catalog-v1/lib/google/cloud/data_catalog/v1/data_catalog/rest/client.rb
+++ b/google-cloud-data_catalog-v1/lib/google/cloud/data_catalog/v1/data_catalog/rest/client.rb
@@ -1246,7 +1246,7 @@ module Google
               #     Examples:
               #
               #     * `pubsub.topic.{PROJECT_ID}.{TOPIC_ID}`
-              #     * `pubsub.topic.{PROJECT_ID}.`\``{TOPIC.ID.SEPARATED.WITH.DOTS}`\`
+              #     * `pubsub.topic.{PROJECT_ID}.`\``\\{TOPIC.ID.SEPARATED.WITH.DOTS}`\`
               #     * `bigquery.table.{PROJECT_ID}.{DATASET_ID}.{TABLE_ID}`
               #     * `bigquery.dataset.{PROJECT_ID}.{DATASET_ID}`
               #     * `datacatalog.entry.{PROJECT_ID}.{LOCATION_ID}.{ENTRY_GROUP_ID}.{ENTRY_ID}`

--- a/google-cloud-data_catalog-v1/proto_docs/google/cloud/datacatalog/v1/datacatalog.rb
+++ b/google-cloud-data_catalog-v1/proto_docs/google/cloud/datacatalog/v1/datacatalog.rb
@@ -372,7 +372,7 @@ module Google
         #     Examples:
         #
         #     * `pubsub.topic.{PROJECT_ID}.{TOPIC_ID}`
-        #     * `pubsub.topic.{PROJECT_ID}.`\``{TOPIC.ID.SEPARATED.WITH.DOTS}`\`
+        #     * `pubsub.topic.{PROJECT_ID}.`\``\\{TOPIC.ID.SEPARATED.WITH.DOTS}`\`
         #     * `bigquery.table.{PROJECT_ID}.{DATASET_ID}.{TABLE_ID}`
         #     * `bigquery.dataset.{PROJECT_ID}.{DATASET_ID}`
         #     * `datacatalog.entry.{PROJECT_ID}.{LOCATION_ID}.{ENTRY_GROUP_ID}.{ENTRY_ID}`

--- a/google-cloud-dataflow-v1beta3/proto_docs/google/dataflow/v1beta3/jobs.rb
+++ b/google-cloud-dataflow-v1beta3/proto_docs/google/dataflow/v1beta3/jobs.rb
@@ -900,7 +900,7 @@ module Google
         # be a partial response, depending on the page size in the ListJobsRequest.
         # However, if the project does not have any jobs, an instance of
         # ListJobsResponse is not returned and the requests's response
-        # body is empty {}.
+        # body is empty \\{}.
         # @!attribute [rw] jobs
         #   @return [::Array<::Google::Cloud::Dataflow::V1beta3::Job>]
         #     A subset of the requested job information.

--- a/google-cloud-dialogflow-cx-v3/proto_docs/google/cloud/dialogflow/cx/v3/agent.rb
+++ b/google-cloud-dialogflow-cx-v3/proto_docs/google/cloud/dialogflow/cx/v3/agent.rb
@@ -205,7 +205,7 @@ module Google
             # @!attribute [rw] engine
             #   @return [::String]
             #     Required. The full name of the Gen App Builder engine related to this
-            #     agent if there is one. Format: `projects/{Project ID}/locations/{Location
+            #     agent if there is one. Format: `projects/\\{Project ID}/locations/\\{Location
             #     ID}/collections/\\{Collection ID}/engines/\\{Engine ID}`
             class GenAppBuilderSettings
               include ::Google::Protobuf::MessageExts

--- a/google-cloud-dialogflow-v2/proto_docs/google/cloud/dialogflow/v2/agent.rb
+++ b/google-cloud-dialogflow-v2/proto_docs/google/cloud/dialogflow/v2/agent.rb
@@ -103,7 +103,7 @@ module Google
             MATCH_MODE_HYBRID = 1
 
             # Can be used for agents with a large number of examples in intents,
-            # especially the ones using @sys.any or very large custom entities.
+            # especially the ones using `@sys`.any or very large custom entities.
             MATCH_MODE_ML_ONLY = 2
           end
 

--- a/google-cloud-dialogflow-v2/proto_docs/google/cloud/dialogflow/v2/agent_coaching_instruction.rb
+++ b/google-cloud-dialogflow-v2/proto_docs/google/cloud/dialogflow/v2/agent_coaching_instruction.rb
@@ -41,7 +41,7 @@ module Google
         # @!attribute [rw] system_action
         #   @return [::String]
         #     Optional. The action that system should take. For example,
-        #     "call GetOrderTime with order_number={order number provided by the
+        #     "call GetOrderTime with order_number=\\{order number provided by the
         #     customer}". If the users don't have plugins or don't want to trigger
         #     plugins, the system_action can be empty
         # @!attribute [r] duplicate_check_result

--- a/google-cloud-dialogflow-v2/proto_docs/google/cloud/dialogflow/v2/audio_config.rb
+++ b/google-cloud-dialogflow-v2/proto_docs/google/cloud/dialogflow/v2/audio_config.rb
@@ -263,7 +263,7 @@ module Google
             # https://en.wikipedia.org/wiki/International_Phonetic_Alphabet
             PHONETIC_ENCODING_IPA = 1
 
-            # X-SAMPA, such as apple -> "{p@l".
+            # X-SAMPA, such as apple -> "\\{p@l".
             # https://en.wikipedia.org/wiki/X-SAMPA
             PHONETIC_ENCODING_X_SAMPA = 2
           end

--- a/google-cloud-dialogflow-v2/proto_docs/google/cloud/dialogflow/v2/conversation.rb
+++ b/google-cloud-dialogflow-v2/proto_docs/google/cloud/dialogflow/v2/conversation.rb
@@ -605,7 +605,7 @@ module Google
           #   @return [::Array<::Google::Cloud::Dialogflow::V2::Message>]
           #     Required. The messages that the Summary will be generated from. It is
           #     expected that this message content is already redacted and does not
-          #     contain any PII. Required fields: {content, language_code, participant,
+          #     contain any PII. Required fields: \\{content, language_code, participant,
           #     participant_role} Optional fields: \\{send_time} If send_time is not
           #     provided, then the messages must be provided in chronological order.
           # @!attribute [rw] parent

--- a/google-cloud-discovery_engine-v1beta/lib/google/cloud/discovery_engine/v1beta/document_service/client.rb
+++ b/google-cloud-discovery_engine-v1beta/lib/google/cloud/discovery_engine/v1beta/document_service/client.rb
@@ -841,7 +841,7 @@ module Google
             #     the documents.
             #
             #     For {::Google::Cloud::DiscoveryEngine::V1beta::GcsSource GcsSource} it is the
-            #     key of the JSON field. For instance, `my_id` for JSON `{"my_id":
+            #     key of the JSON field. For instance, `my_id` for JSON `\\{"my_id":
             #     "some_uuid"}`. For others, it may be the column name of the table where the
             #     unique ids are stored.
             #

--- a/google-cloud-discovery_engine-v1beta/lib/google/cloud/discovery_engine/v1beta/document_service/rest/client.rb
+++ b/google-cloud-discovery_engine-v1beta/lib/google/cloud/discovery_engine/v1beta/document_service/rest/client.rb
@@ -799,7 +799,7 @@ module Google
               #     the documents.
               #
               #     For {::Google::Cloud::DiscoveryEngine::V1beta::GcsSource GcsSource} it is the
-              #     key of the JSON field. For instance, `my_id` for JSON `{"my_id":
+              #     key of the JSON field. For instance, `my_id` for JSON `\\{"my_id":
               #     "some_uuid"}`. For others, it may be the column name of the table where the
               #     unique ids are stored.
               #

--- a/google-cloud-discovery_engine-v1beta/proto_docs/google/cloud/discoveryengine/v1beta/assistant.rb
+++ b/google-cloud-discovery_engine-v1beta/proto_docs/google/cloud/discoveryengine/v1beta/assistant.rb
@@ -64,7 +64,7 @@ module Google
         #     The values consist of admin enabled tools towards the connector
         #     instance. Admin can selectively enable multiple tools on any of the
         #     connector instances that they created in the project. For example
-        #     {"jira1ConnectorName": [(toolId1, "createTicket"), (toolId2,
+        #     \\{"jira1ConnectorName": [(toolId1, "createTicket"), (toolId2,
         #     "transferTicket")],
         #      "gmail1ConnectorName": [(toolId3, "sendEmail"),..] }
         # @!attribute [rw] customer_policy

--- a/google-cloud-discovery_engine-v1beta/proto_docs/google/cloud/discoveryengine/v1beta/import_config.rb
+++ b/google-cloud-discovery_engine-v1beta/proto_docs/google/cloud/discoveryengine/v1beta/import_config.rb
@@ -629,7 +629,7 @@ module Google
         #     the documents.
         #
         #     For {::Google::Cloud::DiscoveryEngine::V1beta::GcsSource GcsSource} it is the
-        #     key of the JSON field. For instance, `my_id` for JSON `{"my_id":
+        #     key of the JSON field. For instance, `my_id` for JSON `\\{"my_id":
         #     "some_uuid"}`. For others, it may be the column name of the table where the
         #     unique ids are stored.
         #

--- a/google-cloud-dlp-v2/proto_docs/google/privacy/dlp/v2/dlp.rb
+++ b/google-cloud-dlp-v2/proto_docs/google/privacy/dlp/v2/dlp.rb
@@ -3008,7 +3008,7 @@ module Google
             # a-z
             ALPHA_LOWER_CASE = 3
 
-            # US Punctuation, one of !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~
+            # US Punctuation, one of !"#$%&'()*+,-./:;<=>?@[\]^_`\\{|}~
             PUNCTUATION = 4
 
             # Whitespace character, one of [ \t\n\x0B\f\r]

--- a/google-cloud-dlp-v2/proto_docs/google/privacy/dlp/v2/storage.rb
+++ b/google-cloud-dlp-v2/proto_docs/google/privacy/dlp/v2/storage.rb
@@ -397,7 +397,7 @@ module Google
         # entire file path (i.e., everything in the url after the bucket name) must
         # match the regular expression.
         #
-        # For example, given the input `{bucket_name: "mybucket", include_regex:
+        # For example, given the input `\\{bucket_name: "mybucket", include_regex:
         # ["directory1/.*"], exclude_regex:
         # ["directory1/excluded.*"]}`:
         #

--- a/google-cloud-eventarc-v1/proto_docs/google/cloud/eventarc/v1/enrollment.rb
+++ b/google-cloud-eventarc-v1/proto_docs/google/cloud/eventarc/v1/enrollment.rb
@@ -66,7 +66,7 @@ module Google
         #   @return [::String]
         #     Required. Destination is the Pipeline that the Enrollment is delivering to.
         #     It must point to the full resource name of a Pipeline. Format:
-        #     "projects/\\{PROJECT_ID}/locations/\\{region}/pipelines/{PIPELINE_ID)"
+        #     "projects/\\{PROJECT_ID}/locations/\\{region}/pipelines/\\{PIPELINE_ID)"
         class Enrollment
           include ::Google::Protobuf::MessageExts
           extend ::Google::Protobuf::MessageExts::ClassMethods

--- a/google-cloud-eventarc-v1/proto_docs/google/cloud/eventarc/v1/google_api_source.rb
+++ b/google-cloud-eventarc-v1/proto_docs/google/cloud/eventarc/v1/google_api_source.rb
@@ -56,7 +56,7 @@ module Google
         #     Required. Destination is the message bus that the GoogleApiSource is
         #     delivering to. It must be point to the full resource name of a MessageBus.
         #     Format:
-        #     "projects/\\{PROJECT_ID}/locations/\\{region}/messagesBuses/{MESSAGE_BUS_ID)
+        #     "projects/\\{PROJECT_ID}/locations/\\{region}/messagesBuses/\\{MESSAGE_BUS_ID)
         # @!attribute [rw] crypto_key_name
         #   @return [::String]
         #     Optional. Resource name of a KMS crypto key (managed by the user) used to

--- a/google-cloud-gemini_data_analytics-v1/proto_docs/google/cloud/geminidataanalytics/v1/context.rb
+++ b/google-cloud-gemini_data_analytics-v1/proto_docs/google/cloud/geminidataanalytics/v1/context.rb
@@ -172,7 +172,7 @@ module Google
         #   @return [::Array<::Google::Cloud::GeminiDataAnalytics::V1::QueryParameter>]
         #     Optional. The list of query parameters.
         #     Example: The parameterized SQL query
-        #     "SELECT * FROM my_table WHERE id = @id" can be matched with any value of
+        #     "SELECT * FROM my_table WHERE id = `@id`" can be matched with any value of
         #     id.
         class ExampleQuery
           include ::Google::Protobuf::MessageExts

--- a/google-cloud-gemini_data_analytics-v1beta/proto_docs/google/cloud/geminidataanalytics/v1beta/context.rb
+++ b/google-cloud-gemini_data_analytics-v1beta/proto_docs/google/cloud/geminidataanalytics/v1beta/context.rb
@@ -172,7 +172,7 @@ module Google
         #   @return [::Array<::Google::Cloud::GeminiDataAnalytics::V1beta::QueryParameter>]
         #     Optional. The list of query parameters.
         #     Example: The parameterized SQL query
-        #     "SELECT * FROM my_table WHERE id = @id" can be matched with any value of
+        #     "SELECT * FROM my_table WHERE id = `@id`" can be matched with any value of
         #     id.
         class ExampleQuery
           include ::Google::Protobuf::MessageExts

--- a/google-cloud-netapp-v1/proto_docs/google/cloud/netapp/v1/volume.rb
+++ b/google-cloud-netapp-v1/proto_docs/google/cloud/netapp/v1/volume.rb
@@ -850,7 +850,7 @@ module Google
         #     backend. The name must meet the following requirements:
         #     *   Be between 1 and 255 characters long.
         #     *   Contain only uppercase or lowercase letters (A-Z, a-z), numbers (0-9),
-        #         and the following special characters: "-", "_", "}", "{", ".".
+        #         and the following special characters: "-", "_", "}", "\\{", ".".
         #     *   Spaces are not allowed.
         # @!attribute [rw] host_groups
         #   @return [::Array<::String>]

--- a/google-cloud-network_security-v1/proto_docs/google/cloud/networksecurity/v1/security_profile_group.rb
+++ b/google-cloud-network_security-v1/proto_docs/google/cloud/networksecurity/v1/security_profile_group.rb
@@ -45,7 +45,7 @@ module Google
         #     client has an up-to-date value before proceeding.
         # @!attribute [r] data_path_id
         #   @return [::Integer]
-        #     Output only. Identifier used by the data-path. Unique within `{container,
+        #     Output only. Identifier used by the data-path. Unique within `\\{container,
         #     location}`.
         # @!attribute [rw] labels
         #   @return [::Google::Protobuf::Map{::String => ::String}]

--- a/google-cloud-network_services-v1/proto_docs/google/cloud/networkservices/v1/extensibility.rb
+++ b/google-cloud-network_services-v1/proto_docs/google/cloud/networkservices/v1/extensibility.rb
@@ -108,7 +108,7 @@ module Google
           #     value is used instead of an image tag.
           #
           #     * Generic artifacts: the `plugin_config_uri` must be in this format:
-          #     `projects/{project}/locations/{location}/repositories/{repository}/
+          #     `projects/\\{project}/locations/\\{location}/repositories/\\{repository}/
           #     genericArtifacts/\\{package}:\\{version}`.
           #     The specified package and version must contain a file with the name
           #     `plugin.config`. When a new `WasmPluginVersion` resource is
@@ -144,7 +144,7 @@ module Google
           #     is used instead of an image tag.
           #
           #     * Generic artifacts: the `image_uri` must be in this format:
-          #     `projects/{project}/locations/{location}/repositories/{repository}/
+          #     `projects/\\{project}/locations/\\{location}/repositories/\\{repository}/
           #     genericArtifacts/\\{package}:\\{version}`.
           #     The specified package and version must contain a file with the name
           #     `plugin.wasm`. When a new `WasmPluginVersion` resource is created, the
@@ -295,7 +295,7 @@ module Google
         #     value is used instead of an image tag.
         #
         #     * Generic artifacts: the `plugin_config_uri` must be in this format:
-        #     `projects/{project}/locations/{location}/repositories/{repository}/
+        #     `projects/\\{project}/locations/\\{location}/repositories/\\{repository}/
         #     genericArtifacts/\\{package}:\\{version}`.
         #     The specified package and version must contain a file with the name
         #     `plugin.config`. When a new `WasmPluginVersion` resource is
@@ -306,7 +306,7 @@ module Google
         # @!attribute [rw] name
         #   @return [::String]
         #     Identifier. Name of the `WasmPluginVersion` resource in the following
-        #     format: `projects/{project}/locations/{location}/wasmPlugins/{wasm_plugin}/
+        #     format: `projects/\\{project}/locations/\\{location}/wasmPlugins/\\{wasm_plugin}/
         #     versions/\\{wasm_plugin_version}`.
         # @!attribute [r] create_time
         #   @return [::Google::Protobuf::Timestamp]
@@ -336,7 +336,7 @@ module Google
         #     is used instead of an image tag.
         #
         #     * Generic artifacts: the `image_uri` must be in this format:
-        #     `projects/{project}/locations/{location}/repositories/{repository}/
+        #     `projects/\\{project}/locations/\\{location}/repositories/\\{repository}/
         #     genericArtifacts/\\{package}:\\{version}`.
         #     The specified package and version must contain a file with the name
         #     `plugin.wasm`. When a new `WasmPluginVersion` resource is created, the

--- a/google-cloud-oracle_database-v1/lib/google/cloud/oracle_database/v1/oracle_database/client.rb
+++ b/google-cloud-oracle_database-v1/lib/google/cloud/oracle_database/v1/oracle_database/client.rb
@@ -1773,7 +1773,7 @@ module Google
             #   @param filter [::String]
             #     Optional. An expression for filtering the results of the request. Only the
             #     `shape_family` and `gcp_oracle_zone_id` fields are supported in the
-            #     following format: `shape_family="{shape_family}" AND
+            #     following format: `shape_family="\\{shape_family}" AND
             #     gcp_oracle_zone_id="\\{gcp_oracle_zone_id}"`.
             #
             # @yield [response, operation] Access the result along with the RPC operation
@@ -1877,7 +1877,7 @@ module Google
             #     Optional. An expression for filtering the results of the request. The
             #     `gcp_oracle_zone_id`, `shape_family`, and `database_edition` fields
             #     are supported in the following format:
-            #     `gcp_oracle_zone_id="{gcp_oracle_zone_id}" AND
+            #     `gcp_oracle_zone_id="\\{gcp_oracle_zone_id}" AND
             #     shape_family="\\{shape_family}" AND database_edition="\\{database_edition}"`.
             #
             # @yield [response, operation] Access the result along with the RPC operation

--- a/google-cloud-oracle_database-v1/lib/google/cloud/oracle_database/v1/oracle_database/rest/client.rb
+++ b/google-cloud-oracle_database-v1/lib/google/cloud/oracle_database/v1/oracle_database/rest/client.rb
@@ -1676,7 +1676,7 @@ module Google
               #   @param filter [::String]
               #     Optional. An expression for filtering the results of the request. Only the
               #     `shape_family` and `gcp_oracle_zone_id` fields are supported in the
-              #     following format: `shape_family="{shape_family}" AND
+              #     following format: `shape_family="\\{shape_family}" AND
               #     gcp_oracle_zone_id="\\{gcp_oracle_zone_id}"`.
               # @yield [result, operation] Access the result along with the TransportOperation object
               # @yieldparam result [::Gapic::Rest::PagedEnumerable<::Google::Cloud::OracleDatabase::V1::MinorVersion>]
@@ -1773,7 +1773,7 @@ module Google
               #     Optional. An expression for filtering the results of the request. The
               #     `gcp_oracle_zone_id`, `shape_family`, and `database_edition` fields
               #     are supported in the following format:
-              #     `gcp_oracle_zone_id="{gcp_oracle_zone_id}" AND
+              #     `gcp_oracle_zone_id="\\{gcp_oracle_zone_id}" AND
               #     shape_family="\\{shape_family}" AND database_edition="\\{database_edition}"`.
               # @yield [result, operation] Access the result along with the TransportOperation object
               # @yieldparam result [::Gapic::Rest::PagedEnumerable<::Google::Cloud::OracleDatabase::V1::DbSystemShape>]

--- a/google-cloud-oracle_database-v1/proto_docs/google/cloud/oracledatabase/v1/minor_version.rb
+++ b/google-cloud-oracle_database-v1/proto_docs/google/cloud/oracledatabase/v1/minor_version.rb
@@ -57,7 +57,7 @@ module Google
         #   @return [::String]
         #     Optional. An expression for filtering the results of the request. Only the
         #     `shape_family` and `gcp_oracle_zone_id` fields are supported in the
-        #     following format: `shape_family="{shape_family}" AND
+        #     following format: `shape_family="\\{shape_family}" AND
         #     gcp_oracle_zone_id="\\{gcp_oracle_zone_id}"`.
         class ListMinorVersionsRequest
           include ::Google::Protobuf::MessageExts

--- a/google-cloud-oracle_database-v1/proto_docs/google/cloud/oracledatabase/v1/oracledatabase.rb
+++ b/google-cloud-oracle_database-v1/proto_docs/google/cloud/oracledatabase/v1/oracledatabase.rb
@@ -373,7 +373,7 @@ module Google
         #     Optional. An expression for filtering the results of the request. The
         #     `gcp_oracle_zone_id`, `shape_family`, and `database_edition` fields
         #     are supported in the following format:
-        #     `gcp_oracle_zone_id="{gcp_oracle_zone_id}" AND
+        #     `gcp_oracle_zone_id="\\{gcp_oracle_zone_id}" AND
         #     shape_family="\\{shape_family}" AND database_edition="\\{database_edition}"`.
         class ListDbSystemShapesRequest
           include ::Google::Protobuf::MessageExts

--- a/google-cloud-recommendation_engine-v1beta1/proto_docs/google/cloud/recommendationengine/v1beta1/common.rb
+++ b/google-cloud-recommendation_engine-v1beta1/proto_docs/google/cloud/recommendationengine/v1beta1/common.rb
@@ -32,7 +32,7 @@ module Google
         #
         #     Feature names and values must be UTF-8 encoded strings.
         #
-        #     For example: `{ "colors": {"value": ["yellow", "green"]},
+        #     For example: `{ "colors": \\{"value": ["yellow", "green"]},
         #                     "sizes": \\{"value":["S", "M"]}`
         # @!attribute [rw] numerical_features
         #   @return [::Google::Protobuf::Map{::String => ::Google::Cloud::RecommendationEngine::V1beta1::FeatureMap::FloatList}]
@@ -41,7 +41,7 @@ module Google
         #
         #     Feature names must be UTF-8 encoded strings.
         #
-        #     For example: `{ "lengths_cm": {"value":[2.3, 15.4]},
+        #     For example: `{ "lengths_cm": \\{"value":[2.3, 15.4]},
         #                     "heights_cm": \\{"value":[8.1, 6.4]} }`
         class FeatureMap
           include ::Google::Protobuf::MessageExts

--- a/google-cloud-retail-v2/lib/google/cloud/retail/v2/prediction_service/client.rb
+++ b/google-cloud-retail-v2/lib/google/cloud/retail/v2/prediction_service/client.rb
@@ -321,12 +321,12 @@ module Google
             #        will return generic (unfiltered) popular products instead of empty if
             #        your filter blocks all prediction results.
             #     * `priceRerankLevel`: String. Default empty. If set to be non-empty, then
-            #        it needs to be one of {'no-price-reranking', 'low-price-reranking',
+            #        it needs to be one of \\{'no-price-reranking', 'low-price-reranking',
             #        'medium-price-reranking', 'high-price-reranking'}. This gives
             #        request-level control and adjusts prediction results based on product
             #        price.
             #     * `diversityLevel`: String. Default empty. If set to be non-empty, then
-            #        it needs to be one of {'no-diversity', 'low-diversity',
+            #        it needs to be one of \\{'no-diversity', 'low-diversity',
             #        'medium-diversity', 'high-diversity', 'auto-diversity'}. This gives
             #        request-level control and adjusts prediction results based on product
             #        category.

--- a/google-cloud-retail-v2/lib/google/cloud/retail/v2/prediction_service/rest/client.rb
+++ b/google-cloud-retail-v2/lib/google/cloud/retail/v2/prediction_service/rest/client.rb
@@ -314,12 +314,12 @@ module Google
               #        will return generic (unfiltered) popular products instead of empty if
               #        your filter blocks all prediction results.
               #     * `priceRerankLevel`: String. Default empty. If set to be non-empty, then
-              #        it needs to be one of {'no-price-reranking', 'low-price-reranking',
+              #        it needs to be one of \\{'no-price-reranking', 'low-price-reranking',
               #        'medium-price-reranking', 'high-price-reranking'}. This gives
               #        request-level control and adjusts prediction results based on product
               #        price.
               #     * `diversityLevel`: String. Default empty. If set to be non-empty, then
-              #        it needs to be one of {'no-diversity', 'low-diversity',
+              #        it needs to be one of \\{'no-diversity', 'low-diversity',
               #        'medium-diversity', 'high-diversity', 'auto-diversity'}. This gives
               #        request-level control and adjusts prediction results based on product
               #        category.

--- a/google-cloud-retail-v2/proto_docs/google/cloud/retail/v2/prediction_service.rb
+++ b/google-cloud-retail-v2/proto_docs/google/cloud/retail/v2/prediction_service.rb
@@ -129,12 +129,12 @@ module Google
         #        will return generic (unfiltered) popular products instead of empty if
         #        your filter blocks all prediction results.
         #     * `priceRerankLevel`: String. Default empty. If set to be non-empty, then
-        #        it needs to be one of {'no-price-reranking', 'low-price-reranking',
+        #        it needs to be one of \\{'no-price-reranking', 'low-price-reranking',
         #        'medium-price-reranking', 'high-price-reranking'}. This gives
         #        request-level control and adjusts prediction results based on product
         #        price.
         #     * `diversityLevel`: String. Default empty. If set to be non-empty, then
-        #        it needs to be one of {'no-diversity', 'low-diversity',
+        #        it needs to be one of \\{'no-diversity', 'low-diversity',
         #        'medium-diversity', 'high-diversity', 'auto-diversity'}. This gives
         #        request-level control and adjusts prediction results based on product
         #        category.

--- a/google-cloud-retail-v2/proto_docs/google/cloud/retail/v2/product.rb
+++ b/google-cloud-retail-v2/proto_docs/google/cloud/retail/v2/product.rb
@@ -248,7 +248,7 @@ module Google
         #     country of a customer. Numerical features. Some examples would be the
         #     height/weight of a product, or age of a customer.
         #
-        #     For example: `{ "vendor": {"text": ["vendor123", "vendor456"]},
+        #     For example: `{ "vendor": \\{"text": ["vendor123", "vendor456"]},
         #     "lengths_cm": \\{"numbers":[2.3, 15.4]}, "heights_cm": \\{"numbers":[8.1, 6.4]}
         #     }`.
         #

--- a/google-cloud-security_center-v1/proto_docs/google/cloud/securitycenter/v1/access.rb
+++ b/google-cloud-security_center-v1/proto_docs/google/cloud/securitycenter/v1/access.rb
@@ -60,7 +60,7 @@ module Google
         #     principals. For most identities, the format is
         #     `principal://iam.googleapis.com/{identity pool name}/subject/{subject}`.
         #     Some GKE identities, such as GKE_WORKLOAD, FREEFORM, and GKE_HUB_WORKLOAD,
-        #     still use the legacy format `serviceAccount:{identity pool
+        #     still use the legacy format `serviceAccount:\\{identity pool
         #     name}[\\{subject}]`.
         # @!attribute [rw] service_account_key_name
         #   @return [::String]
@@ -97,7 +97,7 @@ module Google
         #     A string representing the principal_subject associated with the identity.
         #     As compared to `principal_email`, supports principals that aren't
         #     associated with email addresses, such as third party principals. For most
-        #     identities, the format will be `principal://iam.googleapis.com/{identity
+        #     identities, the format will be `principal://iam.googleapis.com/\\{identity
         #     pool name}/subjects/\\{subject}` except for some GKE identities
         #     (GKE_WORKLOAD, FREEFORM, GKE_HUB_WORKLOAD) that are still in the legacy
         #     format `serviceAccount:{identity pool name}[{subject}]`

--- a/google-cloud-security_center-v2/proto_docs/google/cloud/securitycenter/v2/access.rb
+++ b/google-cloud-security_center-v2/proto_docs/google/cloud/securitycenter/v2/access.rb
@@ -60,7 +60,7 @@ module Google
         #     principals. For most identities, the format is
         #     `principal://iam.googleapis.com/{identity pool name}/subject/{subject}`.
         #     Some GKE identities, such as GKE_WORKLOAD, FREEFORM, and GKE_HUB_WORKLOAD,
-        #     still use the legacy format `serviceAccount:{identity pool
+        #     still use the legacy format `serviceAccount:\\{identity pool
         #     name}[\\{subject}]`.
         # @!attribute [rw] service_account_key_name
         #   @return [::String]
@@ -97,7 +97,7 @@ module Google
         #     A string representing the principal_subject associated with the identity.
         #     As compared to `principal_email`, supports principals that aren't
         #     associated with email addresses, such as third party principals. For most
-        #     identities, the format will be `principal://iam.googleapis.com/{identity
+        #     identities, the format will be `principal://iam.googleapis.com/\\{identity
         #     pool name}/subjects/\\{subject}` except for some GKE identities
         #     (GKE_WORKLOAD, FREEFORM, GKE_HUB_WORKLOAD) that are still in the legacy
         #     format `serviceAccount:{identity pool name}[{subject}]`

--- a/google-cloud-service_management-v1/proto_docs/google/api/documentation.rb
+++ b/google-cloud-service_management-v1/proto_docs/google/api/documentation.rb
@@ -161,7 +161,7 @@ module Google
     #     `[Java][Tutorial.Java]`.
     # @!attribute [rw] content
     #   @return [::String]
-    #     The Markdown content of the page. You can use ```(== include {path}
+    #     The Markdown content of the page. You can use ```(== include \\{path}
     #     ==)``` to include content from a Markdown file. The content can be used
     #     to produce the documentation page such as HTML format page.
     # @!attribute [rw] subpages

--- a/google-cloud-service_usage-v1/proto_docs/google/api/documentation.rb
+++ b/google-cloud-service_usage-v1/proto_docs/google/api/documentation.rb
@@ -161,7 +161,7 @@ module Google
     #     `[Java][Tutorial.Java]`.
     # @!attribute [rw] content
     #   @return [::String]
-    #     The Markdown content of the page. You can use ```(== include {path}
+    #     The Markdown content of the page. You can use ```(== include \\{path}
     #     ==)``` to include content from a Markdown file. The content can be used
     #     to produce the documentation page such as HTML format page.
     # @!attribute [rw] subpages

--- a/google-cloud-spanner-admin-instance-v1/lib/google/cloud/spanner/admin/instance/v1/instance_admin/client.rb
+++ b/google-cloud-spanner-admin-instance-v1/lib/google/cloud/spanner/admin/instance/v1/instance_admin/client.rb
@@ -1156,7 +1156,7 @@ module Google
                 #
                 #   @param parent [::String]
                 #     Required. The instance whose instance partitions should be listed. Values
-                #     are of the form `projects/<project>/instances/<instance>`. Use `{instance}
+                #     are of the form `projects/<project>/instances/<instance>`. Use `\\{instance}
                 #     = '-'` to list instance partitions for all Instances in a project, e.g.,
                 #     `projects/myproject/instances/-`.
                 #   @param page_size [::Integer]

--- a/google-cloud-spanner-admin-instance-v1/lib/google/cloud/spanner/admin/instance/v1/instance_admin/rest/client.rb
+++ b/google-cloud-spanner-admin-instance-v1/lib/google/cloud/spanner/admin/instance/v1/instance_admin/rest/client.rb
@@ -1099,7 +1099,7 @@ module Google
                   #
                   #   @param parent [::String]
                   #     Required. The instance whose instance partitions should be listed. Values
-                  #     are of the form `projects/<project>/instances/<instance>`. Use `{instance}
+                  #     are of the form `projects/<project>/instances/<instance>`. Use `\\{instance}
                   #     = '-'` to list instance partitions for all Instances in a project, e.g.,
                   #     `projects/myproject/instances/-`.
                   #   @param page_size [::Integer]

--- a/google-cloud-spanner-admin-instance-v1/proto_docs/google/spanner/admin/instance/v1/spanner_instance_admin.rb
+++ b/google-cloud-spanner-admin-instance-v1/proto_docs/google/spanner/admin/instance/v1/spanner_instance_admin.rb
@@ -1365,7 +1365,7 @@ module Google
             # @!attribute [rw] parent
             #   @return [::String]
             #     Required. The instance whose instance partitions should be listed. Values
-            #     are of the form `projects/<project>/instances/<instance>`. Use `{instance}
+            #     are of the form `projects/<project>/instances/<instance>`. Use `\\{instance}
             #     = '-'` to list instance partitions for all Instances in a project, e.g.,
             #     `projects/myproject/instances/-`.
             # @!attribute [rw] page_size

--- a/google-cloud-spanner-v1/proto_docs/google/spanner/v1/result_set.rb
+++ b/google-cloud-spanner-v1/proto_docs/google/spanner/v1/result_set.rb
@@ -215,7 +215,7 @@ module Google
         #     A SQL query can be parameterized. In PLAN mode, these parameters can be
         #     undeclared. This indicates the field names and types for those undeclared
         #     parameters in the SQL query. For example, a SQL query like `"SELECT * FROM
-        #     Users where UserId = @userId and UserName = @userName "` could return a
+        #     Users where UserId = `@userId` and UserName = `@userName` "` could return a
         #     `undeclared_parameters` value like:
         #
         #         "fields": [

--- a/google-cloud-talent-v4/proto_docs/google/cloud/talent/v4/job.rb
+++ b/google-cloud-talent-v4/proto_docs/google/cloud/talent/v4/job.rb
@@ -161,7 +161,7 @@ module Google
         #
         #     Language codes must be in BCP-47 format, such as "en-US" or "sr-Latn".
         #     For more information, see
-        #     [Tags for Identifying Languages](https://tools.ietf.org/html/bcp47){:
+        #     [Tags for Identifying Languages](https://tools.ietf.org/html/bcp47)\\{:
         #     class="external" target="_blank" }.
         #
         #     If this field is unspecified and

--- a/google-cloud-talent-v4beta1/proto_docs/google/cloud/talent/v4beta1/job.rb
+++ b/google-cloud-talent-v4beta1/proto_docs/google/cloud/talent/v4beta1/job.rb
@@ -155,7 +155,7 @@ module Google
         #
         #     Language codes must be in BCP-47 format, such as "en-US" or "sr-Latn".
         #     For more information, see
-        #     [Tags for Identifying Languages](https://tools.ietf.org/html/bcp47){:
+        #     [Tags for Identifying Languages](https://tools.ietf.org/html/bcp47)\\{:
         #     class="external" target="_blank" }.
         #
         #     If this field is unspecified and

--- a/google-cloud-text_to_speech-v1/proto_docs/google/cloud/texttospeech/v1/cloud_tts.rb
+++ b/google-cloud-text_to_speech-v1/proto_docs/google/cloud/texttospeech/v1/cloud_tts.rb
@@ -196,7 +196,7 @@ module Google
             # https://en.wikipedia.org/wiki/International_Phonetic_Alphabet
             PHONETIC_ENCODING_IPA = 1
 
-            # X-SAMPA, such as apple -> "{p@l".
+            # X-SAMPA, such as apple -> "\\{p@l".
             # https://en.wikipedia.org/wiki/X-SAMPA
             PHONETIC_ENCODING_X_SAMPA = 2
 

--- a/google-cloud-text_to_speech-v1beta1/proto_docs/google/cloud/texttospeech/v1beta1/cloud_tts.rb
+++ b/google-cloud-text_to_speech-v1beta1/proto_docs/google/cloud/texttospeech/v1beta1/cloud_tts.rb
@@ -208,7 +208,7 @@ module Google
             # https://en.wikipedia.org/wiki/International_Phonetic_Alphabet
             PHONETIC_ENCODING_IPA = 1
 
-            # X-SAMPA, such as apple -> "{p@l".
+            # X-SAMPA, such as apple -> "\\{p@l".
             # https://en.wikipedia.org/wiki/X-SAMPA
             PHONETIC_ENCODING_X_SAMPA = 2
 

--- a/google-shopping-merchant-accounts-v1/proto_docs/google/shopping/merchant/accounts/v1/shippingsettings.rb
+++ b/google-shopping-merchant-accounts-v1/proto_docs/google/shopping/merchant/accounts/v1/shippingsettings.rb
@@ -600,7 +600,7 @@ module Google
           #   @return [::Array<::Google::Shopping::Type::Price>]
           #     Required. A list of inclusive order price upper bounds. The last price's
           #     value can be infinity by setting price amount_micros = -1. For example
-          #     `[{"amount_micros": 10000000, "currency_code": "USD"},
+          #     `[\\{"amount_micros": 10000000, "currency_code": "USD"},
           #     \\{"amount_micros": 500000000, "currency_code": "USD"},
           #     \\{"amount_micros": -1, "currency_code": "USD"}]` represents the headers
           #     "<= $10", "<= $500", and "> $500". All prices within a service must have
@@ -610,7 +610,7 @@ module Google
           #   @return [::Array<::Google::Shopping::Type::Weight>]
           #     Required. A list of inclusive order weight upper bounds. The last weight's
           #     value can be infinity by setting price amount_micros = -1. For example
-          #     `[{"amount_micros": 10000000, "unit": "kg"}, {"amount_micros": 50000000,
+          #     `[\\{"amount_micros": 10000000, "unit": "kg"}, \\{"amount_micros": 50000000,
           #     "unit": "kg"},
           #     \\{"amount_micros": -1, "unit": "kg"}]` represents the headers
           #     "<= 10kg", "<= 50kg", and "> 50kg". All weights within a service must have

--- a/google-shopping-merchant-accounts-v1beta/proto_docs/google/shopping/merchant/accounts/v1beta/shippingsettings.rb
+++ b/google-shopping-merchant-accounts-v1beta/proto_docs/google/shopping/merchant/accounts/v1beta/shippingsettings.rb
@@ -594,7 +594,7 @@ module Google
           #   @return [::Array<::Google::Shopping::Type::Price>]
           #     Required. A list of inclusive order price upper bounds. The last price's
           #     value can be infinity by setting price amount_micros = -1. For example
-          #     `[{"amount_micros": 10000000, "currency_code": "USD"},
+          #     `[\\{"amount_micros": 10000000, "currency_code": "USD"},
           #     \\{"amount_micros": 500000000, "currency_code": "USD"},
           #     \\{"amount_micros": -1, "currency_code": "USD"}]` represents the headers
           #     "<= $10", "<= $500", and "> $500". All prices within a service must have
@@ -604,7 +604,7 @@ module Google
           #   @return [::Array<::Google::Shopping::Type::Weight>]
           #     Required. A list of inclusive order weight upper bounds. The last weight's
           #     value can be infinity by setting price amount_micros = -1. For example
-          #     `[{"amount_micros": 10000000, "unit": "kg"}, {"amount_micros": 50000000,
+          #     `[\\{"amount_micros": 10000000, "unit": "kg"}, \\{"amount_micros": 50000000,
           #     "unit": "kg"},
           #     \\{"amount_micros": -1, "unit": "kg"}]` represents the headers
           #     "<= 10kg", "<= 50kg", and "> 50kg". All weights within a service must have


### PR DESCRIPTION
### Summary

This draft PR previews code regeneration across libraries generated with the fixes in [googleapis/gapic-generator-ruby#1337](https://github.com/googleapis/gapic-generator-ruby/pull/1337).

### Changes
- Escapes multi-line braces (`(?<!\\)\{(?=[^\s])` -> `\\{`) outside backtick spans in proto docstrings, preventing multiline JSON examples and ranges (e.g. `{min: ...\n...}` or `{100, 200, ...}`) from being misparsed by YARD as broken object links.
- Sanitizes unknown doc tags (`(?<=\A|\s)@tag` outside backtick spans -> `` `@tag` ``) so tags like `@pattern` and `@required` in proto comments are rendered as literal text rather than unrecognized YARD tags.

### Verification
- Ran `librarian generate --all` with locally installed `gapic-generator` gem.
- Verified `toys ci --yard --gems google-cloud-compute-v1` passes with 0 warnings and 0 errors.
- Verified `toys ci --test --rubocop --doctest --gems google-cloud-compute-v1` passes with 0 errors/failures.

Related:
- https://github.com/googleapis/gapic-generator-ruby/pull/1337
- https://github.com/googleapis/librarian/issues/7461
- https://github.com/googleapis/librarian/issues/7452