### PR TITLE
chore: update gapic-generator-cloud to 0.52.0

### DIFF
--- a/google-apps-chat-v1/lib/google/apps/chat/v1/chat_service/client.rb
+++ b/google-apps-chat-v1/lib/google/apps/chat/v1/chat_service/client.rb
@@ -4165,26 +4165,26 @@ module Google
             #     For example, the following queries are valid:
             #
             #     ```
-            #     user.name = "users/\\{user}"
+            #     user.name = "users/{user}"
             #     emoji.unicode = "🙂"
-            #     emoji.custom_emoji.uid = "\\{uid}"
+            #     emoji.custom_emoji.uid = "{uid}"
             #     emoji.unicode = "🙂" OR emoji.unicode = "👍"
-            #     emoji.unicode = "🙂" OR emoji.custom_emoji.uid = "\\{uid}"
-            #     emoji.unicode = "🙂" AND user.name = "users/\\{user}"
-            #     (emoji.unicode = "🙂" OR emoji.custom_emoji.uid = "\\{uid}")
-            #     AND user.name = "users/\\{user}"
+            #     emoji.unicode = "🙂" OR emoji.custom_emoji.uid = "{uid}"
+            #     emoji.unicode = "🙂" AND user.name = "users/{user}"
+            #     (emoji.unicode = "🙂" OR emoji.custom_emoji.uid = "{uid}")
+            #     AND user.name = "users/{user}"
             #     ```
             #
             #     The following queries are invalid:
             #
             #     ```
             #     emoji.unicode = "🙂" AND emoji.unicode = "👍"
-            #     emoji.unicode = "🙂" AND emoji.custom_emoji.uid = "\\{uid}"
-            #     emoji.unicode = "🙂" OR user.name = "users/\\{user}"
-            #     emoji.unicode = "🙂" OR emoji.custom_emoji.uid = "\\{uid}" OR
-            #     user.name = "users/\\{user}"
-            #     emoji.unicode = "🙂" OR emoji.custom_emoji.uid = "\\{uid}"
-            #     AND user.name = "users/\\{user}"
+            #     emoji.unicode = "🙂" AND emoji.custom_emoji.uid = "{uid}"
+            #     emoji.unicode = "🙂" OR user.name = "users/{user}"
+            #     emoji.unicode = "🙂" OR emoji.custom_emoji.uid = "{uid}" OR
+            #     user.name = "users/{user}"
+            #     emoji.unicode = "🙂" OR emoji.custom_emoji.uid = "{uid}"
+            #     AND user.name = "users/{user}"
             #     ```
             #
             #     Invalid queries are rejected with an `INVALID_ARGUMENT` error.

--- a/google-apps-chat-v1/lib/google/apps/chat/v1/chat_service/rest/client.rb
+++ b/google-apps-chat-v1/lib/google/apps/chat/v1/chat_service/rest/client.rb
@@ -4038,26 +4038,26 @@ module Google
               #     For example, the following queries are valid:
               #
               #     ```
-              #     user.name = "users/\\{user}"
+              #     user.name = "users/{user}"
               #     emoji.unicode = "🙂"
-              #     emoji.custom_emoji.uid = "\\{uid}"
+              #     emoji.custom_emoji.uid = "{uid}"
               #     emoji.unicode = "🙂" OR emoji.unicode = "👍"
-              #     emoji.unicode = "🙂" OR emoji.custom_emoji.uid = "\\{uid}"
-              #     emoji.unicode = "🙂" AND user.name = "users/\\{user}"
-              #     (emoji.unicode = "🙂" OR emoji.custom_emoji.uid = "\\{uid}")
-              #     AND user.name = "users/\\{user}"
+              #     emoji.unicode = "🙂" OR emoji.custom_emoji.uid = "{uid}"
+              #     emoji.unicode = "🙂" AND user.name = "users/{user}"
+              #     (emoji.unicode = "🙂" OR emoji.custom_emoji.uid = "{uid}")
+              #     AND user.name = "users/{user}"
               #     ```
               #
               #     The following queries are invalid:
               #
               #     ```
               #     emoji.unicode = "🙂" AND emoji.unicode = "👍"
-              #     emoji.unicode = "🙂" AND emoji.custom_emoji.uid = "\\{uid}"
-              #     emoji.unicode = "🙂" OR user.name = "users/\\{user}"
-              #     emoji.unicode = "🙂" OR emoji.custom_emoji.uid = "\\{uid}" OR
-              #     user.name = "users/\\{user}"
-              #     emoji.unicode = "🙂" OR emoji.custom_emoji.uid = "\\{uid}"
-              #     AND user.name = "users/\\{user}"
+              #     emoji.unicode = "🙂" AND emoji.custom_emoji.uid = "{uid}"
+              #     emoji.unicode = "🙂" OR user.name = "users/{user}"
+              #     emoji.unicode = "🙂" OR emoji.custom_emoji.uid = "{uid}" OR
+              #     user.name = "users/{user}"
+              #     emoji.unicode = "🙂" OR emoji.custom_emoji.uid = "{uid}"
+              #     AND user.name = "users/{user}"
               #     ```
               #
               #     Invalid queries are rejected with an `INVALID_ARGUMENT` error.

--- a/google-apps-chat-v1/proto_docs/google/apps/card/v1/card.rb
+++ b/google-apps-chat-v1/proto_docs/google/apps/card/v1/card.rb
@@ -1751,7 +1751,7 @@ module Google
         #     settings under **Customize**.
         # @!attribute [rw] weight
         #   @return [::Integer]
-        #     The stroke weight of the icon. Choose from {100, 200, 300, 400,
+        #     The stroke weight of the icon. Choose from \\{100, 200, 300, 400,
         #     500, 600, 700}. If absent, default value is 400. If any other value is
         #     specified, the default value is used.
         #

--- a/google-apps-chat-v1/proto_docs/google/chat/v1/annotation.rb
+++ b/google-apps-chat-v1/proto_docs/google/chat/v1/annotation.rb
@@ -40,7 +40,7 @@ module Google
         #   "length":7,
         #   "userMention": {
         #     "user": {
-        #       "name":"users/\\{user}",
+        #       "name":"users/{user}",
         #       "displayName":"FooBot",
         #       "avatarUrl":"https://goo.gl/aeDtrS",
         #       "type":"BOT"

--- a/google-apps-chat-v1/proto_docs/google/chat/v1/reaction.rb
+++ b/google-apps-chat-v1/proto_docs/google/chat/v1/reaction.rb
@@ -176,26 +176,26 @@ module Google
         #     For example, the following queries are valid:
         #
         #     ```
-        #     user.name = "users/\\{user}"
+        #     user.name = "users/{user}"
         #     emoji.unicode = "🙂"
-        #     emoji.custom_emoji.uid = "\\{uid}"
+        #     emoji.custom_emoji.uid = "{uid}"
         #     emoji.unicode = "🙂" OR emoji.unicode = "👍"
-        #     emoji.unicode = "🙂" OR emoji.custom_emoji.uid = "\\{uid}"
-        #     emoji.unicode = "🙂" AND user.name = "users/\\{user}"
-        #     (emoji.unicode = "🙂" OR emoji.custom_emoji.uid = "\\{uid}")
-        #     AND user.name = "users/\\{user}"
+        #     emoji.unicode = "🙂" OR emoji.custom_emoji.uid = "{uid}"
+        #     emoji.unicode = "🙂" AND user.name = "users/{user}"
+        #     (emoji.unicode = "🙂" OR emoji.custom_emoji.uid = "{uid}")
+        #     AND user.name = "users/{user}"
         #     ```
         #
         #     The following queries are invalid:
         #
         #     ```
         #     emoji.unicode = "🙂" AND emoji.unicode = "👍"
-        #     emoji.unicode = "🙂" AND emoji.custom_emoji.uid = "\\{uid}"
-        #     emoji.unicode = "🙂" OR user.name = "users/\\{user}"
-        #     emoji.unicode = "🙂" OR emoji.custom_emoji.uid = "\\{uid}" OR
-        #     user.name = "users/\\{user}"
-        #     emoji.unicode = "🙂" OR emoji.custom_emoji.uid = "\\{uid}"
-        #     AND user.name = "users/\\{user}"
+        #     emoji.unicode = "🙂" AND emoji.custom_emoji.uid = "{uid}"
+        #     emoji.unicode = "🙂" OR user.name = "users/{user}"
+        #     emoji.unicode = "🙂" OR emoji.custom_emoji.uid = "{uid}" OR
+        #     user.name = "users/{user}"
+        #     emoji.unicode = "🙂" OR emoji.custom_emoji.uid = "{uid}"
+        #     AND user.name = "users/{user}"
         #     ```
         #
         #     Invalid queries are rejected with an `INVALID_ARGUMENT` error.

--- a/google-apps-chat-v1/proto_docs/google/chat/v1/space.rb
+++ b/google-apps-chat-v1/proto_docs/google/chat/v1/space.rb
@@ -338,7 +338,7 @@ module Google
           #     Optional. Setting for toggling space history on and off.
           # @!attribute [rw] use_at_mention_all
           #   @return [::Google::Apps::Chat::V1::Space::PermissionSetting]
-          #     Optional. Setting for using @all in a space.
+          #     Optional. Setting for using `@all` in a space.
           # @!attribute [rw] manage_apps
           #   @return [::Google::Apps::Chat::V1::Space::PermissionSetting]
           #     Optional. Setting for managing apps in a space.

--- a/google-apps-chat-v1/proto_docs/google/chat/v1/space_notification_setting.rb
+++ b/google-apps-chat-v1/proto_docs/google/chat/v1/space_notification_setting.rb
@@ -42,16 +42,16 @@ module Google
             # Reserved.
             NOTIFICATION_SETTING_UNSPECIFIED = 0
 
-            # Notifications are triggered by @mentions, followed threads, first
+            # Notifications are triggered by `@mentions`, followed threads, first
             # message of new threads. All new threads are automatically followed,
             # unless manually unfollowed by the user.
             ALL = 1
 
-            # The notification is triggered by @mentions, followed threads, first
+            # The notification is triggered by `@mentions`, followed threads, first
             # message of new threads. Not available for 1:1 direct messages.
             MAIN_CONVERSATIONS = 2
 
-            # The notification is triggered by @mentions, followed threads. Not
+            # The notification is triggered by `@mentions`, followed threads. Not
             # available for 1:1 direct messages.
             FOR_YOU = 3
 

--- a/google-apps-events-subscriptions-v1/lib/google/apps/events/subscriptions/v1/subscriptions_service/client.rb
+++ b/google-apps-events-subscriptions-v1/lib/google/apps/events/subscriptions/v1/subscriptions_service/client.rb
@@ -559,11 +559,11 @@ module Google
               #       event_types:"google.workspace.chat.message.v1.created"
               #
               #     event_types:"google.workspace.chat.message.v1.created" AND
-              #       target_resource="//chat.googleapis.com/spaces/\\{space}"
+              #       target_resource="//chat.googleapis.com/spaces/{space}"
               #
               #     ( event_types:"google.workspace.chat.membership.v1.updated" OR
               #       event_types:"google.workspace.chat.message.v1.created" ) AND
-              #       target_resource="//chat.googleapis.com/spaces/\\{space}"
+              #       target_resource="//chat.googleapis.com/spaces/{space}"
               #     ```
               #
               #     The server rejects invalid queries with an `INVALID_ARGUMENT`

--- a/google-apps-events-subscriptions-v1/lib/google/apps/events/subscriptions/v1/subscriptions_service/rest/client.rb
+++ b/google-apps-events-subscriptions-v1/lib/google/apps/events/subscriptions/v1/subscriptions_service/rest/client.rb
@@ -539,11 +539,11 @@ module Google
                 #       event_types:"google.workspace.chat.message.v1.created"
                 #
                 #     event_types:"google.workspace.chat.message.v1.created" AND
-                #       target_resource="//chat.googleapis.com/spaces/\\{space}"
+                #       target_resource="//chat.googleapis.com/spaces/{space}"
                 #
                 #     ( event_types:"google.workspace.chat.membership.v1.updated" OR
                 #       event_types:"google.workspace.chat.message.v1.created" ) AND
