### PR TITLE
chore: add stale branch cleanup tool and test suite

### DIFF
--- a/script/delete-stale-branches.rb
+++ b/script/delete-stale-branches.rb
@@ -1,0 +1,537 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "optparse"
+require "json"
+require "open3"
+require "time"
+
+class StaleBranchCleaner
+  DEFAULT_REPO = "googleapis/google-cloud-ruby"
+  DEFAULT_REMOTE = "origin"
+  DEFAULT_MIN_AGE_DAYS = 30
+  DEFAULT_BATCH_SIZE = 50
+  DEFAULT_PROTECTED_BRANCHES = %w[main master gh-pages].freeze
+  DEFAULT_PROTECTED_PATTERNS = [/^(main|master|gh-pages)$/, /^STABLE_/].freeze
+
+  def initialize(options = {})
+    @options = {
+      dry_run: true,
+      repo: DEFAULT_REPO,
+      remote: DEFAULT_REMOTE,
+      target: "all",
+      min_age_days: DEFAULT_MIN_AGE_DAYS,
+      batch_size: DEFAULT_BATCH_SIZE,
+      limit: nil,
+      method: "git",
+      exclude: nil,
+      include: nil,
+      report: nil,
+      verbose: false,
+      concurrency: 4
+    }.merge(options)
+
+    @stats = Hash.new(0)
+    @branches_data = {}
+    @open_prs = {}
+  end
+
+  def run
+    banner
+    validate_environment
+    fetch_open_prs
+    fetch_remote_branches
+    inspect_branch_metadata
+    classify_branches
+    report_summary
+    execute_deletions if !options[:dry_run]
+    export_report if options[:report]
+  end
+
+  private
+
+  attr_reader :options
+
+  def banner
+    mode = options[:dry_run] ? "\e[33m[DRY RUN - SAFE MODE]\e[0m" : "\e[31m[MUTATING EXECUTION MODE]\e[0m"
+    puts "\n======================================================="
+    puts "  Google Cloud Ruby - Stale Branch Cleanup Tool"
+    puts "  Mode: #{mode}"
+    puts "  Target Repo: #{options[:repo]}"
+    puts "  Target Category: #{options[:target].upcase}"
+    puts "  Min Age: #{options[:min_age_days]} days"
+    puts "=======================================================\n"
+  end
+
+  def validate_environment
+    # Verify gh CLI is available and authenticated
+    out, err, st = Open3.capture3("gh", "auth", "status")
+    unless st.success?
+      fatal_error("GitHub CLI (gh) authentication check failed: #{err}")
+    end
+
+    # Check git identity or repository
+    unless Dir.exist?(".git")
+      fatal_error("Must be executed from inside a git repository root.")
+    end
+  end
+
+  def fetch_open_prs
+    puts "--> Fetching open pull requests from #{options[:repo]}..."
+    cmd = [
+      "gh", "pr", "list",
+      "-R", options[:repo],
+      "--state", "open",
+      "--limit", "500",
+      "--json", "number,title,headRefName,headRepositoryOwner,updatedAt"
+    ]
+    stdout, stderr, status = Open3.capture3(*cmd)
+    unless status.success?
+      fatal_error("Failed to query open PRs via gh CLI: #{stderr}")
+    end
+
+    prs = JSON.parse(stdout)
+    prs.each do |pr|
+      # Note: We track headRefName regardless of fork owner to be extra safe
+      @open_prs[pr["headRefName"]] = {
+        number: pr["number"],
+        title: pr["title"],
+        updated_at: pr["updatedAt"],
+        owner: pr.dig("headRepositoryOwner", "login")
+      }
+    end
+    puts "    Discovered #{@open_prs.size} open PRs across repository.\n"
+  end
+
+  def fetch_remote_branches
+    puts "--> Discovering remote branches via git ls-remote..."
+    cmd = ["git", "ls-remote", "--heads", options[:remote]]
+    stdout, stderr, status = Open3.capture3(*cmd)
+    unless status.success?
+      # Fallback to https url if remote name fails
+      cmd = ["git", "ls-remote", "--heads", "https://github.com/#{options[:repo]}.git"]
+      stdout, stderr, status = Open3.capture3(*cmd)
+      unless status.success?
+        fatal_error("Failed to fetch remote branches: #{stderr}")
+      end
+    end
+
+    branch_names = stdout.lines.map do |line|
+      line.split("\t").last&.strip&.sub(%r{^refs/heads/}, "")
+    end.compact
+
+    puts "    Found #{branch_names.size} remote branches on #{options[:repo]}.\n"
+
+    branch_names.each do |name|
+      @branches_data[name] = {
+        name: name,
+        status: :unclassified,
+        reason: nil,
+        commit_date: nil,
+        commit_headline: nil,
+        pr_number: nil,
+        pr_state: nil,
+        pr_title: nil
+      }
+    end
+  end
+
+  def inspect_branch_metadata
+    # Separate already protected branches (base branches & open PRs)
+    candidates_to_query = []
+
+    @branches_data.each do |name, data|
+      if DEFAULT_PROTECTED_BRANCHES.include?(name)
+        data[:status] = :protected
+        data[:reason] = "Protected base/docs branch"
+      elsif @open_prs.key?(name)
+        pr = @open_prs[name]
+        data[:status] = :protected
+        data[:reason] = "Active Open PR ##{pr[:number]} (#{pr[:title]})"
+        data[:pr_number] = pr[:number]
+        data[:pr_state] = "OPEN"
+        data[:pr_title] = pr[:title]
+      elsif options[:exclude] && name =~ Regexp.new(options[:exclude])
+        data[:status] = :protected
+        data[:reason] = "Matched explicit exclude regex: #{options[:exclude]}"
+      elsif DEFAULT_PROTECTED_PATTERNS.any? { |pat| name =~ pat }
+        data[:status] = :protected
+        data[:reason] = "Matched protected pattern"
+      else
+        candidates_to_query << name
+      end
+    end
+
+    puts "--> Evaluating metadata for #{candidates_to_query.size} candidate branches..."
+    puts "    (Exempted #{@branches_data.size - candidates_to_query.size} branches via base/open PR/exclude protections)"
+
+    # Batch query GraphQL for commit date and associated PR info
+    batch_size = 50
+    slices = candidates_to_query.each_slice(batch_size).to_a
+    total_slices = slices.size
+    # Concurrency Clarity:
+    # 1. `work_queue` (Thread::Queue): Thread-safe FIFO queue distributing candidate branch slices
+    #    (up to 50 branches per GraphQL query) across worker threads. Ensures work is evenly pulled
+    #    without duplicate queries or race conditions.
+    # 2. `mutex` (Thread::Mutex): Serializes writes to the shared `@branches_data` in-memory hash
+    #    and increments `completed_slices` progress counter to prevent race conditions during concurrent
+    #    GraphQL response parsing across worker threads.
+    completed_slices = 0
+    mutex = Mutex.new
+    work_queue = Queue.new
+    slices.each_with_index { |s, idx| work_queue << [s, idx] }
+
+    workers = [options[:concurrency], total_slices].min.times.map do
+      Thread.new do
+        until work_queue.empty?
+          begin
+            slice, idx = work_queue.pop(true)
+          rescue ThreadError
+            break
+          end
+
+          fields = slice.each_with_index.map do |b, i|
+            escaped = b.gsub('\\', '\\\\\\\\').gsub('"', '\\"')
+            <<~GQL
+              b#{i}: ref(qualifiedName: "refs/heads/#{escaped}") {
+                name
+                target {
+                  ... on Commit {
+                    committedDate
+                    messageHeadline
+                  }
+                }
+                associatedPullRequests(first: 1) {
+                  nodes {
+                    number
+                    state
+                    title
+                  }
+                }
+              }
+            GQL
+          end.join("\n")
+
+          query = "query { repository(owner: \"#{options[:repo].split('/').first}\", name: \"#{options[:repo].split('/').last}\") { #{fields} } }"
+          stdout, stderr, status = Open3.capture3("gh", "api", "graphql", "-F", "query=@-", stdin_data: query)
+
+          if status.success?
+            begin
+              parsed = JSON.parse(stdout).dig("data", "repository") || {}
+              mutex.synchronize do
+                parsed.each_value do |node|
+                  next unless node && node["name"]
+                  name = node["name"]
+                  rec = @branches_data[name]
+                  next unless rec
+
+                  rec[:commit_date] = node.dig("target", "committedDate")
+                  rec[:commit_headline] = node.dig("target", "messageHeadline")
+                  pr_node = node.dig("associatedPullRequests", "nodes", 0)
+                  if pr_node
+                    rec[:pr_number] = pr_node["number"]
+                    rec[:pr_state] = pr_node["state"]
+                    rec[:pr_title] = pr_node["title"]
+                  else
+                    rec[:pr_state] = "NO_PR"
+                  end
+                end
+                completed_slices += 1
+                print "\r    Progress: #{completed_slices}/#{total_slices} batches queried (#{(completed_slices.to_f / total_slices * 100).round}%)"
+              end
+            rescue JSON::ParserError => e
+              warn "\nFailed to parse GraphQL batch #{idx}: #{e.message}"
+            end
+          else
+            warn "\nGraphQL batch #{idx} failed: #{stderr}"
+          end
+        end
+      end
+    end
+
+    workers.each(&:join)
+    puts "\n    Metadata fetching complete.\n"
+  end
+
+  def classify_branches
+    now = Time.now
+    min_age_cutoff = now - (options[:min_age_days] * 86_400)
+
+    @branches_data.each do |name, data|
+      next if data[:status] == :protected
+
+      commit_time = data[:commit_date] ? Time.parse(data[:commit_date]) : nil
+      is_bot = name =~ /^(owl-?bot|autosynth)/
+      pr_state = data[:pr_state]
+
+      # 1. Check Recency: If commit is newer than min_age_days, protect it
+      if commit_time && commit_time > min_age_cutoff
+        data[:status] = :protected
+        data[:reason] = "Active work: commit within last #{options[:min_age_days]} days (#{commit_time.strftime('%Y-%m-%d')})"
+        next
+      end
+
+      # 2. Check Inclusion regex if specified
+      if options[:include] && name !~ Regexp.new(options[:include])
+        data[:status] = :skipped
+        data[:reason] = "Does not match include regex: #{options[:include]}"
+        next
+      end
+
+      # 3. Categorize stale branch
+      if is_bot
+        data[:category] = :bot
+        data[:status] = :stale
+        data[:reason] = "Stale automated bot branch (#{pr_state == 'NO_PR' ? 'No PR' : "PR #{pr_state}"})"
+      elsif pr_state == "MERGED"
+        data[:category] = :merged
+        data[:status] = :stale
+        data[:reason] = "Merged PR ##{data[:pr_number]} (#{commit_time ? commit_time.strftime('%Y-%m-%d') : 'unknown date'})"
+      elsif pr_state == "CLOSED"
+        data[:category] = :closed
+        data[:status] = :stale
+        data[:reason] = "Closed/unmerged PR ##{data[:pr_number]} (#{commit_time ? commit_time.strftime('%Y-%m-%d') : 'unknown date'})"
+      else
+        data[:category] = :no_pr
+        data[:status] = :stale
+        data[:reason] = "Abandoned branch with no PR (#{commit_time ? commit_time.strftime('%Y-%m-%d') : 'unknown date'})"
+      end
+    end
+  end
+
+  def report_summary
+    total = @branches_data.size
+    protected_branches = @branches_data.values.select { |b| b[:status] == :protected }
+    stale_branches = @branches_data.values.select { |b| b[:status] == :stale }
+
+    by_category = Hash.new(0)
+    stale_branches.each { |b| by_category[b[:category]] += 1 }
+
+    # Filter by user target selection
+    target_stale = stale_branches.select do |b|
+      case options[:target]
+      when "bot" then b[:category] == :bot
+      when "merged" then b[:category] == :merged
+      when "closed" then b[:category] == :closed
+      when "no-pr" then b[:category] == :no_pr
+      when "all" then true
+      else true
+      end
+    end
+
+    if options[:limit] && options[:limit] > 0
+      target_stale = target_stale.first(options[:limit])
+    end
+
+    @selected_for_action = target_stale
+
+    puts "======================================================="
+    puts "                  EVALUATION SUMMARY                   "
+    puts "======================================================="
+    puts "Total remote branches evaluated: #{total}"
+    puts "\e[32mProtected / Preserved branches:\e[0m  #{protected_branches.size}"
+    puts "  - Base / Hardcoded:           #{protected_branches.count { |b| b[:reason]&.start_with?('Protected') }}"
+    puts "  - Active Open PR Heads:       #{protected_branches.count { |b| b[:reason]&.start_with?('Active Open PR') }}"
+    puts "  - Recent Commit (<#{options[:min_age_days]}d):       #{protected_branches.count { |b| b[:reason]&.start_with?('Active work') }}"
+    puts ""
+    puts "\e[33mStale Candidate Breakdown (all categories):\e[0m #{stale_branches.size}"
+    puts "  - Bot branches (owl-bot/autosynth): #{by_category[:bot]}"
+    puts "  - Merged PR branches:              #{by_category[:merged]}"
+    puts "  - Closed PR branches:              #{by_category[:closed]}"
+    puts "  - No PR branches:                  #{by_category[:no_pr]}"
+    puts "-------------------------------------------------------"
+    puts "\e[1mSelected for action (--target #{options[:target]}):\e[0m \e[36m#{@selected_for_action.size} branches\e[0m"
+    if options[:limit]
+      puts "  (Capped by --limit #{options[:limit]})"
+    end
+    puts "=======================================================\n"
+
+    # Sample table of selected branches
+    sample_size = [15, @selected_for_action.size].min
+    if sample_size > 0
+      puts "Sample Candidates Selected for #{options[:dry_run] ? 'Simulated Deletion' : 'Deletion'} (first #{sample_size} shown):"
+      puts format("%-45s | %-8s | %-10s | %s", "BRANCH NAME", "CATEGORY", "LAST DATE", "DETAILS")
+      puts "-" * 90
+      @selected_for_action.first(sample_size).each do |b|
+        date_str = b[:commit_date] ? b[:commit_date][0..9] : "unknown"
+        cat_str = b[:category].to_s.upcase
+        puts format("%-45s | %-8s | %-10s | %s", b[:name][0..44], cat_str, date_str, (b[:reason] || "")[0..40])
+      end
+      if @selected_for_action.size > sample_size
+        puts "... and #{@selected_for_action.size - sample_size} more branches."
+      end
+      puts ""
+    end
+
+    # List protected open PR branches explicitly for safety audit
+    open_pr_list = protected_branches.select { |b| b[:pr_state] == "OPEN" }
+    puts "Explicitly Protected Active Open PR Branches (#{open_pr_list.size} total):"
+    open_pr_list.each do |b|
+      puts "  \e[32m✓\e[0m #{b[:name].ljust(45)} | PR ##{b[:pr_number]} | #{b[:pr_title]}"
+    end
+    puts ""
+  end
+
+  def execute_deletions
+    if @selected_for_action.empty?
+      puts "No branches match the selection criteria. Nothing to delete."
+      return
+    end
+
+    count = @selected_for_action.size
+    puts "\e[31m[DANGER]\e[0m Preparing to DELETE #{count} branches from #{options[:repo]} via #{options[:method]}..."
+
+    if options[:method] == "git"
+      execute_deletions_git
+    else
+      execute_deletions_api
+    end
+  end
+
+  def execute_deletions_git
+    branches_to_delete = @selected_for_action.map { |b| b[:name] }
+    batches = branches_to_delete.each_slice(options[:batch_size]).to_a
+    total_batches = batches.size
+
+    puts "Executing deletion in #{total_batches} git push batches (batch size: #{options[:batch_size]})..."
+
+    batches.each_with_index do |batch, idx|
+      puts "  Deleting batch #{idx + 1}/#{total_batches} (#{batch.size} branches)..."
+      cmd = ["git", "push", options[:remote], "--delete"] + batch
+      stdout, stderr, status = Open3.capture3(*cmd)
+      if status.success?
+        puts "  \e[32m✓\e[0m Batch #{idx + 1} deleted successfully."
+      else
+        warn "  \e[31m✗\e[0m Batch #{idx + 1} push failed: #{stderr}"
+        # Fallback to individual branch deletion for resilience
+        puts "    Falling back to individual deletions for this batch..."
+        batch.each do |b|
+          single_cmd = ["git", "push", options[:remote], "--delete", b]
+          _sout, serr, sstat = Open3.capture3(*single_cmd)
+          if sstat.success?
+            puts "    \e[32m✓\e[0m Deleted #{b}"
+          else
+            warn "    \e[31m✗\e[0m Failed to delete #{b}: #{serr.strip}"
+          end
+        end
+      end
+    end
+    puts "\nDeletion complete."
+  end
+
+  def execute_deletions_api
+    total = @selected_for_action.size
+    @selected_for_action.each_with_index do |b, idx|
+      name = b[:name]
+      print "\rDeleting branch #{idx + 1}/#{total}: #{name}..."
+      cmd = [
+        "gh", "api",
+        "-X", "DELETE",
+        "repos/#{options[:repo]}/git/refs/heads/#{name}"
+      ]
+      _stdout, stderr, status = Open3.capture3(*cmd)
+      if status.success?
+        # success
+      else
+        warn "\nFailed to delete #{name} via API: #{stderr}"
+      end
+    end
+    puts "\nAPI deletions complete."
+  end
+
+  def export_report
+    path = options[:report]
+    puts "--> Exporting audit report to #{path}..."
+    report_data = {
+      timestamp: Time.now.iso8601,
+      repo: options[:repo],
+      mode: options[:dry_run] ? "dry_run" : "execute",
+      target_category: options[:target],
+      total_evaluated: @branches_data.size,
+      total_protected: @branches_data.values.count { |b| b[:status] == :protected },
+      total_selected: @selected_for_action.size,
+      branches: @branches_data.values
+    }
+
+    File.write(path, JSON.pretty_generate(report_data))
+    puts "    Report written successfully.\n"
+  end
+
+  def fatal_error(msg)
+    warn "\e[31m[ERROR]\e[0m #{msg}"
+    exit 1
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  options = {}
+  parser = OptionParser.new do |opts|
+    opts.banner = "Usage: ruby #{$PROGRAM_NAME} [options]"
+
+    opts.on("-d", "--[no-]dry-run", "Simulate deletions without executing (default: true)") do |v|
+      options[:dry_run] = v
+    end
+
+    opts.on("-e", "--execute", "Execute actual branch deletions (mutating action)") do
+      options[:dry_run] = false
+    end
+
+    opts.on("-t", "--target CATEGORY", "Target category: bot, merged, closed, no-pr, all (default: all)") do |v|
+      options[:target] = v.downcase
+    end
+
+    opts.on("-a", "--min-age-days DAYS", Integer, "Minimum branch age in days to be considered stale (default: 30)") do |v|
+      options[:min_age_days] = v
+    end
+
+    opts.on("-l", "--limit COUNT", Integer, "Maximum number of branches to delete in this run") do |v|
+      options[:limit] = v
+    end
+
+    opts.on("-b", "--batch-size SIZE", Integer, "Branches per git push batch (default: 50)") do |v|
+      options[:batch_size] = v
+    end
+
+    opts.on("-m", "--method METHOD", "Deletion method: git or api (default: git)") do |v|
+      options[:method] = v.downcase
+    end
+
+    opts.on("--exclude REGEX", "Regex pattern of branch names to protect") do |v|
+      options[:exclude] = v
+    end
+
+    opts.on("--include REGEX", "Regex pattern of branch names to target") do |v|
+      options[:include] = v
+    end
+
+    opts.on("-r", "--report FILE", "Path to export JSON audit report") do |v|
+      options[:report] = v
+    end
+
+    opts.on("-v", "--verbose", "Enable verbose debug logging") do
+      options[:verbose] = true
+    end
+
+    opts.on("-h", "--help", "Show this help banner") do
+      puts opts
+      exit 0
+    end
+  end
+
+  parser.parse!
+  StaleBranchCleaner.new(options).run
+end

