### PR TITLE
chore(bigtable): modernize test to 1-node production instance

### DIFF
--- a/google-cloud-bigtable/acceptance/bigtable/project_test.rb
+++ b/google-cloud-bigtable/acceptance/bigtable/project_test.rb
@@ -18,24 +18,23 @@
 require "bigtable_helper"
 
 describe Google::Cloud::Bigtable::Project, :bigtable do
-  let(:instance_id_development) { "google-cloud-ruby-tests-dev" }
-  let(:cluster_id_development) { "ruby-clstr-dev" }
+  let(:instance_id) { "ruby-test-#{random_str}" }
+  let(:cluster_id) { "ruby-clstr-#{random_str}" }
   let(:cluster_location) { "us-east1-b" }
 
   after do
-    instance = bigtable.instance(instance_id_development)
-    instance.delete if instance
+    instance = bigtable.instance instance_id
+    instance&.delete
   end
 
-  it "creates an instance with type development" do
+  it "creates an instance with type production" do
     job = bigtable.create_instance(
-      instance_id_development,
+      instance_id,
       display_name: "Ruby Acceptance Test",
-      type: :DEVELOPMENT,
+      type: :PRODUCTION,
       labels: { env: "test" }
     ) do |clusters|
-      # "Need to have at least one cluster map element in CreateInstanceRequest."
-      clusters.add(cluster_id_development, cluster_location) # nodes not allowed
+      clusters.add cluster_id, cluster_location, nodes: 1
     end
 
     job.wait_until_done!
@@ -44,7 +43,7 @@ describe Google::Cloud::Bigtable::Project, :bigtable do
 
     instance = job.instance
     _(instance).must_be_kind_of Google::Cloud::Bigtable::Instance
-    _(instance.development?).must_equal true
+    _(instance.production?).must_equal true
     _(instance.clusters.count).must_equal 1
     cluster = instance.clusters.first
 


### PR DESCRIPTION
Modernizes the Bigtable `Project#create_instance` acceptance test to create a 1-node production instance instead of using the deprecated `DEVELOPMENT` instance type.

### Deprecation Notice
Per the [Cloud Bigtable release notes (March 19, 2020)](https://cloud.google.com/bigtable/docs/release-notes#March_19_2020):
> *"You can now create a production Cloud Bigtable instance that has one or two nodes per cluster. Prior to this change, production instances had a minimum of three nodes per cluster, and the only way to create smaller clusters was in a development instance."*