-                #       target_resource="//chat.googleapis.com/spaces/\\{space}"
+                #       target_resource="//chat.googleapis.com/spaces/{space}"
                 #     ```
                 #
                 #     The server rejects invalid queries with an `INVALID_ARGUMENT`

--- a/google-apps-events-subscriptions-v1/proto_docs/google/apps/events/subscriptions/v1/subscriptions_service.rb
+++ b/google-apps-events-subscriptions-v1/proto_docs/google/apps/events/subscriptions/v1/subscriptions_service.rb
@@ -153,11 +153,11 @@ module Google
           #       event_types:"google.workspace.chat.message.v1.created"
           #
           #     event_types:"google.workspace.chat.message.v1.created" AND
-          #       target_resource="//chat.googleapis.com/spaces/\\{space}"
+          #       target_resource="//chat.googleapis.com/spaces/{space}"
           #
           #     ( event_types:"google.workspace.chat.membership.v1.updated" OR
           #       event_types:"google.workspace.chat.message.v1.created" ) AND
-          #       target_resource="//chat.googleapis.com/spaces/\\{space}"
+          #       target_resource="//chat.googleapis.com/spaces/{space}"
           #     ```
           #
           #     The server rejects invalid queries with an `INVALID_ARGUMENT`

--- a/google-apps-events-subscriptions-v1beta/lib/google/apps/events/subscriptions/v1beta/subscriptions_service/client.rb
+++ b/google-apps-events-subscriptions-v1beta/lib/google/apps/events/subscriptions/v1beta/subscriptions_service/client.rb
@@ -559,11 +559,11 @@ module Google
               #       event_types:"google.workspace.chat.message.v1.created"
               #
               #     event_types:"google.workspace.chat.message.v1.created" AND
-              #       target_resource="//chat.googleapis.com/spaces/\\{space}"
+              #       target_resource="//chat.googleapis.com/spaces/{space}"
               #
               #     ( event_types:"google.workspace.chat.membership.v1.updated" OR
               #       event_types:"google.workspace.chat.message.v1.created" ) AND
-              #       target_resource="//chat.googleapis.com/spaces/\\{space}"
+              #       target_resource="//chat.googleapis.com/spaces/{space}"
               #     ```
               #
               #     The server rejects invalid queries with an `INVALID_ARGUMENT`

--- a/google-apps-events-subscriptions-v1beta/lib/google/apps/events/subscriptions/v1beta/subscriptions_service/rest/client.rb
+++ b/google-apps-events-subscriptions-v1beta/lib/google/apps/events/subscriptions/v1beta/subscriptions_service/rest/client.rb
@@ -539,11 +539,11 @@ module Google
                 #       event_types:"google.workspace.chat.message.v1.created"
                 #
                 #     event_types:"google.workspace.chat.message.v1.created" AND
-                #       target_resource="//chat.googleapis.com/spaces/\\{space}"
+                #       target_resource="//chat.googleapis.com/spaces/{space}"
                 #
                 #     ( event_types:"google.workspace.chat.membership.v1.updated" OR
                 #       event_types:"google.workspace.chat.message.v1.created" ) AND
-                #       target_resource="//chat.googleapis.com/spaces/\\{space}"
+                #       target_resource="//chat.googleapis.com/spaces/{space}"
                 #     ```
                 #
                 #     The server rejects invalid queries with an `INVALID_ARGUMENT`

--- a/google-apps-events-subscriptions-v1beta/proto_docs/google/apps/events/subscriptions/v1beta/subscriptions_service.rb
+++ b/google-apps-events-subscriptions-v1beta/proto_docs/google/apps/events/subscriptions/v1beta/subscriptions_service.rb
@@ -159,11 +159,11 @@ module Google
           #       event_types:"google.workspace.chat.message.v1.created"
           #
           #     event_types:"google.workspace.chat.message.v1.created" AND
-          #       target_resource="//chat.googleapis.com/spaces/\\{space}"
+          #       target_resource="//chat.googleapis.com/spaces/{space}"
           #
           #     ( event_types:"google.workspace.chat.membership.v1.updated" OR
           #       event_types:"google.workspace.chat.message.v1.created" ) AND
-          #       target_resource="//chat.googleapis.com/spaces/\\{space}"
+          #       target_resource="//chat.googleapis.com/spaces/{space}"
           #     ```
           #
           #     The server rejects invalid queries with an `INVALID_ARGUMENT`

--- a/google-apps-meet-v2/proto_docs/google/apps/meet/v2/resource.rb
+++ b/google-apps-meet-v2/proto_docs/google/apps/meet/v2/resource.rb
@@ -282,7 +282,7 @@ module Google
         #   @return [::String]
         #     Output only. The `fileId` for the underlying MP4 file. For example,
         #     "1kuceFZohVoCh6FulBHxwy6I15Ogpc4hP". Use `$ GET
-        #     https://www.googleapis.com/drive/v3/files/\\{$fileId}?alt=media` to download
+        #     https://www.googleapis.com/drive/v3/files/{$fileId}?alt=media` to download
         #     the blob. For more information, see
         #     https://developers.google.com/drive/api/v3/reference/files/get.
         # @!attribute [r] export_uri

--- a/google-apps-meet-v2beta/proto_docs/google/apps/meet/v2beta/resource.rb
+++ b/google-apps-meet-v2beta/proto_docs/google/apps/meet/v2beta/resource.rb
@@ -478,7 +478,7 @@ module Google
         #   @return [::String]
         #     Output only. The `fileId` for the underlying MP4 file. For example,
         #     "1kuceFZohVoCh6FulBHxwy6I15Ogpc4hP". Use `$ GET
-        #     https://www.googleapis.com/drive/v3/files/\\{$fileId}?alt=media` to download
+        #     https://www.googleapis.com/drive/v3/files/{$fileId}?alt=media` to download
         #     the blob. For more information, see
         #     https://developers.google.com/drive/api/v3/reference/files/get.
         # @!attribute [r] export_uri

--- a/google-cloud-agent_registry-v1/proto_docs/google/cloud/agentregistry/v1/agent.rb
+++ b/google-cloud-agent_registry-v1/proto_docs/google/cloud/agentregistry/v1/agent.rb
@@ -67,10 +67,10 @@ module Google
         #     Output only. Attributes of the Agent.
         #     Valid values:
         #
-        #      * `agentregistry.googleapis.com/system/Framework`: {"framework":
+        #      * `agentregistry.googleapis.com/system/Framework`: \\{"framework":
         #      "google-adk"} - the agent framework used to develop the Agent. Example
         #      values: "google-adk", "langchain", "custom".
-        #      * `agentregistry.googleapis.com/system/RuntimeIdentity`: {"principal":
+        #      * `agentregistry.googleapis.com/system/RuntimeIdentity`: \\{"principal":
         #      "principal://..."} - the runtime identity associated with the Agent.
         #      * `agentregistry.googleapis.com/system/RuntimeReference`: \\{"uri": "//..."}
         #      - the URI of the underlying resource hosting the Agent, for

--- a/google-cloud-agent_registry-v1/proto_docs/google/cloud/agentregistry/v1/mcp_server.rb
+++ b/google-cloud-agent_registry-v1/proto_docs/google/cloud/agentregistry/v1/mcp_server.rb
@@ -52,7 +52,7 @@ module Google
         #     Output only. Attributes of the MCP Server.
         #     Valid values:
         #
-        #      * `agentregistry.googleapis.com/system/RuntimeIdentity`: {"principal":
+        #      * `agentregistry.googleapis.com/system/RuntimeIdentity`: \\{"principal":
         #      "principal://..."} - the runtime identity associated with the MCP Server.
         #      * `agentregistry.googleapis.com/system/RuntimeReference`: \\{"uri": "//..."}
         #      - the URI of the underlying resource hosting the MCP Server, for

--- a/google-cloud-ai_platform-v1/lib/google/cloud/ai_platform/v1/featurestore_online_serving_service/client.rb
+++ b/google-cloud-ai_platform-v1/lib/google/cloud/ai_platform/v1/featurestore_online_serving_service/client.rb
@@ -440,7 +440,7 @@ module Google
             #     Required. The resource name of the EntityType for the entities being
             #     written. Value format:
             #     `projects/{project}/locations/{location}/featurestores/
-            #     \\{featurestore}/entityTypes/\\{entityType}`. For example,
+            #     {featurestore}/entityTypes/{entityType}`. For example,
             #     for a machine learning model predicting user clicks on a website, an
             #     EntityType ID could be `user`.
             #   @param payloads [::Array<::Google::Cloud::AIPlatform::V1::WriteFeatureValuesPayload, ::Hash>]

--- a/google-cloud-ai_platform-v1/lib/google/cloud/ai_platform/v1/featurestore_online_serving_service/rest/client.rb
+++ b/google-cloud-ai_platform-v1/lib/google/cloud/ai_platform/v1/featurestore_online_serving_service/rest/client.rb
@@ -423,7 +423,7 @@ module Google
               #     Required. The resource name of the EntityType for the entities being
               #     written. Value format:
               #     `projects/{project}/locations/{location}/featurestores/
-              #     \\{featurestore}/entityTypes/\\{entityType}`. For example,
+              #     {featurestore}/entityTypes/{entityType}`. For example,
               #     for a machine learning model predicting user clicks on a website, an
               #     EntityType ID could be `user`.
               #   @param payloads [::Array<::Google::Cloud::AIPlatform::V1::WriteFeatureValuesPayload, ::Hash>]

--- a/google-cloud-ai_platform-v1/proto_docs/google/cloud/aiplatform/v1/evaluation_service.rb
+++ b/google-cloud-ai_platform-v1/proto_docs/google/cloud/aiplatform/v1/evaluation_service.rb
@@ -556,7 +556,7 @@ module Google
         #     Required. The type of the computation based metric.
         # @!attribute [rw] parameters
         #   @return [::Google::Protobuf::Struct]
-        #     Optional. A map of parameters for the metric, e.g. {"rouge_type":
+        #     Optional. A map of parameters for the metric, e.g. \\{"rouge_type":
         #     "rougeL"}.
         class ComputationBasedMetricSpec
           include ::Google::Protobuf::MessageExts

--- a/google-cloud-ai_platform-v1/proto_docs/google/cloud/aiplatform/v1/featurestore_online_service.rb
+++ b/google-cloud-ai_platform-v1/proto_docs/google/cloud/aiplatform/v1/featurestore_online_service.rb
@@ -28,7 +28,7 @@ module Google
         #     Required. The resource name of the EntityType for the entities being
         #     written. Value format:
         #     `projects/{project}/locations/{location}/featurestores/
-        #     \\{featurestore}/entityTypes/\\{entityType}`. For example,
+        #     {featurestore}/entityTypes/{entityType}`. For example,
         #     for a machine learning model predicting user clicks on a website, an
         #     EntityType ID could be `user`.
         # @!attribute [rw] payloads

--- a/google-cloud-bigquery-analytics_hub-v1/proto_docs/google/cloud/bigquery/analyticshub/v1/pubsub.rb
+++ b/google-cloud-bigquery-analytics_hub-v1/proto_docs/google/cloud/bigquery/analyticshub/v1/pubsub.rb
@@ -525,24 +525,24 @@ module Google
           #       /**
           #       * Transforms a Pub/Sub message.
           #
-          #       * @return \\{(Object<string, (string | Object<string, string>)>|null)} - To
+          #       * @return {(Object<string, (string | Object<string, string>)>|null)} - To
           #       * filter a message, return `null`. To transform a message return a map
           #       * with the following keys:
-          #       *   - (required) 'data' : \\{string}
-          #       *   - (optional) 'attributes' : \\{Object<string, string>}
+          #       *   - (required) 'data' : {string}
+          #       *   - (optional) 'attributes' : {Object<string, string>}
           #       * Returning empty `attributes` will remove all attributes from the
           #       * message.
           #       *
