### PR TITLE
chore(storage-control): Disable storage control failing tests causing timeouts

### DIFF
--- a/google-cloud-storage-control/samples/acceptance/storage_control_anywhere_cache_test.rb
+++ b/google-cloud-storage-control/samples/acceptance/storage_control_anywhere_cache_test.rb
@@ -27,16 +27,19 @@ describe "Storage Control Anywhere Cache" do
   # Set project to "_" to signify global bucket
   let(:anywhere_cache_name) { "projects/_/buckets/#{bucket_name}/anywhereCaches/#{zone}" }
 
+  # TODO: Re-enable bucket creation and deletion when resolving b/559793640
   before :all do
-    create_bucket_helper bucket_name
+    # create_bucket_helper bucket_name
   end
 
   after :all do
-    count_anywhere_caches bucket_name # Ensure all caches are deleted before deleting bucket
-    delete_bucket_helper bucket_name
+    # count_anywhere_caches bucket_name
+    # delete_bucket_helper bucket_name
   end
 
   it "handles Anywhere cache lifecycle in sequence" do
+    skip "Disabled due to Anywhere Cache deletion timeouts. See b/559793640"
+
     out_create, _err = capture_io do
       create_anywhere_cache bucket_name: bucket_name, zone: zone
     end

--- a/google-cloud-storage-control/samples/storage_control_delete_folder_recursive.rb
+++ b/google-cloud-storage-control/samples/storage_control_delete_folder_recursive.rb
@@ -31,7 +31,8 @@ def delete_folder_recursive bucket_name:, folder_name:
   request = Google::Cloud::Storage::Control::V2::DeleteFolderRecursiveRequest.new name: folder_path
 
   result = storage_control.delete_folder_recursive request
-  result.wait_until_done! timeout: 60
+  operation = storage_control.operations_client.get_operation name: result.name
+  operation.wait_until_done! retry_policy: { timeout: 60, initial_delay: 1 }
 
   puts "Deleted folder recursively: #{folder_name}"
 end


### PR DESCRIPTION
chore: Fix test by using operation with correct bucket name

Bug: 559793640

1. Checking if the caches have been deleted can take hours and this causes CI timeouts.

Skipping the test for now.

Logs:

```
Cache not deleted yet, Retrying in 900 seconds.
Cache not deleted yet, Retrying in 900 seconds.

ERROR: Aborting VM command due to timeout of 10800 seconds
```

2. `wait_until_done!` fails because the operation reuses the initial call's stale bucket routing header instead of the operation name, causing GCS to reject `GetOperation` calls during polling. I am querying the operation directly to fix that.