--- a/script/test_delete_stale_branches.rb
+++ b/script/test_delete_stale_branches.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "minitest/autorun"
+require_relative "delete-stale-branches"
+
+class StaleBranchCleanerTest < Minitest::Test
+  def setup
+    @cleaner = StaleBranchCleaner.new(dry_run: true, min_age_days: 30)
+  end
+
+  def test_base_branches_are_protected
+    branches = @cleaner.send(:instance_variable_get, :@branches_data)
+    branches["main"] = { name: "main", status: :unclassified }
+    branches["gh-pages"] = { name: "gh-pages", status: :unclassified }
+
+    @cleaner.send(:inspect_branch_metadata)
+
+    assert_equal :protected, branches["main"][:status]
+    assert_equal :protected, branches["gh-pages"][:status]
+  end
+
+  def test_open_pr_branches_are_strictly_protected
+    branches = @cleaner.send(:instance_variable_get, :@branches_data)
+    open_prs = @cleaner.send(:instance_variable_get, :@open_prs)
+
+    branches["feat/active-work"] = { name: "feat/active-work", status: :unclassified }
+    open_prs["feat/active-work"] = { number: 1234, title: "Active Feature", updatedAt: Time.now.iso8601 }
+
+    @cleaner.send(:inspect_branch_metadata)
+
+    assert_equal :protected, branches["feat/active-work"][:status]
+    assert_match(/Active Open PR #1234/, branches["feat/active-work"][:reason])
+  end
+
+  def test_recent_commits_within_grace_period_are_protected
+    branches = @cleaner.send(:instance_variable_get, :@branches_data)
+    recent_date = (Time.now - (5 * 86_400)).iso8601 # 5 days ago
+
+    branches["experiment/fresh"] = {
+      name: "experiment/fresh",
+      status: :unclassified,
+      commit_date: recent_date,
+      pr_state: "NO_PR"
+    }
+
+    @cleaner.send(:classify_branches)
+
+    assert_equal :protected, branches["experiment/fresh"][:status]
+    assert_match(/Active work: commit within last 30 days/, branches["experiment/fresh"][:reason])
+  end
+
+  def test_stale_bot_branches_are_categorized_as_bot
+    branches = @cleaner.send(:instance_variable_get, :@branches_data)
+    old_date = (Time.now - (400 * 86_400)).iso8601 # 400 days ago
+
+    branches["owl-bot-12345"] = {
+      name: "owl-bot-12345",
+      status: :unclassified,
+      commit_date: old_date,
+      pr_state: "CLOSED",
+      pr_number: 999
+    }
+
+    branches["autosynth-pkg"] = {
+      name: "autosynth-pkg",
+      status: :unclassified,
+      commit_date: old_date,
+      pr_state: "MERGED",
+      pr_number: 888
+    }
+
+    @cleaner.send(:classify_branches)
+
+    assert_equal :stale, branches["owl-bot-12345"][:status]
+    assert_equal :bot, branches["owl-bot-12345"][:category]
+
+    assert_equal :stale, branches["autosynth-pkg"][:status]
+    assert_equal :bot, branches["autosynth-pkg"][:category]
+  end
+
+  def test_stale_merged_human_branches_are_categorized_as_merged
+    branches = @cleaner.send(:instance_variable_get, :@branches_data)
+    old_date = (Time.now - (100 * 86_400)).iso8601
+
+    branches["feature/done"] = {
+      name: "feature/done",
+      status: :unclassified,
+      commit_date: old_date,
+      pr_state: "MERGED",
+      pr_number: 456
+    }
+
+    @cleaner.send(:classify_branches)
+
+    assert_equal :stale, branches["feature/done"][:status]
+    assert_equal :merged, branches["feature/done"][:category]
+  end
+
+  def test_stale_closed_human_branches_are_categorized_as_closed
+    branches = @cleaner.send(:instance_variable_get, :@branches_data)
+    old_date = (Time.now - (120 * 86_400)).iso8601
+
+    branches["fix/abandoned"] = {
+      name: "fix/abandoned",
+      status: :unclassified,
+      commit_date: old_date,
+      pr_state: "CLOSED",
+      pr_number: 789
+    }
+
+    @cleaner.send(:classify_branches)
+
+    assert_equal :stale, branches["fix/abandoned"][:status]
+    assert_equal :closed, branches["fix/abandoned"][:category]
+  end
+
+  def test_stale_no_pr_branches_are_categorized_as_no_pr
+    branches = @cleaner.send(:instance_variable_get, :@branches_data)
+    old_date = (Time.now - (200 * 86_400)).iso8601
+
+    branches["scratch/test-idea"] = {
+      name: "scratch/test-idea",
+      status: :unclassified,
+      commit_date: old_date,
+      pr_state: "NO_PR"
+    }
+
+    @cleaner.send(:classify_branches)
+
+    assert_equal :stale, branches["scratch/test-idea"][:status]
+    assert_equal :no_pr, branches["scratch/test-idea"][:category]
+  end
+end


### PR DESCRIPTION
## Summary

Addresses Buganizer issue [b/558882844](https://buganizer.corp.google.com/issues/558882844): *"Clean up stale branches in google-cloud-ruby"*.

The `google-cloud-ruby` repository currently has **2,402 remote branches**. Below is the audit summary of the identified stale branches proposed for deletion, along with the safety criteria used to preserve all active and in-flight work.

cc @aandreassa for visibility and confirmation before we execute the branch deletions.

---

## Branch Evaluation & Count Summary

| Category | Count | Status / Action | Description |
| :--- | :---: | :---: | :--- |
| **Protected Base Branches** | 2 | **PRESERVE** | `main`, `gh-pages` |
| **Active Open PR Heads** | 7 | **PRESERVE** | Branches backing active open pull requests on the repo |
| **Recent Activity (<30 days)** | 6 | **PRESERVE** | Branches with commits in the last 30 days |
| **Legacy Bot Branches** | **2,259** | **DELETE** | `owl-bot-*` and `autosynth-*` branches from 2020–2022 |
| **Merged PR Branches** | **13** | **DELETE** | Branches whose associated PR was already merged into `main` |
| **Closed PR Branches** | **88** | **DELETE** | Branches whose PR was closed without merge (>30 days old) |
| **Abandoned No-PR Branches** | **26** | **DELETE** | Old experimental branches with no PR opened (>30 days old) |
| **Total Evaluated** | **2,402** | | **Total Proposed to Delete: 2,386 (99.3% bot)** |

---

## 1. Protected / Preserved Branches (16 Total — Zero Risk to Active Work)

These branches will **NOT** be touched:

### Base & Docsite (2)
- `main` (Default branch)
- `gh-pages` (Documentation site)

### Active Open PR Heads (7)
- `enable-recursive-delete-folder-tests` (PR #36282: feat(storagecontrol): re-enable recursive delete folder integration tests)
- `fix-storage-order-test` (PR #34844: chore(storage): fix order dependency in get_object_contexts test)
- `pubsub-shutdown-docs` (PR #36482: docs(pubsub): Add subscriber shutdown documentation and examples)
- `pubsub-shutdown-options` (PR #36480: feat(pubsub): Support subscriber shutdown options)
- `pubsub-shutdown-stream-inventory` (PR #36479: chore(pubsub): Add inventory wait and stream shutdown nack)
- `release-please--branches--main--components--google-cloud-compute` (PR #36540: chore(main): release google-cloud-compute 1.20.1)
- `release-please--branches--main--components--google-cloud-compute-v1` (PR #36541: chore(main): release google-cloud-compute-v1 3.10.1)

### Recent Activity within 30-Day Grace Period (6)
- `chore/zizmor-fixes` (Last commit: 2026-08-21)
- `ci/demo-doctests-execution` (Last commit: 2026-08-24)
- `owl-bot-copy-google-cloud-compute-v1` (Last commit: 2026-09-02)
- `owl-bot-copy-google-cloud-storage-control-v2` (Last commit: 2026-08-20)
- `release-please--branches--main--components--google-apps-chat-v1` (Last commit: 2026-08-18)
- `tombstone-apigee-registry-v1` (Last commit: 2026-08-12)

---

## 2. Identified Branches to Delete (2,386 Total)

### A. Legacy Bot Branches (2,259 Branches)
Ephemeral branches generated by automated bots between 2020 and 2022 that were left behind:
- **`owl-bot-*`**: 2,249 branches
- **`autosynth-*`**: 10 branches (`autosynth-asset-v1beta1`, `autosynth-datastore`, `autosynth-debugger`, `autosynth-error_reporting`, `autosynth-firestore`, `autosynth-irm`, `autosynth-logging`, `autosynth-pubsub`, `autosynth-trace`, `autosynth-webrisk`)

### B. Merged PR Branches (13 Branches)
Branches whose work was already merged into `main`:

| Branch Name | PR # | Last Commit Date | Commit Headline |
| :--- | :---: | :---: | :--- |
| `context-aware-commits` | #5085 | 2020-03-19 | chore: enable context-aware commits for one API |
| `czahedi-patch-1` | #5916 | 2020-05-06 | Update CODEOWNERS |
| `docpub` | #11049 | 2021-03-30 | fix version setting |
| `release-google-cloud-asset-v1-v0.6.0` | #7607 | 2020-09-03 | chore: updated google-cloud-asset-v1/lib/google/clo |
| `release-google-cloud-dialogflow-v2-v0.6.5` | #7247 | 2020-08-06 | chore: updated google-cloud-dialogflow-v2/lib/googl |
| `release-google-cloud-memcache-v1beta2-v0.1.3` | #7394 | 2020-08-10 | chore: updated google-cloud-memcache-v1beta2/lib/go |
| `release-please--branches--main--components--google-cloud-scheduler` | #24373 | 2026-08-05 | chore(main): release google-cloud-scheduler 3.2.1 |
| `release-please--branches--main--components--grafeas` | #24410 | 2026-08-05 | chore(main): release grafeas 1.8.1 |
| `samples-presubmit-master` | #5397 | 2020-04-09 | expand presubmit check in windows build |
| `shivng-storage-samples` | #19467 | 2022-11-24 | Merge branch 'main' into shivng-storage-samples |
| `srs` | #11208 | 2021-04-23 | chore: add sync repo settings config |
| `system-tests-against-emulator` | #6909 | 2020-06-25 | Update the shell script. |
| `zizmor-cleanup` | #34682 | 2026-07-01 | chore(actions): address zizmor security and contain |

### C. Abandoned No-PR Branches (26 Branches)
Stale ad-hoc branches with no associated pull requests (last updated 2016–2026):

| Branch Name | Last Commit Date | Commit Headline |
| :--- | :---: | :--- |
| `automl-samples` | 2020-05-27 | asdf |
| `bcb-to-fb` | 2021-01-28 | test(datastore): Improve isolation of samples test  |
| `buildozer-games` | 2020-08-11 | DO NOT MERGE: scripts to process synth.py files int |
| `chore/automate-gemfile-locks-phase-2` | 2026-07-08 | chore(deps): enroll Batch 2 generated gems (A-D) in |
| `chore/owlbot-lockfile-automation` | 2026-07-23 | feat: automate lockfile generation in OwlBot and re |
| `chore/renovate-daily-pilot-expansion` | 2026-07-14 | chore(deps): unignore Gemfile.lock in 4 daily pilot |
| `chore/seed-lockfiles-1785437666` | 2026-07-30 | chore(script): drop multithreading and add .gitigno |
| `compose-delete-source` | 2026-06-24 | feat(storage): support deleteSourceObjects option i |
| `demo-generate-asset-v1` | 2026-07-24 | feat: generate google-cloud-asset-v1 |
| `dev/virost/chore/github_creds` | 2026-01-12 | chore: keep debug step commented out |
| `df-samples` | 2020-03-19 | asdf |
| `er-fix-project` | 2026-05-13 | fix(error_reporting): Honor quota_project configura |
| `gcloud-jsondoc` | 2017-09-26 | Update Generator#write_to |
| `gcloud-rdoc` | 2016-11-19 | Add circle.yml file to ignore branch on builds |
| `google-cloud-asset-synth.metadata-test` | 2020-07-29 | no changes |
| `google-cloud-pubsub-v1-stable` | 2025-07-09 | chore(secret_manager): Added SecretManager Tags Sam |
| `lifecycle-action-multipart-upload-extend` | 2022-06-28 | Add matches prefix/suffix rule to new lifecycle act |
| `pubsub-docs` | 2021-09-22 | docs(pubsub): correct spelling |
| `pubsub-exactly-once-delivery-support` | 2022-05-18 | feat: Initial generation of google-cloud-bigquery-d |
| `rad` | 2020-10-26 | asdf |
| `ruby-2.3-compatible` | 2019-10-07 | chore(container_analysis): Ensure container-analysi |
| `stateless` | 2026-03-13 | feat(bigquery): Stateless Queries |
| `test-b` | 2025-09-09 | empty |
| `test-run-gapic-gitignore-lockfile-blockchainnodeengine` | 2026-07-28 | feat(blockchainnodeengine-v1): track native Gemfile |
| `test-run-gapic-gitignore-lockfile-modelarmor` | 2026-07-28 | feat(modelarmor-v1): track native Gemfile.lock from |
| `yard-gcloud` | 2016-11-19 | Add circle.yml file to ignore branch on builds |

### D. Closed / Unmerged PR Branches (88 Branches)
<details>
<summary><b>Click to expand full list of 88 closed PR branches</b></summary>

| Branch Name | PR # | Last Commit Date | Commit Headline |
| :--- | :---: | :---: | :--- |
| `add-delete-folder-recursive-sample` | #34034 | 2026-06-10 | samples(storagecontrol): add delete folder recursiv |
| `admin-latest` | #30529 | 2025-06-18 | Add missing subscriber method |
| `ads-manager-paths` | #27486 | 2024-10-24 | feat: Initial generation of google-ads-ad_manager-v |
| `bigquery-ci-test` | #34024 | 2026-07-13 | chore: test CI presubmits |
| `bq-5mb-json-test` | #31568 | 2025-10-01 | chore: Add integration test for JSON uploads over 5 |
| `chat-library-gen` | #25440 | 2024-03-26 | rubocop fix to .owlbot.rb |
| `chore/add-lockfile-seeder` | #35041 | 2026-07-30 | chore: strictly bind root Gemfile.lock ignore to ro |
| `chore/phase2-expansion-round-2` | #34976 | 2026-07-20 | chore(deps): generate lockfiles and enroll 10 clien |
| `chore/renovate-schedule-grouping` | #35106 | 2026-08-04 | chore(renovate): restrict update schedule to weeken |
| `chore/renovate-wildcard-enrolled-lockfiles` | #34988 | 2026-07-21 | chore(deps): align Renovate config with gapic-gener |
| `compose-delete-source-objects-ruby` | #34662 | 2026-06-23 | feat(storage): support delete_source_objects in com |
| `compute-accept-fix` | #34623 | 2026-06-18 | test(compute-v1): Address flaky tests |
| `dataplex-v1-fix` | #33976 | 2026-05-22 | chore(google-cloud-dataplex-v1): Skip generator of  |
| `demo-gen-fix-07-2026` | #34726 | 2026-07-08 | chore: Demo generator fix |
| `demo-generator` | #35083 | 2026-07-31 | chore: Demo for google protobuf updates to ~> 33.2 |
| `feat-ruby-delete-folder-recursive` | #34605 | 2026-06-11 | feat(ruby): add deleteFolderRecursive sample |
| `firestore-headers-issue` | #23532 | 2023-11-09 | Comment print statements |
| `firestore-replace-legacy-header` | #24490 | 2024-01-29 | Fix a failing test |
| `fix_chrome_session` | #25306 | 2024-03-14 | chore: remove other options |
| `fix_storage_labels` | #19213 | 2022-09-26 | Added the time delay |
| `g-husam-patch-1` | #34678 | 2026-07-09 | chore(renovate): merge main updates into json5 conf |
| `google-cloud-dataplex-v1-fix` | #33820 | 2026-04-09 | fix(dataplex)!: remove deprecated Explore-related m |
| `mb.synthtool_import` | #4411 | 2019-11-13 | Imported synthtool |
| `obsolete-resource-settings` | #29311 | 2025-03-07 | chore: obsolete google-cloud-resource_settings-v1 a |
| `pin-conformance-tests` | #34724 | 2026-07-07 | chore: pin GH Actions by SHA in conformance workflo |
| `polling-harness-bigtable` | #26132 | 2024-06-18 | chore: Utilize polling harness in Bigtable replicat |
| `pubsub_dev` | #13303 | 2021-08-10 | Revert before merge: Use staging endpoint |
| `release-gcloud-v0.25.0` | #7904 | 2020-10-09 | Release gcloud 0.25.0 |
| `release-google-analytics-admin-v1alpha-v0.5.1` | #9912 | 2021-03-01 | chore: release google-analytics-admin-v1alpha 0.5.1 |
| `release-google-cloud-access_approval-v0.4.0` | #7870 | 2020-10-16 | Release google-cloud-access_approval 0.4.0 |
| `release-google-cloud-asset-v0.7.1` | #4909 | 2020-03-10 | updated google-cloud-asset/lib/google/cloud/asset/v |
| `release-google-cloud-asset-v1beta1-v0.3.0` | #7881 | 2020-10-16 | Release google-cloud-asset-v1beta1 0.3.0 |
| `release-google-cloud-asset-v2.0.0` | #7876 | 2020-10-16 | Release google-cloud-asset 2.0.0 |
| `release-google-cloud-automl-v0.4.1` | #4446 | 2019-11-25 | updated google-cloud-automl/lib/google/cloud/automl |
| `release-google-cloud-bigquery-v1.23.1` | #8046 | 2020-10-28 | Release google-cloud-bigquery 1.23.1 |
| `release-google-cloud-bigtable-v0.8.1` | #4405 | 2019-12-03 | updated google-cloud-bigtable/lib/google/cloud/bigt |
| `release-google-cloud-bigtable-v2.3.1` | #10832 | 2021-03-09 | chore: release google-cloud-bigtable 2.3.1 |
| `release-google-cloud-bigtable-v3.0.0` | #7937 | 2020-10-16 | Release google-cloud-bigtable 3.0.0 |
| `release-google-cloud-container-v2.0.0` | #7879 | 2020-10-16 | Release google-cloud-container 2.0.0 |
| `release-google-cloud-container_analysis-v2.0.0` | #7882 | 2020-10-16 | Release google-cloud-container_analysis 2.0.0 |
| `release-google-cloud-dataproc-v2.0.0` | #7899 | 2020-10-16 | Release google-cloud-dataproc 2.0.0 |
| `release-google-cloud-debugger-v0.37.0` | #7057 | 2020-07-21 | updated google-cloud-debugger/lib/google/cloud/debu |
| `release-google-cloud-dialogflow-v2.0.0` | #7889 | 2020-10-16 | Release google-cloud-dialogflow 2.0.0 |
| `release-google-cloud-env-v1.5.0` | #7987 | 2020-10-16 | Release google-cloud-env 1.5.0 |
| `release-google-cloud-error_reporting-v0.36.0` | #7056 | 2020-07-21 | updated google-cloud-error_reporting/lib/google/clo |
| `release-google-cloud-language-v2.0.0` | #7909 | 2020-10-16 | Release google-cloud-language 2.0.0 |
| `release-google-cloud-memcache-v0.2.0` | #9621 | 2021-02-24 | chore: release google-cloud-memcache 0.2.0 |
| `release-google-cloud-monitoring-v0.37.3` | #5560 | 2020-04-20 | updated google-cloud-monitoring/lib/google/cloud/mo |
| `release-google-cloud-monitoring-v0.39.0` | #6296 | 2020-06-01 | updated google-cloud-monitoring/lib/google/cloud/mo |
| `release-google-cloud-os_login-v2.0.0` | #7886 | 2020-10-16 | Release google-cloud-os_login 2.0.0 |
| `release-google-cloud-pubsub-v1.3.2` | #4912 | 2020-03-09 | updated google-cloud-pubsub/lib/google/cloud/pubsub |
| `release-google-cloud-redis-v2.0.0` | #7896 | 2020-10-16 | Release google-cloud-redis 2.0.0 |
| `release-google-cloud-secret_manager-v0.1.1` | #4695 | 2020-01-17 | updated google-cloud-secret_manager/lib/google/clou |
| `release-google-cloud-security_center-v2.0.0` | #7913 | 2020-10-16 | Release google-cloud-security_center 2.0.0 |
| `release-google-cloud-service_directory-v0.4.0` | #7911 | 2020-12-07 | chore: release google-cloud-service_directory 0.4.0 |
| `release-google-cloud-spanner-v2.1.1` | #7610 | 2020-09-04 | chore: updated google-cloud-spanner/lib/google/clou |
| `release-google-cloud-spanner-v3.0.0` | #7933 | 2020-10-16 | Release google-cloud-spanner 3.0.0 |
| `release-google-cloud-speech-v0.42.0` | #5140 | 2020-05-05 | updated google-cloud-speech/lib/google/cloud/speech |
| `release-google-cloud-speech-v2.0.0` | #7928 | 2020-10-16 | Release google-cloud-speech 2.0.0 |
| `release-google-cloud-storage-v1.23.1` | #4386 | 2019-11-12 | updated google-cloud-storage/lib/google/cloud/stora |
| `release-google-cloud-storage-v1.24.1` | #4440 | 2019-12-12 | updated google-cloud-storage/lib/google/cloud/stora |
| `release-google-cloud-storage-v1.26.3` | #6993 | 2020-07-28 | chore: updated google-cloud-storage/lib/google/clou |
| `release-google-cloud-storage-v1.28.1` | #7622 | 2020-09-15 | Release google-cloud-storage 1.28.1 |
| `release-google-cloud-storage-v1.29.3` | #8411 | 2021-01-08 | chore: release google-cloud-storage 1.29.3 |
| `release-google-cloud-storage-v2.0.0` | #7127 | 2020-08-26 | chore: updated google-cloud-storage/lib/google/clou |
| `release-google-cloud-talent-v0.21.0` | #7925 | 2020-10-16 | Release google-cloud-talent 0.21.0 |
| `release-google-cloud-talent-v2.0.0` | #8041 | 2020-10-16 | Release google-cloud-talent 2.0.0 |
| `release-google-cloud-trace-v0.36.2` | #4447 | 2019-12-05 | updated google-cloud-trace/lib/google/cloud/trace/v |
| `release-google-cloud-translate-v4.0.0` | #8018 | 2020-10-16 | Release google-cloud-translate 4.0.0 |
| `release-google-cloud-video_intelligence-v2.0.4` | #4919 | 2020-03-10 | updated google-cloud-video_intelligence/lib/google/ |
| `release-google-cloud-video_intelligence-v4.0.0` | #7934 | 2020-10-16 | Release google-cloud-video_intelligence 4.0.0 |
| `release-google-cloud-vision-v0.39.0` | #5144 | 2020-06-01 | updated google-cloud-vision/lib/google/cloud/vision |
| `release-google-cloud-vision-v2.0.0` | #7927 | 2020-10-16 | Release google-cloud-vision 2.0.0 |
| `release-google-cloud-webrisk-v0.7.0` | #7924 | 2020-10-16 | Release google-cloud-webrisk 0.7.0 |
| `release-please--branches--main--components--google-cloud-merchant-issue_resolution-v1beta` | #30423 | 2025-05-22 | 🦉 Updates from OwlBot post-processor |
| `release-stackdriver-v0.17.0` | #8178 | 2020-12-02 | chore: release stackdriver 0.17.0 |
| `remove-dupe-samples` | #8584 | 2021-01-07 | Removing samples that are in ruby-docs-samples |
| `renovate/core-handwritten-gems-lockfiles` | #34767 | 2026-07-14 | chore(deps): update core handwritten gems lockfiles |
| `renovate/major-core-handwritten-gems-lockfiles` | #34768 | 2026-07-14 | chore(deps): update core handwritten gems lockfiles |
| `sg-google-chat-v1` | #25337 | 2024-03-07 | feat: Initial release of generated goog-apps-chat-v |
| `test-ci` | #34751 | 2026-07-15 | chore: test |
| `test-generator-updates` | #34013 | 2026-06-04 | chore: Showcase of generator updates |
| `test-protobuf-36` | #34788 | 2026-07-14 | chore: Test upgrade to Protocol Buffers v36.0-rc1 |
| `test-pubsub-all` | #30580 | 2025-06-27 | Merge remote-tracking branch 'origin/main' into pub |
| `test-run-gapic-gitignore-lockfile` | #35030 | 2026-07-28 | feat(language-v2): track native Gemfile.lock from g |
| `test-run-gapic-minitest-reporters-language-v2` | #35032 | 2026-07-29 | feat(language-v2): regenerate language-v2 with reno |
| `test-run-speech-v1` | #35036 | 2026-07-29 | chore(speech-v1): test regenerate gapic client to v |
| `viacheslav-rostovtsev-patch-1` | #30593 | 2025-07-01 | Update aggregate_query_test.rb |

</details>

---

## Confirmation & Next Steps
- Once @aandreassa confirms this list, we will proceed with deleting the identified branches.