-          #       * @param  \\{(Object<string, (string | Object<string, string>)>} Pub/Sub
+          #       * @param  {(Object<string, (string | Object<string, string>)>} Pub/Sub
           #       * message. Keys:
-          #       *   - (required) 'data' : \\{string}
-          #       *   - (required) 'attributes' : \\{Object<string, string>}
+          #       *   - (required) 'data' : {string}
+          #       *   - (required) 'attributes' : {Object<string, string>}
           #       *
-          #       * @param  \\{Object<string, any>} metadata - Pub/Sub message metadata.
+          #       * @param  {Object<string, any>} metadata - Pub/Sub message metadata.
           #       * Keys:
-          #       *   - (required) 'message_id'  : \\{string}
-          #       *   - (optional) 'publish_time': \\{string} YYYY-MM-DDTHH:MM:SSZ format
-          #       *   - (optional) 'ordering_key': \\{string}
+          #       *   - (required) 'message_id'  : {string}
+          #       *   - (optional) 'publish_time': {string} YYYY-MM-DDTHH:MM:SSZ format
+          #       *   - (optional) 'ordering_key': {string}
           #       */
           #
           #       function <function_name>(message, metadata) {

--- a/google-cloud-bigtable-v2/lib/google/cloud/bigtable/v2/bigtable/client.rb
+++ b/google-cloud-bigtable-v2/lib/google/cloud/bigtable/v2/bigtable/client.rb
@@ -1333,7 +1333,7 @@ module Google
             #     `@` character followed by the parameter name (for example, `@firstName`) in
             #     the query string.
             #
-            #     For example, if param_types["firstName"] = Bytes then @firstName will be a
+            #     For example, if param_types["firstName"] = Bytes then `@firstName` will be a
             #     query parameter of type Bytes. The specific `Value` to be used for the
             #     query execution must be sent in `ExecuteQueryRequest` in the `params` map.
             #

--- a/google-cloud-bigtable-v2/lib/google/cloud/bigtable/v2/bigtable/rest/client.rb
+++ b/google-cloud-bigtable-v2/lib/google/cloud/bigtable/v2/bigtable/rest/client.rb
@@ -1197,7 +1197,7 @@ module Google
               #     `@` character followed by the parameter name (for example, `@firstName`) in
               #     the query string.
               #
-              #     For example, if param_types["firstName"] = Bytes then @firstName will be a
+              #     For example, if param_types["firstName"] = Bytes then `@firstName` will be a
               #     query parameter of type Bytes. The specific `Value` to be used for the
               #     query execution must be sent in `ExecuteQueryRequest` in the `params` map.
               # @yield [result, operation] Access the result along with the TransportOperation object

--- a/google-cloud-bigtable-v2/proto_docs/google/bigtable/v2/bigtable.rb
+++ b/google-cloud-bigtable-v2/proto_docs/google/bigtable/v2/bigtable.rb
@@ -926,7 +926,7 @@ module Google
         #     `@` character followed by the parameter name (for example, `@firstName`) in
         #     the query string.
         #
-        #     For example, if param_types["firstName"] = Bytes then @firstName will be a
+        #     For example, if param_types["firstName"] = Bytes then `@firstName` will be a
         #     query parameter of type Bytes. The specific `Value` to be used for the
         #     query execution must be sent in `ExecuteQueryRequest` in the `params` map.
         class PrepareQueryRequest

--- a/google-cloud-chronicle-v1/lib/google/cloud/chronicle/v1/rule_execution_error_service/client.rb
+++ b/google-cloud-chronicle-v1/lib/google/cloud/chronicle/v1/rule_execution_error_service/client.rb
@@ -226,8 +226,8 @@ module Google
             #     A filter that can be used to retrieve specific rule execution errors.
             #     Only the following filters are allowed:
             #     ```
-            #       rule = "\\{Rule.name}"
-            #       curated_rule = "\\{CuratedRule.name}"
+            #       rule = "{Rule.name}"
+            #       curated_rule = "{CuratedRule.name}"
             #     ```
             #     The value for rule or curated_rule must be a valid rule resource name or a
             #     valid curated rule resource name specified in quotes.
@@ -238,9 +238,9 @@ module Google
             #     corresponding to the most recent revision of the rule will be returned. So
             #     these variations are all allowed:
             #     ```
-            #       rule = "\\{Rule.name}"
-            #       rule = "\\{Rule.name}@\\{Rule.revision_id}"
-            #       rule = "\\{Rule.name}@-"
+            #       rule = "{Rule.name}"
+            #       rule = "{Rule.name}@{Rule.revision_id}"
+            #       rule = "{Rule.name}@-"
             #     ```
             #     Revision IDs are not supported for curated rules.
             #

--- a/google-cloud-chronicle-v1/lib/google/cloud/chronicle/v1/rule_execution_error_service/rest/client.rb
+++ b/google-cloud-chronicle-v1/lib/google/cloud/chronicle/v1/rule_execution_error_service/rest/client.rb
@@ -219,8 +219,8 @@ module Google
               #     A filter that can be used to retrieve specific rule execution errors.
               #     Only the following filters are allowed:
               #     ```
-              #       rule = "\\{Rule.name}"
-              #       curated_rule = "\\{CuratedRule.name}"
+              #       rule = "{Rule.name}"
+              #       curated_rule = "{CuratedRule.name}"
               #     ```
               #     The value for rule or curated_rule must be a valid rule resource name or a
               #     valid curated rule resource name specified in quotes.
@@ -231,9 +231,9 @@ module Google
               #     corresponding to the most recent revision of the rule will be returned. So
               #     these variations are all allowed:
               #     ```
-              #       rule = "\\{Rule.name}"
-              #       rule = "\\{Rule.name}@\\{Rule.revision_id}"
-              #       rule = "\\{Rule.name}@-"
+              #       rule = "{Rule.name}"
+              #       rule = "{Rule.name}@{Rule.revision_id}"
+              #       rule = "{Rule.name}@-"
               #     ```
               #     Revision IDs are not supported for curated rules.
               # @yield [result, operation] Access the result along with the TransportOperation object

--- a/google-cloud-chronicle-v1/proto_docs/google/cloud/chronicle/v1/rule_execution_error.rb
+++ b/google-cloud-chronicle-v1/proto_docs/google/cloud/chronicle/v1/rule_execution_error.rb
@@ -45,8 +45,8 @@ module Google
         #     A filter that can be used to retrieve specific rule execution errors.
         #     Only the following filters are allowed:
         #     ```
-        #       rule = "\\{Rule.name}"
-        #       curated_rule = "\\{CuratedRule.name}"
+        #       rule = "{Rule.name}"
+        #       curated_rule = "{CuratedRule.name}"
         #     ```
         #     The value for rule or curated_rule must be a valid rule resource name or a
         #     valid curated rule resource name specified in quotes.
@@ -57,9 +57,9 @@ module Google
         #     corresponding to the most recent revision of the rule will be returned. So
         #     these variations are all allowed:
         #     ```
-        #       rule = "\\{Rule.name}"
-        #       rule = "\\{Rule.name}@\\{Rule.revision_id}"
-        #       rule = "\\{Rule.name}@-"
+        #       rule = "{Rule.name}"
+        #       rule = "{Rule.name}@{Rule.revision_id}"
+        #       rule = "{Rule.name}@-"
         #     ```
         #     Revision IDs are not supported for curated rules.
         class ListRuleExecutionErrorsRequest

--- a/google-cloud-cloud_security_compliance-v1/proto_docs/google/cloud/cloudsecuritycompliance/v1/deployment.rb
+++ b/google-cloud-cloud_security_compliance-v1/proto_docs/google/cloud/cloudsecuritycompliance/v1/deployment.rb
@@ -86,11 +86,11 @@ module Google
         #     {
         #      cloud_control_deployment_reference: {
         #        cloud_control_deployment:
-        #        "organizations/\\{organization}/locations/\\{location}/cloudControlDeployments/cc-deployment-1"
+        #        "organizations/{organization}/locations/{location}/cloudControlDeployments/cc-deployment-1"
         #      },
         #      cloud_control_deployment_reference: {
         #       cloud_control_deployment:
-        #       "organizations/\\{organization}/locations/\\{location}/cloudControlDeployments/cc-deployment-2"
+        #       "organizations/{organization}/locations/{location}/cloudControlDeployments/cc-deployment-2"
         #      }
         #     ```
         class FrameworkDeployment
@@ -436,7 +436,7 @@ module Google
         #     ```
         #     {
         #       framework:
-        #       "organizations/\\{organization}/locations/\\{location}/frameworks/\\{framework}",
+        #       "organizations/{organization}/locations/{location}/frameworks/{framework}",
         #       major_revision_id: 1
         #     }
         #     ```

--- a/google-cloud-config_delivery-v1/proto_docs/google/cloud/configdelivery/v1/config_delivery.rb
+++ b/google-cloud-config_delivery-v1/proto_docs/google/cloud/configdelivery/v1/config_delivery.rb
@@ -26,7 +26,7 @@ module Google
         #   @return [::String]
         #     Identifier. Name of the `ResourceBundle`. Format is
         #     `projects/{project}/locations/{location}/resourceBundle
-        #     /[a-z][a-z0-9\-]\\{0,62}`.
+        #     /[a-z][a-z0-9\-]{0,62}`.
         # @!attribute [r] create_time
         #   @return [::Google::Protobuf::Timestamp]
         #     Output only. Time `ResourceBundle` was created.

--- a/google-cloud-config_service-v1/proto_docs/google/cloud/config/v1/config.rb
+++ b/google-cloud-config_service-v1/proto_docs/google/cloud/config/v1/config.rb
@@ -47,7 +47,7 @@ module Google
         #   @return [::String]
         #     Output only. Revision name that was most recently applied.
         #     Format: `projects/{project}/locations/{location}/deployments/{deployment}/
-        #     revisions/\\{revision}`
+        #     revisions/{revision}`
         # @!attribute [r] state_detail
         #   @return [::String]
         #     Output only. Additional information regarding the current state.
@@ -794,7 +794,7 @@ module Google
         #   @return [::String]
         #     Revision name. Format:
         #     `projects/{project}/locations/{location}/deployments/{deployment}/
-        #     revisions/\\{revision}`
+        #     revisions/{revision}`
         # @!attribute [r] create_time
         #   @return [::Google::Protobuf::Timestamp]
         #     Output only. Time when the revision was created.

--- a/google-cloud-data_catalog-v1/lib/google/cloud/data_catalog/v1/data_catalog/client.rb
+++ b/google-cloud-data_catalog-v1/lib/google/cloud/data_catalog/v1/data_catalog/client.rb
@@ -1338,7 +1338,7 @@ module Google
             #     Examples:
             #
             #     * `pubsub.topic.{PROJECT_ID}.{TOPIC_ID}`
-            #     * `pubsub.topic.{PROJECT_ID}.`\``{TOPIC.ID.SEPARATED.WITH.DOTS}`\`
+            #     * `pubsub.topic.{PROJECT_ID}.`\``\\{TOPIC.ID.SEPARATED.WITH.DOTS}`\`
             #     * `bigquery.table.{PROJECT_ID}.{DATASET_ID}.{TABLE_ID}`
             #     * `bigquery.dataset.{PROJECT_ID}.{DATASET_ID}`
             #     * `datacatalog.entry.{PROJECT_ID}.{LOCATION_ID}.{ENTRY_GROUP_ID}.{ENTRY_ID}`

--- a/google-cloud-data_catalog-v1/lib/google/cloud/data_catalog/v1/data_catalog/rest/client.rb
+++ b/google-cloud-data_catalog-v1/lib/google/cloud/data_catalog/v1/data_catalog/rest/client.rb
@@ -1246,7 +1246,7 @@ module Google
               #     Examples:
               #
               #     * `pubsub.topic.{PROJECT_ID}.{TOPIC_ID}`
