### PR TITLE
chore: update librarian version to v0.40.0

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: ruby
-version: v0.39.1-0.20260831182628-509cd77c2487
+version: v0.40.0
 sources:
   googleapis:
     commit: 40c9c54b96bfc48dc7794aa55166c3b560abdbd4


### PR DESCRIPTION
Update librarian version to v0.40.0.
### Included Librarian Updates
- googleapis/librarian#7413: fix(librarian): add validates path existence in sources