-              #     * `pubsub.topic.{PROJECT_ID}.`\``{TOPIC.ID.SEPARATED.WITH.DOTS}`\`
+              #     * `pubsub.topic.{PROJECT_ID}.`\``\\{TOPIC.ID.SEPARATED.WITH.DOTS}`\`
               #     * `bigquery.table.{PROJECT_ID}.{DATASET_ID}.{TABLE_ID}`
               #     * `bigquery.dataset.{PROJECT_ID}.{DATASET_ID}`
               #     * `datacatalog.entry.{PROJECT_ID}.{LOCATION_ID}.{ENTRY_GROUP_ID}.{ENTRY_ID}`

--- a/google-cloud-data_catalog-v1/proto_docs/google/cloud/datacatalog/v1/datacatalog.rb
+++ b/google-cloud-data_catalog-v1/proto_docs/google/cloud/datacatalog/v1/datacatalog.rb
@@ -372,7 +372,7 @@ module Google
         #     Examples:
         #
         #     * `pubsub.topic.{PROJECT_ID}.{TOPIC_ID}`
-        #     * `pubsub.topic.{PROJECT_ID}.`\``{TOPIC.ID.SEPARATED.WITH.DOTS}`\`
+        #     * `pubsub.topic.{PROJECT_ID}.`\``\\{TOPIC.ID.SEPARATED.WITH.DOTS}`\`
         #     * `bigquery.table.{PROJECT_ID}.{DATASET_ID}.{TABLE_ID}`
         #     * `bigquery.dataset.{PROJECT_ID}.{DATASET_ID}`
         #     * `datacatalog.entry.{PROJECT_ID}.{LOCATION_ID}.{ENTRY_GROUP_ID}.{ENTRY_ID}`

--- a/google-cloud-dataflow-v1beta3/proto_docs/google/dataflow/v1beta3/jobs.rb
+++ b/google-cloud-dataflow-v1beta3/proto_docs/google/dataflow/v1beta3/jobs.rb
@@ -900,7 +900,7 @@ module Google
         # be a partial response, depending on the page size in the ListJobsRequest.
         # However, if the project does not have any jobs, an instance of
         # ListJobsResponse is not returned and the requests's response
-        # body is empty {}.
+        # body is empty \\{}.
         # @!attribute [rw] jobs
         #   @return [::Array<::Google::Cloud::Dataflow::V1beta3::Job>]
         #     A subset of the requested job information.

--- a/google-cloud-dataplex-v1/proto_docs/google/cloud/dataplex/v1/data_quality.rb
+++ b/google-cloud-dataplex-v1/proto_docs/google/cloud/dataplex/v1/data_quality.rb
@@ -798,7 +798,7 @@ module Google
           # aliases](https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#explicit_alias_syntax).
           #
           # Example: `SELECT MIN(col1) AS min_col1, MAX(col1) AS max_col1 FROM
-          # $\\{data()}`
+          # ${data()}`
           # @!attribute [rw] description
           #   @return [::String]
           #     Optional. Specifies the description of the debug query.

--- a/google-cloud-dataqna-v1alpha/proto_docs/google/cloud/dataqna/v1alpha/annotated_string.rb
+++ b/google-cloud-dataqna-v1alpha/proto_docs/google/cloud/dataqna/v1alpha/annotated_string.rb
@@ -43,9 +43,9 @@ module Google
         #
         # ```
         # markups = [
-        #   \\{DIMENSION, 4, 12}, // 'countries'
-        #   \\{METRIC, 17, 26}, // 'population'
-        #   \\{FILTER, 31, 36}  // 'Africa'
+        #   {DIMENSION, 4, 12}, // 'countries'
+        #   {METRIC, 17, 26}, // 'population'
+        #   {FILTER, 31, 36}  // 'Africa'
         # ]
         # ```
         #

--- a/google-cloud-dataqna-v1alpha/proto_docs/google/cloud/dataqna/v1alpha/auto_suggestion_service.rb
+++ b/google-cloud-dataqna-v1alpha/proto_docs/google/cloud/dataqna/v1alpha/auto_suggestion_service.rb
@@ -92,8 +92,8 @@ module Google
           #  text_formatted = "top product_group"
           #  html_formatted = "top <b>product_group</b>"
           #  markups {
-          #   \\{type: TEXT, start_char_index: 0, length: 3}
-          #   \\{type: DIMENSION, start_char_index: 4, length: 13}
+          #   {type: TEXT, start_char_index: 0, length: 3}
+          #   {type: DIMENSION, start_char_index: 4, length: 13}
           #  }
           # }
           #

--- a/google-cloud-dialogflow-cx-v3/proto_docs/google/cloud/dialogflow/cx/v3/agent.rb
+++ b/google-cloud-dialogflow-cx-v3/proto_docs/google/cloud/dialogflow/cx/v3/agent.rb
@@ -206,7 +206,7 @@ module Google
             #   @return [::String]
             #     Required. The full name of the Gen App Builder engine related to this
             #     agent if there is one. Format: `projects/{Project ID}/locations/{Location
-            #     ID}/collections/\\{Collection ID}/engines/\\{Engine ID}`
+            #     ID}/collections/{Collection ID}/engines/{Engine ID}`
             class GenAppBuilderSettings
               include ::Google::Protobuf::MessageExts
               extend ::Google::Protobuf::MessageExts::ClassMethods

--- a/google-cloud-dialogflow-cx-v3/proto_docs/google/cloud/dialogflow/cx/v3/session.rb
+++ b/google-cloud-dialogflow-cx-v3/proto_docs/google/cloud/dialogflow/cx/v3/session.rb
@@ -626,8 +626,8 @@ module Google
           #     {
           #       "subscription plan": "Business Premium Plus",
           #       "devices owned": [
-          #         \\{"model": "Google Pixel 7"},
-          #         \\{"model": "Google Pixel Tablet"}
+          #         {"model": "Google Pixel 7"},
+          #         {"model": "Google Pixel Tablet"}
           #       ]
           #     }
           #     ```

--- a/google-cloud-dialogflow-v2/lib/google/cloud/dialogflow/v2/conversations/client.rb
+++ b/google-cloud-dialogflow-v2/lib/google/cloud/dialogflow/v2/conversations/client.rb
@@ -1188,8 +1188,8 @@ module Google
             #     {
             #       "subscription plan": "Business Premium Plus",
             #       "devices owned": [
-            #         \\{"model": "Google Pixel 7"},
-            #         \\{"model": "Google Pixel Tablet"}
+            #         {"model": "Google Pixel 7"},
+            #         {"model": "Google Pixel Tablet"}
             #       ]
             #     }
             #     ```

--- a/google-cloud-dialogflow-v2/lib/google/cloud/dialogflow/v2/conversations/rest/client.rb
+++ b/google-cloud-dialogflow-v2/lib/google/cloud/dialogflow/v2/conversations/rest/client.rb
@@ -1119,8 +1119,8 @@ module Google
               #     {
               #       "subscription plan": "Business Premium Plus",
               #       "devices owned": [
-              #         \\{"model": "Google Pixel 7"},
-              #         \\{"model": "Google Pixel Tablet"}
+              #         {"model": "Google Pixel 7"},
+              #         {"model": "Google Pixel Tablet"}
               #       ]
               #     }
               #     ```

--- a/google-cloud-dialogflow-v2/proto_docs/google/cloud/dialogflow/v2/agent.rb
+++ b/google-cloud-dialogflow-v2/proto_docs/google/cloud/dialogflow/v2/agent.rb
@@ -103,7 +103,7 @@ module Google
             MATCH_MODE_HYBRID = 1
 
             # Can be used for agents with a large number of examples in intents,
-            # especially the ones using @sys.any or very large custom entities.
+            # especially the ones using `@sys`.any or very large custom entities.
             MATCH_MODE_ML_ONLY = 2
           end
 

--- a/google-cloud-dialogflow-v2/proto_docs/google/cloud/dialogflow/v2/agent_coaching_instruction.rb
+++ b/google-cloud-dialogflow-v2/proto_docs/google/cloud/dialogflow/v2/agent_coaching_instruction.rb
@@ -41,7 +41,7 @@ module Google
         # @!attribute [rw] system_action
         #   @return [::String]
         #     Optional. The action that system should take. For example,
-        #     "call GetOrderTime with order_number={order number provided by the
+        #     "call GetOrderTime with order_number=\\{order number provided by the
         #     customer}". If the users don't have plugins or don't want to trigger
         #     plugins, the system_action can be empty
         # @!attribute [r] duplicate_check_result

--- a/google-cloud-dialogflow-v2/proto_docs/google/cloud/dialogflow/v2/audio_config.rb
+++ b/google-cloud-dialogflow-v2/proto_docs/google/cloud/dialogflow/v2/audio_config.rb
@@ -263,7 +263,7 @@ module Google
             # https://en.wikipedia.org/wiki/International_Phonetic_Alphabet
             PHONETIC_ENCODING_IPA = 1
 
-            # X-SAMPA, such as apple -> "{p@l".
+            # X-SAMPA, such as apple -> "\\{p@l".
             # https://en.wikipedia.org/wiki/X-SAMPA
             PHONETIC_ENCODING_X_SAMPA = 2
           end

--- a/google-cloud-dialogflow-v2/proto_docs/google/cloud/dialogflow/v2/conversation.rb
+++ b/google-cloud-dialogflow-v2/proto_docs/google/cloud/dialogflow/v2/conversation.rb
@@ -605,7 +605,7 @@ module Google
           #   @return [::Array<::Google::Cloud::Dialogflow::V2::Message>]
           #     Required. The messages that the Summary will be generated from. It is
           #     expected that this message content is already redacted and does not
-          #     contain any PII. Required fields: {content, language_code, participant,
+          #     contain any PII. Required fields: \\{content, language_code, participant,
           #     participant_role} Optional fields: \\{send_time} If send_time is not
           #     provided, then the messages must be provided in chronological order.
           # @!attribute [rw] parent
@@ -785,8 +785,8 @@ module Google
         #     {
         #       "subscription plan": "Business Premium Plus",
         #       "devices owned": [
-        #         \\{"model": "Google Pixel 7"},
-        #         \\{"model": "Google Pixel Tablet"}
+        #         {"model": "Google Pixel 7"},
+        #         {"model": "Google Pixel Tablet"}
         #       ]
         #     }
         #     ```

--- a/google-cloud-discovery_engine-v1beta/proto_docs/google/cloud/discoveryengine/v1beta/assistant.rb
+++ b/google-cloud-discovery_engine-v1beta/proto_docs/google/cloud/discoveryengine/v1beta/assistant.rb
@@ -64,7 +64,7 @@ module Google
         #     The values consist of admin enabled tools towards the connector
         #     instance. Admin can selectively enable multiple tools on any of the
         #     connector instances that they created in the project. For example
-        #     {"jira1ConnectorName": [(toolId1, "createTicket"), (toolId2,
+        #     \\{"jira1ConnectorName": [(toolId1, "createTicket"), (toolId2,
         #     "transferTicket")],
         #      "gmail1ConnectorName": [(toolId3, "sendEmail"),..] }
         # @!attribute [rw] customer_policy

--- a/google-cloud-error_reporting-v1beta1/lib/google/cloud/error_reporting/v1beta1/report_errors_service/client.rb
+++ b/google-cloud-error_reporting-v1beta1/lib/google/cloud/error_reporting/v1beta1/report_errors_service/client.rb
@@ -194,7 +194,7 @@ module Google
             # a `key` parameter. For example:
             #
             # `POST
-            # https://clouderrorreporting.googleapis.com/v1beta1/\\{projectName}/events:report?key=123ABC456`
+            # https://clouderrorreporting.googleapis.com/v1beta1/{projectName}/events:report?key=123ABC456`
             #
             # **Note:** [Error Reporting] (https://cloud.google.com/error-reporting)
             # is a service built on Cloud Logging and can analyze log entries when all of

--- a/google-cloud-error_reporting-v1beta1/lib/google/cloud/error_reporting/v1beta1/report_errors_service/rest/client.rb
+++ b/google-cloud-error_reporting-v1beta1/lib/google/cloud/error_reporting/v1beta1/report_errors_service/rest/client.rb
@@ -187,7 +187,7 @@ module Google
               # a `key` parameter. For example:
               #
               # `POST
-              # https://clouderrorreporting.googleapis.com/v1beta1/\\{projectName}/events:report?key=123ABC456`
+              # https://clouderrorreporting.googleapis.com/v1beta1/{projectName}/events:report?key=123ABC456`
               #
               # **Note:** [Error Reporting] (https://cloud.google.com/error-reporting)
               # is a service built on Cloud Logging and can analyze log entries when all of

--- a/google-cloud-eventarc-v1/proto_docs/google/cloud/eventarc/v1/enrollment.rb
+++ b/google-cloud-eventarc-v1/proto_docs/google/cloud/eventarc/v1/enrollment.rb
@@ -66,7 +66,7 @@ module Google
         #   @return [::String]
         #     Required. Destination is the Pipeline that the Enrollment is delivering to.
         #     It must point to the full resource name of a Pipeline. Format:
-        #     "projects/\\{PROJECT_ID}/locations/\\{region}/pipelines/{PIPELINE_ID)"
+        #     "projects/\\{PROJECT_ID}/locations/\\{region}/pipelines/\\{PIPELINE_ID)"
         class Enrollment
           include ::Google::Protobuf::MessageExts
           extend ::Google::Protobuf::MessageExts::ClassMethods

--- a/google-cloud-eventarc-v1/proto_docs/google/cloud/eventarc/v1/google_api_source.rb
+++ b/google-cloud-eventarc-v1/proto_docs/google/cloud/eventarc/v1/google_api_source.rb
@@ -56,7 +56,7 @@ module Google
         #     Required. Destination is the message bus that the GoogleApiSource is
         #     delivering to. It must be point to the full resource name of a MessageBus.
         #     Format:
-        #     "projects/\\{PROJECT_ID}/locations/\\{region}/messagesBuses/{MESSAGE_BUS_ID)
+        #     "projects/\\{PROJECT_ID}/locations/\\{region}/messagesBuses/\\{MESSAGE_BUS_ID)
         # @!attribute [rw] crypto_key_name
         #   @return [::String]
         #     Optional. Resource name of a KMS crypto key (managed by the user) used to

--- a/google-cloud-eventarc-v1/proto_docs/google/cloud/eventarc/v1/pipeline.rb
+++ b/google-cloud-eventarc-v1/proto_docs/google/cloud/eventarc/v1/pipeline.rb
@@ -297,7 +297,7 @@ module Google
             #
             #     ```
             #     {
-            #       "headers": headers.merge(\\{"new-header-key": "new-header-value"}),
+            #       "headers": headers.merge({"new-header-key": "new-header-value"}),
             #       "body": "new-body"
             #     }
             #     ```

--- a/google-cloud-gemini_data_analytics-v1/proto_docs/google/cloud/geminidataanalytics/v1/context.rb
+++ b/google-cloud-gemini_data_analytics-v1/proto_docs/google/cloud/geminidataanalytics/v1/context.rb
@@ -172,7 +172,7 @@ module Google
         #   @return [::Array<::Google::Cloud::GeminiDataAnalytics::V1::QueryParameter>]
         #     Optional. The list of query parameters.
         #     Example: The parameterized SQL query
-        #     "SELECT * FROM my_table WHERE id = @id" can be matched with any value of
+        #     "SELECT * FROM my_table WHERE id = `@id`" can be matched with any value of
         #     id.
         class ExampleQuery
           include ::Google::Protobuf::MessageExts

--- a/google-cloud-gemini_data_analytics-v1beta/proto_docs/google/cloud/geminidataanalytics/v1beta/context.rb
+++ b/google-cloud-gemini_data_analytics-v1beta/proto_docs/google/cloud/geminidataanalytics/v1beta/context.rb
@@ -172,7 +172,7 @@ module Google
         #   @return [::Array<::Google::Cloud::GeminiDataAnalytics::V1beta::QueryParameter>]
         #     Optional. The list of query parameters.
         #     Example: The parameterized SQL query
-        #     "SELECT * FROM my_table WHERE id = @id" can be matched with any value of
+        #     "SELECT * FROM my_table WHERE id = `@id`" can be matched with any value of
         #     id.
         class ExampleQuery
           include ::Google::Protobuf::MessageExts

--- a/google-cloud-iap-v1/lib/google/cloud/iap/v1/identity_aware_proxy_admin_service/client.rb
+++ b/google-cloud-iap-v1/lib/google/cloud/iap/v1/identity_aware_proxy_admin_service/client.rb
@@ -676,7 +676,7 @@ module Google
             #   @param expression [::String]
             #     Required. User input string expression. Should be of the form
             #     `attributes.saml_attributes.filter(attribute, attribute.name in
-            #     ['\\{attribute_name}', '\\{attribute_name}'])`
+            #     ['{attribute_name}', '{attribute_name}'])`
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [::Google::Cloud::Iap::V1::ValidateIapAttributeExpressionResponse]

--- a/google-cloud-iap-v1/lib/google/cloud/iap/v1/identity_aware_proxy_admin_service/rest/client.rb
+++ b/google-cloud-iap-v1/lib/google/cloud/iap/v1/identity_aware_proxy_admin_service/rest/client.rb
@@ -634,7 +634,7 @@ module Google
               #   @param expression [::String]
               #     Required. User input string expression. Should be of the form
               #     `attributes.saml_attributes.filter(attribute, attribute.name in
-              #     ['\\{attribute_name}', '\\{attribute_name}'])`
+              #     ['{attribute_name}', '{attribute_name}'])`
               # @yield [result, operation] Access the result along with the TransportOperation object
               # @yieldparam result [::Google::Cloud::Iap::V1::ValidateIapAttributeExpressionResponse]
               # @yieldparam operation [::Gapic::Rest::TransportOperation]

--- a/google-cloud-iap-v1/proto_docs/google/cloud/iap/v1/service.rb
+++ b/google-cloud-iap-v1/proto_docs/google/cloud/iap/v1/service.rb
@@ -503,7 +503,7 @@ module Google
         #   @return [::String]
         #     Required. User input string expression. Should be of the form
         #     `attributes.saml_attributes.filter(attribute, attribute.name in
-        #     ['\\{attribute_name}', '\\{attribute_name}'])`
+        #     ['{attribute_name}', '{attribute_name}'])`
         class ValidateIapAttributeExpressionRequest
           include ::Google::Protobuf::MessageExts
           extend ::Google::Protobuf::MessageExts::ClassMethods

--- a/google-cloud-netapp-v1/proto_docs/google/cloud/netapp/v1/volume.rb
+++ b/google-cloud-netapp-v1/proto_docs/google/cloud/netapp/v1/volume.rb
@@ -850,7 +850,7 @@ module Google
         #     backend. The name must meet the following requirements:
         #     *   Be between 1 and 255 characters long.
         #     *   Contain only uppercase or lowercase letters (A-Z, a-z), numbers (0-9),
-        #         and the following special characters: "-", "_", "}", "{", ".".
+        #         and the following special characters: "-", "_", "}", "\\{", ".".
         #     *   Spaces are not allowed.
         # @!attribute [rw] host_groups
         #   @return [::Array<::String>]

--- a/google-cloud-network_services-v1/proto_docs/google/cloud/networkservices/v1/extensibility.rb
+++ b/google-cloud-network_services-v1/proto_docs/google/cloud/networkservices/v1/extensibility.rb
@@ -109,7 +109,7 @@ module Google
           #
           #     * Generic artifacts: the `plugin_config_uri` must be in this format:
           #     `projects/{project}/locations/{location}/repositories/{repository}/
-          #     genericArtifacts/\\{package}:\\{version}`.
+          #     genericArtifacts/{package}:{version}`.
           #     The specified package and version must contain a file with the name
           #     `plugin.config`. When a new `WasmPluginVersion` resource is
           #     created, the checksum of the contents of the file is saved in the
@@ -145,7 +145,7 @@ module Google
           #
           #     * Generic artifacts: the `image_uri` must be in this format:
           #     `projects/{project}/locations/{location}/repositories/{repository}/
-          #     genericArtifacts/\\{package}:\\{version}`.
+          #     genericArtifacts/{package}:{version}`.
           #     The specified package and version must contain a file with the name
           #     `plugin.wasm`. When a new `WasmPluginVersion` resource is created, the
           #     checksum of the contents of the file is saved in the `image_digest`
@@ -296,7 +296,7 @@ module Google
         #
         #     * Generic artifacts: the `plugin_config_uri` must be in this format:
         #     `projects/{project}/locations/{location}/repositories/{repository}/
-        #     genericArtifacts/\\{package}:\\{version}`.
+        #     genericArtifacts/{package}:{version}`.
         #     The specified package and version must contain a file with the name
         #     `plugin.config`. When a new `WasmPluginVersion` resource is
         #     created, the checksum of the contents of the file is saved in the
@@ -307,7 +307,7 @@ module Google
         #   @return [::String]
         #     Identifier. Name of the `WasmPluginVersion` resource in the following
         #     format: `projects/{project}/locations/{location}/wasmPlugins/{wasm_plugin}/
-        #     versions/\\{wasm_plugin_version}`.
+        #     versions/{wasm_plugin_version}`.
         # @!attribute [r] create_time
         #   @return [::Google::Protobuf::Timestamp]
         #     Output only. The timestamp when the resource was created.
@@ -337,7 +337,7 @@ module Google
         #
         #     * Generic artifacts: the `image_uri` must be in this format:
         #     `projects/{project}/locations/{location}/repositories/{repository}/
-        #     genericArtifacts/\\{package}:\\{version}`.
+        #     genericArtifacts/{package}:{version}`.
         #     The specified package and version must contain a file with the name
         #     `plugin.wasm`. When a new `WasmPluginVersion` resource is created, the
         #     checksum of the contents of the file is saved in the `image_digest`

--- a/google-cloud-optimization-v1/proto_docs/google/cloud/optimization/v1/fleet_routing.rb
+++ b/google-cloud-optimization-v1/proto_docs/google/cloud/optimization/v1/fleet_routing.rb
@@ -2914,7 +2914,7 @@ module Google
         #     done as follows:
         #     ```
         #     fields { name: "vehicles" index: 4}
-        #     fields { name: "shipments" index: 2 sub_field \\{name: "pickups" index: 0} }
+        #     fields { name: "shipments" index: 2 sub_field {name: "pickups" index: 0} }
         #     ```
         #     Note, however, that the cardinality of `fields` should not change for a
         #     given error code.

--- a/google-cloud-oracle_database-v1/lib/google/cloud/oracle_database/v1/oracle_database/client.rb
+++ b/google-cloud-oracle_database-v1/lib/google/cloud/oracle_database/v1/oracle_database/client.rb
@@ -1774,7 +1774,7 @@ module Google
             #     Optional. An expression for filtering the results of the request. Only the
             #     `shape_family` and `gcp_oracle_zone_id` fields are supported in the
             #     following format: `shape_family="{shape_family}" AND
-            #     gcp_oracle_zone_id="\\{gcp_oracle_zone_id}"`.
+            #     gcp_oracle_zone_id="{gcp_oracle_zone_id}"`.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [::Gapic::PagedEnumerable<::Google::Cloud::OracleDatabase::V1::MinorVersion>]
@@ -1878,7 +1878,7 @@ module Google
             #     `gcp_oracle_zone_id`, `shape_family`, and `database_edition` fields
             #     are supported in the following format:
             #     `gcp_oracle_zone_id="{gcp_oracle_zone_id}" AND
-            #     shape_family="\\{shape_family}" AND database_edition="\\{database_edition}"`.
+            #     shape_family="{shape_family}" AND database_edition="{database_edition}"`.
             #
             # @yield [response, operation] Access the result along with the RPC operation
             # @yieldparam response [::Gapic::PagedEnumerable<::Google::Cloud::OracleDatabase::V1::DbSystemShape>]
@@ -7816,7 +7816,7 @@ module Google
             #   @param filter [::String]
             #     Optional. Filter expression that matches a subset of the DbVersions to
             #     show. The supported filter for dbSystem creation is `db_system_shape =
-            #     \\{db_system_shape} AND storage_management = \\{storage_management}`. If no
+            #     {db_system_shape} AND storage_management = {storage_management}`. If no
             #     filter is provided, all DbVersions will be returned.
             #
             # @yield [response, operation] Access the result along with the RPC operation

--- a/google-cloud-oracle_database-v1/lib/google/cloud/oracle_database/v1/oracle_database/rest/client.rb
+++ b/google-cloud-oracle_database-v1/lib/google/cloud/oracle_database/v1/oracle_database/rest/client.rb
@@ -1677,7 +1677,7 @@ module Google
               #     Optional. An expression for filtering the results of the request. Only the
               #     `shape_family` and `gcp_oracle_zone_id` fields are supported in the
               #     following format: `shape_family="{shape_family}" AND
-              #     gcp_oracle_zone_id="\\{gcp_oracle_zone_id}"`.
+              #     gcp_oracle_zone_id="{gcp_oracle_zone_id}"`.
               # @yield [result, operation] Access the result along with the TransportOperation object
               # @yieldparam result [::Gapic::Rest::PagedEnumerable<::Google::Cloud::OracleDatabase::V1::MinorVersion>]
               # @yieldparam operation [::Gapic::Rest::TransportOperation]
@@ -1774,7 +1774,7 @@ module Google
               #     `gcp_oracle_zone_id`, `shape_family`, and `database_edition` fields
               #     are supported in the following format:
               #     `gcp_oracle_zone_id="{gcp_oracle_zone_id}" AND
-              #     shape_family="\\{shape_family}" AND database_edition="\\{database_edition}"`.
+              #     shape_family="{shape_family}" AND database_edition="{database_edition}"`.
               # @yield [result, operation] Access the result along with the TransportOperation object
               # @yieldparam result [::Gapic::Rest::PagedEnumerable<::Google::Cloud::OracleDatabase::V1::DbSystemShape>]
               # @yieldparam operation [::Gapic::Rest::TransportOperation]
@@ -7299,7 +7299,7 @@ module Google
               #   @param filter [::String]
               #     Optional. Filter expression that matches a subset of the DbVersions to
               #     show. The supported filter for dbSystem creation is `db_system_shape =
-              #     \\{db_system_shape} AND storage_management = \\{storage_management}`. If no
+              #     {db_system_shape} AND storage_management = {storage_management}`. If no
               #     filter is provided, all DbVersions will be returned.
               # @yield [result, operation] Access the result along with the TransportOperation object
               # @yieldparam result [::Gapic::Rest::PagedEnumerable<::Google::Cloud::OracleDatabase::V1::DbVersion>]

--- a/google-cloud-oracle_database-v1/proto_docs/google/cloud/oracledatabase/v1/db_version.rb
+++ b/google-cloud-oracle_database-v1/proto_docs/google/cloud/oracledatabase/v1/db_version.rb
@@ -78,7 +78,7 @@ module Google
         #   @return [::String]
         #     Optional. Filter expression that matches a subset of the DbVersions to
         #     show. The supported filter for dbSystem creation is `db_system_shape =
-        #     \\{db_system_shape} AND storage_management = \\{storage_management}`. If no
+        #     {db_system_shape} AND storage_management = {storage_management}`. If no
         #     filter is provided, all DbVersions will be returned.
         class ListDbVersionsRequest
           include ::Google::Protobuf::MessageExts

--- a/google-cloud-oracle_database-v1/proto_docs/google/cloud/oracledatabase/v1/minor_version.rb
+++ b/google-cloud-oracle_database-v1/proto_docs/google/cloud/oracledatabase/v1/minor_version.rb
@@ -58,7 +58,7 @@ module Google
         #     Optional. An expression for filtering the results of the request. Only the
         #     `shape_family` and `gcp_oracle_zone_id` fields are supported in the
         #     following format: `shape_family="{shape_family}" AND
-        #     gcp_oracle_zone_id="\\{gcp_oracle_zone_id}"`.
+        #     gcp_oracle_zone_id="{gcp_oracle_zone_id}"`.
         class ListMinorVersionsRequest
           include ::Google::Protobuf::MessageExts
           extend ::Google::Protobuf::MessageExts::ClassMethods

--- a/google-cloud-oracle_database-v1/proto_docs/google/cloud/oracledatabase/v1/oracledatabase.rb
+++ b/google-cloud-oracle_database-v1/proto_docs/google/cloud/oracledatabase/v1/oracledatabase.rb
@@ -374,7 +374,7 @@ module Google
         #     `gcp_oracle_zone_id`, `shape_family`, and `database_edition` fields
         #     are supported in the following format:
         #     `gcp_oracle_zone_id="{gcp_oracle_zone_id}" AND
-        #     shape_family="\\{shape_family}" AND database_edition="\\{database_edition}"`.
+        #     shape_family="{shape_family}" AND database_edition="{database_edition}"`.
         class ListDbSystemShapesRequest
           include ::Google::Protobuf::MessageExts
           extend ::Google::Protobuf::MessageExts::ClassMethods

--- a/google-cloud-pubsub-v1/proto_docs/google/pubsub/v1/pubsub.rb
+++ b/google-cloud-pubsub-v1/proto_docs/google/pubsub/v1/pubsub.rb
@@ -755,24 +755,24 @@ module Google
         #       /**
         #       * Transforms a Pub/Sub message.
         #
-        #       * @return \\{(Object<string, (string | Object<string, string>)>|null)} - To
+        #       * @return {(Object<string, (string | Object<string, string>)>|null)} - To
         #       * filter a message, return `null`. To transform a message return a map
         #       * with the following keys:
-        #       *   - (required) 'data' : \\{string}
-        #       *   - (optional) 'attributes' : \\{Object<string, string>}
+        #       *   - (required) 'data' : {string}
+        #       *   - (optional) 'attributes' : {Object<string, string>}
         #       * Returning empty `attributes` will remove all attributes from the
         #       * message.
         #       *
-        #       * @param  \\{(Object<string, (string | Object<string, string>)>} Pub/Sub
+        #       * @param  {(Object<string, (string | Object<string, string>)>} Pub/Sub
         #       * message. Keys:
-        #       *   - (required) 'data' : \\{string}
-        #       *   - (required) 'attributes' : \\{Object<string, string>}
+        #       *   - (required) 'data' : {string}
+        #       *   - (required) 'attributes' : {Object<string, string>}
         #       *
-        #       * @param  \\{Object<string, any>} metadata - Pub/Sub message metadata.
+        #       * @param  {Object<string, any>} metadata - Pub/Sub message metadata.
         #       * Keys:
-        #       *   - (optional) 'message_id'  : \\{string}
-        #       *   - (optional) 'publish_time': \\{string} YYYY-MM-DDTHH:MM:SSZ format
-        #       *   - (optional) 'ordering_key': \\{string}
+        #       *   - (optional) 'message_id'  : {string}
+        #       *   - (optional) 'publish_time': {string} YYYY-MM-DDTHH:MM:SSZ format
+        #       *   - (optional) 'ordering_key': {string}
         #       */
         #
         #       function <function_name>(message, metadata) {

--- a/google-cloud-recommendation_engine-v1beta1/proto_docs/google/cloud/recommendationengine/v1beta1/common.rb
+++ b/google-cloud-recommendation_engine-v1beta1/proto_docs/google/cloud/recommendationengine/v1beta1/common.rb
@@ -33,7 +33,7 @@ module Google
         #     Feature names and values must be UTF-8 encoded strings.
         #
         #     For example: `{ "colors": {"value": ["yellow", "green"]},
-        #                     "sizes": \\{"value":["S", "M"]}`
+        #                     "sizes": {"value":["S", "M"]}`
         # @!attribute [rw] numerical_features
         #   @return [::Google::Protobuf::Map{::String => ::Google::Cloud::RecommendationEngine::V1beta1::FeatureMap::FloatList}]
         #     Numerical features. Some examples would be the height/weight of a product,
@@ -42,7 +42,7 @@ module Google
         #     Feature names must be UTF-8 encoded strings.
         #
         #     For example: `{ "lengths_cm": {"value":[2.3, 15.4]},
-        #                     "heights_cm": \\{"value":[8.1, 6.4]} }`
+        #                     "heights_cm": {"value":[8.1, 6.4]} }`
         class FeatureMap
           include ::Google::Protobuf::MessageExts
           extend ::Google::Protobuf::MessageExts::ClassMethods

--- a/google-cloud-retail-v2/lib/google/cloud/retail/v2/prediction_service/client.rb
+++ b/google-cloud-retail-v2/lib/google/cloud/retail/v2/prediction_service/client.rb
@@ -321,12 +321,12 @@ module Google
             #        will return generic (unfiltered) popular products instead of empty if
             #        your filter blocks all prediction results.
             #     * `priceRerankLevel`: String. Default empty. If set to be non-empty, then
-            #        it needs to be one of {'no-price-reranking', 'low-price-reranking',
+            #        it needs to be one of \\{'no-price-reranking', 'low-price-reranking',
             #        'medium-price-reranking', 'high-price-reranking'}. This gives
             #        request-level control and adjusts prediction results based on product
             #        price.
             #     * `diversityLevel`: String. Default empty. If set to be non-empty, then
-            #        it needs to be one of {'no-diversity', 'low-diversity',
+            #        it needs to be one of \\{'no-diversity', 'low-diversity',
             #        'medium-diversity', 'high-diversity', 'auto-diversity'}. This gives
             #        request-level control and adjusts prediction results based on product
             #        category.

--- a/google-cloud-retail-v2/lib/google/cloud/retail/v2/prediction_service/rest/client.rb
+++ b/google-cloud-retail-v2/lib/google/cloud/retail/v2/prediction_service/rest/client.rb
@@ -314,12 +314,12 @@ module Google
               #        will return generic (unfiltered) popular products instead of empty if
               #        your filter blocks all prediction results.
               #     * `priceRerankLevel`: String. Default empty. If set to be non-empty, then
-              #        it needs to be one of {'no-price-reranking', 'low-price-reranking',
+              #        it needs to be one of \\{'no-price-reranking', 'low-price-reranking',
               #        'medium-price-reranking', 'high-price-reranking'}. This gives
               #        request-level control and adjusts prediction results based on product
               #        price.
               #     * `diversityLevel`: String. Default empty. If set to be non-empty, then
-              #        it needs to be one of {'no-diversity', 'low-diversity',
+              #        it needs to be one of \\{'no-diversity', 'low-diversity',
               #        'medium-diversity', 'high-diversity', 'auto-diversity'}. This gives
               #        request-level control and adjusts prediction results based on product
               #        category.

--- a/google-cloud-retail-v2/proto_docs/google/cloud/retail/v2/prediction_service.rb
+++ b/google-cloud-retail-v2/proto_docs/google/cloud/retail/v2/prediction_service.rb
@@ -129,12 +129,12 @@ module Google
         #        will return generic (unfiltered) popular products instead of empty if
         #        your filter blocks all prediction results.
         #     * `priceRerankLevel`: String. Default empty. If set to be non-empty, then
-        #        it needs to be one of {'no-price-reranking', 'low-price-reranking',
+        #        it needs to be one of \\{'no-price-reranking', 'low-price-reranking',
         #        'medium-price-reranking', 'high-price-reranking'}. This gives
         #        request-level control and adjusts prediction results based on product
         #        price.
         #     * `diversityLevel`: String. Default empty. If set to be non-empty, then
-        #        it needs to be one of {'no-diversity', 'low-diversity',
+        #        it needs to be one of \\{'no-diversity', 'low-diversity',
         #        'medium-diversity', 'high-diversity', 'auto-diversity'}. This gives
         #        request-level control and adjusts prediction results based on product
         #        category.

--- a/google-cloud-retail-v2/proto_docs/google/cloud/retail/v2/product.rb
+++ b/google-cloud-retail-v2/proto_docs/google/cloud/retail/v2/product.rb
@@ -249,7 +249,7 @@ module Google
         #     height/weight of a product, or age of a customer.
         #
         #     For example: `{ "vendor": {"text": ["vendor123", "vendor456"]},
-        #     "lengths_cm": \\{"numbers":[2.3, 15.4]}, "heights_cm": \\{"numbers":[8.1, 6.4]}
+        #     "lengths_cm": {"numbers":[2.3, 15.4]}, "heights_cm": {"numbers":[8.1, 6.4]}
         #     }`.
         #
         #     This field needs to pass all below criteria, otherwise an INVALID_ARGUMENT

--- a/google-cloud-security_center-v1/proto_docs/google/cloud/securitycenter/v1/access.rb
+++ b/google-cloud-security_center-v1/proto_docs/google/cloud/securitycenter/v1/access.rb
@@ -61,7 +61,7 @@ module Google
         #     `principal://iam.googleapis.com/{identity pool name}/subject/{subject}`.
         #     Some GKE identities, such as GKE_WORKLOAD, FREEFORM, and GKE_HUB_WORKLOAD,
         #     still use the legacy format `serviceAccount:{identity pool
-        #     name}[\\{subject}]`.
+        #     name}[{subject}]`.
         # @!attribute [rw] service_account_key_name
         #   @return [::String]
         #     The name of the service account key that was used to create or exchange
@@ -98,7 +98,7 @@ module Google
         #     As compared to `principal_email`, supports principals that aren't
         #     associated with email addresses, such as third party principals. For most
         #     identities, the format will be `principal://iam.googleapis.com/{identity
-        #     pool name}/subjects/\\{subject}` except for some GKE identities
+        #     pool name}/subjects/{subject}` except for some GKE identities
         #     (GKE_WORKLOAD, FREEFORM, GKE_HUB_WORKLOAD) that are still in the legacy
         #     format `serviceAccount:{identity pool name}[{subject}]`
         class ServiceAccountDelegationInfo

--- a/google-cloud-security_center-v2/proto_docs/google/cloud/securitycenter/v2/access.rb
+++ b/google-cloud-security_center-v2/proto_docs/google/cloud/securitycenter/v2/access.rb
@@ -61,7 +61,7 @@ module Google
         #     `principal://iam.googleapis.com/{identity pool name}/subject/{subject}`.
         #     Some GKE identities, such as GKE_WORKLOAD, FREEFORM, and GKE_HUB_WORKLOAD,
         #     still use the legacy format `serviceAccount:{identity pool
-        #     name}[\\{subject}]`.
+        #     name}[{subject}]`.
         # @!attribute [rw] service_account_key_name
         #   @return [::String]
         #     The name of the service account key that was used to create or exchange
@@ -98,7 +98,7 @@ module Google
         #     As compared to `principal_email`, supports principals that aren't
         #     associated with email addresses, such as third party principals. For most
         #     identities, the format will be `principal://iam.googleapis.com/{identity
-        #     pool name}/subjects/\\{subject}` except for some GKE identities
+        #     pool name}/subjects/{subject}` except for some GKE identities
         #     (GKE_WORKLOAD, FREEFORM, GKE_HUB_WORKLOAD) that are still in the legacy
         #     format `serviceAccount:{identity pool name}[{subject}]`
         class ServiceAccountDelegationInfo

--- a/google-cloud-support-v2/lib/google/cloud/support/v2/case_attachment_service/client.rb
+++ b/google-cloud-support-v2/lib/google/cloud/support/v2/case_attachment_service/client.rb
@@ -314,7 +314,7 @@ module Google
             # supportApiService = googleapiclient.discovery.build(
             #     serviceName="cloudsupport",
             #     version=api_version,
-            #     discoveryServiceUrl=f"https://cloudsupport.googleapis.com/$discovery/rest?version=\\{api_version}",
+            #     discoveryServiceUrl=f"https://cloudsupport.googleapis.com/$discovery/rest?version={api_version}",
             # )
             # request = (
             #     supportApiService.cases()

--- a/google-cloud-support-v2/lib/google/cloud/support/v2/case_attachment_service/rest/client.rb
+++ b/google-cloud-support-v2/lib/google/cloud/support/v2/case_attachment_service/rest/client.rb
@@ -300,7 +300,7 @@ module Google
               # supportApiService = googleapiclient.discovery.build(
               #     serviceName="cloudsupport",
               #     version=api_version,
-              #     discoveryServiceUrl=f"https://cloudsupport.googleapis.com/$discovery/rest?version=\\{api_version}",
+              #     discoveryServiceUrl=f"https://cloudsupport.googleapis.com/$discovery/rest?version={api_version}",
               # )
               # request = (
               #     supportApiService.cases()

--- a/google-cloud-support-v2/lib/google/cloud/support/v2/comment_service/client.rb
+++ b/google-cloud-support-v2/lib/google/cloud/support/v2/comment_service/client.rb
@@ -398,7 +398,7 @@ module Google
             # supportApiService = googleapiclient.discovery.build(
             #     serviceName="cloudsupport",
             #     version=api_version,
-            #     discoveryServiceUrl=f"https://cloudsupport.googleapis.com/$discovery/rest?version=\\{api_version}",
+            #     discoveryServiceUrl=f"https://cloudsupport.googleapis.com/$discovery/rest?version={api_version}",
             # )
             #
             # request = supportApiService.cases().comments().get(

--- a/google-cloud-support-v2/lib/google/cloud/support/v2/comment_service/rest/client.rb
+++ b/google-cloud-support-v2/lib/google/cloud/support/v2/comment_service/rest/client.rb
@@ -377,7 +377,7 @@ module Google
               # supportApiService = googleapiclient.discovery.build(
               #     serviceName="cloudsupport",
               #     version=api_version,
-              #     discoveryServiceUrl=f"https://cloudsupport.googleapis.com/$discovery/rest?version=\\{api_version}",
+              #     discoveryServiceUrl=f"https://cloudsupport.googleapis.com/$discovery/rest?version={api_version}",
               # )
               #
               # request = supportApiService.cases().comments().get(

--- a/google-cloud-support-v2/lib/google/cloud/support/v2/support_event_subscription_service/client.rb
+++ b/google-cloud-support-v2/lib/google/cloud/support/v2/support_event_subscription_service/client.rb
@@ -760,7 +760,7 @@ module Google
             # supportApiService = googleapiclient.discovery.build(
             #     serviceName="cloudsupport",
             #     version=api_version,
-            #     discoveryServiceUrl=f"https://cloudsupport.googleapis.com/$discovery/rest?version=\\{api_version}",
+            #     discoveryServiceUrl=f"https://cloudsupport.googleapis.com/$discovery/rest?version={api_version}",
             # )
             #
             # request = supportApiService.supportEventSubscriptions().expunge(

--- a/google-cloud-support-v2/lib/google/cloud/support/v2/support_event_subscription_service/rest/client.rb
+++ b/google-cloud-support-v2/lib/google/cloud/support/v2/support_event_subscription_service/rest/client.rb
@@ -711,7 +711,7 @@ module Google
               # supportApiService = googleapiclient.discovery.build(
               #     serviceName="cloudsupport",
               #     version=api_version,
-              #     discoveryServiceUrl=f"https://cloudsupport.googleapis.com/$discovery/rest?version=\\{api_version}",
+              #     discoveryServiceUrl=f"https://cloudsupport.googleapis.com/$discovery/rest?version={api_version}",
               # )
               #
               # request = supportApiService.supportEventSubscriptions().expunge(

--- a/google-cloud-support-v2beta/lib/google/cloud/support/v2beta/support_event_subscription_service/client.rb
+++ b/google-cloud-support-v2beta/lib/google/cloud/support/v2beta/support_event_subscription_service/client.rb
@@ -760,7 +760,7 @@ module Google
             # supportApiService = googleapiclient.discovery.build(
             #     serviceName="cloudsupport",
             #     version=api_version,
-            #     discoveryServiceUrl=f"https://cloudsupport.googleapis.com/$discovery/rest?version=\\{api_version}",
+            #     discoveryServiceUrl=f"https://cloudsupport.googleapis.com/$discovery/rest?version={api_version}",
             # )
             #
             # request = supportApiService.supportEventSubscriptions().expunge(

--- a/google-cloud-support-v2beta/lib/google/cloud/support/v2beta/support_event_subscription_service/rest/client.rb
+++ b/google-cloud-support-v2beta/lib/google/cloud/support/v2beta/support_event_subscription_service/rest/client.rb
@@ -711,7 +711,7 @@ module Google
               # supportApiService = googleapiclient.discovery.build(
               #     serviceName="cloudsupport",
               #     version=api_version,
-              #     discoveryServiceUrl=f"https://cloudsupport.googleapis.com/$discovery/rest?version=\\{api_version}",
+              #     discoveryServiceUrl=f"https://cloudsupport.googleapis.com/$discovery/rest?version={api_version}",
               # )
               #
               # request = supportApiService.supportEventSubscriptions().expunge(

--- a/google-cloud-talent-v4/proto_docs/google/cloud/talent/v4/job.rb
+++ b/google-cloud-talent-v4/proto_docs/google/cloud/talent/v4/job.rb
@@ -161,7 +161,7 @@ module Google
         #
         #     Language codes must be in BCP-47 format, such as "en-US" or "sr-Latn".
         #     For more information, see
-        #     [Tags for Identifying Languages](https://tools.ietf.org/html/bcp47){:
+        #     [Tags for Identifying Languages](https://tools.ietf.org/html/bcp47)\\{:
         #     class="external" target="_blank" }.
         #
         #     If this field is unspecified and

--- a/google-cloud-talent-v4beta1/proto_docs/google/cloud/talent/v4beta1/job.rb
+++ b/google-cloud-talent-v4beta1/proto_docs/google/cloud/talent/v4beta1/job.rb
@@ -155,7 +155,7 @@ module Google
         #
         #     Language codes must be in BCP-47 format, such as "en-US" or "sr-Latn".
         #     For more information, see
-        #     [Tags for Identifying Languages](https://tools.ietf.org/html/bcp47){:
+        #     [Tags for Identifying Languages](https://tools.ietf.org/html/bcp47)\\{:
         #     class="external" target="_blank" }.
         #
         #     If this field is unspecified and

--- a/google-cloud-text_to_speech-v1/proto_docs/google/cloud/texttospeech/v1/cloud_tts.rb
+++ b/google-cloud-text_to_speech-v1/proto_docs/google/cloud/texttospeech/v1/cloud_tts.rb
@@ -196,7 +196,7 @@ module Google
             # https://en.wikipedia.org/wiki/International_Phonetic_Alphabet
             PHONETIC_ENCODING_IPA = 1
 
-            # X-SAMPA, such as apple -> "{p@l".
+            # X-SAMPA, such as apple -> "\\{p@l".
             # https://en.wikipedia.org/wiki/X-SAMPA
             PHONETIC_ENCODING_X_SAMPA = 2
 

--- a/google-cloud-text_to_speech-v1beta1/proto_docs/google/cloud/texttospeech/v1beta1/cloud_tts.rb
+++ b/google-cloud-text_to_speech-v1beta1/proto_docs/google/cloud/texttospeech/v1beta1/cloud_tts.rb
@@ -208,7 +208,7 @@ module Google
             # https://en.wikipedia.org/wiki/International_Phonetic_Alphabet
             PHONETIC_ENCODING_IPA = 1
 
-            # X-SAMPA, such as apple -> "{p@l".
+            # X-SAMPA, such as apple -> "\\{p@l".
             # https://en.wikipedia.org/wiki/X-SAMPA
             PHONETIC_ENCODING_X_SAMPA = 2
 

--- a/google-iam-v1beta/proto_docs/google/iam/v1beta/workload_identity_pool.rb
+++ b/google-iam-v1beta/proto_docs/google/iam/v1beta/workload_identity_pool.rb
@@ -142,9 +142,9 @@ module Google
       #         "google.subject":"assertion.arn",
       #         "attribute.aws_role":
       #             "assertion.arn.contains('assumed-role')"
-      #             " ? assertion.arn.extract('\\{account_arn}assumed-role/')"
+      #             " ? assertion.arn.extract('{account_arn}assumed-role/')"
       #             "   + 'assumed-role/'"
-      #             "   + assertion.arn.extract('assumed-role/\\{role_name}/')"
+      #             "   + assertion.arn.extract('assumed-role/{role_name}/')"
       #             " : assertion.arn",
       #       }
       #       ```
@@ -161,7 +161,7 @@ module Google
       #       a Google token.
       #
       #       ```
-      #       \\{"google.subject": "assertion.sub"}
+      #       {"google.subject": "assertion.sub"}
       #       ```
       # @!attribute [rw] attribute_condition
       #   @return [::String]

--- a/google-maps-route_optimization-v1/proto_docs/google/maps/routeoptimization/v1/route_optimization_service.rb
+++ b/google-maps-route_optimization-v1/proto_docs/google/maps/routeoptimization/v1/route_optimization_service.rb
@@ -2559,9 +2559,9 @@ module Google
         #     The total duration should be equal to the sum of all durations above.
         #     For routes, it also corresponds to:
         #     ```
-        #     {::Google::Maps::RouteOptimization::V1::ShipmentRoute#vehicle_end_time ShipmentRoute.vehicle_end_time}
+        #     [ShipmentRoute.vehicle_end_time][google.maps.routeoptimization.v1.ShipmentRoute.vehicle_end_time]
         #     -
-        #     {::Google::Maps::RouteOptimization::V1::ShipmentRoute#vehicle_start_time ShipmentRoute.vehicle_start_time}
+        #     [ShipmentRoute.vehicle_start_time][google.maps.routeoptimization.v1.ShipmentRoute.vehicle_start_time]
         #     ```
         # @!attribute [rw] travel_distance_meters
         #   @return [::Float]
@@ -2814,7 +2814,7 @@ module Google
         #     done as follows:
         #     ```
         #     fields { name: "vehicles" index: 4}
-        #     fields { name: "shipments" index: 2 sub_field \\{name: "pickups" index: 0} }
+        #     fields { name: "shipments" index: 2 sub_field {name: "pickups" index: 0} }
         #     ```
         #     Note, however, that the cardinality of `fields` should not change for a
         #     given error code.

--- a/google-shopping-merchant-accounts-v1/proto_docs/google/shopping/merchant/accounts/v1/shippingsettings.rb
+++ b/google-shopping-merchant-accounts-v1/proto_docs/google/shopping/merchant/accounts/v1/shippingsettings.rb
@@ -601,8 +601,8 @@ module Google
           #     Required. A list of inclusive order price upper bounds. The last price's
           #     value can be infinity by setting price amount_micros = -1. For example
           #     `[{"amount_micros": 10000000, "currency_code": "USD"},
-          #     \\{"amount_micros": 500000000, "currency_code": "USD"},
-          #     \\{"amount_micros": -1, "currency_code": "USD"}]` represents the headers
+          #     {"amount_micros": 500000000, "currency_code": "USD"},
+          #     {"amount_micros": -1, "currency_code": "USD"}]` represents the headers
           #     "<= $10", "<= $500", and "> $500". All prices within a service must have
           #     the same currency. Must be non-empty. Must be positive except -1. Can only
           #     be set if all other fields are not set.
@@ -612,7 +612,7 @@ module Google
           #     value can be infinity by setting price amount_micros = -1. For example
           #     `[{"amount_micros": 10000000, "unit": "kg"}, {"amount_micros": 50000000,
           #     "unit": "kg"},
-          #     \\{"amount_micros": -1, "unit": "kg"}]` represents the headers
+          #     {"amount_micros": -1, "unit": "kg"}]` represents the headers
           #     "<= 10kg", "<= 50kg", and "> 50kg". All weights within a service must have
           #     the same unit. Must be non-empty. Must be positive except -1. Can only be
           #     set if all other fields are not set.

--- a/google-shopping-merchant-accounts-v1beta/proto_docs/google/shopping/merchant/accounts/v1beta/shippingsettings.rb
+++ b/google-shopping-merchant-accounts-v1beta/proto_docs/google/shopping/merchant/accounts/v1beta/shippingsettings.rb
@@ -595,8 +595,8 @@ module Google
           #     Required. A list of inclusive order price upper bounds. The last price's
           #     value can be infinity by setting price amount_micros = -1. For example
           #     `[{"amount_micros": 10000000, "currency_code": "USD"},
-          #     \\{"amount_micros": 500000000, "currency_code": "USD"},
-          #     \\{"amount_micros": -1, "currency_code": "USD"}]` represents the headers
+          #     {"amount_micros": 500000000, "currency_code": "USD"},
+          #     {"amount_micros": -1, "currency_code": "USD"}]` represents the headers
           #     "<= $10", "<= $500", and "> $500". All prices within a service must have
           #     the same currency. Must be non-empty. Must be positive except -1. Can only
           #     be set if all other fields are not set.
@@ -606,7 +606,7 @@ module Google
           #     value can be infinity by setting price amount_micros = -1. For example
           #     `[{"amount_micros": 10000000, "unit": "kg"}, {"amount_micros": 50000000,
           #     "unit": "kg"},
-          #     \\{"amount_micros": -1, "unit": "kg"}]` represents the headers
+          #     {"amount_micros": -1, "unit": "kg"}]` represents the headers
           #     "<= 10kg", "<= 50kg", and "> 50kg". All weights within a service must have
           #     the same unit. Must be non-empty. Must be positive except -1. Can only be
           #     set if all other fields are not set.

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -20,7 +20,7 @@ sources:
 tools:
   gem:
     - name: gapic-generator-cloud
-      version: 0.51.1
+      version: 0.52.0
     - name: grpc-tools
       version: 1.78.1
   protoc:


### PR DESCRIPTION
## Summary

Updates `gapic-generator-cloud` to `0.52.0` in `librarian.yaml` and regenerates libraries with `librarian generate -all`.

The prefix of this pull request is `chore:` because this update only improves YARD documentation formatting and internal tooling without introducing any breaking or user-facing changes to the client library interfaces.

## Analysis of Code Diffs by Recent `gapic-generator-ruby` Pull Requests

All generated code diffs in this PR originate from improvements in `gapic-generator-ruby` merged in the past week (< 1 week) and released in `gapic-generator` / `gapic-generator-cloud` 0.52.0 ([#1343](https://github.com/googleapis/gapic-generator-ruby/pull/1343)):

### 1. Preserving Braces in Code Blocks & Inline Spans ([#1337](https://github.com/googleapis/gapic-generator-ruby/pull/1337))

* **Merged PR**: [gapic-generator-ruby#1337](https://github.com/googleapis/gapic-generator-ruby/pull/1337) - `fix(generator): escape multi-line braces and backtick unknown doc tags in yard formatting`
* **Root Cause & Fix**: Previously, `FormattingUtils.format_doc_lines` did not track Markdown fenced code blocks (```) or multiline inline code spans (` `...` `). When braces appeared inside code snippets or JSON examples, the generator incorrectly escaped them as `\{...\}`. In PR #1337, `format_doc_lines` now maintains block state (`in_fence` and `in_code_span`) and preserves braces untouched inside code blocks and inline spans.
* **Diffs in this PR**:
  - `google-apps-chat-v1`: Restores unescaped braces in Markdown fenced code blocks (e.g. `user.name = "users/{user}"` and `emoji.custom_emoji.uid = "{uid}"` instead of `users/\{user}`).
  - `google-cloud-ai_platform-v1`: In inline code spans, braces in resource name templates are preserved without escapes (e.g. `projects/{project}/locations/{location}/featurestores/{featurestore}/entityTypes/{entityType}`).
  - `google-cloud-dataqna-v1alpha`: In `annotated_string.rb` and `auto_suggestion_service.rb`, code examples now render `{DIMENSION, 4, 12}` and `{type: TEXT, ...}` without unnecessary backslash escapes.
  - Similar code-block brace cleanups occur across `google-cloud-bigquery-analytics_hub-v1`, `google-cloud-pubsub-v1`, `google-cloud-chronicle-v1`, `google-cloud-network_services-v1`, `google-cloud-oracle_database-v1`, `google-iam-v1beta`, `google-maps-route_optimization-v1`, and `google-shopping-merchant-accounts-v1*`.

### 2. Escaping Multiline Braces in Prose ([#1337](https://github.com/googleapis/gapic-generator-ruby/pull/1337))

* **Merged PR**: [gapic-generator-ruby#1337](https://github.com/googleapis/gapic-generator-ruby/pull/1337)
* **Root Cause & Fix**: YARD interprets `{...}` in prose as link or tag directives. When literal braces span across lines (such as multiline JSON examples or number ranges), YARD fails to parse them, causing build warnings and doc errors. PR #1337 added `escape_prose_braces`, escaping unescaped `{` outside backtick spans as `\{`.
* **Diffs in this PR**:
  - `google-apps-chat-v1/proto_docs/google/apps/card/v1/card.rb`: Escapes multiline range syntax `Choose from \{100, 200, 300, 400, 500, 600, 700}.`
  - `google-cloud-agent_registry-v1/proto_docs/google/cloud/agentregistry/v1/agent.rb` & `mcp_server.rb`: Escapes multiline JSON examples in prose: `\{"framework": ...}` and `\{"principal": ...}`.
  - `google-cloud-ai_platform-v1/proto_docs/google/cloud/aiplatform/v1/evaluation_service.rb`: Escapes multiline parameter example `e.g. \{"rouge_type": "rougeL"}.`
  - `google-cloud-cloud_security_compliance-v1/proto_docs/.../deployment.rb`: Escapes multiline JSON `\{"key": ...}`.

### 3. Sanitizing Unknown Doc Tags ([#1337](https://github.com/googleapis/gapic-generator-ruby/pull/1337))

* **Merged PR**: [gapic-generator-ruby#1337](https://github.com/googleapis/gapic-generator-ruby/pull/1337)
* **Root Cause & Fix**: Words starting with `@` in proto comments (e.g. `@all` or `@mentions`) were interpreted by YARD as doc tag directives, producing `@unknown tag` warnings. PR #1337 introduced `sanitize_prose_tags` to wrap any tag not recognized by YARD in backticks (e.g. ``` `@all` ```).
* **Diffs in this PR**:
  - `google-apps-chat-v1/proto_docs/google/chat/v1/space.rb`: Sanitizes `@all` -> ``` `@all` ```.
  - `google-apps-chat-v1/proto_docs/google/chat/v1/space_notification_setting.rb`: Sanitizes `@mentions` -> ``` `@mentions` ```.

### 4. Other Generator Features in 0.52.0 ([#1340](https://github.com/googleapis/gapic-generator-ruby/pull/1340), [#1342](https://github.com/googleapis/gapic-generator-ruby/pull/1342))

* **[gapic-generator-ruby#1340](https://github.com/googleapis/gapic-generator-ruby/pull/1340)**: Automatically rejoins split doc URLs across newlines (b/153077040) and strips dangling cross-reference links for messages absent from proto docs (b/158466893), which unblocks onboarding `google-cloud-automl-v1`.
* **[gapic-generator-ruby#1342](https://github.com/googleapis/gapic-generator-ruby/pull/1342)**: Adds generator support for `ruby-cloud-renamed-from` parameter, which unblocks onboarding renamed wrapper gems (`google-cloud-run-client` and `google-iam-client`).

## Verification

* `librarian install`: Successfully installed `gapic-generator-cloud` 0.52.0 and dependencies.
* `librarian generate -all`: Ran cleanly across all configured gems.
* Local CI verification across representative modified gems (`google-apps-chat-v1`, `google-cloud-dialogflow-v2`, `google-cloud-oracle_database-v1`, `google-cloud-bigtable-v2`):
  * Unit tests: 818 runs, 0 failures, 0 errors, 0 skips (`toys ci --test`)
  * RuboCop: 0 offenses (`toys ci --rubocop`)
  * YARD documentation generation: 0 warnings, 0 errors (`toys ci --yard`)